### PR TITLE
fix: set appear animation for Dialog

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -46,7 +46,12 @@ export const DialogContentInner: FC<Props> = ({
         className="wrapper"
         classNames="wrapper"
         in={isOpen}
-        timeout={300}
+        timeout={{
+          appear: 500,
+          enter: 300,
+          exit: 300,
+        }}
+        appear
         unmountOnExit
       >
         <Wrapper>
@@ -69,6 +74,13 @@ const Wrapper = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
+  &.wrapper-appear {
+    opacity: 0;
+  }
+  &.wrapper-appear-active {
+    transition: opacity 500ms;
+    opacity: 1;
+  }
   &.wrapper-enter {
     opacity: 0;
   }


### PR DESCRIPTION
In #776 , I used React-transition-group to set the fade-out animation to Dialog component.
Because of #776 , "opened" Dialog's appear-animation no longer works.

##### Before #776 

![before-776](https://user-images.githubusercontent.com/19551419/82686569-0669a800-9c91-11ea-92da-ae5fa64ac5fd.gif)

##### After #776 

![after-776](https://user-images.githubusercontent.com/19551419/82686723-40d34500-9c91-11ea-800a-fe9e3bc3c14f.gif)

"opened" Dialog doesn't fade-in anymore like the above.
This PR fixes it.

### This PR

![after-this-pr](https://user-images.githubusercontent.com/19551419/82687035-ba6b3300-9c91-11ea-9d70-ccb43b71af2e.gif)
