### PR TITLE
Change Pagination component colors

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -66,7 +66,7 @@ const List = styled.ul`
     return css`
       display: flex;
       border-radius: ${frame.border.radius.s};
-      border: 1px solid ${palette.Mono_P10};
+      border: 1px solid ${palette.Mono_P20};
       padding: 0;
 
       & > li {

--- a/src/components/Pagination/PaginationItem.tsx
+++ b/src/components/Pagination/PaginationItem.tsx
@@ -56,10 +56,14 @@ const Item = styled.span`
       outline: 0;
       transition: ${isTouchDevice ? 'none' : `background-color ${interaction.hover.animation}`};
 
-      &.active,
-      &.hover {
-        background-color: ${palette.Main};
+      &.active {
         color: ${palette.White};
+        background-color: ${palette.Main};
+      }
+
+      &.hover {
+        color: ${palette.Main};
+        background-color: ${palette.Mono_P05};
       }
     `
   }}


### PR DESCRIPTION
According to https://github.com/kufu/smarthr-ui/projects/1#card-18945881 this PR changes colors 
 of Pagination component as followings. 7 is active, 10 is hovered.

### before

<img src="https://user-images.githubusercontent.com/51349177/58847352-964bc600-86bd-11e9-9acb-f25a6ec88f34.png" width=400>

### after

<img src="https://user-images.githubusercontent.com/51349177/58847365-a5327880-86bd-11e9-88aa-2a3295238a75.png" width=400>

In the card https://github.com/kufu/smarthr-ui/projects/1#card-18945881, only background color on hover is specified but white text on Mono_P50 is difficult to read. so I picked Main color for text but i'm not sure this is appropriate.