### PR TITLE
fix: typo Heading default type

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -21,7 +21,7 @@ export type HeadingTagTypes = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span'
 
 export const Heading: FC<Props> = ({
   tag = 'h1' as HeadingTagTypes,
-  type = 'ScreenTitle',
+  type = 'screenTitle',
   className = '',
   children,
 }) => {


### PR DESCRIPTION
`Heading` のデフォルトスタイル `sceeenTitle` がタイポに依り機能していなかった。