### PR TITLE
feat: add buttons props types for AppNavi component

### DIFF
--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -25,8 +25,14 @@ const List = styled.ul`
     }
   }
 `
-const Link: FC<{ to: string; children: ReactNode }> = ({ to, children, ...props }) => (
-  <a href={to} {...props}>
+const Link: FC<{ to: string; children: ReactNode; disabled?: boolean; className?: string }> = ({
+  to,
+  children,
+  disabled = false,
+  className = '',
+  ...props
+}) => (
+  <a className={className} {...(disabled ? {} : { href: to })} {...props}>
     {children}
   </a>
 )
@@ -35,6 +41,7 @@ const buttons = [
     children: 'カレントボタン',
     icon: 'fa-file' as const,
     current: true,
+    onClick: action('click!!'),
   },
   {
     children: 'ボタン',
@@ -90,6 +97,16 @@ storiesOf('AppNavi', module)
   .add('without children', () => (
     <Wrapper>
       <AppNavi label="プラスメニュー" buttons={buttons} />
+    </Wrapper>
+  ))
+  .add('with disalbed', () => (
+    <Wrapper>
+      <AppNavi
+        label="プラスメニュー"
+        buttons={buttons.map((item) => ({ ...item, disabled: true }))}
+      >
+        <Child>Some child components</Child>
+      </AppNavi>
     </Wrapper>
   ))
 

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -77,7 +77,7 @@ storiesOf('AppNavi', module)
   .add('with children', () => (
     <Wrapper>
       <AppNavi label="プラスメニュー" buttons={buttons}>
-        <Child>Some child component</Child>
+        <Child>Some child components</Child>
       </AppNavi>
     </Wrapper>
   ))

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -1,52 +1,96 @@
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
-import * as React from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled from 'styled-components'
 
 import { AppNavi } from './AppNavi'
 
+const List = styled.ul`
+  margin: 0;
+  padding: 8px 0;
+  list-style: none;
+
+  & > li > button {
+    line-height: 40px;
+    width: 100%;
+    padding: 0 20px;
+    border: none;
+    background-color: #fff;
+    font-size: 14px;
+    color: #333;
+
+    &:hover {
+      background-color: #f5f5f5;
+    }
+  }
+`
+const Link: FC<{ to: string; children: ReactNode }> = ({ to, children, ...props }) => (
+  <a href={to} {...props}>
+    {children}
+  </a>
+)
 const buttons = [
   {
-    children: 'ボタン1',
+    children: 'カレントボタン',
     icon: 'fa-file' as const,
     current: true,
   },
   {
-    children: 'ボタン2',
+    children: 'ボタン',
     icon: 'fa-user-alt' as const,
     onClick: action('click!!'),
   },
   {
-    children: 'ボタン3',
+    children: 'アンカー',
     icon: 'fa-cog' as const,
-    onClick: action('click!!'),
+    href: 'http://www.google.com',
+  },
+  {
+    children: 'ドロップダウン',
+    icon: 'fa-chart-pie' as const,
+    dropdownContent: (
+      <List>
+        <li>
+          <button onClick={action('clicked item 1')}>ドロップダウンアイテム1</button>
+        </li>
+        <li>
+          <button onClick={action('clicked item 2')}>ドロップダウンアイテム2</button>
+        </li>
+        <li>
+          <button onClick={action('clicked item 3')}>ドロップダウンアイテム3</button>
+        </li>
+        <li>
+          <button onClick={action('clicked item 4')}>ドロップダウンアイテム4</button>
+        </li>
+      </List>
+    ),
+  },
+  {
+    children: 'カスタムタグ',
+    icon: 'fa-birthday-cake' as const,
+    tag: Link,
+    to: 'http://www.google.com',
   },
 ]
 
-storiesOf('AppNavi', module).add('all', () => (
-  <React.Fragment>
+storiesOf('AppNavi', module)
+  .add('with children', () => (
     <Wrapper>
-      <Description>No child component</Description>
-      <AppNavi label="プラスメニュー" buttons={buttons} />
-    </Wrapper>
-    <Wrapper>
-      <Description>With a child component</Description>
       <AppNavi label="プラスメニュー" buttons={buttons}>
-        <ChildComponent>Some child component</ChildComponent>
+        <Child>Some child component</Child>
       </AppNavi>
     </Wrapper>
-  </React.Fragment>
-))
+  ))
+  .add('without children', () => (
+    <Wrapper>
+      <AppNavi label="プラスメニュー" buttons={buttons} />
+    </Wrapper>
+  ))
 
 const Wrapper = styled.div`
-  padding-top: 16px;
+  padding: 32px 0;
+  background-color: #f5f6fa;
 `
-
-const Description = styled.p`
-  margin-bottom: 8px;
-  padding: 0 20px;
-`
-
-const ChildComponent = styled.p`
+const Child = styled.p`
   margin: 0 0 0 auto;
 `

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -4,6 +4,7 @@ import React, { FC, ReactNode } from 'react'
 import styled from 'styled-components'
 
 import { AppNavi } from './AppNavi'
+import readme from './README.md'
 
 const List = styled.ul`
   margin: 0;
@@ -74,6 +75,11 @@ const buttons = [
 ]
 
 storiesOf('AppNavi', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
   .add('with children', () => (
     <Wrapper>
       <AppNavi label="プラスメニュー" buttons={buttons}>

--- a/src/components/AppNavi/AppNavi.test.tsx
+++ b/src/components/AppNavi/AppNavi.test.tsx
@@ -9,34 +9,57 @@ describe('AppNavi', () => {
       palette: {
         TEXT_BLACK: 'black',
         TEXT_GREY: 'grey',
+        TEXT_DISABLED: 'white',
       },
     })
 
-    describe('if icon does not exist', () => {
+    describe('if options does not exist', () => {
       it('should return null', () => {
         expect(getIconComponent(theme)).toBeNull()
       })
     })
 
-    describe('if icon exist', () => {
-      it('svg should be rendered', () => {
-        const component = mount(getIconComponent(theme, 'fa-archive')!)
-        expect(component.exists('svg')).toBeTruthy()
-      })
-
-      describe('if current is true', () => {
-        const component = mount(getIconComponent(theme, 'fa-archive', true)!)
-
-        it('svg color should be TEXT_BLACK color', () => {
-          expect(component.find('svg').props().color).toBe('black')
+    describe('if options exist', () => {
+      describe('if icon does not exist', () => {
+        it('should return null', () => {
+          expect(getIconComponent(theme, {})).toBeNull()
         })
       })
 
-      describe('if current is false', () => {
-        const component = mount(getIconComponent(theme, 'fa-archive', false)!)
+      describe('if icon exist', () => {
+        it('svg should be rendered', () => {
+          const component = mount(getIconComponent(theme, { icon: 'fa-archive' })!)
+          expect(component.exists('svg')).toBeTruthy()
+        })
 
-        it('svg color should be TEXT_GREY color', () => {
-          expect(component.find('svg').props().color).toBe('grey')
+        describe('if current is true', () => {
+          const component = mount(getIconComponent(theme, { icon: 'fa-archive', current: true })!)
+
+          it('svg color should be TEXT_BLACK color', () => {
+            expect(component.find('svg').props().color).toBe('black')
+          })
+        })
+
+        describe('if current is false', () => {
+          describe('if disabled is true', () => {
+            const component = mount(
+              getIconComponent(theme, { icon: 'fa-archive', current: false, disabled: true })!,
+            )
+
+            it('svg color should be TEXT_DISABLED color', () => {
+              expect(component.find('svg').props().color).toBe('white')
+            })
+          })
+
+          describe('if disabled is flase', () => {
+            const component = mount(
+              getIconComponent(theme, { icon: 'fa-archive', current: false, disabled: false })!,
+            )
+
+            it('svg color should be TEXT_GREY color', () => {
+              expect(component.find('svg').props().color).toBe('grey')
+            })
+          })
         })
       })
     })

--- a/src/components/AppNavi/AppNavi.test.tsx
+++ b/src/components/AppNavi/AppNavi.test.tsx
@@ -1,0 +1,44 @@
+import { mount } from 'enzyme'
+
+import { getIconComponent } from './appNaviHelper'
+import { createTheme } from '../../themes/createTheme'
+
+describe('AppNavi', () => {
+  describe('getIconComponent', () => {
+    const theme = createTheme({
+      palette: {
+        TEXT_BLACK: 'black',
+        TEXT_GREY: 'grey',
+      },
+    })
+
+    describe('if icon does not exist', () => {
+      it('should return null', () => {
+        expect(getIconComponent(theme)).toBeNull()
+      })
+    })
+
+    describe('if icon exist', () => {
+      it('svg should be rendered', () => {
+        const component = mount(getIconComponent(theme, 'fa-archive')!)
+        expect(component.exists('svg')).toBeTruthy()
+      })
+
+      describe('if current is true', () => {
+        const component = mount(getIconComponent(theme, 'fa-archive', true)!)
+
+        it('svg color should be TEXT_BLACK color', () => {
+          expect(component.find('svg').props().color).toBe('black')
+        })
+      })
+
+      describe('if current is false', () => {
+        const component = mount(getIconComponent(theme, 'fa-archive', false)!)
+
+        it('svg color should be TEXT_GREY color', () => {
+          expect(component.find('svg').props().color).toBe('grey')
+        })
+      })
+    })
+  })
+})

--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -1,15 +1,20 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
-import { StatusLabel } from '../StatusLabel/StatusLabel'
+import { StatusLabel as StatusLabelComponent } from '../StatusLabel/StatusLabel'
 import { AppNaviButton, AppNaviButtonProps } from './AppNaviButton'
+import { AppNaviAnchor, AppNaviAnchorProps } from './AppNaviAnchor'
+import { AppNaviDropdown, AppNaviDropdownProps } from './AppNaviDropdown'
+import { AppNaviCustomTag, AppNaviCustomTagProps } from './AppNaviCustomTag'
 
 interface Props {
   label?: string
-  buttons?: AppNaviButtonProps[]
-  children?: React.ReactNode
+  buttons?: Array<
+    AppNaviButtonProps | AppNaviAnchorProps | AppNaviDropdownProps | AppNaviCustomTagProps
+  >
+  children?: ReactNode
 }
 
 export const AppNavi: FC<Props> = ({ label, buttons, children = null }) => {
@@ -17,23 +22,57 @@ export const AppNavi: FC<Props> = ({ label, buttons, children = null }) => {
 
   return (
     <Wrapper themes={theme}>
-      {label && (
-        <StatusLabelWrapper themes={theme}>
-          <StatusLabel>{label}</StatusLabel>
-        </StatusLabelWrapper>
+      {label && <StatusLabel themes={theme}>{label}</StatusLabel>}
+
+      {buttons && (
+        <Buttons themes={theme}>
+          {buttons.map((button, i) => {
+            if ('href' in button) {
+              return (
+                <li key={i}>
+                  <AppNaviAnchor href={button.href} icon={button.icon} current={button.current}>
+                    {button.children}
+                  </AppNaviAnchor>
+                </li>
+              )
+            }
+
+            if ('dropdownContent' in button) {
+              return (
+                <li key={i}>
+                  <AppNaviDropdown
+                    dropdownContent={button.dropdownContent}
+                    icon={button.icon}
+                    current={button.current}
+                  >
+                    {button.children}
+                  </AppNaviDropdown>
+                </li>
+              )
+            }
+
+            if ('tag' in button) {
+              const { tag, icon, current, children: buttonChildren, ...props } = button
+              return (
+                <li key={i}>
+                  <AppNaviCustomTag tag={tag} icon={icon} current={current} {...props}>
+                    {buttonChildren}
+                  </AppNaviCustomTag>
+                </li>
+              )
+            }
+
+            return (
+              <li key={i}>
+                <AppNaviButton icon={button.icon} current={button.current} onClick={button.onClick}>
+                  {button.children}
+                </AppNaviButton>
+              </li>
+            )
+          })}
+        </Buttons>
       )}
 
-      {buttons &&
-        buttons.map((button, index) => (
-          <AppNaviButton
-            icon={button.icon}
-            current={button.current}
-            key={index}
-            onClick={button.onClick}
-          >
-            {button.children}
-          </AppNaviButton>
-        ))}
       {children}
     </Wrapper>
   )
@@ -47,21 +86,40 @@ const Wrapper = styled.nav<{ themes: Theme }>`
       display: flex;
       align-items: center;
       width: 100%;
-      height: ${pxToRem(40)};
+      height: 40px;
       padding: 0 ${pxToRem(20)};
       background-color: #fff;
       box-sizing: border-box;
-      box-shadow: 0 ${pxToRem(1)} ${pxToRem(4)} rgba(0, 0, 0, 0.15);
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
     `
   }}
 `
-const StatusLabelWrapper = styled.span<{ themes: Theme }>`
+const StatusLabel = styled(StatusLabelComponent)<{ themes: Theme }>`
   ${({ themes }) => {
     const { pxToRem, space } = themes.size
 
     return css`
-      display: inline-block;
       margin-right: ${pxToRem(space.XS)};
+    `
+  }}
+`
+const Buttons = styled.ul<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { pxToRem, space } = themes.size
+
+    return css`
+      display: flex;
+      align-items: center;
+      margin: 0;
+      padding: 0;
+
+      > li {
+        list-style: none;
+
+        &:not(:first-child) {
+          margin-left: ${pxToRem(space.XS)};
+        }
+      }
     `
   }}
 `

--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -30,7 +30,12 @@ export const AppNavi: FC<Props> = ({ label, buttons, children = null }) => {
             if ('href' in button) {
               return (
                 <li key={i}>
-                  <AppNaviAnchor href={button.href} icon={button.icon} current={button.current}>
+                  <AppNaviAnchor
+                    href={button.href}
+                    icon={button.icon}
+                    current={button.current}
+                    disabled={button.disabled}
+                  >
                     {button.children}
                   </AppNaviAnchor>
                 </li>
@@ -44,6 +49,7 @@ export const AppNavi: FC<Props> = ({ label, buttons, children = null }) => {
                     dropdownContent={button.dropdownContent}
                     icon={button.icon}
                     current={button.current}
+                    disabled={button.disabled}
                   >
                     {button.children}
                   </AppNaviDropdown>
@@ -55,7 +61,13 @@ export const AppNavi: FC<Props> = ({ label, buttons, children = null }) => {
               const { tag, icon, current, children: buttonChildren, ...props } = button
               return (
                 <li key={i}>
-                  <AppNaviCustomTag tag={tag} icon={icon} current={current} {...props}>
+                  <AppNaviCustomTag
+                    tag={tag}
+                    icon={icon}
+                    current={current}
+                    disabled={button.disabled}
+                    {...props}
+                  >
                     {buttonChildren}
                   </AppNaviCustomTag>
                 </li>
@@ -64,7 +76,12 @@ export const AppNavi: FC<Props> = ({ label, buttons, children = null }) => {
 
             return (
               <li key={i}>
-                <AppNaviButton icon={button.icon} current={button.current} onClick={button.onClick}>
+                <AppNaviButton
+                  icon={button.icon}
+                  current={button.current}
+                  disabled={button.disabled}
+                  onClick={button.onClick}
+                >
                   {button.children}
                 </AppNaviButton>
               </li>

--- a/src/components/AppNavi/AppNaviAnchor.tsx
+++ b/src/components/AppNavi/AppNaviAnchor.tsx
@@ -6,14 +6,14 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { Props as IconProps } from '../Icon'
 import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
 
-export type AppNaviButtonProps = {
+export type AppNaviAnchorProps = {
   children: ReactNode
+  href: string
   current?: boolean
   icon?: IconProps['name']
-  onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon, onClick }) => {
+export const AppNaviAnchor: FC<AppNaviAnchorProps> = ({ children, href, current, icon }) => {
   const theme = useTheme()
   const iconComponent = getIconComponent(theme, icon, current)
 
@@ -27,13 +27,13 @@ export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon,
   }
 
   return (
-    <InActive themes={theme} onClick={onClick}>
+    <InActive themes={theme} href={href}>
       {iconComponent}
       {children}
     </InActive>
   )
 }
 
-const InActive = styled.button<{ themes: Theme }>`
+const InActive = styled.a<{ themes: Theme }>`
   ${InActiveStyle}
 `

--- a/src/components/AppNavi/AppNaviAnchor.tsx
+++ b/src/components/AppNavi/AppNaviAnchor.tsx
@@ -4,22 +4,30 @@ import styled from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Props as IconProps } from '../Icon'
-import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
+import { buttonStyle, getIconComponent } from './appNaviHelper'
 
 export type AppNaviAnchorProps = {
   children: ReactNode
   href: string
-  current?: boolean
   icon?: IconProps['name']
+  current?: boolean
+  disabled?: boolean
 }
 
-export const AppNaviAnchor: FC<AppNaviAnchorProps> = ({ children, href, current, icon }) => {
+export const AppNaviAnchor: FC<AppNaviAnchorProps> = ({
+  children,
+  href,
+  icon,
+  current,
+  disabled = false,
+}) => {
   const theme = useTheme()
-  const iconComponent = getIconComponent(theme, icon, current)
+  const iconComponent = getIconComponent(theme, { icon, current, disabled })
+  const additional = disabled ? { className: 'disabled' } : { href }
 
   if (current) {
     return (
-      <Active themes={theme} aria-selected="true">
+      <Active themes={theme} aria-selected="true" {...additional}>
         {iconComponent}
         {children}
       </Active>
@@ -27,13 +35,16 @@ export const AppNaviAnchor: FC<AppNaviAnchorProps> = ({ children, href, current,
   }
 
   return (
-    <InActive themes={theme} href={href}>
+    <InActive themes={theme} {...additional}>
       {iconComponent}
       {children}
     </InActive>
   )
 }
 
+const Active = styled.a<{ themes: Theme }>`
+  ${buttonStyle.active}
+`
 const InActive = styled.a<{ themes: Theme }>`
-  ${InActiveStyle}
+  ${buttonStyle.inactive}
 `

--- a/src/components/AppNavi/AppNaviButton.tsx
+++ b/src/components/AppNavi/AppNaviButton.tsx
@@ -4,22 +4,37 @@ import styled from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Props as IconProps } from '../Icon'
-import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
+import { buttonStyle, getIconComponent } from './appNaviHelper'
 
 export type AppNaviButtonProps = {
   children: ReactNode
-  current?: boolean
   icon?: IconProps['name']
+  current?: boolean
+  disabled?: boolean
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon, onClick }) => {
+export const AppNaviButton: FC<AppNaviButtonProps> = ({
+  children,
+  icon,
+  current,
+  disabled = false,
+  onClick,
+}) => {
   const theme = useTheme()
-  const iconComponent = getIconComponent(theme, icon, current)
+  const iconComponent = getIconComponent(theme, { icon, current, disabled })
+  const additionalProps = disabled
+    ? {
+        disabled,
+        className: 'disabled',
+      }
+    : {
+        onClick,
+      }
 
   if (current) {
     return (
-      <Active themes={theme} aria-selected="true">
+      <Active themes={theme} aria-selected="true" {...additionalProps}>
         {iconComponent}
         {children}
       </Active>
@@ -27,13 +42,16 @@ export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon,
   }
 
   return (
-    <InActive themes={theme} onClick={onClick}>
+    <InActive themes={theme} {...additionalProps}>
       {iconComponent}
       {children}
     </InActive>
   )
 }
 
+const Active = styled.button<{ themes: Theme }>`
+  ${buttonStyle.active}
+`
 const InActive = styled.button<{ themes: Theme }>`
-  ${InActiveStyle}
+  ${buttonStyle.inactive}
 `

--- a/src/components/AppNavi/AppNaviCustomTag.tsx
+++ b/src/components/AppNavi/AppNaviCustomTag.tsx
@@ -1,21 +1,30 @@
 import React, { FC, ReactNode } from 'react'
-import styled from 'styled-components'
+import styled, { AnyStyledComponent } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Props as IconProps } from '../Icon'
 import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
 
-export type AppNaviButtonProps = {
+export type AppNaviCustomTagProps = {
   children: ReactNode
+  tag: AnyStyledComponent
   current?: boolean
   icon?: IconProps['name']
-  onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
-}
+} & {}
 
-export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon, onClick }) => {
+export const AppNaviCustomTag: FC<AppNaviCustomTagProps> = ({
+  children,
+  tag,
+  current,
+  icon,
+  ...props
+}) => {
   const theme = useTheme()
   const iconComponent = getIconComponent(theme, icon, current)
+  const InActive = styled(tag)<{ themes: Theme }>`
+    ${InActiveStyle}
+  `
 
   if (current) {
     return (
@@ -27,13 +36,9 @@ export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon,
   }
 
   return (
-    <InActive themes={theme} onClick={onClick}>
+    <InActive themes={theme} {...props}>
       {iconComponent}
       {children}
     </InActive>
   )
 }
-
-const InActive = styled.button<{ themes: Theme }>`
-  ${InActiveStyle}
-`

--- a/src/components/AppNavi/AppNaviCustomTag.tsx
+++ b/src/components/AppNavi/AppNaviCustomTag.tsx
@@ -4,31 +4,38 @@ import styled, { AnyStyledComponent } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Props as IconProps } from '../Icon'
-import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
+import { buttonStyle, getIconComponent } from './appNaviHelper'
 
 export type AppNaviCustomTagProps = {
   children: ReactNode
   tag: AnyStyledComponent
-  current?: boolean
   icon?: IconProps['name']
+  current?: boolean
+  disabled?: boolean
 } & {}
 
 export const AppNaviCustomTag: FC<AppNaviCustomTagProps> = ({
   children,
   tag,
-  current,
   icon,
+  current,
+  disabled = false,
   ...props
 }) => {
   const theme = useTheme()
-  const iconComponent = getIconComponent(theme, icon, current)
+  const iconComponent = getIconComponent(theme, { icon, current, disabled })
+  const additionalProps = disabled ? { disabled: true, className: 'disabled' } : {}
+
+  const Active = styled(tag)<{ themes: Theme }>`
+    ${buttonStyle.active}
+  `
   const InActive = styled(tag)<{ themes: Theme }>`
-    ${InActiveStyle}
+    ${buttonStyle.inactive}
   `
 
   if (current) {
     return (
-      <Active themes={theme} aria-selected="true">
+      <Active themes={theme} aria-selected="true" {...additionalProps}>
         {iconComponent}
         {children}
       </Active>
@@ -36,7 +43,7 @@ export const AppNaviCustomTag: FC<AppNaviCustomTagProps> = ({
   }
 
   return (
-    <InActive themes={theme} {...props}>
+    <InActive themes={theme} {...props} {...additionalProps}>
       {iconComponent}
       {children}
     </InActive>

--- a/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/src/components/AppNavi/AppNaviDropdown.tsx
@@ -5,40 +5,41 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Dropdown, DropdownContent, DropdownTrigger } from '../Dropdown'
 import { Props as IconProps } from '../Icon'
-import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
+import { buttonStyle, getIconComponent } from './appNaviHelper'
 
 export type AppNaviDropdownProps = {
   children: ReactNode
   dropdownContent: ReactNode
-  current?: boolean
   icon?: IconProps['name']
+  current?: boolean
+  disabled?: boolean
 }
 
 export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
   children,
   dropdownContent,
-  current,
   icon,
+  current,
+  disabled,
 }) => {
   const theme = useTheme()
-  const iconComponent = getIconComponent(theme, icon, current)
-
-  if (current) {
-    return (
-      <Active themes={theme} aria-selected="true">
-        {iconComponent}
-        {children}
-      </Active>
-    )
-  }
+  const iconComponent = getIconComponent(theme, { icon, current, disabled })
+  const additionalProps = disabled ? { disabled: true, className: 'disabled' } : {}
 
   return (
     <Dropdown>
       <DropdownTrigger>
-        <InActive themes={theme}>
-          {iconComponent}
-          {children}
-        </InActive>
+        {current ? (
+          <Active themes={theme} aria-selected="true" {...additionalProps}>
+            {iconComponent}
+            {children}
+          </Active>
+        ) : (
+          <InActive themes={theme} {...additionalProps}>
+            {iconComponent}
+            {children}
+          </InActive>
+        )}
       </DropdownTrigger>
 
       <DropdownContent>{dropdownContent}</DropdownContent>
@@ -46,6 +47,9 @@ export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
   )
 }
 
+const Active = styled.button<{ themes: Theme }>`
+  ${buttonStyle.active}
+`
 const InActive = styled.button<{ themes: Theme }>`
-  ${InActiveStyle}
+  ${buttonStyle.inactive}
 `

--- a/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/src/components/AppNavi/AppNaviDropdown.tsx
@@ -3,17 +3,23 @@ import styled from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
+import { Dropdown, DropdownContent, DropdownTrigger } from '../Dropdown'
 import { Props as IconProps } from '../Icon'
 import { Active, InActiveStyle, getIconComponent } from './appNaviHelper'
 
-export type AppNaviButtonProps = {
+export type AppNaviDropdownProps = {
   children: ReactNode
+  dropdownContent: ReactNode
   current?: boolean
   icon?: IconProps['name']
-  onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon, onClick }) => {
+export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
+  children,
+  dropdownContent,
+  current,
+  icon,
+}) => {
   const theme = useTheme()
   const iconComponent = getIconComponent(theme, icon, current)
 
@@ -27,10 +33,16 @@ export const AppNaviButton: FC<AppNaviButtonProps> = ({ children, current, icon,
   }
 
   return (
-    <InActive themes={theme} onClick={onClick}>
-      {iconComponent}
-      {children}
-    </InActive>
+    <Dropdown>
+      <DropdownTrigger>
+        <InActive themes={theme}>
+          {iconComponent}
+          {children}
+        </InActive>
+      </DropdownTrigger>
+
+      <DropdownContent>{dropdownContent}</DropdownContent>
+    </Dropdown>
   )
 }
 

--- a/src/components/AppNavi/README.md
+++ b/src/components/AppNavi/README.md
@@ -14,6 +14,7 @@ const buttons = [
     children: 'current',
     icon: 'fa-file' as const,
     current: true,
+    disabled: true,
   },
   {
     children: 'button',
@@ -60,8 +61,9 @@ const component = () => (
 | Name     | Required | Type                                                             | DefaultValue | Description                   |
 | -------- | -------- | ---------------------------------------------------------------- | ------------ | ----------------------------- |
 | children | ✓        | **React.ReactNode**                                              | -            | Button text.                  |
-| current  | -        | **boolean**                                                      | -            | Whether to give active style. |
 | icon     | -        | **IconProps['name']**                                            | -            | Name of Icon component.       |
+| current  | -        | **boolean**                                                      | -            | Whether to give active style. |
+| disabled | -        | **boolean**                                                      | false        | Disable button.               |
 | onClick  | -        | **(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void** | -            | Button's click handler.       |
 
 IconProps is props of Icon component.
@@ -72,8 +74,9 @@ IconProps is props of Icon component.
 | -------- | -------- | --------------------- | ------------ | ----------------------------- |
 | children | ✓        | **React.ReactNode**   | -            | Anchor text.                  |
 | href     | ✓        | **string**            | -            | Href of anchor.               |
-| current  | -        | **boolean**           | -            | Whether to give active style. |
 | icon     | -        | **IconProps['name']** | -            | Name of Icon component.       |
+| current  | -        | **boolean**           | -            | Whether to give active style. |
+| disabled | -        | **boolean**           | false        | Disable anchor.               |
 
 ### AppNaviDropdownProps
 
@@ -81,16 +84,18 @@ IconProps is props of Icon component.
 | --------------- | -------- | --------------------- | ------------ | ----------------------------- |
 | children        | ✓        | **React.ReactNode**   | -            | Button text.                  |
 | dropdownContent | ✓        | **React.ReactNode**   | -            | Content of DropdownContent.   |
-| current         | -        | **boolean**           | -            | Whether to give active style. |
 | icon            | -        | **IconProps['name']** | -            | Name of Icon component.       |
+| current         | -        | **boolean**           | -            | Whether to give active style. |
+| disabled        | -        | **boolean**           | false        | Disable button.               |
 
 ### AppNaviCustomTagProps
 
-| Name     | Required | Type                   | DefaultValue | Description                   |
-| -------- | -------- | ---------------------- | ------------ | ----------------------------- |
-| children | ✓        | **React.ReactNode**    | -            | Button text.                  |
-| tag      | ✓        | **AnyStyledComponent** | -            | Custom tag component.         |
-| current  | -        | **boolean**            | -            | Whether to give active style. |
-| icon     | -        | **IconProps['name']**  | -            | Name of Icon component.       |
+| Name     | Required | Type                   | DefaultValue | Description                        |
+| -------- | -------- | ---------------------- | ------------ | ---------------------------------- |
+| children | ✓        | **React.ReactNode**    | -            | Button text.                       |
+| tag      | ✓        | **AnyStyledComponent** | -            | Custom tag component.              |
+| icon     | -        | **IconProps['name']**  | -            | Name of Icon component.            |
+| current  | -        | **boolean**            | -            | Whether to give active style.      |
+| disabled | -        | **boolean**            | false        | Pass disabled props to custom tag. |
 
 AnyStyledComponent is type of styled-components.

--- a/src/components/AppNavi/README.md
+++ b/src/components/AppNavi/README.md
@@ -1,0 +1,96 @@
+# AppNavi
+
+```tsx
+import React, { FC, ReactNode } from 'react'
+import { AppNavi } from 'smarthr-ui'
+
+const CustomLink: FC<{ to: string; children: ReactNode }> = ({ to, children, ...props }) => (
+  <a href={to} {...props}>
+    {children}
+  </a>
+)
+const buttons = [
+  {
+    children: 'current',
+    icon: 'fa-file' as const,
+    current: true,
+  },
+  {
+    children: 'button',
+    icon: 'fa-user-alt' as const,
+    onClick: () => console.log('click'),
+  },
+  {
+    children: 'anchor',
+    icon: 'fa-cog' as const,
+    href: 'http://www.google.com',
+  },
+  {
+    children: 'dropdown',
+    icon: 'fa-chart-pie' as const,
+    dropdownContent: <div>dropdown content</div>,
+  },
+  {
+    children: 'custom tag',
+    icon: 'fa-birthday-cake' as const,
+    tag: CustomLink,
+    to: 'http://www.google.com',
+  },
+]
+
+const component = () => (
+  <AppNavi label="label text" buttons={buttons}>
+    <p>child component</p>
+  </AppNavi>
+)
+```
+
+## props
+
+### AppNavi props
+
+| Name     | Required | Type                                                                                                 | DefaultValue | Description                                      |
+| -------- | -------- | ---------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------ |
+| label    | -        | **string**                                                                                           | -            | Label text.                                      |
+| buttons  | -        | **Array<AppNaviButtonProps \| AppNaviAnchorProps \| AppNaviDropdownProps \| AppNaviCustomTagProps>** | -            | Button props array                               |
+| children | -        | **React.ReactNode**                                                                                  | -            | Element to be additionally displayed in AppNavi. |
+
+### AppNaviButtonProps
+
+| Name     | Required | Type                                                             | DefaultValue | Description                   |
+| -------- | -------- | ---------------------------------------------------------------- | ------------ | ----------------------------- |
+| children | ✓        | **React.ReactNode**                                              | -            | Button text.                  |
+| current  | -        | **boolean**                                                      | -            | Whether to give active style. |
+| icon     | -        | **IconProps['name']**                                            | -            | Name of Icon component.       |
+| onClick  | -        | **(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void** | -            | Button's click handler.       |
+
+IconProps is props of Icon component.
+
+### AppNaviAnchorProps
+
+| Name     | Required | Type                  | DefaultValue | Description                   |
+| -------- | -------- | --------------------- | ------------ | ----------------------------- |
+| children | ✓        | **React.ReactNode**   | -            | Anchor text.                  |
+| href     | ✓        | **string**            | -            | Href of anchor.               |
+| current  | -        | **boolean**           | -            | Whether to give active style. |
+| icon     | -        | **IconProps['name']** | -            | Name of Icon component.       |
+
+### AppNaviDropdownProps
+
+| Name            | Required | Type                  | DefaultValue | Description                   |
+| --------------- | -------- | --------------------- | ------------ | ----------------------------- |
+| children        | ✓        | **React.ReactNode**   | -            | Button text.                  |
+| dropdownContent | ✓        | **React.ReactNode**   | -            | Content of DropdownContent.   |
+| current         | -        | **boolean**           | -            | Whether to give active style. |
+| icon            | -        | **IconProps['name']** | -            | Name of Icon component.       |
+
+### AppNaviCustomTagProps
+
+| Name     | Required | Type                   | DefaultValue | Description                   |
+| -------- | -------- | ---------------------- | ------------ | ----------------------------- |
+| children | ✓        | **React.ReactNode**    | -            | Button text.                  |
+| tag      | ✓        | **AnyStyledComponent** | -            | Custom tag component.         |
+| current  | -        | **boolean**            | -            | Whether to give active style. |
+| icon     | -        | **IconProps['name']**  | -            | Name of Icon component.       |
+
+AnyStyledComponent is type of styled-components.

--- a/src/components/AppNavi/appNaviHelper.tsx
+++ b/src/components/AppNavi/appNaviHelper.tsx
@@ -5,15 +5,26 @@ import { Theme } from '../../hooks/useTheme'
 
 import { Icon, Props as IconProps } from '../Icon'
 
-export const getIconComponent = (theme: Theme, icon?: IconProps['name'], current?: boolean) => {
-  if (!icon) return null
+export const getIconComponent = (
+  theme: Theme,
+  options?: { icon?: IconProps['name']; current?: boolean; disabled?: boolean },
+) => {
+  const opts = {
+    icon: null,
+    current: false,
+    disabled: false,
+    ...options,
+  }
+  const { TEXT_BLACK, TEXT_DISABLED, TEXT_GREY } = theme.palette
+
+  if (!opts.icon) return null
 
   return (
     <IconWrapper themes={theme}>
       <Icon
-        name={icon}
+        name={opts.icon}
         size={14}
-        color={current ? theme.palette.TEXT_BLACK : theme.palette.TEXT_GREY}
+        color={opts.current ? TEXT_BLACK : opts.disabled ? TEXT_DISABLED : TEXT_GREY}
       />
     </IconWrapper>
   )
@@ -33,6 +44,7 @@ const IconWrapper = styled.figure<{ themes: Theme }>`
 const BaseStyle = css<{ themes: Theme }>`
   ${({ themes }) => {
     const { pxToRem, font } = themes.size
+    const { hoverColor } = themes.palette
 
     return css`
       display: flex;
@@ -45,10 +57,20 @@ const BaseStyle = css<{ themes: Theme }>`
       font-size: ${pxToRem(font.TALL)};
       font-weight: bold;
       text-decoration: none;
+      transition: background-color 0.3s;
+
+      &:not(.disabled) {
+        cursor: pointer;
+
+        &:hover {
+          background-color: ${hoverColor('#fff')};
+        }
+      }
     `
   }}
 `
-export const Active = styled.span<{ themes: Theme }>`
+
+const ActiveStyle = css<{ themes: Theme }>`
   ${({ themes }) => {
     const { size, palette } = themes
 
@@ -70,19 +92,18 @@ export const Active = styled.span<{ themes: Theme }>`
     `
   }}
 `
-export const InActiveStyle = css<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { TEXT_GREY, hoverColor } = themes.palette
+const InActiveStyle = css<{ themes: Theme }>`
+  ${({ themes }) => css`
+    ${BaseStyle}
+    color: ${themes.palette.TEXT_GREY};
 
-    return css`
-      ${BaseStyle}
-      color: ${TEXT_GREY};
-      cursor: pointer;
-      transition: background-color 0.3s;
-
-      &:hover{
-        background-color: ${hoverColor('#fff')};
-      }
-    `
-  }}
+    &.disabled {
+      color: ${themes.palette.TEXT_DISABLED};
+    }
+`}
 `
+
+export const buttonStyle = {
+  active: ActiveStyle,
+  inactive: InActiveStyle,
+}

--- a/src/components/AppNavi/appNaviHelper.tsx
+++ b/src/components/AppNavi/appNaviHelper.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme } from '../../hooks/useTheme'
+
+import { Icon, Props as IconProps } from '../Icon'
+
+export const getIconComponent = (theme: Theme, icon?: IconProps['name'], current?: boolean) => {
+  if (!icon) return null
+
+  return (
+    <IconWrapper themes={theme}>
+      <Icon
+        name={icon}
+        size={14}
+        color={current ? theme.palette.TEXT_BLACK : theme.palette.TEXT_GREY}
+      />
+    </IconWrapper>
+  )
+}
+
+const IconWrapper = styled.figure<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { pxToRem, space } = themes.size
+
+    return css`
+      display: flex;
+      padding: 0;
+      margin: 0 ${pxToRem(space.XXS)} 0 0;
+    `
+  }}
+`
+const BaseStyle = css<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { pxToRem, font } = themes.size
+
+    return css`
+      display: flex;
+      align-items: center;
+      box-sizing: border-box;
+      height: 40px;
+      padding: 0 0.4rem;
+      background: none;
+      border: none;
+      font-size: ${pxToRem(font.TALL)};
+      font-weight: bold;
+      text-decoration: none;
+    `
+  }}
+`
+export const Active = styled.span<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { size, palette } = themes
+
+    return css`
+      ${BaseStyle}
+      color: ${palette.TEXT_BLACK};
+      position: relative;
+
+      &::after {
+        content: '';
+        display: block;
+        height: ${size.pxToRem(3)};
+        background-color: ${palette.MAIN};
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
+    `
+  }}
+`
+export const InActiveStyle = css<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { TEXT_GREY, hoverColor } = themes.palette
+
+    return css`
+      ${BaseStyle}
+      color: ${TEXT_GREY};
+      cursor: pointer;
+      transition: background-color 0.3s;
+
+      &:hover{
+        background-color: ${hoverColor('#fff')};
+      }
+    `
+  }}
+`

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -616,6 +616,7 @@ export const iconMap = {
   'fa-wrench': FaWrench,
   'fa-yen-sign': FaYenSign,
 }
+
 export const Icon: React.FC<Props> = ({ name, className = '', ...props }) => {
   const SvgIcon = iconMap[name]
   return <SvgIcon className={className} {...props} />

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,1 +1,1 @@
-export { Icon, iconMap } from './Icon'
+export { Icon, iconMap, Props } from './Icon'


### PR DESCRIPTION
Enabled to display the following elements in addition to buttons in AppNavi.

- anchor tag
- Dropdown Component
- Custom Component

![image](https://user-images.githubusercontent.com/11153463/84119003-be0f0000-aa6e-11ea-8963-891ec1033294.png)

![image](https://user-images.githubusercontent.com/11153463/84118830-7d16eb80-aa6e-11ea-837f-8c7f7d05d2e6.png)


## Conditions

- If there is `href`, it becomes an anchor
- If there is `dropdownContent`, it becomes dropdown
- If there is `tag`, it becomes custom tag
- In the case of conditions other than the above three, it becomes button

### BREAKING CHANGE

Added `disabled` props for button props array.
With this change, it is no longer disabled by default when passing true for `current` props.
