### PR TITLE
fix: table 内 th の詳細度が高すぎる

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled.table<{ themes: Theme }>`
       border-spacing: 0;
       background-color: ${COLUMN};
 
-      & > thead > tr > th {
+      th {
         background-color: ${COLUMN};
       }
     `


### PR DESCRIPTION
`table` 内 `th` の詳細度が高すぎるため、スタイルのオーバーライドが面倒になってる。
厳密に `table > thead > tr > th` である必要はまったくない。

これが | `table > thead > tr > th`
--- | ---
こうなる | `table th`