### PR TITLE
fix: improve TextButton broder-color to transparent

### DIFF
--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -32,7 +32,7 @@ const textStyle = css`
       background-color: transparent;
       color: ${palette.TEXT_BLACK};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
-      border: ${frame.border.lineWidth} ${frame.border.lineStyle} #fff;
+      border: ${frame.border.lineWidth} ${frame.border.lineStyle} transparent;
 
       &.hover {
         background-color: ${palette.hoverColor('#fff')};


### PR DESCRIPTION
`border-top` が `white` だと白背景以外では浮いてしまう。
`background-color` に合わせて `transparent` に変更する。