### PR TITLE
feat: add DropZone component

### DIFF
--- a/src/components/DropZone/DropZone.stories.tsx
+++ b/src/components/DropZone/DropZone.stories.tsx
@@ -1,0 +1,79 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+
+import { DropZone } from './DropZone'
+import { useTheme, Theme } from '../../hooks/useTheme'
+import readme from './README.md'
+
+const onSelectFiles = action('onSelectFiles')
+
+storiesOf('DropZone', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
+  .add('all', () => {
+    const theme = useTheme()
+
+    return (
+      <Group>
+        <li>
+          <Text>Default</Text>
+          <DropZone onSelectFiles={onSelectFiles} />
+        </li>
+
+        <li>
+          <Text>With children</Text>
+          <DropZone onSelectFiles={onSelectFiles}>
+            <DropZoneText theme={theme}>
+              <span>ここにドラッグ&ドロップ</span>
+              <span>または</span>
+            </DropZoneText>
+          </DropZone>
+        </li>
+
+        <li>
+          <Text>Button accepting only image files</Text>
+          <DropZone onSelectFiles={onSelectFiles} accept="image/*">
+            <DropZoneText theme={theme}>
+              <span>ここにドラッグ&ドロップ</span>
+              <span>または</span>
+            </DropZoneText>
+          </DropZone>
+        </li>
+      </Group>
+    )
+  })
+
+const Group = styled.ul`
+  list-style: none;
+  padding: 24px;
+  & > li:not(:first-child) {
+    margin-top: 24px;
+  }
+`
+
+const Text = styled.p`
+  margin: 0 0 16px 0;
+  font-size: 16px;
+`
+
+const DropZoneText = styled.p<{ theme: Theme }>`
+  ${({ theme }) => {
+    const { palette } = theme
+    return css`
+      margin: 0;
+      span {
+        display: block;
+        margin: 0 0 16px;
+        text-align: center;
+        font-size: 14px;
+        line-height: 1;
+        color: ${palette.TEXT_GREY};
+      }
+    `
+  }}
+`

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -52,7 +52,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ children, onSelectFiles, acc
   )
 
   const onClickButton = () => {
-    if (fileRef.current) fileRef.current.click()
+    fileRef.current!.click()
   }
 
   return (

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -1,0 +1,94 @@
+import React, { ChangeEvent, DragEvent, useCallback, useState, useRef } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+import { SecondaryButton } from '../Button'
+import { Icon } from '../Icon'
+
+type DropZoneProps = {
+  onSelectFiles: (
+    e: DragEvent<HTMLElement> | ChangeEvent<HTMLInputElement>,
+    files: FileList | null,
+  ) => void
+  accept?: string
+}
+
+const overrideEventDefault = (e: DragEvent<HTMLElement>) => {
+  e.preventDefault()
+  e.stopPropagation()
+}
+
+export const DropZone: React.FC<DropZoneProps> = ({ children, onSelectFiles, accept = '' }) => {
+  const theme = useTheme()
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [filesDraggedOver, setFilesDraggedOver] = useState(false)
+
+  const onDrop = useCallback(
+    (e: DragEvent<HTMLElement>) => {
+      overrideEventDefault(e)
+      setFilesDraggedOver(false)
+      onSelectFiles(e, e.dataTransfer.files)
+    },
+    [setFilesDraggedOver, onSelectFiles],
+  )
+
+  const onDragOver = useCallback(
+    (e: DragEvent<HTMLElement>) => {
+      overrideEventDefault(e)
+      setFilesDraggedOver(true)
+    },
+    [setFilesDraggedOver],
+  )
+
+  const onDragLeave = useCallback(() => {
+    setFilesDraggedOver(false)
+  }, [setFilesDraggedOver])
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      onSelectFiles(e, e.target.files)
+    },
+    [onSelectFiles],
+  )
+
+  const onClickButton = () => {
+    if (fileRef.current) fileRef.current.click()
+  }
+
+  return (
+    <Wrapper
+      theme={theme}
+      filesDraggedOver={filesDraggedOver}
+      onDrop={onDrop}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+    >
+      {children}
+      <SecondaryButton prefix={<Icon size={14} name="fa-folder-open" />} onClick={onClickButton}>
+        ファイルを選択
+      </SecondaryButton>
+      <input ref={fileRef} type="file" multiple accept={accept} onChange={onChange} />
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div<{ theme: Theme; filesDraggedOver: boolean }>`
+  ${({ theme, filesDraggedOver }) => {
+    const { palette, frame, size } = theme
+    const border = filesDraggedOver
+      ? `solid ${frame.border.lineWidth} ${palette.MAIN}`
+      : `dashed ${frame.border.lineWidth} ${palette.BORDER}`
+    return css`
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: ${size.pxToRem(size.space.L)};
+      border: ${border};
+      background-color: ${palette.COLUMN};
+      > input {
+        display: none;
+      }
+    `
+  }}
+`

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -1,0 +1,16 @@
+# DropZone
+
+```tsx
+import { DropZone } from 'smarthr-ui'
+
+<DropZone onDropFiles={onDropFiles} onSelectFiles={onSelectFiles} accept="image/*">
+  <p>Drop your files here.</p>
+</DropZone>
+```
+
+## props
+
+| Name          | Required | Type         | DefaultValue | Description                                                                                                                |
+| ------------- | -------- | ------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| onSelectFiles | true     | **function** | -            | Fired when files are selected by dropping or through the button. Arguments are Event object and FileList object.<br><br>function: (e: DragEvent<HTMLElement> | ChangeEvent<HTMLInputElement>, files: FileList | null) => void                |
+| accept        | -        | **string**   | ''           | One or more unique file type specifiers describing file types to allow to select.<br><b>(Not affect to dropping files)</b> |

--- a/src/components/DropZone/index.tsx
+++ b/src/components/DropZone/index.tsx
@@ -1,0 +1,1 @@
+export * from './DropZone'

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { BlankImage } from './components/Image'
 export { Heading } from './components/Heading'
 export { HeadlineArea } from './components/HeadlineArea'
 export { Select } from './components/Select'
+export { DropZone } from './components/DropZone'
 export { DefinitionList } from './components/DefinitionList'
 export {
   AccordionPanel,


### PR DESCRIPTION
DropZone component accepts files drop and files select via the button.

It takes props below:
- `children`: `ReactNode`
  - child components that will appear inside the droppable area.
- `onSelectFiles`: `(e: DragEvent<HTMLElement> | ChangeEvent<HTMLInputElement>, files: FileList | null) => void`
  - the callback function called when you drop files or select files via the button
- `accept`: `string`
  - file types that `<input type='file' />` accepts (no effect to file drop)