### PR TITLE
chore: use package.json's checksum for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - modules-cache-{{ .ENVIRONMENT.CACHE_KEY }}-{{ checksum "yarn.lock" }}
+          - v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
           - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: modules-cache-{{ .ENVIRONMENT.CACHE_KEY }}-{{ checksum "yarn.lock" }}
+          key: v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       # run tests!
       - run: yarn audit --groups dependencies
       - run: yarn lint
@@ -32,13 +32,13 @@ commands:
           fi
       - restore_cache:
           keys:
-            - modules-cache-{{ .ENVIRONMENT.CACHE_KEY }}-{{ checksum "yarn.lock" }}
+            - v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
             - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: modules-cache-{{ .ENVIRONMENT.CACHE_KEY }}-{{ checksum "yarn.lock" }}
+          key: v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: yarn test-visual
 jobs:
   node-v10:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          - dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
           - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          key: dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       # run tests!
       - run: yarn audit --groups dependencies
       - run: yarn lint
@@ -32,13 +32,13 @@ commands:
           fi
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            - dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
             - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          key: dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: yarn test-visual
 jobs:
   node-v10:


### PR DESCRIPTION
use `checksum package.json` and `checksum yarn.lock` as circleci cache key.