### PR TITLE
fix(dropdown): change initial position for dropdown component

### DIFF
--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -14,8 +14,8 @@ export const DropdownContentInner: FC<Props> = ({ triggerRect, children }) => {
   const theme = useTheme()
   const [isMounted, setIsMounted] = useState(false)
   const [contentBox, setContentBox] = useState<ContentBoxStyle>({
-    top: 'auto',
-    left: 'auto',
+    top: '0',
+    left: '0',
     maxHeight: '',
   })
   const wrapperRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
# What I did

Change the initial position for `DropdownContentInner` from `top: 'auto', left: 'auto'` to `top: '0', left: '0'`.

# Why I did
When the position is `auto`, the `DropdownContentInner` component possibly appears outside the window for a moment, and that causes an unexpected scrollbar flash.

1. Hit the trigger.
<img width="496" alt="cap_1" src="https://user-images.githubusercontent.com/14817308/70423039-1cebc080-1ab0-11ea-9b99-eee4dfa307ec.png">

2. An unexpected scrollbar shows up for  a moment because the invisible `DropdownContentInner` is outside the window.
<img width="496" alt="cap_2" src="https://user-images.githubusercontent.com/14817308/70423173-57edf400-1ab0-11ea-84dd-f35dfbfd4a75.png">

3. As the `DropdownContentInner` is set to the right position, the scrollbar goes away.
<img width="496" alt="cap_3" src="https://user-images.githubusercontent.com/14817308/70423233-705e0e80-1ab0-11ea-9635-3d65ff2bfdd8.png">

Setting `top: '0', left: '0'` solves it.
