### PR TITLE
Change TableCell props name

### DIFF
--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -6,7 +6,11 @@ import { useTheme, Theme } from '../../hooks/useTheme'
 
 import { TableGroupContext } from './Table'
 
+// TODO: colspan and rowspan are incorrect naming conventions and are now deprecated and removed later.
+// Delete in January 2020.
 export type Props = {
+  colSpan?: number
+  rowSpan?: number
   colspan?: number
   rowspan?: number
   highlighted?: boolean
@@ -19,6 +23,8 @@ export const Cell: FC<Props> = ({
   className = '',
   children,
   onClick,
+  colSpan,
+  rowSpan,
   colspan,
   rowspan,
   highlighted = false,
@@ -29,8 +35,8 @@ export const Cell: FC<Props> = ({
   const props = {
     children,
     onClick,
-    colSpan: colspan,
-    rowSpan: rowspan,
+    colSpan: colSpan || colspan,
+    rowSpan: rowSpan || rowspan,
     className: classNames,
     themes: theme,
   }

--- a/src/components/Table/README.md
+++ b/src/components/Table/README.md
@@ -58,6 +58,6 @@ import { Table, Body, Head, Row, Cell } from 'smarthr-ui'
 | ----------- | -------- | -------------- | ------------ | ------------------------------------------------ |
 | className   | -        | **string**     | -            | className for component                          |
 | highlighted | -        | **boolean**    | false        | If true, the cell has a className of highlighted |
-| colspan     | -        | **number**     | -            | Indicates for how many columns the cell extends. |
-| rowspan     | -        | **number**     | -            | Indicates for how many rows the cell extends.    |
+| colSpan     | -        | **number**     | -            | Indicates for how many columns the cell extends. |
+| rowSpan     | -        | **number**     | -            | Indicates for how many rows the cell extends.    |
 | onClick     | -        | **() => void** | -            | Fires when clicked.                              |

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -90,11 +90,11 @@ storiesOf('Table', module)
         </Table>
       </li>
       <li>
-        colspan / rowspan
+        colSpan / rowSpan
         <Table>
           <Head>
             <Row>
-              <Cell colspan={3}>colspan=3</Cell>
+              <Cell colSpan={3}>colSpan=3</Cell>
               <Cell>cell</Cell>
               <Cell>cell</Cell>
               <Cell>cell</Cell>
@@ -110,7 +110,7 @@ storiesOf('Table', module)
               <Cell>cell</Cell>
             </Row>
             <Row>
-              <Cell rowspan={0}>rowspan=0</Cell>
+              <Cell rowSpan={0}>rowSpan=0</Cell>
               <Cell>cell</Cell>
               <Cell>cell</Cell>
               <Cell>cell</Cell>


### PR DESCRIPTION
The current Cell props `colspan` and `rowspan` are not correct for props naming, so change them to `colSpan` and `rowSpan`.
This change is a destructive change, but I do not want to increase the major version now, so I will deprecate the previous props and upgrade the patch version.

Issue: https://github.com/kufu/smarthr-ui/issues/480