### PR TITLE
test: add a test for missing exports in src/index.ts

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,49 @@
+import ts from 'typescript'
+import util from 'util'
+import fs from 'fs'
+
+const readFile = util.promisify(fs.readFile)
+const readdir = util.promisify(fs.readdir)
+
+const IGNORE_DIRS = ['__tests__', 'Base', 'Icon']
+
+describe('index', () => {
+  it('should export all components in the components directory from index.ts', async () => {
+    const actual = await getExportedComponents('./src/index.ts')
+    const expected = await getExistingComponents('./src/components/', IGNORE_DIRS)
+    expect(expected.sort()).toEqual(actual.sort())
+  })
+})
+
+const getAllExportPaths = (sourceFile: ts.SourceFile): string[] => {
+  const exportPaths: string[] = []
+  ts.forEachChild(sourceFile, node => {
+    if (ts.isExportDeclaration(node)) {
+      node.forEachChild((child: ts.Node) => {
+        if (ts.isStringLiteral(child)) {
+          exportPaths.push(`${child.text}`)
+        }
+      })
+    }
+  })
+  return exportPaths
+}
+
+const isNonComponentsExports = (file: string) => file.indexOf('./components/') !== -1
+const getComponentName = (file: string) => file.replace('./components/', '')
+
+const parseFile = async (filePath: string): Promise<string[]> => {
+  const source = await readFile(filePath)
+  const sourceFile = ts.createSourceFile(filePath, source.toString(), ts.ScriptTarget.Latest)
+  return getAllExportPaths(sourceFile)
+}
+
+const getExportedComponents = async (file: string): Promise<string[]> => {
+  const files = await parseFile(file)
+  return files.filter(isNonComponentsExports).map(getComponentName)
+}
+
+const getExistingComponents = async (file: string, filterDirs: string[]): Promise<string[]> => {
+  const dirs = await readdir(file)
+  return dirs.filter(dir => !filterDirs.includes(dir))
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
 }


### PR DESCRIPTION
Fix #188

This PR adds a test to verify that all components are exported from `src/index.ts`.
The test only checks whether component files are exported from `src/index.ts` or not, which means it doesn't check each `export` statements.
(If we need to verify that every `export` statement in components are exported from `src/index.ts`, I'll add the test in later.)

I've also added an ignore list to allow non-exported components.

```
const IGNORE_DIRS = ['__tests__', 'Base', 'Icon']
```

@nabeliwo Is it ok to ignore `Base` and `Icon` components?