### PR TITLE
fix: fix props type for AppNavi

### DIFF
--- a/src/components/AppNavi/AppNaviCustomTag.tsx
+++ b/src/components/AppNavi/AppNaviCustomTag.tsx
@@ -1,5 +1,5 @@
-import React, { FC, ReactNode } from 'react'
-import styled, { AnyStyledComponent } from 'styled-components'
+import React, { ComponentType, FC, ReactNode } from 'react'
+import styled from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
@@ -8,11 +8,11 @@ import { buttonStyle, getIconComponent } from './appNaviHelper'
 
 export type AppNaviCustomTagProps = {
   children: ReactNode
-  tag: AnyStyledComponent
+  tag: ComponentType<any>
   icon?: IconProps['name']
   current?: boolean
   disabled?: boolean
-} & {}
+} & { [key: string]: any }
 
 export const AppNaviCustomTag: FC<AppNaviCustomTagProps> = ({
   children,

--- a/src/components/AppNavi/README.md
+++ b/src/components/AppNavi/README.md
@@ -90,12 +90,12 @@ IconProps is props of Icon component.
 
 ### AppNaviCustomTagProps
 
-| Name     | Required | Type                   | DefaultValue | Description                        |
-| -------- | -------- | ---------------------- | ------------ | ---------------------------------- |
-| children | ✓        | **React.ReactNode**    | -            | Button text.                       |
-| tag      | ✓        | **AnyStyledComponent** | -            | Custom tag component.              |
-| icon     | -        | **IconProps['name']**  | -            | Name of Icon component.            |
-| current  | -        | **boolean**            | -            | Whether to give active style.      |
-| disabled | -        | **boolean**            | false        | Pass disabled props to custom tag. |
+| Name     | Required | Type                         | DefaultValue | Description                        |
+| -------- | -------- | ---------------------------- | ------------ | ---------------------------------- |
+| children | ✓        | **React.ReactNode**          | -            | Button text.                       |
+| tag      | ✓        | **React.ComponentType<any>** | -            | Custom tag component.              |
+| icon     | -        | **IconProps['name']**        | -            | Name of Icon component.            |
+| current  | -        | **boolean**                  | -            | Whether to give active style.      |
+| disabled | -        | **boolean**                  | false        | Pass disabled props to custom tag. |
 
-AnyStyledComponent is type of styled-components.
+and additional key value, `{ key: [string]: any }`.


### PR DESCRIPTION
Modified type to accommodate custom components like `react-router-dom`'s `Link`.

- AnyStyledComponent -> ComponentType<any>
- {} -> { [key: string]: any }