### PR TITLE
fix: add necessary dependencies of hooks in CurrencyInput

### DIFF
--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -41,6 +41,8 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
       if (props.value === undefined && props.defaultValue !== undefined) {
         formatValue(formatCurrency(props.defaultValue))
       }
+      // when component did mount
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     useEffect(() => {
@@ -53,7 +55,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
           formatValue(formatCurrency(innerRef.current.value))
         }
       }
-    }, [isFocused])
+    }, [isFocused, props.value, formatValue])
 
     const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
       setIsFocused(true)


### PR DESCRIPTION
## Related URL
#878 

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Adding dependencies of hooks, or suppressing `react-hooks/exhaustive-deps` rule
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* add normal deps of hooks
* add comment to disable eslint rule
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
