### PR TITLE
fix: improve behavior of portal on DropdownContent

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -189,6 +189,31 @@ storiesOf('Dropdown', module)
       </Legends>
     </Wrapper>
   ))
+  .add('rta', () => (
+    <Wrapper>
+      <Dropdown>
+        <DropdownTrigger>
+          <SecondaryButton>RTA</SecondaryButton>
+        </DropdownTrigger>
+        <DropdownContent controllable>
+          <DropdownScrollArea>
+            <RTAContainer>
+              <Dropdown>
+                <DropdownTrigger>
+                  <SecondaryButton>Uncontrollable Dropdown</SecondaryButton>
+                </DropdownTrigger>
+                <DropdownContent>
+                  <DropdownScrollArea>
+                    <ListMenu />
+                  </DropdownScrollArea>
+                </DropdownContent>
+              </Dropdown>
+            </RTAContainer>
+          </DropdownScrollArea>
+        </DropdownContent>
+      </Dropdown>
+    </Wrapper>
+  ))
 
 const List = styled.ul`
   margin: 0;
@@ -268,4 +293,8 @@ const Fixed = styled.div`
   font-weight: bold;
   line-height: 40px;
   color: #333;
+`
+
+const RTAContainer = styled.div`
+  padding: 2rem;
 `


### PR DESCRIPTION
https://deploy-preview-921--smarthr-ui.netlify.app/?path=/story/dropdown--rta
ドロップダウン内のportal（この例ではドロップダウン）を押下した時、親のドロップダウンが閉じてしまう現象のサンプル

- 現状の動作
  - 子のドロップダウンコンテンツを押下した時、親のドロップダウンが閉じ、子のドロップダウン選択アクションが発生しない
- 想定する正常動作
  - 子のドロップダウンコンテンツを押下した時、親のドロップダウンが閉じず、子のドロップダウン選択アクションが発生する