### PR TITLE
fix: change not to pass className to Background in Dialog

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -57,7 +57,7 @@ export const DialogContentInner: FC<Props> = ({
         unmountOnExit
       >
         <Wrapper ref={domRef}>
-          <Background onClick={onClickOverlay} themes={theme} {...props} />
+          <Background onClick={onClickOverlay} themes={theme} />
           <Inner themes={theme} {...props}>
             {children}
           </Inner>


### PR DESCRIPTION
When we extend `Dialog` by `styled-components`, there is a problem to display background like this.

```ts
const extendedDialog = styled(Dialog)`
  width: 200px;
`
```

![スクリーンショット 2020-06-30 14 54 02](https://user-images.githubusercontent.com/270422/86089134-9990cb80-bae2-11ea-9930-230b180c538a.png)

This problem is caused by passing `className`  to `Background`. So I exclude it.