### PR TITLE
fix: pass other props to AppNaviCustomTag

### DIFF
--- a/src/components/AppNavi/AppNaviCustomTag.tsx
+++ b/src/components/AppNavi/AppNaviCustomTag.tsx
@@ -35,7 +35,7 @@ export const AppNaviCustomTag: FC<AppNaviCustomTagProps> = ({
 
   if (current) {
     return (
-      <Active themes={theme} aria-selected="true" {...additionalProps}>
+      <Active themes={theme} aria-selected="true" {...props} {...additionalProps}>
         {iconComponent}
         {children}
       </Active>


### PR DESCRIPTION
When using custom tag, props additionally passed when `current: true` is reflected.