### PR TITLE
Make `theme` props for ThemeProvider component optional

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,7 +5,6 @@ import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { withA11y } from '@storybook/addon-a11y'
 import { addReadme } from 'storybook-readme'
 
-import { createTheme } from '../src/themes/createTheme'
 import { ThemeProvider } from '../src/themes/ThemeProvider'
 
 const req = require.context('../src/components', true, /.stories.tsx$/)
@@ -29,7 +28,7 @@ addParameters({ viewport: { viewports: INITIAL_VIEWPORTS } })
 
 addDecorator(withA11y)
 addDecorator(addReadme)
-addDecorator(Story => <ThemeProvider theme={createTheme()}><Story /></ThemeProvider>)
+addDecorator(Story => <ThemeProvider><Story /></ThemeProvider>)
 
 configure(loadStories, module)
 

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
 
-import { CreatedTheme, createTheme } from '../themes/createTheme'
+import { ThemeProperty, CreatedTheme, createTheme } from '../themes/createTheme'
 
 export const ThemeContext = React.createContext<CreatedTheme>(createTheme())
 const { Provider } = ThemeContext
 
 interface Props extends React.Props<{}> {
-  theme: CreatedTheme
+  theme?: ThemeProperty
 }
 
-export const ThemeProvider: React.FC<Props> = ({ theme, children }) => {
-  return <Provider value={theme}>{children}</Provider>
+export const ThemeProvider: React.FC<Props> = ({ theme = {}, children }) => {
+  return <Provider value={createTheme(theme)}>{children}</Provider>
 }

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -7,7 +7,7 @@ import {
 import { CreatedPaletteTheme, createPalette, PaletteProperty } from './createPalette'
 import { CreatedSizeTheme, createSize, SizeProperty } from './createSize'
 
-interface ThemeProperty {
+export interface ThemeProperty {
   palette?: PaletteProperty
   size?: SizeProperty
   frame?: FrameProperty


### PR DESCRIPTION
Since the default theme is set internally, giving the default theme to the ThemeProvider component can be optional.