### PR TITLE
Fix Dropdown trigger bug

### DIFF
--- a/src/components/Dropdown/DropdownCloser.tsx
+++ b/src/components/Dropdown/DropdownCloser.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
 
+import { DropdownContext } from './Dropdown'
 import { DropdownContentContext } from './DropdownContent'
 
 type Props = {
@@ -8,9 +9,11 @@ type Props = {
 }
 
 export const DropdownCloser: React.FC<Props> = ({ children, className = '' }) => {
+  const { dropdownKey } = useContext(DropdownContext)
   const { onClickCloser } = useContext(DropdownContentContext)
+
   return (
-    <div className={className} onClick={onClickCloser}>
+    <div className={`${dropdownKey} ${className}`} onClick={onClickCloser}>
       {children}
     </div>
   )

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -20,11 +20,14 @@ export const DropdownContent: React.FC<Props> = ({
   className = '',
   children,
 }) => {
-  const { DropdownContentRoot, triggerRect, onClickCloser } = useContext(DropdownContext)
+  const { dropdownKey, DropdownContentRoot, triggerRect, onClickCloser } = useContext(
+    DropdownContext,
+  )
+
   return (
     <DropdownContentRoot>
       <DropdownContentContext.Provider value={{ onClickCloser }}>
-        <DropdownContentInner triggerRect={triggerRect} className={className}>
+        <DropdownContentInner triggerRect={triggerRect} className={`${dropdownKey} ${className}`}>
           {controllable ? children : <DropdownCloser>{children}</DropdownCloser>}
         </DropdownContentInner>
       </DropdownContentContext.Provider>

--- a/src/components/Dropdown/DropdownTrigger.tsx
+++ b/src/components/Dropdown/DropdownTrigger.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export const DropdownTrigger: React.FC<Props> = ({ children, className = '' }) => {
-  const { active, onClickTrigger } = useContext(DropdownContext)
+  const { dropdownKey, active, onClickTrigger } = useContext(DropdownContext)
 
   return (
     <Wrapper
@@ -22,7 +22,7 @@ export const DropdownTrigger: React.FC<Props> = ({ children, className = '' }) =
           left: rect.left,
         })
       }}
-      className={className}
+      className={`${dropdownKey} ${className}`}
     >
       {React.Children.map(children, (child: any) => {
         const props = child.props ? child.props : {}

--- a/src/components/Dropdown/dropdownHelper.ts
+++ b/src/components/Dropdown/dropdownHelper.ts
@@ -5,9 +5,21 @@ export type Rect = {
   left: number
 }
 
-export function hasParentElement(element: HTMLElement | null, parent: HTMLElement | null): boolean {
+export function getRandomStr() {
+  return Math.random()
+    .toString(32)
+    .substring(2)
+}
+
+export function includeDropdownElement(
+  element: HTMLElement | null,
+  dropdownClassName: string,
+): boolean {
   if (!element) return false
-  return element === parent || hasParentElement(element.parentElement, parent)
+  return (
+    element.classList.contains(dropdownClassName) ||
+    includeDropdownElement(element.parentElement, dropdownClassName)
+  )
 }
 
 type Size = { width: number; height: number }


### PR DESCRIPTION
## Problem

`DropdownContent` does not disappear even if `DropdownTrigger` is clicked again with `DropdownContent` displayed.

## Cause

`onClickBody` caused `DropdownTrigger` click event with `DropdownContent` disappeared first, so it was displayed again.

## Resolution

Stop `onClickBody` when clicking `Trigger`, `Content` or `Closer`.