### PR TITLE
feat(Dialog): close a dialog when escape key is pressed

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -9,6 +9,7 @@ type Props = ActionDialogContentProps & {
   isOpen: boolean
   onClickClose: () => void
   onClickOverlay?: () => void
+  onPressEscape?: () => void
 }
 
 export const ActionDialog: React.FC<Props> = ({
@@ -22,6 +23,7 @@ export const ActionDialog: React.FC<Props> = ({
   onClickClose,
   actionDisabled = false,
   onClickOverlay = () => {},
+  onPressEscape = () => {},
   ...props
 }) => {
   const element = useRef(document.createElement('div')).current
@@ -37,7 +39,7 @@ export const ActionDialog: React.FC<Props> = ({
   if (!isOpen) return null
 
   return createPortal(
-    <DialogContentInner onClickOverlay={onClickOverlay} {...props}>
+    <DialogContentInner onClickOverlay={onClickOverlay} onPressEscape={onPressEscape} {...props}>
       <ActionDialogContentInner
         title={title}
         closeText={closeText}

--- a/src/components/Dialog/ActionDialogContent.tsx
+++ b/src/components/Dialog/ActionDialogContent.tsx
@@ -25,7 +25,7 @@ export const ActionDialogContent: React.FC<ActionDialogContentProps> = ({
 
   return (
     <DialogContentRoot>
-      <DialogContentInner onClickOverlay={onClickClose} {...props}>
+      <DialogContentInner onClickOverlay={onClickClose} onPressEscape={onClickClose} {...props}>
         <ActionDialogContentInner
           title={title}
           closeText={closeText}

--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -20,7 +20,7 @@ const DialogController: React.FC = () => {
   return (
     <div>
       <SecondaryButton onClick={onClickOpen}>Dialog</SecondaryButton>
-      <Dialog isOpen={isOpen} onClickOverlay={onClickClose}>
+      <Dialog isOpen={isOpen} onClickOverlay={onClickClose} onPressEscape={onClickClose}>
         <DialogControllerTitle>Dialog</DialogControllerTitle>
         <DialogControllerText>
           The value of isOpen must be managed by you, but you can customize content freely.
@@ -91,6 +91,7 @@ const MessageDialogController: React.FC = () => {
         closeText="close"
         onClickClose={onClickClose}
         onClickOverlay={onClickClose}
+        onPressEscape={onClickClose}
       />
     </div>
   )
@@ -118,6 +119,7 @@ const ActionDialogController: React.FC = () => {
         }}
         onClickClose={onClickClose}
         onClickOverlay={onClickClose}
+        onPressEscape={onClickClose}
       >
         <DialogControllerBox>
           <li>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -6,6 +6,7 @@ import { DialogContentInner } from './DialogContentInner'
 type Props = {
   isOpen: boolean
   onClickOverlay?: () => void
+  onPressEscape?: () => void
   top?: number
   right?: number
   bottom?: number
@@ -16,6 +17,7 @@ export const Dialog: React.FC<Props> = ({
   isOpen,
   children,
   onClickOverlay = () => {},
+  onPressEscape = () => {},
   ...props
 }) => {
   const element = useRef(document.createElement('div')).current
@@ -31,7 +33,7 @@ export const Dialog: React.FC<Props> = ({
   if (!isOpen) return null
 
   return createPortal(
-    <DialogContentInner onClickOverlay={onClickOverlay} {...props}>
+    <DialogContentInner onClickOverlay={onClickOverlay} onPressEscape={onPressEscape} {...props}>
       {children}
     </DialogContentInner>,
     element,

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -24,7 +24,7 @@ export const DialogContent: React.FC<Props> = ({ children, ...props }) => {
   return (
     <DialogContentRoot>
       <DialogContentContext.Provider value={{ onClickClose }}>
-        <DialogContentInner onClickOverlay={onClickClose} {...props}>
+        <DialogContentInner onClickOverlay={onClickClose} onPressEscape={onClickClose} {...props}>
           {children}
         </DialogContentInner>
       </DialogContentContext.Provider>

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -2,9 +2,11 @@ import React, { ReactNode, FC } from 'react'
 import styled, { css, createGlobalStyle, keyframes } from 'styled-components'
 
 import { useTheme, Theme } from '../../hooks/useTheme'
+import { useHandleEscape } from '../../hooks/useHandleEscape'
 
 type Props = {
   onClickOverlay?: () => void
+  onPressEscape?: () => void
   top?: number
   right?: number
   bottom?: number
@@ -23,8 +25,14 @@ function exist(value: any) {
   return value !== undefined && value !== null
 }
 
-export const DialogContentInner: FC<Props> = ({ onClickOverlay, children, ...props }) => {
+export const DialogContentInner: FC<Props> = ({
+  onClickOverlay,
+  onPressEscape = () => {},
+  children,
+  ...props
+}) => {
   const theme = useTheme()
+  useHandleEscape(onPressEscape)
   return (
     <Wrapper>
       <Background onClick={onClickOverlay} themes={theme} {...props} />

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -9,6 +9,7 @@ type Props = MessageDialogContentProps & {
   isOpen: boolean
   onClickClose: () => void
   onClickOverlay?: () => void
+  onPressEscape?: () => void
 }
 
 export const MessageDialog: React.FC<Props> = ({
@@ -18,6 +19,7 @@ export const MessageDialog: React.FC<Props> = ({
   closeText,
   onClickClose,
   onClickOverlay = () => {},
+  onPressEscape = () => {},
   ...props
 }) => {
   const element = useRef(document.createElement('div')).current
@@ -33,7 +35,7 @@ export const MessageDialog: React.FC<Props> = ({
   if (!isOpen) return null
 
   return createPortal(
-    <DialogContentInner onClickOverlay={onClickOverlay} {...props}>
+    <DialogContentInner onClickOverlay={onClickOverlay} onPressEscape={onPressEscape} {...props}>
       <MessageDialogContentInner
         title={title}
         description={description}

--- a/src/components/Dialog/MessageDialogContent.tsx
+++ b/src/components/Dialog/MessageDialogContent.tsx
@@ -21,7 +21,7 @@ export const MessageDialogContent: React.FC<MessageDialogContentProps> = ({
 
   return (
     <DialogContentRoot>
-      <DialogContentInner onClickOverlay={onClickClose} {...props}>
+      <DialogContentInner onClickOverlay={onClickClose} onPressEscape={onClickClose} {...props}>
         <MessageDialogContentInner
           title={title}
           description={description}

--- a/src/hooks/useHandleEscape.ts
+++ b/src/hooks/useHandleEscape.ts
@@ -1,0 +1,18 @@
+import { useCallback, useEffect } from 'react'
+
+export const useHandleEscape = (cb: () => void) => {
+  const handleKeyPress = useCallback(
+    (e: KeyboardEvent) => {
+      // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+      // Esc is a IE/Edge specific value
+      if (e.key === 'Escape' || e.key === 'Esc') {
+        cb()
+      }
+    },
+    [cb],
+  )
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress)
+    return () => document.removeEventListener('keydown', handleKeyPress)
+  }, [handleKeyPress])
+}


### PR DESCRIPTION
This PR enables us to close a dialog using `esc` key, many libraries support this, so I think `smarthr-ui` should support this.

To support this, I've added `onPressEscape` prop into dialog components.
I haven't tested this on Windows, so please test this on Windows if you could 🙏 