### PR TITLE
fix: change storybook loader color

### DIFF
--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -12,9 +12,9 @@ storiesOf('Loader', module).add('all', () => (
       <Loader size="l" />
     </GrayWrapper>
     <WhiteWrapper>
-      <Loader color="#00c4cc" />
-      <Loader color="#0081cc" />
-      <Loader color="#f80" />
+      <Loader color="#00a5ab" />
+      <Loader color="#007bc2" />
+      <Loader color="#ff8800" />
       <Loader color="#ef475b" />
     </WhiteWrapper>
   </>


### PR DESCRIPTION
## What

**[SHRUI-30]**
The color of the storybook loader was changed because it is not the main color.

## Screenshots

|before  |after  |
|---|---|
|![Apr-10-2020 18-27-05](https://user-images.githubusercontent.com/23610884/78980520-025a4e80-7b59-11ea-92fd-901e0dc1f021.gif)|![Apr-10-2020 18-27-31](https://user-images.githubusercontent.com/23610884/78980545-0dad7a00-7b59-11ea-8df4-1587544b0bf0.gif)|




