### PR TITLE
fix: box-shadow value in Base

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled.div<{ radius: string }>`
   ${({ radius }) => {
     return css`
       border-radius: ${radius};
-      box-shadow: 'rgba(51, 51, 51, 0.3) 1px 1px 4px 0';
+      box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
       background-color: #fff;
     `
   }}


### PR DESCRIPTION
Sorry, I set invalid box-shadow value in [this Pull Request](https://github.com/kufu/smarthr-ui/pull/527) 🙇 

I fixed the css property to valid value again.