### PR TITLE
BREAKING CHANGE: segment and modify currency input

### DIFF
--- a/src/components/Input/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput.tsx
@@ -1,0 +1,44 @@
+import React, { ChangeEvent, FC, FocusEvent, useState } from 'react'
+
+import { Input, Props as InputProps } from './Input'
+
+type Props = Omit<InputProps, 'type' | 'defaultValue'> & {
+  value?: string
+}
+
+export const CurrencyInput: FC<Props> = ({ onChange, onFocus, onBlur, ...props }) => {
+  const [value, setValue] = useState(props.value || '')
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value)
+    onChange && onChange(e)
+  }
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+    const commaExcluded = value.replace(/,/g, '')
+    setValue(commaExcluded)
+    onFocus && onFocus(e)
+  }
+
+  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+    const shaped = value
+      .replace(/[０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0)) // convert number and dot to half-width
+      .replace(/[−ー]/, '-') // replace full-width minus
+      .replace(/[^0-9.-]|(?!^)-|^\.+|\.+$/g, '') // exclude non-numeric characters
+    const splited = shaped.split('.')
+    const integerPart = splited[0].replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') // add comma to integer every 3 digits
+    const formattedArray = Object.assign(splited, [integerPart])
+    setValue(formattedArray.join('.'))
+    onBlur && onBlur(e)
+  }
+
+  return (
+    <Input
+      type="text"
+      value={value}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    />
+  )
+}

--- a/src/components/Input/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput.tsx
@@ -74,7 +74,6 @@ function convertToCurrency(value?: string) {
   const shaped = value
     .replace(/[０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0)) // convert number and dot to half-width
     .replace(/[−ー]/, '-') // replace full-width minus
-    // .replace(/[^0-9.-]|(?!^)-|^\.+|\.+$/g, '') // exclude non-numeric characters
     .replace(/[^0-9.-]/g, '') // exclude non-numeric characters
   const splited = shaped.split('.')
   const integerPart = splited[0].replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') // add comma to integer every 3 digits

--- a/src/components/Input/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput.tsx
@@ -1,44 +1,83 @@
-import React, { ChangeEvent, FC, FocusEvent, useState } from 'react'
+import React, { ChangeEvent, FC, FocusEvent, useCallback, useEffect, useState } from 'react'
 
 import { Input, Props as InputProps } from './Input'
 
-type Props = Omit<InputProps, 'type' | 'defaultValue'> & {
+type Props = Omit<InputProps, 'type' | 'value' | 'defaultValue'> & {
   value?: string
+  onChangeValue?: (value: string) => void
 }
 
-export const CurrencyInput: FC<Props> = ({ onChange, onFocus, onBlur, ...props }) => {
-  const [value, setValue] = useState(props.value || '')
+export const CurrencyInput: FC<Props> = ({
+  value,
+  onChangeValue,
+  onChange,
+  onFocus,
+  onBlur,
+  ...props
+}) => {
+  const [controlledValue, setControlledValue] = useState(value || '')
+  const [isFocused, setIsFocused] = useState(false)
+
+  const changeValue = useCallback(
+    (changed = '') => {
+      if (changed === controlledValue) {
+        return
+      }
+      setControlledValue(changed)
+      onChangeValue && onChangeValue(changed)
+    },
+    [controlledValue, onChangeValue],
+  )
+
+  useEffect(() => {
+    if (isFocused) {
+      setControlledValue(value || '')
+    } else {
+      changeValue(convertToCurrency(value))
+    }
+  }, [isFocused, value, controlledValue, changeValue])
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value)
+    changeValue(e.target.value)
     onChange && onChange(e)
   }
 
   const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
-    const commaExcluded = value.replace(/,/g, '')
-    setValue(commaExcluded)
+    setIsFocused(true)
+    const commaExcluded = controlledValue.replace(/,/g, '')
+    changeValue(commaExcluded)
     onFocus && onFocus(e)
   }
 
   const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
-    const shaped = value
-      .replace(/[０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0)) // convert number and dot to half-width
-      .replace(/[−ー]/, '-') // replace full-width minus
-      .replace(/[^0-9.-]|(?!^)-|^\.+|\.+$/g, '') // exclude non-numeric characters
-    const splited = shaped.split('.')
-    const integerPart = splited[0].replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') // add comma to integer every 3 digits
-    const formattedArray = Object.assign(splited, [integerPart])
-    setValue(formattedArray.join('.'))
+    setIsFocused(false)
+    changeValue(convertToCurrency(controlledValue))
     onBlur && onBlur(e)
   }
 
   return (
     <Input
       type="text"
-      value={value}
+      value={controlledValue}
       onChange={handleChange}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      {...props}
     />
   )
