### PR TITLE
feat: add an entry point for ES Modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ typings/
 # End of https://www.gitignore.io/api/node
 
 lib/
+esm/
 .cache
 
 storybook-static/

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "node": ">=8.0.0"
   },
   "files": [
+    "esm",
     "lib"
   ],
   "homepage": "https://github.com/kufu/smarthr-ui#readme",
@@ -92,6 +93,7 @@
     ]
   },
   "main": "lib/index.js",
+  "module": "esm/index.js",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
@@ -101,7 +103,9 @@
     "url": "git+https://github.com/kufu/smarthr-ui.git"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "run-p build:*",
+    "build:lib": "tsc -p tsconfig.build.json",
+    "build:esm": "tsc -p tsconfig.esm.build.json",
     "build-storybook": "build-storybook",
     "clean": "rimraf ./lib",
     "fix": "fixpack",

--- a/src/libs/lodash.ts
+++ b/src/libs/lodash.ts
@@ -1,5 +1,5 @@
-import _merge = require('lodash.merge')
-import _range = require('lodash.range')
+import _merge from 'lodash.merge'
+import _range from 'lodash.range'
 
 export const merge = _merge
 export const range = _range

--- a/tsconfig.esm.build.json
+++ b/tsconfig.esm.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./esm",
+    "module": "esnext"
+  }
+}


### PR DESCRIPTION
This PR is to add a new entry point that is for ES Modules, which is intended to enable Tree Shaking with webpack.

To use `esm/` for bundling with webpack, I've added a `module` field in `package.json`.

But this is an issue  with the sentence `import _merge = require('lodash.merge')`.
Because `import 〜 require('xxx')` can't use with `module: es2015 or esnext` in `compilerOptions` so I use import/export statement instead of `import ~ require`.
It seems to be fine because we enable `esModuleInterop` compilerOption.
