### PR TITLE
add a config for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2.1
+
+commands:
+  run-npm-test:
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "yarn.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+      # run tests!
+      - run: yarn lint
+      - run: yarn test
+jobs:
+  node-v8:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - run-npm-test
+  node-v10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - run-npm-test
+
+workflows:
+  multiple_builds:
+    jobs:
+      - node-v8
+      - node-v10

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "lint": "run-p lint:*",
     "format": "tslint --fix 'src/**/*.ts{,x}'",
     "clean": "rimraf ./lib",
-    "prepublish": "yarn release",
+    "prepack": "yarn release",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "test": "echo 'TODO'"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This is a PR to add a setting for CircleCI.
I'll add `npm test` later so it is added as a dummy.

In addition to that, I've changed a place to run `yarn release` from `prepublish` to `prepack` because `prepublish` is executed even after running `yarn install`.

https://docs.npmjs.com/misc/scripts