### PR TITLE
fix: dialog focus management

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "SmartHR-UI Team",
   "dependencies": {
     "dayjs": "^1.9.7",
+    "focus-trap": "^6.2.3",
     "lodash.merge": "^4.6.2",
     "lodash.range": "^3.2.0",
     "polished": "^4.0.5",

--- a/src/components/Dialog/Dialog.opened.stories.tsx
+++ b/src/components/Dialog/Dialog.opened.stories.tsx
@@ -6,6 +6,22 @@ import styled from 'styled-components'
 import { ActionDialog, MessageDialog } from '.'
 import readme from './README.md'
 
+const dummyText = (
+  <>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+    labore et dolore magna aliqua.
+    <br />
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat.
+    <br />
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+    pariatur.
+    <br />
+    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
+    id est laborum.
+  </>
+)
+
 storiesOf('Dialog', module)
   .addParameters({
     readme: {
@@ -16,21 +32,7 @@ storiesOf('Dialog', module)
     <MessageDialog
       isOpen={true}
       title="MessageDialog"
-      description={
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
-          ut labore et dolore magna aliqua.
-          <br />
-          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-          commodo consequat.
-          <br />
-          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-          nulla pariatur.
-          <br />
-          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-          anim id est laborum.
-        </p>
-      }
+      description={<p>{dummyText}</p>}
       closeText="close"
       onClickClose={action('clicked close')}
     />
@@ -45,18 +47,28 @@ storiesOf('Dialog', module)
       onClickAction={action('clicked action')}
       onClickClose={action('clicked close')}
     >
+      <Text>{dummyText}</Text>
+    </ActionDialog>
+  ))
+  .add('ActionDialog with Long Contents', () => (
+    <ActionDialog
+      isOpen={true}
+      title="ActionDialog"
+      closeText="close"
+      actionText="execute"
+      actionTheme="primary"
+      onClickAction={action('clicked action')}
+      onClickClose={action('clicked close')}
+    >
+      <Text>{dummyText}</Text>
+      <Text>{dummyText}</Text>
+      <Text>{dummyText}</Text>
+      <Text>{dummyText}</Text>
       <Text>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua.
-        <br />
-        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-        <br />
-        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur.
-        <br />
-        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-        anim id est laborum.
+        <label>
+          <input type="checkbox" />
+          Agree
+        </label>
       </Text>
     </ActionDialog>
   ))

--- a/src/components/Dialog/Dialog.uncontrollable.stories.tsx
+++ b/src/components/Dialog/Dialog.uncontrollable.stories.tsx
@@ -24,7 +24,7 @@ const FormDialog: React.FC = () => {
   return (
     <DialogWrapper>
       <DialogTrigger>
-        <SecondaryButton>Dialog</SecondaryButton>
+        <SecondaryButton aria-haspopup="dialog">Dialog</SecondaryButton>
       </DialogTrigger>
       <DialogContent>
         <Inner>
@@ -84,7 +84,7 @@ storiesOf('Dialog', module)
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton>
+            <SecondaryButton aria-haspopup="dialog">
               Modal position can be changed. top: 50px, left: 200px.
             </SecondaryButton>
           </DialogTrigger>
@@ -101,7 +101,7 @@ storiesOf('Dialog', module)
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton>right: 50px, bottom: 100px.</SecondaryButton>
+            <SecondaryButton aria-haspopup="dialog">right: 50px, bottom: 100px.</SecondaryButton>
           </DialogTrigger>
           <DialogContent right={50} bottom={100}>
             <Inner>
@@ -142,7 +142,7 @@ storiesOf('Dialog', module)
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton>ActionDialog</SecondaryButton>
+            <SecondaryButton aria-haspopup="dialog">ActionDialog</SecondaryButton>
           </DialogTrigger>
           <ActionDialogContent
             title="Title Message"

--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -16,7 +16,9 @@ const DialogController: React.FC = () => {
 
   return (
     <div>
-      <button onClick={onClickOpen} aria-haspopup="dialog">open dialog</button>
+      <button onClick={onClickOpen} type="button" aria-haspopup="dialog">
+        open dialog
+      </button>
       <Dialog isOpen={isOpen} onClickOverlay={onClickClose}>
         <p>text</p>
         <button onClick={onClickClose}>close dialog</button>
@@ -34,7 +36,7 @@ import { DialogWrapper, DialogTrigger, DialogContent, DialogCloser } from 'smart
 const Component: React.FC = () => (
   <DialogWrapper>
     <DialogTrigger>
-      <button>open dialog</button>
+      <button type="button" aria-haspopup="dialog">open dialog</button>
     </DialogTrigger>
     <DialogContent>
       <p>text</p>
@@ -88,7 +90,9 @@ const DialogController: React.FC = () => {
 
   return (
     <div>
-      <button onClick={onClickOpen} aria-haspopup="dialog">open dialog</button>
+      <button onClick={onClickOpen} type="button" aria-haspopup="dialog">
+        open dialog
+      </button>
       <MessageDialog
         isOpen={isOpen}
         title="title message"
@@ -109,7 +113,7 @@ import { DialogWrapper, DialogTrigger, MessageDialogContent } from 'smarthr-ui'
 const Component: React.FC = () => (
   <DialogWrapper>
     <DialogTrigger>
-      <button>open dialog</button>
+      <button type="button" aria-haspopup="dialog">open dialog</button>
     </DialogTrigger>
     <MessageDialogContent
       title="title message"
@@ -164,7 +168,9 @@ const DialogController: React.FC = () => {
 
   return (
     <div>
-      <button onClick={onClickOpen} aria-haspopup="dialog">open dialog</button>
+      <button onClick={onClickOpen} type="button" aria-haspopup="dialog">
+        open dialog
+      </button>
       <ActionDialog
         isOpen={isOpen}
         title="title message"
@@ -189,7 +195,9 @@ import { DialogWrapper, DialogTrigger, ActionDialogContent } from 'smarthr-ui'
 const Component: React.FC = () => (
   <DialogWrapper>
     <DialogTrigger>
-      <button>open dialog</button>
+      <button type="button" aria-haspopup="dialog">
+        open dialog
+      </button>
     </DialogTrigger>
     <ActionDialogContent
       title="title message"
@@ -243,9 +251,31 @@ ActionDialogContent
 
 ## Accessibility
 
+### usage
+
+#### Recommend
+
+- Add Name by `title` or `ariaLabel` or `ariaLabelledby` props.
+- Add `aria-haspopup="dialog"` to trigger
+- Add Close Action in Dialog Contents.
+
 ### ARIA
 
 - Dialog component has `role` set to `"dialog"`.
 - Dialog component has `aria-modal` set to `true`.
 - Uncontrollable Dialog has `aria-haspopup` set to `"dialog"` in the trigger. When using controllable Dialog, set `aria-haspopup` to `"dialog"` in the trigger.
 - MessageDialog and ActionDialog set the title value to the `aria-label` value. When using Dialog and DialogContent, you can specify a value for `aria-label` in `ariaLabel` props. Alternatively, you can use the aria-labelledby attribute by passing the id value in `ariaLabelledby` props.
+
+### Keyboard Interaction
+
+> When a dialog opens, focus moves to an element inside the dialog. See notes below regarding initial focus placement.
+
+> `Tab`: Moves focus to the next tabbable element inside the dialog.
+If focus is on the last tabbable element inside the dialog, moves focus to the first tabbable element inside the dialog.
+
+> `Shift + Tab`: Moves focus to the previous tabbable element inside the dialog.
+If focus is on the first tabbable element inside the dialog, moves focus to the last tabbable element inside the dialog.
+
+> `Escape`: Closes the dialog.
+
+[WAI-ARIA Authoring Practices 1.1 - 3.9 Dialog(Modal) - Keyboard Interaction](https://www.w3.org/TR/wai-aria-practices-1.1/#keyboard-interaction-7)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9779,6 +9779,13 @@ focus-lock@^0.6.6:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
   integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
 
+focus-trap@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.2.3.tgz#1f1443063f08241020d4ffb269bab9847ada97b7"
+  integrity sha512-87orNbj6UqKEDxmqDfYBDLBbqgxNIA5cXUBvHCt7dZ8/L0KTuzkjKoI0xXHU+5TyI9fImqfOJyvEkXYmZeClZA==
+  dependencies:
+    tabbable "^5.1.4"
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -17812,6 +17819,11 @@ symbol.prototype.description@^1.0.0:
   dependencies:
     es-abstract "^1.17.0-next.1"
     has-symbols "^1.0.1"
+
+tabbable@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.4.tgz#5278929c16d0d909c2cfcdfcfa89dd86bce5dd1a"
+  integrity sha512-M1thgfxQ6NGuiSv6I+392zkDcyE5f0DbZPkUQaxnFNu9n9UR/GuE0ii2Hf3l7CQHNiraYhD8W3GBRp35W/+kXg==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
## Related URL

resolve #886 

## Overview

1. `<Dialog>` を起動したら `<DialogContentInner>` 内のフォーカス用ダミー要素にフォーカスする
2. `<Dialog>` を閉じたら `<Dialog>` を開いたトリガーの要素にフォーカスする
3. `<Dialog>` をフォーカストラップとする（フォーカスを `<Dialog>` の外に出ないようにする） 

## What I did

- `createFocusTrap` を利用して、 `isOpen` をトリガーにし `<DialogContentInner>` にてフォーカストラップを発動
- `<Dialog>` を起動するトリガーボタンに `aria-haspopup` を付与
- README.md に Accessibility の章を追加し、利用時の推奨事項とキーボードインタラクションについて追加

Storybook: https://deploy-preview-889--smarthr-ui.netlify.app/?path=/story/dialog--controllable

### フォーカストラップ

WHY: モーダルの後ろにあるコンテンツにアクセスできてしまうと、混乱を招いてしまうため

#### ライブラリの選定

バンドルサイズと依存の少なさから `focus-trap/focus-trap` とした。
他のコンポーネントでも色々使う & React 依存で問題ないなら `@react-aria/focus` が良さそう

##### 採用

###### [focus-trap/focus-trap: Trap focus within a DOM node.](https://github.com/focus-trap/focus-trap)

個人のOSSでSEEKING CO-MAINTAINERS だったが、メンテナも集まり org 化された。もともと依存も少なく枯れているがやや記述量が多い。バンドルサイズが小さい。

**BUNDLE SIZE**

- MINIFIED: 6.2kB
- MINIFIED + GZIPPED: 2.3kB

##### 不採用

###### [@react-aria/focus](https://www.npmjs.com/package/@react-aria/focus)

AdobeがメンテしているReact ARIAの一部。フォーカストラップ以外にもフォーカス管理ができる。React依存。他の `@react-aria` のパッケージを使うときにコードの共通化ができて結果サイズは小さくなりそう。他にフォーカス管理する用途やコンポーネントが少ないため不採用。

**BUNDLE SIZE**

- MINIFIED 19.2 kB
- MINIFIED + GZIPPED 6.2 kB

###### [focus\-trap/focus\-trap\-react: A React component that traps focus](https://github.com/focus-trap/focus-trap-react)

=> React 縛り。SEEKING CO-MAINTAINERS でメンテナンスが行われてるが、現状 React.findDOMNode が残っているなどコードが古い。

[theKashey/react\-focus\-lock: It is a trap\! A lock for a Focus\. 🔓](https://github.com/theKashey/react-focus-lock)

=> Storybook,  [Atlassian AtlasKit](https://atlaskit.atlassian.com/) でも使われている。React 依存でよければありかも知れない。

**BUNDLE SIZE**

- MINIFIED 2.3kB
- MINIFIED + GZIPPED 854B

## Capture

<details open>
<summary><a href="https://deploy-preview-889--smarthr-ui.netlify.app/?path=/story/dialog--controllable">controllable</a></summary>
<img src="https://user-images.githubusercontent.com/6724665/100192062-96382980-2f34-11eb-8c14-5ddcb309325e.gif" alt="Screen capture of controllable dialog keyboard Operation" />
</details>

## need Discus / 要検討

- フォーカストラップに利用するパッケージ
- `<Inner>` の `:first-child` に要素を置くことでスタイルが崩れる可能性が無いかどうか

## Issue

- `<Dialog>` 内にスクロール可能な領域があるとフォーカスが当たるようになるが、一度フォーカスした後、フォーカスを外すとフォーカスが当たらなくなる（Chrome / Edgeのみ）