### PR TITLE
Change 'term' prop type of DefinitionListItem to React.ReactNode

### DIFF
--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Heading } from '../Heading'
 import { Base } from '../Base'
 import { DefinitionList } from './DefinitionList'
+import { Icon } from '../Icon'
 
 const DefinitionListItems = [
   {
@@ -44,6 +45,30 @@ storiesOf('DefinitionList', module).add('all', () => (
     <Content>
       <DefinitionList items={DefinitionListItems} layout="triple"></DefinitionList>
     </Content>
+
+    <Title type="sectionTitle">customized</Title>
+    <Content>
+      <DefinitionList
+        items={[
+          {
+            term: 'term 1',
+            description: 'description 1',
+          },
+          {
+            term: (
+              <Term>
+                <span>term 2</span>
+                <Alert>
+                  <Icon name="fa-exclamation-circle" size={11} color="#ef475b" />
+                  <AlertText>error occurred</AlertText>
+                </Alert>
+              </Term>
+            ),
+            description: 'description 2',
+          },
+        ]}
+      ></DefinitionList>
+    </Content>
   </Wrapper>
 ))
 
@@ -56,4 +81,18 @@ const Title = styled(Heading)`
 const Content = styled(Base)`
   margin: 0 0 32px;
   padding: 24px;
+`
+const Term = styled.span`
+  display: flex;
+  align-items: center;
+`
+const Alert = styled.span`
+  display: flex;
+  align-items: center;
+  margin-left: 8px;
+`
+const AlertText = styled.span`
+  margin-left: 4px;
+  color: #333;
+  font-size: 11px;
 `

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -7,8 +7,8 @@ import { DefinitionListItem, DefinitionListItemProps } from './DefinitionListIte
 
 type LayoutType = 'single' | 'double' | 'triple'
 type Props = {
-  layout?: LayoutType
   items: DefinitionListItemProps[]
+  layout?: LayoutType
   className?: string
 }
 

--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { ReactNode, FC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useTheme, Theme } from '../../hooks/useTheme'
@@ -6,16 +6,16 @@ import { useTheme, Theme } from '../../hooks/useTheme'
 import { Heading, Props as HeadingProps } from '../Heading'
 
 export type DefinitionListItemProps = {
-  term: string
+  term: ReactNode
+  description: ReactNode
   termTag?: HeadingProps['tag']
-  description: React.ReactNode
   className?: string
 }
 
 export const DefinitionListItem: FC<DefinitionListItemProps> = ({
   term,
-  termTag = 'span',
   description,
+  termTag = 'span',
   className = '',
 }) => {
   const theme = useTheme()

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,10 +1,10 @@
-import React, { FC } from 'react'
+import React, { ReactNode, FC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useTheme, Theme } from '../../hooks/useTheme'
 
 export type Props = {
-  children: string
+  children: ReactNode
   type?: HeadingTypes
   tag?: HeadingTagTypes
   className?: string


### PR DESCRIPTION
In `DefinitionList`, I want to modify the type of props so that it can support UI like the following image

![image](https://user-images.githubusercontent.com/11153463/72695722-e5773600-3b7c-11ea-8c5f-aeb2444cd5c0.png)