### PR TITLE
fix: Fix export test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 const readFile = util.promisify(fs.readFile)
 const readdir = util.promisify(fs.readdir)
 
-const IGNORE_DIRS = ['__tests__', 'Base', 'Icon']
+const IGNORE_DIRS = ['__tests__', 'Icon']
 
 describe('index', () => {
   it('should export all components in the components directory from index.ts', async () => {


### PR DESCRIPTION
`src / index.test.ts` checks that all components are exported
Since `Base component` was not supposed to be exported so far, it was set to ignore during testing.
The test was fixed because there was a change to export `Base component`.