### PR TITLE
Set auto-assign setting

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,21 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - nabeliwo
+  - wacky
+  - im36-123
+  - AtsushiM
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+  - WIP
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1


### PR DESCRIPTION
Added [auto-assign](https://github.com/apps/auto-assign) to assign reviewers automatically.

Reviewers will be randomly assigned from the four members nabeliwo, @wacky, @im36-123 and @AtsushiM.

You can avoid assigning a review by putting the word 'WIP' in the PR title.