### PR TITLE
Header コンポーネントのテナント名領域に node が入るようにしたいんじゃー

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -17,6 +17,7 @@ type Props = {
     avatar: string
   }
   currentTenantName: string
+  displayTenantName?: React.ReactNode
   notificationLength: number
   onClickLogo: () => void
   onClickHelp: () => void
@@ -39,6 +40,7 @@ export const Header: FC<Props> = ({
   isCrew = false,
   user,
   currentTenantName,
+  displayTenantName,
   notificationLength,
   onClickLogo,
   onClickHelp,
@@ -64,7 +66,9 @@ export const Header: FC<Props> = ({
         <HeaderLogo onClick={onClickLogo} aria-label="SmartHR" themes={theme}>
           <SmartHRLogo />
         </HeaderLogo>
-        <TenantName themes={theme}>{currentTenantName}</TenantName>
+        <TenantName themes={theme}>
+          {displayTenantName ? displayTenantName : currentTenantName}
+        </TenantName>
       </HeaderColumn>
 
       <HeaderColumn>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -17,7 +17,7 @@ type Props = {
     avatar: string
   }
   currentTenantName: string
-  displayTenantName?: React.ReactNode
+  tenantContent?: React.ReactNode
   notificationLength: number
   onClickLogo: () => void
   onClickHelp: () => void
@@ -40,7 +40,7 @@ export const Header: FC<Props> = ({
   isCrew = false,
   user,
   currentTenantName,
-  displayTenantName,
+  tenantContent,
   notificationLength,
   onClickLogo,
   onClickHelp,
@@ -66,9 +66,7 @@ export const Header: FC<Props> = ({
         <HeaderLogo onClick={onClickLogo} aria-label="SmartHR" themes={theme}>
           <SmartHRLogo />
         </HeaderLogo>
-        <TenantName themes={theme}>
-          {displayTenantName ? displayTenantName : currentTenantName}
-        </TenantName>
+        <TenantName themes={theme}>{tenantContent ? tenantContent : currentTenantName}</TenantName>
       </HeaderColumn>
 
       <HeaderColumn>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -147,7 +147,7 @@ const HeaderLogo = styled.button<{ themes: Theme }>`
     `
   }}
 `
-const TenantName = styled.p<{ themes: Theme }>`
+const TenantName = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
     const { size } = themes
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -31,6 +31,7 @@ type Props = {
   onClickProfile?: () => void
   onClickCompany?: () => void
   onClickSchool?: () => void
+  className?: string
 }
 
 export const Header: FC<Props> = ({
@@ -52,12 +53,13 @@ export const Header: FC<Props> = ({
   onClickProfile,
   onClickCompany,
   onClickSchool,
+  className,
 }) => {
   const theme = useTheme()
   const { displayName, avatar } = user
 
   return (
-    <Wrapper themes={theme}>
+    <Wrapper themes={theme} className={className}>
       <HeaderColumn>
         <HeaderLogo onClick={onClickLogo} aria-label="SmartHR" themes={theme}>
           <SmartHRLogo />

--- a/src/components/Header/README.md
+++ b/src/components/Header/README.md
@@ -13,6 +13,7 @@ import { Header } from 'smarthr-ui'
     avatar: 'https://placehold.jp/150x150.png',
   }}
   currentTenantName="example, Inc."
+  displayTenantName={<div>example, Inc.</div>}
   notificationLength={999}
   onClickLogo={handleClickLogo}
   onClickHelp={handleClickHelp}
@@ -40,6 +41,7 @@ import { Header } from 'smarthr-ui'
 | isCrew                 | -        | **boolean**                                     | false        | Whether viewer is crew.                     |
 | user                   | ✓        | **{ displayName: string,<br> avatar: string }** | -            | Viewer's user informations.                 |
 | currentTenantName      | ✓        | **string**                                      | -            | Current tenant name.                        |
+| displayTenantName      | -        | **node**                                        | -            | The content of tenant name area.            |
 | notificationLength     | ✓        | **number**                                      | -            | Number of notifications.                    |
 | onClickLogo            | ✓        | **() => void**                                  | -            | Fires when the logo clicked.                |
 | onClickHelp            | ✓        | **() => void**                                  | -            | Fires when the help clicked.                |


### PR DESCRIPTION
## Overview
https://smarthr.atlassian.net/browse/SHRUI-143?atlOrigin=eyJpIjoiM2JmZDgyMjRkMmI0NDkyODg5YWNjMTViMGI4ODBlZTkiLCJwIjoiaiJ9

- テナント名領域に ReactNode が入るようにしたい
  - 現状は string しか入らず、ドロップダウンなどを差し込めないので
- ついでにスタイル拡張できるようにしたい

## What I did

- Header に `displayTenantName` props を追加
  - optional な props で、入力なければ `currentTenantName` をそのまま表示
- 同 Header に `className` props を追加

## Capture

![image](https://user-images.githubusercontent.com/1614892/88765173-116d1700-d1b1-11ea-9ce4-35f4896cfc7f.png)

