### PR TITLE
fix: Add ThemeProvider to DropdownContent

### DIFF
--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useEffect } from 'react'
 import { render } from 'react-dom'
 
+import { InjectedProps, withTheme } from '../../hocs/withTheme'
+import { ThemeProvider } from '../../themes/ThemeProvider'
 import { Rect } from './dropdownHelper'
 import { DropdownContext } from './Dropdown'
 import { DropdownContentInner } from './DropdownContentInner'
@@ -17,6 +19,7 @@ export const toggleContentView = (className: string, additionalClassName?: strin
   active: boolean,
   triggerRect: Rect,
   children: React.ReactNode,
+  theme: InjectedProps['theme'],
   onClickCloser: () => void,
 ) => () => {
   if (active) {
@@ -25,9 +28,11 @@ export const toggleContentView = (className: string, additionalClassName?: strin
     if (additionalClassName) classNames += ` ${additionalClassName}`
     element.className = classNames
     render(
-      <DropdownContentContext.Provider value={{ onClickCloser }}>
-        <DropdownContentInner triggerRect={triggerRect}>{children}</DropdownContentInner>
-      </DropdownContentContext.Provider>,
+      <ThemeProvider theme={theme}>
+        <DropdownContentContext.Provider value={{ onClickCloser }}>
+          <DropdownContentInner triggerRect={triggerRect}>{children}</DropdownContentInner>
+        </DropdownContentContext.Provider>
+      </ThemeProvider>,
       document.body.appendChild(element),
     )
   } else {
@@ -36,13 +41,24 @@ export const toggleContentView = (className: string, additionalClassName?: strin
   }
 }
 
-export const DropdownContent: React.FC<{}> = ({ children }) => {
+const DropdownContentComponent: React.FC<{ children: React.ReactNode } & InjectedProps> = ({
+  theme,
+  children,
+}) => {
   const { key, active, triggerRect, onClickCloser } = useContext(DropdownContext)
 
   useEffect(
-    toggleContentView(`dropdown-content-${key}`)(active, triggerRect, children, onClickCloser),
+    toggleContentView(`dropdown-content-${key}`)(
+      active,
+      triggerRect,
+      children,
+      theme,
+      onClickCloser,
+    ),
     [active, children, key, onClickCloser],
   )
 
   return null
 }
+
+export const DropdownContent = withTheme(DropdownContentComponent)

--- a/src/components/Dropdown/DropdownControllableContent.tsx
+++ b/src/components/Dropdown/DropdownControllableContent.tsx
@@ -1,9 +1,12 @@
 import React, { useContext, useEffect } from 'react'
 
+import { InjectedProps, withTheme } from '../../hocs/withTheme'
 import { DropdownContext } from './Dropdown'
 import { toggleContentView } from './DropdownContent'
 
-export const DropdownControllableContent: React.FC<{}> = ({ children }) => {
+const DropdownControllableContentComponent: React.FC<
+  { children: React.ReactNode } & InjectedProps
+> = ({ theme, children }) => {
   const { key, active, triggerRect, onClickCloser } = useContext(DropdownContext)
 
   useEffect(
@@ -11,6 +14,7 @@ export const DropdownControllableContent: React.FC<{}> = ({ children }) => {
       active,
       triggerRect,
       children,
+      theme,
       onClickCloser,
     ),
     [active, children, key, onClickCloser],
@@ -18,3 +22,5 @@ export const DropdownControllableContent: React.FC<{}> = ({ children }) => {
 
   return null
 }
+
+export const DropdownControllableContent = withTheme(DropdownControllableContentComponent)


### PR DESCRIPTION
# Problem

The theme is not applied to the content displayed in the Dropdown.

# Resolution

When passing DropdownContent to ReactDOM.render, also pass ThemeProvider.