### PR TITLE
fix: dropdown scroll area height for ie

### DIFF
--- a/src/components/Dropdown/DropdownScrollArea.tsx
+++ b/src/components/Dropdown/DropdownScrollArea.tsx
@@ -15,6 +15,7 @@ const Wrapper = styled.div`
   flex: 1 1 auto;
 
   /* IE11 */
+  /* stylelint-disable-next-line selector-type-no-unknown */
   _:-ms-lang(x)::-ms-backdrop,
   & {
     max-height: 300px;

--- a/src/components/Dropdown/DropdownScrollArea.tsx
+++ b/src/components/Dropdown/DropdownScrollArea.tsx
@@ -19,10 +19,4 @@ const Wrapper = styled.div`
   & {
     max-height: 300px;
   }
-
-  /* Edge */
-  _:-ms-lang(x)::backdrop,
-  & {
-    max-height: 300px;
-  }
 `

--- a/src/components/Dropdown/DropdownScrollArea.tsx
+++ b/src/components/Dropdown/DropdownScrollArea.tsx
@@ -12,5 +12,17 @@ export const DropdownScrollArea: React.FC<Props> = ({ children, className = '' }
 
 const Wrapper = styled.div`
   overflow-y: scroll;
-  flex: 1;
+  flex: 1 1 auto;
+
+  /* IE11 */
+  _:-ms-lang(x)::-ms-backdrop,
+  & {
+    max-height: 300px;
+  }
+
+  /* Edge */
+  _:-ms-lang(x)::backdrop,
+  & {
+    max-height: 300px;
+  }
 `


### PR DESCRIPTION
IE11にて DropdownScrollAreaの高さが0になってしまうバグが見つかったため対応します。