### PR TITLE
Fix editor lint error

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "url": "git+https://github.com/kufu/smarthr-ui.git"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "build-storybook": "build-storybook",
     "clean": "rimraf ./lib",
     "fix": "fixpack",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
     "noEmitOnError": true,
     "esModuleInterop": true
   },
-  "exclude": ["node_modules", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
+  "exclude": ["node_modules"],
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
The editor's lint error now occurs during this PR ( https://github.com/kufu/smarthr-ui/pull/162 ).
When I import README.md, `module not found` is displayed.

Lint error is displayed but it was merged because It build was successful.

I solved this problem with the configuration file.