### PR TITLE
Modify style that do not shrink the Checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -58,6 +58,7 @@ const Wrapper = styled.div`
       display: inline-block;
       width: 20px;
       height: 20px;
+      flex-shrink: 0;
       border-radius: ${frame.border.radius.s};
       border: ${frame.border.default};
       background-color: ${palette.White};

--- a/src/components/Checkbox/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Checkbox/__test__/__snapshots__/index.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`Checkbox should be match snapshot 1`] = `
             "componentStyle": ComponentStyle {
               "componentId": "sc-bdVaJa",
               "isStatic": false,
-              "lastClassName": "gtcKYe",
+              "lastClassName": "NbjhZ",
               "rules": Array [
                 "
   ",
@@ -277,7 +277,7 @@ exports[`Checkbox should be match snapshot 1`] = `
         }
       >
         <div
-          className="active  light sc-bdVaJa gtcKYe"
+          className="active  light sc-bdVaJa NbjhZ"
         >
           <styled.span>
             <StyledComponent


### PR DESCRIPTION
When CheckboxLabel does not have enough space, Checkbox is shrinked by flex layout.
 So I modified Checkbox style not to be shrinked.

![スクリーンショット 2019-07-19 18 09 09](https://user-images.githubusercontent.com/52398501/61525122-c58e7a80-aa52-11e9-84c5-e4df6e22bbb7.png)


#### after amending

![スクリーンショット 2019-07-19 18 31 35](https://user-images.githubusercontent.com/52398501/61525478-785ed880-aa53-11e9-8214-f6f206e8ea2a.png)

