### PR TITLE
fix: width for input element in Input

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -132,6 +132,7 @@ const StyledInput = styled.input<Props & { themes: Theme }>`
     return css`
       flex-grow: 1;
       display: inline-block;
+      width: 100%;
       padding: ${size.pxToRem(size.space.XXS)} 0;
       border: none;
       background-color: transparent;


### PR DESCRIPTION
## Overview

When setting small width to `Input` component, the actual input element exceeds the given width.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Added `width: 100%;` to input element.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

When setting `width={75}`

before | after
-- | --
![image](https://user-images.githubusercontent.com/14817308/88623633-583f0c00-d0e0-11ea-9063-8c3dec234742.png) | ![image](https://user-images.githubusercontent.com/14817308/88623676-6ee56300-d0e0-11ea-94aa-f7826c9b63dc.png)



<!--
Please attach a capture if it looks different.
-->
