### PR TITLE
fix: change storybook dropdown style

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -192,7 +192,7 @@ storiesOf('Dropdown', module)
 
 const List = styled.ul`
   margin: 0;
-  padding: 10px 0;
+  padding: 8px 0;
   list-style: none;
 
   & > li > button {
@@ -201,7 +201,8 @@ const List = styled.ul`
     padding: 0 20px;
     border: none;
     background-color: #fff;
-    font-size: 16px;
+    font-size: 14px;
+    color: #333;
 
     &:hover {
       background-color: #f5f5f5;
@@ -210,6 +211,7 @@ const List = styled.ul`
 `
 const Wrapper = styled.div`
   padding: 24px;
+  color: #333;
 `
 const Legends = styled.ul`
   margin: 0;
@@ -228,7 +230,8 @@ const ControllableBoxMain = styled.div`
 `
 const Text = styled.p`
   margin: 0;
-  font-size: 16px;
+  font-size: 14px;
+  color: #333;
 `
 const ControllableBoxBottom = styled.div`
   display: flex;
@@ -261,7 +264,8 @@ const Fixed = styled.div`
   width: 100%;
   padding: 0 20px;
   border: none;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: bold;
   line-height: 40px;
+  color: #333;
 `


### PR DESCRIPTION
## What 

**[SHRUI-30]**

- ulの上下paddingを10px→8pxに変更
- dropdown内のfont-sizeを14pxに変更
- dropdown内のcolorを#333333に変更