### PR TITLE
:bug: fix to focus input on Modal

### DIFF
--- a/src/components/Modal/Box.tsx
+++ b/src/components/Modal/Box.tsx
@@ -21,7 +21,7 @@ interface MergedStyledProps extends InjectedProps {
 
 const BoxComponent: React.FC<Props & InjectedProps> = ({ active, children, ...props }) => (
   <Wrapper className={active ? 'active' : ''} {...props}>
-    <Inner {...props}>{children}</Inner>
+    {active ? <Inner {...props}>{children}</Inner> : null}
   </Wrapper>
 )
 

--- a/src/components/Modal/Box.tsx
+++ b/src/components/Modal/Box.tsx
@@ -39,7 +39,7 @@ const Wrapper = styled.div`
       width: 100%;
       height: 100%;
       background-color: ${theme.palette.Overlay};
-      transition: all 0.3s ease-in-out;
+      transition: opacity 0.3s ease-in-out;
 
       &.active {
         visibility: visible;


### PR DESCRIPTION
Currently, focusing input on Modal doesn't work because the children of Modal doesn't rerender even the Modal state has been changed. The reason is that current implementation mounts children at the same time as Modal is mounted and then the Modal only changes the state of Wrapper, which means children are always the same reference so React skips to update children.

This PR makes to mount children only when the `active` state is `true`.