### PR TITLE
fix: memoize DropdownContentRoot

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useMemo } from 'react'
 
 import { Rect, hasParentElement } from './dropdownHelper'
 import { createPortal } from 'react-dom'
@@ -43,10 +43,15 @@ export const Dropdown: React.FC<{}> = ({ children }) => {
   }, [element])
 
   // This is the root container of a dropdown content located in outside the DOM tree
-  const DropdownContentRoot = (props: { children: React.ReactNode }) => {
-    if (!active) return null
-    return createPortal(props.children, element)
-  }
+  const DropdownContentRoot = useMemo<React.FC<{ children: React.ReactNode }>>(
+    () => props => {
+      if (!active) return null
+      return createPortal(props.children, element)
+    },
+    [active, element],
+  )
+  // set the displayName explicit for DevTools
+  DropdownContentRoot.displayName = 'DropdownContentRoot'
 
   return (
     <DropdownContext.Provider


### PR DESCRIPTION
This fixes a bug that DrowdownContent loses the state when an update happens outside its Dropdown.
The state includes a focus state,  a controlled value, and so on.

This is caused by that DropdownContentRoot is created at every time when Dropdown is rendered.
So I've fixed the issue to memoize DropdownContentRoot using `useMemo`. 
