### PR TITLE
feat: add currency mode into Input

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -16,6 +16,10 @@ storiesOf('Input', module).add('all', () => (
       <Input type="number" defaultValue="1" />
     </li>
     <li>
+      <Txt>number (thousands separated)</Txt>
+      <Input type="number" thousandsSeparated defaultValue="1,000.1234" />
+    </li>
+    <li>
       <Txt>password</Txt>
       <Input type="password" defaultValue="password" />
     </li>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -21,11 +21,15 @@ export type Props = InputHTMLAttributes<HTMLInputElement> & {
   error?: boolean
   width?: number | string
   autoFocus?: boolean
+  thousandsSeparated?: boolean
 }
 
-export const Input: FC<Props> = ({ autoFocus, ...props }) => {
+export const Input: FC<Props> = ({ type, autoFocus, thousandsSeparated, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLInputElement>(null)
+
+  const isCurrency = type === 'number' && thousandsSeparated
+  const actualType = isCurrency ? 'text' : type
 
   useEffect(() => {
     if (autoFocus && ref && ref.current) {
@@ -33,7 +37,7 @@ export const Input: FC<Props> = ({ autoFocus, ...props }) => {
     }
   }, [autoFocus])
 
-  return <StyledInput {...props} ref={ref} themes={theme} />
+  return <StyledInput type={actualType} {...props} ref={ref} themes={theme} />
 }
 
 const StyledInput = styled.input<Props & { themes: Theme }>`

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { FC, InputHTMLAttributes, useEffect, useRef } from 'react'
+import React, { FC, FocusEvent, InputHTMLAttributes, useEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -24,12 +24,42 @@ export type Props = InputHTMLAttributes<HTMLInputElement> & {
   thousandsSeparated?: boolean
 }
 
-export const Input: FC<Props> = ({ type, autoFocus, thousandsSeparated, ...props }) => {
+export const Input: FC<Props> = ({
+  type,
+  onFocus,
+  onBlur,
+  autoFocus,
+  thousandsSeparated,
+  ...props
+}) => {
   const theme = useTheme()
   const ref = useRef<HTMLInputElement>(null)
 
   const isCurrency = type === 'number' && thousandsSeparated
   const actualType = isCurrency ? 'text' : type
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+    if (isCurrency && ref.current) {
+      const commaExcluded = ref.current.value.replace(/,/g, '')
+      ref.current.value = commaExcluded
+    }
+    onFocus && onFocus(e)
+  }
+
+  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+    if (isCurrency && ref.current) {
+      const value = ref.current.value
+      const shaped = value
+        .replace(/[０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0)) // convert number and dot to half-width
+        .replace(/[−ー]/, '-') // replace full-width minus
+        .replace(/[^0-9.-]|(?!^)-|^\.+|\.+$/g, '') // exclude non-numeric characters
+      const splited = shaped.split('.')
+      const integerPart = splited[0].replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') // add comma to integer every 3 digits
+      const formattedArray = Object.assign(splited, [integerPart])
+      ref.current.value = formattedArray.join('.')
+    }
+    onBlur && onBlur(e)
+  }
 
   useEffect(() => {
     if (autoFocus && ref && ref.current) {
@@ -37,7 +67,16 @@ export const Input: FC<Props> = ({ type, autoFocus, thousandsSeparated, ...props
     }
   }, [autoFocus])
 
-  return <StyledInput type={actualType} {...props} ref={ref} themes={theme} />
+  return (
+    <StyledInput
+      type={actualType}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      {...props}
+      ref={ref}
+      themes={theme}
+    />
+  )
 }
 
 const StyledInput = styled.input<Props & { themes: Theme }>`


### PR DESCRIPTION
Add `thousandsSeparated` props into `Input` that enable to control currency data.
When `type` is "number" and `thousandsSeparated` is true, the `Input` become currency mode.

In currency mode,
* add comma to integer part every 3 digits.
* remove no-numeric characters.
* convert full-width characters to half-width.