### PR TITLE
fix: Add enough padding to Input so the text doesn't go under the icon

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -64,8 +64,8 @@ const SelectBox = styled.select<{ themes: Theme }>`
     return css`
       display: inline-block;
       width: 100%;
-      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.M)}
-        ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XXS)};
+      padding: ${size.pxToRem(size.space.XXS)};
+      padding-right: ${size.pxToRem(size.space.M)};
       border-radius: ${frame.border.radius.m};
       border: ${frame.border.default};
       background-color: #fff;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -64,7 +64,8 @@ const SelectBox = styled.select<{ themes: Theme }>`
     return css`
       display: inline-block;
       width: 100%;
-      padding: ${size.pxToRem(size.space.XXS)};
+      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.M)}
+        ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XXS)};
       border-radius: ${frame.border.radius.m};
       border: ${frame.border.default};
       background-color: #fff;


### PR DESCRIPTION
Fixed that the text for the Input component possibly goes under the icon.

before | after
-- | --
<img width="271" alt="スクリーンショット 2020-02-21 18 59 45" src="https://user-images.githubusercontent.com/14817308/75024276-7a52b380-54dc-11ea-9929-2d8eff5300fe.png"> | <img width="271" alt="スクリーンショット 2020-02-21 18 58 37" src="https://user-images.githubusercontent.com/14817308/75024287-7de63a80-54dc-11ea-95ba-e956c94669b7.png">