### PR TITLE
Add onClickBackground props to Modal

### DIFF
--- a/src/components/Modal/Box.tsx
+++ b/src/components/Modal/Box.tsx
@@ -5,11 +5,11 @@ import { InjectedProps, withTheme } from '../../hocs/withTheme'
 
 interface Props {
   active: boolean
+  onClickBackground?: () => void
   top?: number
   right?: number
   bottom?: number
   left?: number
-  hideModal?: () => void
   children?: React.ReactNode
 }
 
@@ -20,11 +20,11 @@ interface MergedStyledProps extends InjectedProps {
   left?: number
 }
 
-const BoxComponent: React.FC<Props> = ({ active, children, hideModal, ...props }) => (
+const BoxComponent: React.FC<Props> = ({ active, children, onClickBackground, ...props }) => (
   <Wrapper className={active ? 'active' : ''} {...props}>
     {active ? (
       <React.Fragment>
-        <Background {...props} onClick={hideModal} />
+        <Background {...props} onClick={onClickBackground} />
         <Inner {...props}>{children}</Inner>
         {/* Suppresses scrolling of body while modal is displayed */}
         <ScrollSuppressing />

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -14,7 +14,7 @@ class ModalController extends React.PureComponent {
     return (
       <div>
         <button onClick={this.onClickOpen}>Controllable Modal</button>
-        <Modal isOpen={this.state.isOpen}>
+        <Modal isOpen={this.state.isOpen} onClickBackground={this.onClickClose}>
           <Inner>
             <button onClick={this.onClickClose}>Close Modal</button>
           </Inner>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,6 +5,7 @@ import { Box } from './Box'
 
 interface Props {
   isOpen: boolean
+  onClickBackground?: () => void
   top?: number
   right?: number
   bottom?: number

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -13,7 +13,7 @@ interface Props {
 export const ModalContent: React.FC<Props> = ({ children, ...props }) => (
   <ModalConsumer>
     {({ active, hideModal }) => (
-      <Box active={active} hideModal={hideModal} {...props}>
+      <Box active={active} onClickBackground={hideModal} {...props}>
         {children}
       </Box>
     )}


### PR DESCRIPTION
The background click cannot be handled when Modal is imported.
Added onClickBackground props to allow the user to click the background and close the modal.