### PR TITLE
Fix footer color to brand color 

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -58,7 +58,7 @@ const Wrapper = styled.footer<{ themes: Theme }>`
     justify-content: space-between;
     height: 60px;
     padding: 0 ${themes.size.pxToRem(themes.size.space.S)};
-    background-color: ${themes.palette.HEADER_GREEN};
+    background-color: ${themes.palette.BRAND};
     color: #fff;
     font-size: ${themes.size.pxToRem(themes.size.font.TALL)};
   `}

--- a/src/themes/createPalette.ts
+++ b/src/themes/createPalette.ts
@@ -33,7 +33,6 @@ export interface CreatedPaletteTheme {
   WARNING: string
   SCRIM: string
   OVERLAY: string
-  HEADER_GREEN: string
   BRAND: string
   OUTLINE: string
 }
@@ -51,7 +50,6 @@ export const defaultPalette = {
   WARNING: '#ff8800',
   SCRIM: 'rgba(0,0,0,0.5)',
   OVERLAY: 'rgba(0,0,0,0.15)',
-  HEADER_GREEN: '#57d0d5',
   BRAND: '#00c4cc',
 }
 


### PR DESCRIPTION
# What I did
- change Footer color to BRAND Color
- remove HEADER_GREEN from palette
- update snapshots

before | ![image](https://user-images.githubusercontent.com/19403400/82002245-45e43300-9698-11ea-91a2-4e3cc04dbc18.png)
--- | ---
after | ![image](https://user-images.githubusercontent.com/19403400/82001898-3f08f080-9697-11ea-8897-ed686e72a4e6.png)


# Why we should do this change

For the BRAND TEAM