### PR TITLE
fix: calendar date in storybook

### DIFF
--- a/src/components/Calendar/Calendar.stories.tsx
+++ b/src/components/Calendar/Calendar.stories.tsx
@@ -14,7 +14,7 @@ storiesOf('Calendar', module)
     },
   })
   .add('All', () => {
-    const [value, setValue] = useState(new Date())
+    const [value, setValue] = useState(new Date(2020, 0, 1))
     const [value2, setValue2] = useState(new Date(2020, 0, 20))
     return (
       <List>


### PR DESCRIPTION
`Calender`のstorybookが実行日によって描画内容が変動してreg-suitに引っかかってしまうため、初期`value`値を過去の日付にすることで表示上の差分が出ないように変更。