### PR TITLE
chore: fix Calendar story

### DIFF
--- a/src/components/Calendar/Calendar.stories.tsx
+++ b/src/components/Calendar/Calendar.stories.tsx
@@ -14,8 +14,9 @@ storiesOf('Calendar', module)
     },
   })
   .add('All', () => {
-    const [value, setValue] = useState(new Date())
+    const [value, setValue] = useState(new Date(2020, 6, 5))
     const [value2, setValue2] = useState(new Date(2020, 0, 20))
+
     return (
       <List>
         <dt>Default</dt>


### PR DESCRIPTION
If you pass today's date to `value` props of `Calendar Component` in Storybook, Visual regression testing will make a difference every day, so pass a specific date instead of today's date.