### PR TITLE
:recycle: Refactor Modal and Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -8,7 +8,7 @@ import { DropdownContent } from './DropdownContent'
 
 storiesOf('Dropdown', module).add('all', () => (
   <Wrapper>
-    <Dropdown dropdownKey="test-1">
+    <Dropdown>
       <DropdownTrigger>
         <Txt>Click me (left position)</Txt>
       </DropdownTrigger>
@@ -17,7 +17,7 @@ storiesOf('Dropdown', module).add('all', () => (
       </DropdownContent>
     </Dropdown>
 
-    <Dropdown dropdownKey="test-2">
+    <Dropdown>
       <DropdownTrigger>
         <Txt>Click me (right position)</Txt>
       </DropdownTrigger>

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -2,14 +2,11 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import { LightBalloon } from '../Balloon'
+import { DropdownConsumer } from './Dropdown'
 
 export interface Rect {
   right: number
   left: number
-}
-interface Props extends React.Props<{}> {
-  clientRect?: Rect
-  active?: boolean
 }
 
 const getPositionClassName = (clientRect?: Rect): 'center' | 'left' | 'right' => {
@@ -19,17 +16,19 @@ const getPositionClassName = (clientRect?: Rect): 'center' | 'left' | 'right' =>
   return 'center'
 }
 
-export const DropdownContent: React.FC<Props> = ({ active, clientRect, children }) => (
-  <Wrapper
-    className={`DropdownContent ${active ? 'active' : ''} ${getPositionClassName(clientRect)}`}
-  >
-    <LightBalloon vertical="top" horizontal={getPositionClassName(clientRect)}>
-      {children}
-    </LightBalloon>
-  </Wrapper>
+export const DropdownContent: React.FC<{}> = ({ children }) => (
+  <DropdownConsumer>
+    {({ active, clientRect }) => (
+      <Wrapper
+        className={`DropdownContent ${active ? 'active' : ''} ${getPositionClassName(clientRect)}`}
+      >
+        <LightBalloon vertical="top" horizontal={getPositionClassName(clientRect)}>
+          {children}
+        </LightBalloon>
+      </Wrapper>
+    )}
+  </DropdownConsumer>
 )
-
-DropdownContent.displayName = 'DropdownContent'
 
 const Wrapper = styled.div`
   visibility: hidden;

--- a/src/components/Dropdown/DropdownTrigger.tsx
+++ b/src/components/Dropdown/DropdownTrigger.tsx
@@ -1,31 +1,35 @@
 import * as React from 'react'
+import { DropdownConsumer } from './Dropdown'
 
-interface Props {
-  dropdownKey?: string
-  active?: boolean
-  onClick?: () => void
-}
+export const DropdownTrigger: React.FC<{}> = ({ children }) => (
+  <DropdownConsumer>
+    {({ toggleDropdown, active }) => (
+      <button
+        className="DropdownTrigger"
+        /* tslint:disable:jsx-no-lambda */
+        onClick={e => {
+          e.preventDefault()
+          toggleDropdown(e.currentTarget.getBoundingClientRect())
+        }}
+      >
+        {React.Children.map(children, (child: any) => {
+          const props = child.props ? child.props : {}
+          const { className = '' } = props
 
-export const DropdownTrigger: React.FC<Props> = ({ children, dropdownKey, active, onClick }) => (
-  <button className="DropdownTrigger" onClick={onClick}>
-    {React.Children.map(children, (child: any) => {
-      const props = child.props ? child.props : {}
-      const { className = '' } = props
+          switch (typeof child) {
+            case 'string':
+              return child
 
-      switch (typeof child) {
-        case 'string':
-          return child
+            case 'object':
+              return React.cloneElement(child, {
+                className: `${active ? 'active' : ''} ${className}`,
+              })
 
-        case 'object':
-          return React.cloneElement(child, {
-            className: `${dropdownKey} ${active ? 'active' : ''} ${className}`,
-          })
-
-        default:
-          return null
-      }
-    })}
-  </button>
+            default:
+              return null
+          }
+        })}
+      </button>
+    )}
+  </DropdownConsumer>
 )
-
-DropdownTrigger.displayName = 'DropdownTrigger'

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -6,7 +6,7 @@ import { Modal, ModalTrigger, ModalEraser, ModalContent } from './'
 
 storiesOf('Modal', module).add('all', () => (
   <div>
-    <Modal modalKey="test-modal-1">
+    <Modal>
       <ModalTrigger>
         <Txt>Click me (Modal1)</Txt>
       </ModalTrigger>
@@ -19,7 +19,7 @@ storiesOf('Modal', module).add('all', () => (
       </ModalContent>
     </Modal>
 
-    <Modal modalKey="test-modal-2">
+    <Modal>
       <ModalTrigger>
         <Txt>Click me (Modal2)</Txt>
       </ModalTrigger>

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -1,40 +1,17 @@
 import * as React from 'react'
 import styled from 'styled-components'
 
-import { ModalEraser } from './ModalEraser'
+import { ModalConsumer } from './Modal'
 
-interface Props {
-  active?: boolean
-  onClick?: () => void
-}
-
-export class ModalContent extends React.PureComponent<Props> {
-  public static displayName = 'ModalContent'
-  private erasers: Element[] = []
-
-  public componentDidMount() {
-    this.erasers = Array.from(document.getElementsByClassName(ModalEraser.displayName || ''))
-    this.erasers.forEach(eraser => {
-      eraser.addEventListener('click', this.props.onClick as any)
-    })
-  }
-
-  public componentWillUnmount() {
-    this.erasers.forEach(eraser => {
-      eraser.removeEventListener('click', this.props.onClick as any)
-    })
-  }
-
-  public render() {
-    const { active, children } = this.props
-
-    return (
-      <Wrapper className={`ModalContent ${active ? 'active' : ''}`}>
-        <div>{children}</div>
+export const ModalContent: React.FC<{}> = props => (
+  <ModalConsumer>
+    {({ active }) => (
+      <Wrapper className={active ? 'active' : ''}>
+        <div>{props.children}</div>
       </Wrapper>
-    )
-  }
-}
+    )}
+  </ModalConsumer>
+)
 
 const Wrapper = styled.div`
   visibility: hidden;

--- a/src/components/Modal/ModalEraser.tsx
+++ b/src/components/Modal/ModalEraser.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
+import { ModalConsumer } from './Modal'
 
 export const ModalEraser: React.FC<{}> = ({ children }) => (
-  <div className="ModalEraser">{children}</div>
+  <ModalConsumer>{({ hideModal }) => <div onClick={hideModal}>{children}</div>}</ModalConsumer>
 )
-
-ModalEraser.displayName = 'ModalEraser'

--- a/src/components/Modal/ModalTrigger.tsx
+++ b/src/components/Modal/ModalTrigger.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react'
+import { ModalConsumer } from './Modal'
 
-interface Props {
-  onClick?: () => void
-}
-
-export const ModalTrigger: React.FC<Props> = ({ children, onClick }) => (
-  <div className="ModalTrigger" onClick={onClick}>
-    {children}
-  </div>
+export const ModalTrigger: React.FC<{}> = ({ children }) => (
+  <ModalConsumer>{({ showModal }) => <div onClick={showModal}>{children}</div>}</ModalConsumer>
 )
-
-ModalTrigger.displayName = 'ModalTrigger'


### PR DESCRIPTION
I've refactored `Modal` and `Dropdown` component with Context API to reduce the complexity.

I've removed some classNames because they are no longer required.
But it might have to revert if the classNames is used as an interface overriding the style.