+}
+
+function convertToCurrency(value?: string) {
+  if (!value) {
+    return ''
+  }
+  const shaped = value
+    .replace(/[０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0)) // convert number and dot to half-width
+    .replace(/[−ー]/, '-') // replace full-width minus
+    // .replace(/[^0-9.-]|(?!^)-|^\.+|\.+$/g, '') // exclude non-numeric characters
+    .replace(/[^0-9.-]/g, '') // exclude non-numeric characters
+  const splited = shaped.split('.')
+  const integerPart = splited[0].replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') // add comma to integer every 3 digits
+  const formattedArray = Object.assign(splited, [integerPart])
+  return formattedArray.join('.')
 }

--- a/src/components/Input/CurrencyInput/CurrencyInput.stories.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.stories.tsx
@@ -4,22 +4,29 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import { CurrencyInput } from './CurrencyInput'
+import readme from './README.md'
 
-storiesOf('Input/currency', module).add('all', () => {
-  const [value, setValue] = React.useState('1234567890')
-  return (
-    <Wrapper>
-      <Txt>currency (add comma to integer every 3 digits)</Txt>
-      <CurrencyInput
-        value={value}
-        onChangeValue={(changed) => {
-          action('changed value')(changed)
-          setValue(changed)
-        }}
-      />
-    </Wrapper>
-  )
-})
+storiesOf('Input/currency', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
+  .add('all', () => {
+    const [value, setValue] = React.useState('1234567890')
+    return (
+      <Wrapper>
+        <Txt>currency (add comma to integer every 3 digits)</Txt>
+        <CurrencyInput
+          value={value}
+          onChangeValue={(changed) => {
+            action('changed value')(changed)
+            setValue(changed)
+          }}
+        />
+      </Wrapper>
+    )
+  })
 
 const Txt = styled.p`
   margin: 0 0 8px 0;

--- a/src/components/Input/CurrencyInput/CurrencyInput.stories.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.stories.tsx
@@ -1,0 +1,29 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { CurrencyInput } from './CurrencyInput'
+
+storiesOf('Input/currency', module).add('all', () => {
+  const [value, setValue] = React.useState('1234567890')
+  return (
+    <Wrapper>
+      <Txt>currency (add comma to integer every 3 digits)</Txt>
+      <CurrencyInput
+        value={value}
+        onChangeValue={(changed) => {
+          action('changed value')(changed)
+          setValue(changed)
+        }}
+      />
+    </Wrapper>
+  )
+})
+
+const Txt = styled.p`
+  margin: 0 0 8px 0;
+`
+const Wrapper = styled.div`
+  padding: 24px;
+`

--- a/src/components/Input/CurrencyInput/CurrencyInput.stories.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.stories.tsx
@@ -19,9 +19,13 @@ storiesOf('Input/currency', module)
         <Txt>currency (add comma to integer every 3 digits)</Txt>
         <CurrencyInput
           value={value}
-          onChangeValue={(changed) => {
-            action('changed value')(changed)
-            setValue(changed)
+          onChange={(e) => {
+            action('changed')(e)
+            setValue(e.target.value)
+          }}
+          onFormatValue={(formatted) => {
+            action('formatted')(formatted)
+            setValue(formatted)
           }}
         />
       </Wrapper>

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -1,4 +1,12 @@
-import React, { FocusEvent, forwardRef, useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  FocusEvent,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 
 import { Input, Props as InputProps } from '../Input'
 
@@ -11,17 +19,12 @@ type Props = Omit<InputProps, 'type' | 'value' | 'defaultValue'> & {
 export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
   ({ onFormatValue, onFocus, onBlur, ...props }, ref) => {
     const innerRef = useRef<HTMLInputElement>(null)
-    useEffect(() => {
-      // combine ref
-      if (!ref) return
-
-      if (typeof ref === 'function') {
-        ref(innerRef.current)
-      } else {
-        ref.current = innerRef.current
-      }
-    }, [ref])
     const [isFocused, setIsFocused] = useState(false)
+
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => innerRef.current,
+    )
 
     const formatValue = useCallback(
       (formatted = '') => {

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -33,7 +33,7 @@ export const CurrencyInput: FC<Props> = ({
     if (isFocused) {
       setControlledValue(value || '')
     } else {
-      changeValue(convertToCurrency(value))
+      changeValue(formatCurrency(value))
     }
   }, [isFocused, value, controlledValue, changeValue])
 
@@ -51,7 +51,7 @@ export const CurrencyInput: FC<Props> = ({
 
   const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
     setIsFocused(false)
-    changeValue(convertToCurrency(controlledValue))
+    changeValue(formatCurrency(controlledValue))
     onBlur && onBlur(e)
   }
 
@@ -67,7 +67,7 @@ export const CurrencyInput: FC<Props> = ({
   )
 }
 
-function convertToCurrency(value?: string) {
+function formatCurrency(value?: string) {
   if (!value) {
     return ''
   }

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -44,7 +44,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
       if (!isFocused && props.value !== undefined) {
         formatValue(formatCurrency(props.value))
       }
-    }, [isFocused, props.value, formatValue])
+    }, [isFocused, formatValue])
 
     const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
       setIsFocused(true)

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -35,6 +35,12 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
     )
 
     useEffect(() => {
+      if (props.value === undefined && props.defaultValue !== undefined) {
+        formatValue(formatCurrency(props.defaultValue))
+      }
+    }, [])
+
+    useEffect(() => {
       if (!isFocused && props.value !== undefined) {
         formatValue(formatCurrency(props.value))
       }

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -41,10 +41,16 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
     }, [])
 
     useEffect(() => {
-      if (!isFocused && props.value !== undefined) {
-        formatValue(formatCurrency(props.value))
+      if (!isFocused) {
+        if (props.value !== undefined) {
+          // for controlled component
+          formatValue(formatCurrency(props.value))
+        } else if (innerRef.current) {
+          // for uncontrolled component
+          formatValue(formatCurrency(innerRef.current.value))
+        }
       }
-    }, [isFocused, formatValue])
+    }, [isFocused])
 
     const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
       setIsFocused(true)
@@ -57,9 +63,6 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
 
     const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
       setIsFocused(false)
-      if (innerRef.current) {
-        formatValue(formatCurrency(innerRef.current.value))
-      }
       onBlur && onBlur(e)
     }
 

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, FC, FocusEvent, useCallback, useEffect, useState } from 'react'
 
-import { Input, Props as InputProps } from './Input'
+import { Input, Props as InputProps } from '../Input'
 
 type Props = Omit<InputProps, 'type' | 'value' | 'defaultValue'> & {
   value?: string

--- a/src/components/Input/CurrencyInput/README.md
+++ b/src/components/Input/CurrencyInput/README.md
@@ -9,8 +9,11 @@ function MyApp() {
   return (
     <CurrencyInput
       value={value}
-      onChangeValue={(changed) => {
-        setValue(changed)
+      onChange={(e) => {
+        setValue(e.target.value)
+      }}
+      onFormatValue={(formatted) => {
+        setValue(formatted)
       }}
     />
   )
@@ -21,9 +24,10 @@ function MyApp() {
 
 **CurrencyInput**
 
-This component has props of `Input` component excluding `type` and `defaultValue`.
+This component has props of `Input` component excluding `type` prop.
 
-| Name          | Required | Type                        | DefaultValue | Description                                                    |
-| ------------- | -------- | --------------------------- | ------------ | -------------------------------------------------------------- |
-| value         | -        | **string**                  | -            | Value of input, but it allows only string type.                |
-| onChangeValue | -        | **(value: string) => void** | -            | Handler Function when value changed, or formatted to currency. |
+| Name          | Required | Type                        | DefaultValue | Description                                              |
+| ------------- | -------- | --------------------------- | ------------ | -------------------------------------------------------- |
+| value         | -        | **string**                  | -            | Value of input that is allowed only string type.         |
+| defaultValue  | -        | **string**                  | -            | Default value of input that is allowed only string type. |
+| onFormatValue | -        | **(value: string) => void** | -            | Handler Function when value formatted.                   |

--- a/src/components/Input/CurrencyInput/README.md
+++ b/src/components/Input/CurrencyInput/README.md
@@ -1,0 +1,29 @@
+# CurrencyInput
+
+```tsx
+import { CurrencyInput } from 'smarthr-ui'
+
+function MyApp() {
+  const [value, setValue] = React.useState('2000')
+
+  return (
+    <CurrencyInput
+      value={value}
+      onChangeValue={(changed) => {
+        setValue(changed)
+      }}
+    />
+  )
+}
+```
+
+## props
+
+**CurrencyInput**
+
+This component has props of `Input` component excluding `type` and `defaultValue`.
+
+| Name          | Required | Type                        | DefaultValue | Description                                                    |
+| ------------- | -------- | --------------------------- | ------------ | -------------------------------------------------------------- |
+| value         | -        | **string**                  | -            | Value of input, but it allows only string type.                |
+| onChangeValue | -        | **(value: string) => void** | -            | Handler Function when value changed, or formatted to currency. |

--- a/src/components/Input/CurrencyInput/index.ts
+++ b/src/components/Input/CurrencyInput/index.ts
@@ -1,0 +1,1 @@
+export { CurrencyInput } from './CurrencyInput'

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import { Input } from './Input'
+import { CurrencyInput } from './CurrencyInput'
 
 import { Icon } from '../Icon'
 
@@ -19,7 +20,7 @@ storiesOf('Input', module).add('all', () => (
     </li>
     <li>
       <Txt>number (thousands separated)</Txt>
-      <Input type="number" thousandsSeparated defaultValue="1,000.1234" />
+      <CurrencyInput />
     </li>
     <li>
       <Txt>password</Txt>

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -8,58 +8,71 @@ import { CurrencyInput } from './CurrencyInput'
 
 import { Icon } from '../Icon'
 
-storiesOf('Input', module).add('all', () => (
-  <List>
-    <li>
-      <Txt>text</Txt>
-      <Input type="text" defaultValue="string" />
-    </li>
-    <li>
-      <Txt>number</Txt>
-      <Input type="number" defaultValue="1" />
-    </li>
-    <li>
-      <Txt>number (thousands separated)</Txt>
-      <CurrencyInput />
-    </li>
-    <li>
-      <Txt>password</Txt>
-      <Input type="password" defaultValue="password" />
-    </li>
-    <li>
-      <Txt>placeholder</Txt>
-      <Input placeholder="string" />
-    </li>
-    <li>
-      <Txt>width</Txt>
-      <Input defaultValue="width: 100%" width="100%" />
-    </li>
-    <li>
-      <Txt>onChange</Txt>
-      <Input onChange={action('onChange!!')} />
-    </li>
-    <li>
-      <Txt>onBlur</Txt>
-      <Input onBlur={action('onBlur!!')} />
-    </li>
-    <li>
-      <Txt>disabled</Txt>
-      <Input disabled={true} />
-    </li>
-    <li>
-      <Txt>error</Txt>
-      <Input error={true} />
-    </li>
-    <li>
-      <Txt>prefix</Txt>
-      <Input prefix={<Icon name="fa-search" color="#d6d6d6" />} />
-    </li>
-    <li>
-      <Txt>suffix</Txt>
-      <Input suffix={<Icon name="fa-search" color="#d6d6d6" />} />
-    </li>
-  </List>
-))
+storiesOf('Input', module)
+  .add('all', () => (
+    <List>
+      <li>
+        <Txt>text</Txt>
+        <Input type="text" defaultValue="string" />
+      </li>
+      <li>
+        <Txt>number</Txt>
+        <Input type="number" defaultValue="1" />
+      </li>
+      <li>
+        <Txt>password</Txt>
+        <Input type="password" defaultValue="password" />{' '}
+      </li>{' '}
+      <li>
+        {' '}
+        <Txt>placeholder</Txt>
+        <Input placeholder="string" />
+      </li>
+      <li>
+        <Txt>width</Txt>
+        <Input defaultValue="width: 100%" width="100%" />
+      </li>
+      <li>
+        <Txt>onChange</Txt>
+        <Input onChange={action('onChange!!')} />
+      </li>
+      <li>
+        <Txt>onBlur</Txt>
+        <Input onBlur={action('onBlur!!')} />
+      </li>
+      <li>
+        <Txt>disabled</Txt>
+        <Input disabled={true} />
+      </li>
+      <li>
+        <Txt>error</Txt>
+        <Input error={true} />
+      </li>
+      <li>
+        <Txt>prefix</Txt>
+        <Input prefix={<Icon name="fa-search" color="#d6d6d6" />} />
+      </li>
+      <li>
+        <Txt>suffix</Txt>
+        <Input suffix={<Icon name="fa-search" color="#d6d6d6" />} />
+      </li>
+    </List>
+  ))
+  .add('currency', () => {
+    const [value, setValue] = React.useState('1234567890')
+    return (
+      <Wrapper>
+        <Txt>currency (add comma to integer every 3 digits)</Txt>
+        <CurrencyInput
+          value={value}
+          onChangeValue={(changed) => {
+            action('changed value')(changed)
+            setValue(changed)
+          }}
+        />
+      </Wrapper>
+    )
+  })
 
 const List = styled.ul`
   padding: 0 24px;
@@ -71,4 +84,7 @@ const List = styled.ul`
 `
 const Txt = styled.p`
   margin: 0 0 8px 0;
+`
+const Wrapper = styled.div`
+  padding: 24px;
 `

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -4,75 +4,58 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import { Input } from './Input'
-import { CurrencyInput } from './CurrencyInput'
 
 import { Icon } from '../Icon'
 
-storiesOf('Input', module)
-  .add('all', () => (
-    <List>
-      <li>
-        <Txt>text</Txt>
-        <Input type="text" defaultValue="string" />
-      </li>
-      <li>
-        <Txt>number</Txt>
-        <Input type="number" defaultValue="1" />
-      </li>
-      <li>
-        <Txt>password</Txt>
-        <Input type="password" defaultValue="password" />{' '}
-      </li>{' '}
-      <li>
-        {' '}
-        <Txt>placeholder</Txt>
-        <Input placeholder="string" />
-      </li>
-      <li>
-        <Txt>width</Txt>
-        <Input defaultValue="width: 100%" width="100%" />
-      </li>
-      <li>
-        <Txt>onChange</Txt>
-        <Input onChange={action('onChange!!')} />
-      </li>
-      <li>
-        <Txt>onBlur</Txt>
-        <Input onBlur={action('onBlur!!')} />
-      </li>
-      <li>
-        <Txt>disabled</Txt>
-        <Input disabled={true} />
-      </li>
-      <li>
-        <Txt>error</Txt>
-        <Input error={true} />
-      </li>
-      <li>
-        <Txt>prefix</Txt>
-        <Input prefix={<Icon name="fa-search" color="#d6d6d6" />} />
-      </li>
-      <li>
-        <Txt>suffix</Txt>
-        <Input suffix={<Icon name="fa-search" color="#d6d6d6" />} />
-      </li>
-    </List>
-  ))
-  .add('currency', () => {
-    const [value, setValue] = React.useState('1234567890')
-    return (
-      <Wrapper>
-        <Txt>currency (add comma to integer every 3 digits)</Txt>
-        <CurrencyInput
-          value={value}
-          onChangeValue={(changed) => {
-            action('changed value')(changed)
-            setValue(changed)
-          }}
-        />
-      </Wrapper>
-    )
-  })
+storiesOf('Input', module).add('all', () => (
+  <List>
+    <li>
+      <Txt>text</Txt>
+      <Input type="text" defaultValue="string" />
+    </li>
+    <li>
+      <Txt>number</Txt>
+      <Input type="number" defaultValue="1" />
+    </li>
+    <li>
+      <Txt>password</Txt>
+      <Input type="password" defaultValue="password" />{' '}
+    </li>{' '}
+    <li>
+      {' '}
+      <Txt>placeholder</Txt>
+      <Input placeholder="string" />
+    </li>
+    <li>
+      <Txt>width</Txt>
+      <Input defaultValue="width: 100%" width="100%" />
+    </li>
+    <li>
+      <Txt>onChange</Txt>
+      <Input onChange={action('onChange!!')} />
+    </li>
+    <li>
+      <Txt>onBlur</Txt>
+      <Input onBlur={action('onBlur!!')} />
+    </li>
+    <li>
+      <Txt>disabled</Txt>
+      <Input disabled={true} />
+    </li>
+    <li>
+      <Txt>error</Txt>
+      <Input error={true} />
+    </li>
+    <li>
+      <Txt>prefix</Txt>
+      <Input prefix={<Icon name="fa-search" color="#d6d6d6" />} />
+    </li>
+    <li>
+      <Txt>suffix</Txt>
+      <Input suffix={<Icon name="fa-search" color="#d6d6d6" />} />
+    </li>
+  </List>
+))
 
 const List = styled.ul`
   padding: 0 24px;
@@ -84,7 +67,4 @@ const List = styled.ul`
 `
 const Txt = styled.p`
   margin: 0 0 8px 0;
-`
-const Wrapper = styled.div`
-  padding: 24px;
 `

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -29,50 +29,22 @@ export type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> & {
   error?: boolean
   width?: number | string
   autoFocus?: boolean
-  thousandsSeparated?: boolean
   prefix?: ReactNode
   suffix?: ReactNode
 }
 
-export const Input: FC<Props> = ({
-  type,
-  onFocus,
-  onBlur,
-  autoFocus,
-  thousandsSeparated,
-  prefix,
-  suffix,
-  ...props
-}) => {
+export const Input: FC<Props> = ({ onFocus, onBlur, autoFocus, prefix, suffix, ...props }) => {
   const theme = useTheme()
   const ref = useRef<HTMLInputElement>(null)
   const [isFocused, setIsFocused] = useState(false)
 
-  const isCurrency = type === 'number' && thousandsSeparated
-  const actualType = isCurrency ? 'text' : type
-
   const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
     setIsFocused(true)
-    if (isCurrency && ref.current) {
-      const commaExcluded = ref.current.value.replace(/,/g, '')
-      ref.current.value = commaExcluded
-    }
     onFocus && onFocus(e)
   }
 
   const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
     setIsFocused(false)
-    if (isCurrency && ref.current) {
-      const value = ref.current.value
-      const shaped = value
-        .replace(/[０-９．]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0)) // convert number and dot to half-width
-        .replace(/[−ー]/, '-') // replace full-width minus
-        .replace(/[^0-9.-]|(?!^)-|^\.+|\.+$/g, '') // exclude non-numeric characters
-      const splited = shaped.split('.')
-      const integerPart = splited[0].replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') // add comma to integer every 3 digits
-      const formattedArray = Object.assign(splited, [integerPart])
-      ref.current.value = formattedArray.join('.')
-    }
     onBlur && onBlur(e)
   }
 
@@ -92,14 +64,7 @@ export const Input: FC<Props> = ({
       onClick={() => ref.current?.focus()}
     >
       {prefix && <Prefix themes={theme}>{prefix}</Prefix>}
-      <StyledInput
-        type={actualType}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        {...props}
-        ref={ref}
-        themes={theme}
-      />
+      <StyledInput onFocus={handleFocus} onBlur={handleBlur} {...props} ref={ref} themes={theme} />
       {suffix && <Suffix themes={theme}>{suffix}</Suffix>}
     </Wrapper>
   )

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactNode,
   forwardRef,
   useEffect,
+  useImperativeHandle,
   useRef,
   useState,
 } from 'react'
@@ -37,18 +38,12 @@ export const Input = forwardRef<HTMLInputElement, Props>(
   ({ onFocus, onBlur, autoFocus, prefix, suffix, ...props }, ref) => {
     const theme = useTheme()
     const innerRef = useRef<HTMLInputElement>(null)
-    useEffect(() => {
-      // combine ref
-      if (!ref) return
-
-      if (typeof ref === 'function') {
-        ref(innerRef.current)
-      } else {
-        ref.current = innerRef.current
-      }
-    }, [ref])
-
     const [isFocused, setIsFocused] = useState(false)
+
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => innerRef.current,
+    )
 
     const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
       setIsFocused(true)

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,8 +1,8 @@
 import React, {
-  FC,
   FocusEvent,
   InputHTMLAttributes,
   ReactNode,
+  forwardRef,
   useEffect,
   useRef,
   useState,
@@ -33,42 +33,61 @@ export type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> & {
   suffix?: ReactNode
 }
 
-export const Input: FC<Props> = ({ onFocus, onBlur, autoFocus, prefix, suffix, ...props }) => {
-  const theme = useTheme()
-  const ref = useRef<HTMLInputElement>(null)
-  const [isFocused, setIsFocused] = useState(false)
+export const Input = forwardRef<HTMLInputElement, Props>(
+  ({ onFocus, onBlur, autoFocus, prefix, suffix, ...props }, ref) => {
+    const theme = useTheme()
+    const innerRef = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+      // combine ref
+      if (!ref) return
 
-  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
-    setIsFocused(true)
-    onFocus && onFocus(e)
-  }
+      if (typeof ref === 'function') {
+        ref(innerRef.current)
+      } else {
+        ref.current = innerRef.current
+      }
+    }, [ref])
 
-  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
-    setIsFocused(false)
-    onBlur && onBlur(e)
-  }
+    const [isFocused, setIsFocused] = useState(false)
 
-  useEffect(() => {
-    if (autoFocus && ref && ref.current) {
-      ref.current.focus()
+    const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+      setIsFocused(true)
+      onFocus && onFocus(e)
     }
-  }, [autoFocus])
 
-  return (
-    <Wrapper
-      themes={theme}
-      width={props.width}
-      isFocused={isFocused}
-      disabled={props.disabled}
-      error={props.error}
-      onClick={() => ref.current?.focus()}
-    >
-      {prefix && <Prefix themes={theme}>{prefix}</Prefix>}
-      <StyledInput onFocus={handleFocus} onBlur={handleBlur} {...props} ref={ref} themes={theme} />
-      {suffix && <Suffix themes={theme}>{suffix}</Suffix>}
-    </Wrapper>
-  )
-}
+    const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+      setIsFocused(false)
+      onBlur && onBlur(e)
+    }
+
+    useEffect(() => {
+      if (autoFocus && innerRef.current) {
+        innerRef.current.focus()
+      }
+    }, [autoFocus])
+
+    return (
+      <Wrapper
+        themes={theme}
+        width={props.width}
+        isFocused={isFocused}
+        disabled={props.disabled}
+        error={props.error}
+        onClick={() => innerRef.current?.focus()}
+      >
+        {prefix && <Prefix themes={theme}>{prefix}</Prefix>}
+        <StyledInput
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          {...props}
+          ref={innerRef}
+          themes={theme}
+        />
+        {suffix && <Suffix themes={theme}>{suffix}</Suffix>}
+      </Wrapper>
+    )
+  },
+)
 
 const Wrapper = styled.span<{
   themes: Theme

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,1 +1,2 @@
 export * from './Input'
+export { CurrencyInput } from './CurrencyInput'

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export {
 } from './components/Dropdown'
 export { FieldSet } from './components/FieldSet'
 export { FlashMessage } from './components/FlashMessage'
-export { Input } from './components/Input'
+export { Input, CurrencyInput } from './components/Input'
 export { Textarea } from './components/Textarea'
 export { Loader } from './components/Loader'
 export {


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/jira/software/projects/SHRUI/boards/99?selectedIssue=SHRUI-136
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

現状、通貨用Inputの整形タイミングがblur時だけになっていますが、それではアプリケーションで使用するにあたっては不十分であるため、親側からのvalue, defaultValueが渡ってくることを考慮した整形タイミングに変更します。

また、役割の明確化のため通貨用機能を`Input`コンポーネントから別コンポーネントへの切り出しも行います。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

* 通貨用整形機能を`CurrencyInput`コンポーネントとして切り出し
  * READMEを分離するため、ディレクトリも変更
* 整形を掛けるタイミングを追加
  * 初回描画時
    * value, defaultValue値を参照
  * `value` propsの値が親側で変更された時
    * ただし自身がフォーカスされている時（つまり入力中）は整形しない
* `onFormatValue`ハンドラを追加
  * 自動整形による変更をハンドリングできるようにするため独自のハンドラを追加
* `Input` コンポーネントに[ref forwarding](https://ja.reactjs.org/docs/forwarding-refs.html)を追加
  * [非制御コンポーネント](https://ja.reactjs.org/docs/uncontrolled-components.html)のままvalueを制御するためには`Input`にrefを通す必要があったため追加
  * 使用側で制御 / 非制御を選択できるようにするために、`CurrencyInput`は非制御コンポーネントとして実装する必要がある

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

![スクリーンショット 2020-07-13 18 20 08](https://user-images.githubusercontent.com/270422/87287821-8693e780-c535-11ea-91aa-85b580964bb6.png)

<!--
Please attach a capture if it looks different.
-->
