### PR TITLE
fix: fix that some styles doesn’t work

### DIFF
--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -49,11 +49,11 @@ const Th = styled.th<{ themes: Theme; onClick?: () => void }>`
     const { size, palette, interaction } = themes
 
     return css`
-      font-size: ${size.pxToRem(size.font.SHORT)}
+      font-size: ${size.pxToRem(size.font.SHORT)};
       font-weight: bold;
       padding: ${size.pxToRem(size.space.XS)};
       color: ${palette.TEXT_GREY};
-      transition: ${isTouchDevice ? 'none' : `background-color ${interaction.hover.animation}`}
+      transition: ${isTouchDevice ? 'none' : `background-color ${interaction.hover.animation}`};
       text-align: left;
       line-height: 1.5;
       vertical-align: middle;


### PR DESCRIPTION
Currently, some styles of Cell component has problem, because of missing `;`. 
This problem became apparent with the update of Styled-components. There seems to be a difference in output between v4 and v5.

**Input**
_Note: some properties have no `;`_
```tsx
const Th = styled.th<{ themes: Theme}>`
  ${({ themes}) => {
    const { size, palette, interaction } = themes

    return css`
      font-size: ${size.pxToRem(size.font.SHORT)}
      font-weight: bold;
      padding: ${size.pxToRem(size.space.XS)};
      color: ${palette.TEXT_GREY};
      transition: ${isTouchDevice ? 'none' : `background-color ${interaction.hover.animation}`}
      text-align: left;
      line-height: 1.5;
      vertical-align: middle;
    `
  }}
`
```

**Output (v4)**
```css
.foo {
    font-size: 0.6875rem;
    font-weight: bold;
    padding: 1rem;
    color: #767676;
    -webkit-transition: background-color .3s ease-out;
    transition: background-color .3s ease-out;
    text-align: left;
    line-height: 1.5;
    vertical-align: middle;
}
```

**Output (v5)**
`font-size` and `transition` have wrong value.
```css
.foo {
    font-size: 0.6875rem font-weight:bold;
    padding: 1rem;
    color: #767676;
    -webkit-transition: background-color .3s ease-out text-align:left;
    transition: background-color .3s ease-out text-align:left;
    line-height: 1.5;
    vertical-align: middle;
}
```

Lines without `;` seem to be convert to value until the next `;` (I think this is the correct behavior).

So, I added `;` to enable properties correctly. 