### PR TITLE
Input component supports anything other than text, number, password

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,7 +4,20 @@ import styled, { css } from 'styled-components'
 import { useTheme, Theme } from '../../hooks/useTheme'
 
 export type Props = InputHTMLAttributes<HTMLInputElement> & {
-  type?: 'text' | 'number' | 'password'
+  type?:
+    | 'text'
+    | 'search'
+    | 'tel'
+    | 'url'
+    | 'email'
+    | 'password'
+    | 'datetime'
+    | 'date'
+    | 'month'
+    | 'week'
+    | 'time'
+    | 'datetime-local'
+    | 'number'
   error?: boolean
   width?: number | string
   autoFocus?: boolean


### PR DESCRIPTION
`type` props corresponds to the following items.

- text
- search
- tel
- url
- email
- password
- datetime
- date
- month
- week
- time
- datetime-local
- number

Issue: https://github.com/kufu/smarthr-ui/issues/483