### PR TITLE
fix: change not to use rowSpan=0

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -110,7 +110,7 @@ storiesOf('Table', module)
               <Cell>cell</Cell>
             </Row>
             <Row>
-              <Cell rowSpan={0}>rowSpan=0</Cell>
+              <Cell rowSpan={2}>rowSpan=2</Cell>
               <Cell>cell</Cell>
               <Cell>cell</Cell>
               <Cell>cell</Cell>


### PR DESCRIPTION
In IE11 and Edge, `rowSpan=0` is not working correctly. So I change it not to use `rowSpan=0`.

* before
![スクリーンショット 2020-06-29 11 48 07](https://user-images.githubusercontent.com/270422/85976057-9fb87680-ba14-11ea-989c-0ff14dd7dac1.png)
* after
![スクリーンショット 2020-06-29 11 48 49](https://user-images.githubusercontent.com/270422/85976063-a3e49400-ba14-11ea-8618-eb368684c4ba.png)
