### PR TITLE
Quit re-rendering Dialog

### DIFF
--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { SecondaryButton } from '../Button'
 import { RadioButtonLabel } from '../RadioButtonLabel'
+import { Input } from '../Input'
 import { Dialog, MessageDialog, ActionDialog } from '.'
 import readme from './README.md'
 
@@ -51,7 +52,7 @@ const DialogController: React.FC = () => {
             />
           </li>
           <li>
-            <input name="test" value={text} onChange={e => onChangeText(e.currentTarget.value)} />
+            <Input name="test" value={text} onChange={e => onChangeText(e.currentTarget.value)} />
           </li>
         </DialogControllerBox>
         <DialogControllerBottom>
@@ -99,9 +100,11 @@ const MessageDialogController: React.FC = () => {
 const ActionDialogController: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = React.useState('hoge')
+  const [text, setText] = useState('')
   const onClickOpen = () => setIsOpen(true)
   const onClickClose = () => setIsOpen(false)
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
+  const onChangeText = (txt: string) => setText(txt)
 
   return (
     <div>
@@ -142,6 +145,14 @@ const ActionDialogController: React.FC = () => {
               label="piyo"
               checked={value === 'piyo'}
               onChange={onChange}
+            />
+          </li>
+          <li>
+            <Input
+              name="test"
+              value={text}
+              onChange={e => onChangeText(e.currentTarget.value)}
+              autoFocus
             />
           </li>
         </DialogControllerBox>

--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 
 import { SecondaryButton } from '../Button'
 import { RadioButtonLabel } from '../RadioButtonLabel'
-import { Input } from '../Input'
 import { Dialog, MessageDialog, ActionDialog } from '.'
 import readme from './README.md'
 
@@ -52,7 +51,7 @@ const DialogController: React.FC = () => {
             />
           </li>
           <li>
-            <Input name="test" value={text} onChange={e => onChangeText(e.currentTarget.value)} />
+            <input name="test" value={text} onChange={e => onChangeText(e.currentTarget.value)} />
           </li>
         </DialogControllerBox>
         <DialogControllerBottom>
@@ -100,11 +99,9 @@ const MessageDialogController: React.FC = () => {
 const ActionDialogController: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = React.useState('hoge')
-  const [text, setText] = useState('')
   const onClickOpen = () => setIsOpen(true)
   const onClickClose = () => setIsOpen(false)
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
-  const onChangeText = (txt: string) => setText(txt)
 
   return (
     <div>
@@ -145,14 +142,6 @@ const ActionDialogController: React.FC = () => {
               label="piyo"
               checked={value === 'piyo'}
               onChange={onChange}
-            />
-          </li>
-          <li>
-            <Input
-              name="test"
-              value={text}
-              onChange={e => onChangeText(e.currentTarget.value)}
-              autoFocus
             />
           </li>
         </DialogControllerBox>

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react'
-import styled, { css, createGlobalStyle } from 'styled-components'
+import React, { ReactNode, FC } from 'react'
+import styled, { css, createGlobalStyle, keyframes } from 'styled-components'
 
 import { useTheme, Theme } from '../../hooks/useTheme'
 
@@ -9,7 +9,7 @@ type Props = {
   right?: number
   bottom?: number
   left?: number
-  children: React.ReactNode
+  children: ReactNode
 }
 
 type StyleProps = {
@@ -23,16 +23,10 @@ function exist(value: any) {
   return value !== undefined && value !== null
 }
 
-export const DialogContentInner: React.FC<Props> = ({ onClickOverlay, children, ...props }) => {
+export const DialogContentInner: FC<Props> = ({ onClickOverlay, children, ...props }) => {
   const theme = useTheme()
-  const [isMounted, setIsMounted] = useState(false)
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
   return (
-    <Wrapper className={isMounted ? 'active' : ''}>
+    <Wrapper>
       <Background onClick={onClickOverlay} themes={theme} {...props} />
       <Inner themes={theme} {...props}>
         {children}
@@ -43,8 +37,13 @@ export const DialogContentInner: React.FC<Props> = ({ onClickOverlay, children, 
   )
 }
 
+const fadeIn = keyframes`
+  0% { opacity: 0 }
+  30% { opacity: 0.1 }
+  70% { opacity: 0.9 }
+  100% { opacity: 1 }
+`
 const Wrapper = styled.div`
-  visibility: hidden;
   opacity: 0;
   z-index: 10000;
   position: fixed;
@@ -52,12 +51,7 @@ const Wrapper = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  transition: opacity 0.3s ease-in-out;
-
-  &.active {
-    visibility: visible;
-    opacity: 1;
-  }
+  animation: 0.3s 0s both ${fadeIn};
 `
 const Inner = styled.div<StyleProps & { themes: Theme }>`
   ${({ themes, top, right, bottom, left }) => {


### PR DESCRIPTION
## Problem

`Dialog` is re-rendered after rendering children of `Dialog`.
For example, if autoFocus was used for input in children of `Dialog`, autoFocus would be lost due to re-rendering of `Dialog`.

## Cause

Since `DialogContentInner` used the setter of useState after mount to rewrite `className` to generate a fade-in  animation, re-rendering occurred.

## Solution

Change the animation method of fade-in from `transition` to `keyframe`.
As a result, you can animate without adding `className` after mounting.