### PR TITLE
refactor: Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 
-import { Rect, getRandomStr, getParentElementByClassNameRecursively } from './dropdownHelper'
+import { Rect, hasParentElement } from './dropdownHelper'
 
 type DropdownContextType = {
-  key: string
+  element: HTMLElement | null
   active: boolean
   triggerRect: Rect
   onClickTrigger: (rect: Rect) => void
@@ -13,7 +13,7 @@ type DropdownContextType = {
 const initialRect = { top: 0, right: 0, bottom: 0, left: 0 }
 
 export const DropdownContext = React.createContext<DropdownContextType>({
-  key: '',
+  element: null,
   active: false,
   triggerRect: initialRect,
   onClickTrigger: () => {},
@@ -21,23 +21,22 @@ export const DropdownContext = React.createContext<DropdownContextType>({
 })
 
 export const Dropdown: React.FC<{}> = ({ children }) => {
-  const [key, setKey] = useState('')
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
+  const element = useRef(document.createElement('div'))
+
   useEffect(() => {
-    const newKey = getRandomStr()
     const onClickBody = (e: any) => {
-      if (getParentElementByClassNameRecursively(e.target, `dropdown-trigger-${newKey}`)) return
+      if (hasParentElement(e.target, element.current)) return
       setActive(false)
     }
 
-    setKey(newKey)
+    document.body.appendChild(element.current)
     document.body.addEventListener('click', onClickBody, false)
 
     return () => {
-      const element = document.querySelector(`.dropdown-content-${newKey}`)
-      if (element) document.body.removeChild(element)
+      document.body.removeChild(element.current)
       document.body.removeEventListener('click', onClickBody, false)
     }
   }, [])
@@ -45,7 +44,7 @@ export const Dropdown: React.FC<{}> = ({ children }) => {
   return (
     <DropdownContext.Provider
       value={{
-        key,
+        element: element.current,
         active,
         triggerRect,
         onClickTrigger: rect => {

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 
 import { DropdownContext } from './Dropdown'
 import { DropdownContentInner } from './DropdownContentInner'
+import { DropdownCloser } from './DropdownCloser'
 
 export const DropdownContentContext = React.createContext<{
   onClickCloser: () => void
@@ -14,14 +15,16 @@ type Props = {
   controllable?: boolean
 }
 
-export const DropdownContent: React.FC<Props> = ({ children }) => {
+export const DropdownContent: React.FC<Props> = ({ controllable = false, children }) => {
   const { element, active, triggerRect, onClickCloser } = useContext(DropdownContext)
 
   if (!active || !element) return null
 
   return createPortal(
     <DropdownContentContext.Provider value={{ onClickCloser }}>
-      <DropdownContentInner triggerRect={triggerRect}>{children}</DropdownContentInner>
+      <DropdownContentInner triggerRect={triggerRect}>
+        {controllable ? children : <DropdownCloser>{children}</DropdownCloser>}
+      </DropdownContentInner>
     </DropdownContentContext.Provider>,
     element,
   )

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -10,31 +10,14 @@ export const DropdownContentContext = React.createContext<{
   onClickCloser: () => {},
 })
 
-export function createElement(tagName: string, className: string) {
-  const element = document.createElement(tagName)
-  element.className = className
-  return element
-}
-
 type Props = {
   controllable?: boolean
 }
 
-export const DropdownContent: React.FC<Props> = ({ controllable = false, children }) => {
-  const { key, active, triggerRect, onClickCloser } = useContext(DropdownContext)
+export const DropdownContent: React.FC<Props> = ({ children }) => {
+  const { element, active, triggerRect, onClickCloser } = useContext(DropdownContext)
 
-  if (!active) return null
-
-  const contentClassName = `dropdown-content-${key}`
-  let element = document.querySelector(`.${contentClassName}`)
-
-  if (!element) {
-    element = createElement(
-      'div',
-      `${contentClassName} ${controllable ? `dropdown-trigger-${key}` : ''}`,
-    )
-    document.body.appendChild(element)
-  }
+  if (!active || !element) return null
 
   return createPortal(
     <DropdownContentContext.Provider value={{ onClickCloser }}>

--- a/src/components/Dropdown/DropdownTrigger.tsx
+++ b/src/components/Dropdown/DropdownTrigger.tsx
@@ -4,11 +4,10 @@ import styled from 'styled-components'
 import { DropdownContext } from './Dropdown'
 
 export const DropdownTrigger: React.FC<{}> = ({ children }) => {
-  const { key, active, onClickTrigger } = useContext(DropdownContext)
+  const { active, onClickTrigger } = useContext(DropdownContext)
 
   return (
     <Wrapper
-      className={`dropdown-trigger-${key}`}
       onClick={e => {
         const rect = e.currentTarget.getBoundingClientRect()
         onClickTrigger({

--- a/src/components/Dropdown/dropdownHelper.ts
+++ b/src/components/Dropdown/dropdownHelper.ts
@@ -5,26 +5,9 @@ export type Rect = {
   left: number
 }
 
-export function getRandomStr() {
-  const str = 'abcdefghijklmnopqrstuvwxyz'
-  const strLen = str.length
-  let result = ''
-
-  for (let i = 0; i < 8; i++) {
-    result += str[Math.floor(Math.random() * strLen)]
-  }
-
-  return result
-}
-
-export function getParentElementByClassNameRecursively(
-  element: HTMLElement | null,
-  className: string = '',
-): HTMLElement | null {
-  if (!element) return null
-  if (element.classList.contains(className)) return element
-  if (element === document.body) return null
-  return getParentElementByClassNameRecursively(element.parentElement, className)
+export function hasParentElement(element: HTMLElement | null, parent: HTMLElement | null): boolean {
+  if (!element) return false
+  return element === parent || hasParentElement(element.parentElement, parent)
 }
 
 type Size = { width: number; height: number }


### PR DESCRIPTION
This PR makes implementations of Dropdown simple.
It uses a reference of a DOM element by `useRef` instead of using `className` to manage the elements in a Portal.
Also, I've moved DOM operations located in DropdownContent into Dropdown to make DOM operations cohesion.