### PR TITLE
Add onClickOverlay props to to ActionDialog and MessageDialog

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -8,6 +8,7 @@ import { ActionDialogContentInner } from './ActionDialogContentInner'
 type Props = ActionDialogContentProps & {
   isOpen: boolean
   onClickClose: () => void
+  onClickOverlay?: () => void
 }
 
 export const ActionDialog: React.FC<Props> = ({
@@ -20,6 +21,7 @@ export const ActionDialog: React.FC<Props> = ({
   onClickAction,
   onClickClose,
   actionDisabled = false,
+  onClickOverlay = () => {},
   ...props
 }) => {
   const element = useRef(document.createElement('div')).current
@@ -35,7 +37,7 @@ export const ActionDialog: React.FC<Props> = ({
   if (!isOpen) return null
 
   return createPortal(
-    <DialogContentInner onClickOverlay={onClickClose} {...props}>
+    <DialogContentInner onClickOverlay={onClickOverlay} {...props}>
       <ActionDialogContentInner
         title={title}
         closeText={closeText}

--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -90,6 +90,7 @@ const MessageDialogController: React.FC = () => {
         }
         closeText="close"
         onClickClose={onClickClose}
+        onClickOverlay={onClickClose}
       />
     </div>
   )
@@ -116,6 +117,7 @@ const ActionDialogController: React.FC = () => {
           setTimeout(closeDialog, 1000)
         }}
         onClickClose={onClickClose}
+        onClickOverlay={onClickClose}
       >
         <DialogControllerBox>
           <li>

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -8,6 +8,7 @@ import { MessageDialogContentInner } from './MessageDialogContentInner'
 type Props = MessageDialogContentProps & {
   isOpen: boolean
   onClickClose: () => void
+  onClickOverlay?: () => void
 }
 
 export const MessageDialog: React.FC<Props> = ({
@@ -16,6 +17,7 @@ export const MessageDialog: React.FC<Props> = ({
   description,
   closeText,
   onClickClose,
+  onClickOverlay = () => {},
   ...props
 }) => {
   const element = useRef(document.createElement('div')).current
@@ -31,7 +33,7 @@ export const MessageDialog: React.FC<Props> = ({
   if (!isOpen) return null
 
   return createPortal(
-    <DialogContentInner onClickOverlay={onClickClose} {...props}>
+    <DialogContentInner onClickOverlay={onClickOverlay} {...props}>
       <MessageDialogContentInner
         title={title}
         description={description}


### PR DESCRIPTION
In `ActionDialog` and `MessageDialog`, the function specified for `onClickClose` props has been specified for both the close button and overlay click handlers so far.

However, I felt that it was strange that the function specified in `onClickClose` was called when the overlay was clicked, so I added a new props called `onClickOverlay`.

