### PR TITLE
fix: change cache key for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          - dependencies-test-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           # fallback to using the latest cache if no exact match is found
           - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          key: dependencies-test-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       # run tests!
       - run: yarn audit --groups dependencies
       - run: yarn lint
@@ -33,13 +33,13 @@ commands:
           fi
       - restore_cache:
           keys:
-            - dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            - dependencies-reg-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
             - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
-          key: dependencies-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+          key: dependencies-reg-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run: yarn test-visual
 jobs:
   node-v10:


### PR DESCRIPTION
異なるdocker間で同一のcache keyを共有すると、あるdocker上で作られたcacheの場所によっては他のdockerからアクセスできないことがあるので、testとreg-suitで異なるcache keyになるように修正しました。

参考：https://support.circleci.com/hc/ja/articles/360004250693-%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5%E3%81%AE%E5%BE%A9%E5%85%83%E3%81%8C-Permission-Denied-%E3%81%A7%E5%A4%B1%E6%95%97%E3%81%99%E3%82%8B