### PR TITLE
feat: add maxlength attribute and text counter to textarea

### DIFF
--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -22,6 +22,10 @@ storiesOf('Textarea', module).add('all', () => (
       <Txt>error</Txt>
       <Textarea error={true} />
     </li>
+    <li>
+      <Txt>maxLength</Txt>
+      <Textarea maxLength={140} />
+    </li>
   </List>
 ))
 

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -24,7 +24,7 @@ storiesOf('Textarea', module).add('all', () => (
     </li>
     <li>
       <Txt>maxLength</Txt>
-      <Textarea maxLength={140} />
+      <Textarea maxLength={140} defaultValue="message" />
     </li>
   </List>
 ))

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -1,33 +1,42 @@
 import { storiesOf } from '@storybook/react'
-import * as React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { Textarea } from './Textarea'
 
-storiesOf('Textarea', module).add('all', () => (
-  <List>
-    <li>
-      <Txt>normal</Txt>
-      <Textarea />
-    </li>
-    <li>
-      <Txt>width</Txt>
-      <Textarea width="100%" />
-    </li>
-    <li>
-      <Txt>disabled</Txt>
-      <Textarea disabled={true} />
-    </li>
-    <li>
-      <Txt>error</Txt>
-      <Textarea error={true} />
-    </li>
-    <li>
-      <Txt>maxLength</Txt>
-      <Textarea maxLength={140} defaultValue="message👌" />
-    </li>
-  </List>
-))
+storiesOf('Textarea', module).add('all', () => {
+  const [value, setValue] = useState('message👌')
+  const onChangeValue = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+    setValue(e.currentTarget.value)
+  return (
+    <List>
+      <li>
+        <Txt>normal</Txt>
+        <Textarea />
+      </li>
+      <li>
+        <Txt>width</Txt>
+        <Textarea width="100%" />
+      </li>
+      <li>
+        <Txt>disabled</Txt>
+        <Textarea disabled={true} />
+      </li>
+      <li>
+        <Txt>error</Txt>
+        <Textarea error={true} />
+      </li>
+      <li>
+        <Txt>maxLength (defaultValue)</Txt>
+        <Textarea maxLength={140} defaultValue="message👌" />
+      </li>
+      <li>
+        <Txt>maxLength (value)</Txt>
+        <Textarea maxLength={140} value={value} onChange={onChangeValue} />
+      </li>
+    </List>
+  )
+})
 
 const List = styled.ul`
   padding: 0 24px;

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -24,7 +24,7 @@ storiesOf('Textarea', module).add('all', () => (
     </li>
     <li>
       <Txt>maxLength</Txt>
-      <Textarea maxLength={140} defaultValue="message" />
+      <Textarea maxLength={140} defaultValue="message👌" />
     </li>
   </List>
 ))

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -9,8 +9,11 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   autoFocus?: boolean
 }
 
+// https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
+const surrogatePairs = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
+
 const stringLength = (value: string) => {
-  return value.length - (value.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || []).length
+  return value.length - (value.match(surrogatePairs) || []).length
 }
 
 export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -19,9 +19,8 @@ const stringLength = (value: string) => {
 export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLTextAreaElement>(null)
-  const [count, setCount] = useState(
-    props.defaultValue ? stringLength(props.defaultValue as string) : 0,
-  )
+  const currentValue = (props.defaultValue || props.value) as string
+  const [count, setCount] = useState(currentValue ? stringLength(currentValue) : 0)
 
   useEffect(() => {
     if (autoFocus && ref && ref.current) {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -12,7 +12,7 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLTextAreaElement>(null)
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(props.defaultValue ? (props.defaultValue as string).length : 0)
 
   useEffect(() => {
     if (autoFocus && ref && ref.current) {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -9,16 +9,23 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   autoFocus?: boolean
 }
 
-const getStringLength = (value: string) => {
+const getStringLength = (value: string | number | readonly string[]) => {
+  const formattedValue =
+    typeof value === 'number' || typeof value === 'string'
+      ? `${value}`
+      : Array.isArray(value)
+      ? value.join(',')
+      : ''
+
   // https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
   const surrogatePairs = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
-  return value.length - (value.match(surrogatePairs) || []).length
+  return formattedValue.length - (formattedValue.match(surrogatePairs) || []).length
 }
 
 export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLTextAreaElement>(null)
-  const currentValue = (props.defaultValue || props.value) as string
+  const currentValue = props.defaultValue || props.value
   const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
 
   useEffect(() => {

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -9,10 +9,9 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   autoFocus?: boolean
 }
 
-// https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
-const surrogatePairs = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
-
-const stringLength = (value: string) => {
+const getStringLength = (value: string) => {
+  // https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
+  const surrogatePairs = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
   return value.length - (value.match(surrogatePairs) || []).length
 }
 
@@ -20,7 +19,7 @@ export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLTextAreaElement>(null)
   const currentValue = (props.defaultValue || props.value) as string
-  const [count, setCount] = useState(currentValue ? stringLength(currentValue) : 0)
+  const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
 
   useEffect(() => {
     if (autoFocus && ref && ref.current) {
@@ -29,7 +28,7 @@ export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   }, [autoFocus])
 
   const handleKeyup = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    setCount(stringLength(event.currentTarget.value))
+    setCount(getStringLength(event.currentTarget.value))
   }
 
   return (

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -9,10 +9,16 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   autoFocus?: boolean
 }
 
+const stringLength = (value: string) => {
+  return value.length - (value.match(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g) || []).length
+}
+
 export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLTextAreaElement>(null)
-  const [count, setCount] = useState(props.defaultValue ? (props.defaultValue as string).length : 0)
+  const [count, setCount] = useState(
+    props.defaultValue ? stringLength(props.defaultValue as string) : 0,
+  )
 
   useEffect(() => {
     if (autoFocus && ref && ref.current) {
@@ -21,8 +27,7 @@ export const Textarea: FC<Props> = ({ autoFocus, maxLength, ...props }) => {
   }, [autoFocus])
 
   const handleKeyup = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const value = event.currentTarget.value
-    setCount(value.length - (value.split(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g).length - 1))
+    setCount(stringLength(event.currentTarget.value))
   }
 
   return (


### PR DESCRIPTION
## Changes
An update to the TextArea component. 

* add 'maxlength' attribute
* show character counter if the maxlength attribute is enabled

## State Description
|  default  |  character overload  |
| ---- | ---- |
| ![スクリーンショット 2020-07-08 17 53 08](https://user-images.githubusercontent.com/4032232/86898821-23c0db80-c144-11ea-81f3-00ba6a2a843f.png) | ![スクリーンショット 2020-07-08 17 53 24](https://user-images.githubusercontent.com/4032232/86898851-2b808000-c144-11ea-95bf-ecc660bc37f4.png)|
