### PR TITLE
refactor: [Dropdown] remove the usage of a ramdom string

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -40,34 +40,37 @@ export const Dropdown: FC<Props> = ({ children }) => {
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
-  const element = useRef(document.createElement('div')).current
+  const portalElementRef = useRef(document.createElement('div'))
   const triggerElementRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const onClickBody = (e: any) => {
       // ignore events from events within DropdownTrigger and DropdownContent
-      if (e.target === triggerElementRef.current || hasParentElement(e.target, element)) {
+      if (
+        e.target === triggerElementRef.current ||
+        hasParentElement(e.target, portalElementRef.current)
+      ) {
         return
       }
       setActive(false)
     }
-
-    document.body.appendChild(element)
+    const portalElement = portalElementRef.current
+    document.body.appendChild(portalElement)
     document.body.addEventListener('click', onClickBody, false)
 
     return () => {
-      document.body.removeChild(element)
+      document.body.removeChild(portalElement)
       document.body.removeEventListener('click', onClickBody, false)
     }
-  }, [element])
+  }, [])
 
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(
     () => props => {
       if (!active) return null
-      return createPortal(props.children, element)
+      return createPortal(props.children, portalElementRef.current)
     },
-    [active, element],
+    [active],
   )
   // set the displayName explicit for DevTools
   DropdownContentRoot.displayName = 'DropdownContentRoot'

--- a/src/components/Dropdown/DropdownCloser.tsx
+++ b/src/components/Dropdown/DropdownCloser.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react'
 import styled, { css } from 'styled-components'
 
-import { DropdownContext } from './Dropdown'
 import { DropdownContentContext } from './DropdownContent'
 import { DropdownContentInnerContext } from './DropdownContentInner'
 
@@ -11,13 +10,12 @@ type Props = {
 }
 
 export const DropdownCloser: React.FC<Props> = ({ children, className = '' }) => {
-  const { dropdownKey } = useContext(DropdownContext)
   const { onClickCloser, controllable, scrollable } = useContext(DropdownContentContext)
   const { maxHeight } = useContext(DropdownContentInnerContext)
 
   return (
     <Wrapper
-      className={`${dropdownKey} ${className}`}
+      className={className}
       onClick={onClickCloser}
       maxHeight={maxHeight}
       controllable={controllable}

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -25,9 +25,7 @@ export const DropdownContent: React.FC<Props> = ({
   className = '',
   children,
 }) => {
-  const { dropdownKey, DropdownContentRoot, triggerRect, onClickCloser } = useContext(
-    DropdownContext,
-  )
+  const { DropdownContentRoot, triggerRect, onClickCloser } = useContext(DropdownContext)
 
   return (
     <DropdownContentRoot>
@@ -35,7 +33,7 @@ export const DropdownContent: React.FC<Props> = ({
         <DropdownContentInner
           triggerRect={triggerRect}
           scrollable={scrollable}
-          className={`${dropdownKey} ${className}`}
+          className={className}
           controllable={controllable}
         >
           {children}

--- a/src/components/Dropdown/DropdownTrigger.tsx
+++ b/src/components/Dropdown/DropdownTrigger.tsx
@@ -9,10 +9,11 @@ type Props = {
 }
 
 export const DropdownTrigger: React.FC<Props> = ({ children, className = '' }) => {
-  const { dropdownKey, active, onClickTrigger } = useContext(DropdownContext)
+  const { active, onClickTrigger, triggerElementRef } = useContext(DropdownContext)
 
   return (
     <Wrapper
+      ref={triggerElementRef}
       onClick={e => {
         const rect = e.currentTarget.getBoundingClientRect()
         onClickTrigger({
@@ -22,7 +23,7 @@ export const DropdownTrigger: React.FC<Props> = ({ children, className = '' }) =
           left: rect.left,
         })
       }}
-      className={`${dropdownKey} ${className}`}
+      className={className}
     >
       {React.Children.map(children, (child: any) => {
         const props = child.props ? child.props : {}

--- a/src/components/Dropdown/dropdownHelper.ts
+++ b/src/components/Dropdown/dropdownHelper.ts
@@ -5,21 +5,9 @@ export type Rect = {
   left: number
 }
 
-export function getRandomStr() {
-  return Math.random()
-    .toString(32)
-    .substring(2)
-}
-
-export function includeDropdownElement(
-  element: HTMLElement | null,
-  dropdownClassName: string,
-): boolean {
+export function hasParentElement(element: HTMLElement | null, parent: HTMLElement | null): boolean {
   if (!element) return false
-  return (
-    element.classList.contains(dropdownClassName) ||
-    includeDropdownElement(element.parentElement, dropdownClassName)
-  )
+  return element === parent || hasParentElement(element.parentElement, parent)
 }
 
 type Size = { width: number; height: number }


### PR DESCRIPTION
This is just a refactoring for style, so feel free to merge this or close this.

This PR is to remove the usage of a className generated randomly.
I've used a ref of `DropdownTrigger` and verified whether an event came from the `DropdownTrigger` or not.
I've also ignored events that come from within `DropdownContent`.