### PR TITLE
refactor: do not expose about Portals to outside the Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,50 +1,56 @@
 import React, { useState, useEffect, useRef } from 'react'
 
 import { Rect, hasParentElement } from './dropdownHelper'
+import { createPortal } from 'react-dom'
 
 type DropdownContextType = {
-  element: HTMLElement | null
   active: boolean
   triggerRect: Rect
   onClickTrigger: (rect: Rect) => void
   onClickCloser: () => void
+  DropdownContentRoot: React.FC<{ children: React.ReactNode }>
 }
 
 const initialRect = { top: 0, right: 0, bottom: 0, left: 0 }
 
 export const DropdownContext = React.createContext<DropdownContextType>({
-  element: null,
   active: false,
   triggerRect: initialRect,
   onClickTrigger: () => {},
   onClickCloser: () => {},
+  DropdownContentRoot: () => null,
 })
 
 export const Dropdown: React.FC<{}> = ({ children }) => {
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
-  const element = useRef(document.createElement('div'))
+  const element = useRef(document.createElement('div')).current
 
   useEffect(() => {
     const onClickBody = (e: any) => {
-      if (hasParentElement(e.target, element.current)) return
+      if (hasParentElement(e.target, element)) return
       setActive(false)
     }
 
-    document.body.appendChild(element.current)
+    document.body.appendChild(element)
     document.body.addEventListener('click', onClickBody, false)
 
     return () => {
-      document.body.removeChild(element.current)
+      document.body.removeChild(element)
       document.body.removeEventListener('click', onClickBody, false)
     }
-  }, [])
+  }, [element])
+
+  // This is the root container of a dropdown content located in outside the DOM tree
+  const DropdownContentRoot = (props: { children: React.ReactNode }) => {
+    if (!active) return null
+    return createPortal(props.children, element)
+  }
 
   return (
     <DropdownContext.Provider
       value={{
-        element: element.current,
         active,
         triggerRect,
         onClickTrigger: rect => {
@@ -53,6 +59,7 @@ export const Dropdown: React.FC<{}> = ({ children }) => {
           if (newActive) setTriggerRect(rect)
         },
         onClickCloser: () => setActive(false),
+        DropdownContentRoot,
       }}
     >
       {children}

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react'
-import { createPortal } from 'react-dom'
 
 import { DropdownContext } from './Dropdown'
 import { DropdownContentInner } from './DropdownContentInner'
@@ -16,16 +15,14 @@ type Props = {
 }
 
 export const DropdownContent: React.FC<Props> = ({ controllable = false, children }) => {
-  const { element, active, triggerRect, onClickCloser } = useContext(DropdownContext)
-
-  if (!active || !element) return null
-
-  return createPortal(
-    <DropdownContentContext.Provider value={{ onClickCloser }}>
-      <DropdownContentInner triggerRect={triggerRect}>
-        {controllable ? children : <DropdownCloser>{children}</DropdownCloser>}
-      </DropdownContentInner>
-    </DropdownContentContext.Provider>,
-    element,
+  const { DropdownContentRoot, triggerRect, onClickCloser } = useContext(DropdownContext)
+  return (
+    <DropdownContentRoot>
+      <DropdownContentContext.Provider value={{ onClickCloser }}>
+        <DropdownContentInner triggerRect={triggerRect}>
+          {controllable ? children : <DropdownCloser>{children}</DropdownCloser>}
+        </DropdownContentInner>
+      </DropdownContentContext.Provider>
+    </DropdownContentRoot>
   )
 }


### PR DESCRIPTION
This is an addition PR of #391. 
This PR makes the implementation related to Portals not expose outside `Dropdown` so the implementation of `DropdownContent` becomes simple and doesn't have to know it's rendered on Portals.

I've also fixed a warning of `react-hooks/exhaustive-deps`.