### PR TITLE
fix: dropdown flickers

### DIFF
--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -14,6 +14,7 @@ type Props = {
 export const DropdownContentInner: FC<Props> = ({ triggerRect, children, className }) => {
   const theme = useTheme()
   const [isMounted, setIsMounted] = useState(false)
+  const [isActive, setIsActive] = useState(false)
   const [contentBox, setContentBox] = useState<ContentBoxStyle>({
     top: '0',
     left: '0',
@@ -23,6 +24,7 @@ export const DropdownContentInner: FC<Props> = ({ triggerRect, children, classNa
 
   useEffect(() => {
     setIsMounted(true)
+    setIsActive(false)
   }, [])
 
   useEffect(() => {
@@ -44,6 +46,7 @@ export const DropdownContentInner: FC<Props> = ({ triggerRect, children, classNa
           },
         ),
       )
+      setIsActive(true)
     }
   }, [isMounted, triggerRect])
 
@@ -51,7 +54,7 @@ export const DropdownContentInner: FC<Props> = ({ triggerRect, children, classNa
     <Wrapper
       ref={wrapperRef}
       contentBox={contentBox}
-      className={`${className} ${isMounted ? 'active' : ''}`}
+      className={`${className} ${isActive ? 'active' : ''}`}
       themes={theme}
     >
       {children}

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -24,7 +24,6 @@ export const DropdownContentInner: FC<Props> = ({ triggerRect, children, classNa
 
   useEffect(() => {
     setIsMounted(true)
-    setIsActive(false)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
細かな条件は調べきれていませんが、DropdownContent の内容が画面左上に一瞬表示されてしまう場合があります。
コンポーネントのマウント後に位置を計算していますが、 visibilityの設定もマウント直後に行っているため、 計算後の値が反映される前に一瞬表示してしまうようです。

`setContentBox` 後に `active` クラスをつけるためのstateを変更するように修正しました。