### PR TITLE
AccordionPanel をキーボード操作可能にする

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -11,12 +11,24 @@ import { AccordionPanel } from './AccordionPanel'
 import { AccordionPanelItem } from './AccordionPanelItem'
 import { AccordionPanelTrigger } from './AccordionPanelTrigger'
 import { AccordionPanelContent } from './AccordionPanelContent'
+import { FieldSet } from '../FieldSet'
 
 import readme from './README.md'
 
 const arr = Array.from({ length: 3 })
 // prettier-ignore
 const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+const content = () => (
+  <Stack>
+    <div>{lorem}</div>
+    <div>
+      <FieldSet label="Name" required={true} />
+    </div>
+    <div>
+      <FieldSet label="Email" />
+    </div>
+  </Stack>
+)
 
 const AccordionPanelController: VFC<{ theme: Theme }> = ({ theme }) => {
   const [expandedId, setExpandedId] = useState('')
@@ -49,9 +61,7 @@ const AccordionPanelController: VFC<{ theme: Theme }> = ({ theme }) => {
             <AccordionPanelItem key={i} name={`accordion-panel-${i}`}>
               <AccordionPanelTrigger>AccordionPanelItem {i}</AccordionPanelTrigger>
               <AccordionPanelContent>
-                <Content themes={theme}>
-                  <div>{lorem}</div>
-                </Content>
+                <Content themes={theme}>{content()}</Content>
               </AccordionPanelContent>
             </AccordionPanelItem>
           ))}
@@ -80,9 +90,7 @@ storiesOf('AccordionPanel', module)
                   <AccordionPanelItem name={`left-icon-${i}`}>
                     <AccordionPanelTrigger>Left Icon (default) {i}</AccordionPanelTrigger>
                     <AccordionPanelContent>
-                      <Content themes={theme}>
-                        <div>{lorem}</div>
-                      </Content>
+                      <Content themes={theme}>{content()}</Content>
                     </AccordionPanelContent>
                   </AccordionPanelItem>
                 </li>
@@ -98,9 +106,7 @@ storiesOf('AccordionPanel', module)
                   <AccordionPanelItem name={`right-icon-${i}`}>
                     <AccordionPanelTrigger>Right Icon {i}</AccordionPanelTrigger>
                     <AccordionPanelContent>
-                      <Content themes={theme}>
-                        <div>{lorem}</div>
-                      </Content>
+                      <Content themes={theme}>{content()}</Content>
                     </AccordionPanelContent>
                   </AccordionPanelItem>
                 </li>
@@ -116,9 +122,7 @@ storiesOf('AccordionPanel', module)
                   <AccordionPanelItem name={`no-icon-${i}`}>
                     <AccordionPanelTrigger>No Icon {i}</AccordionPanelTrigger>
                     <AccordionPanelContent>
-                      <Content themes={theme}>
-                        <div>{lorem}</div>
-                      </Content>
+                      <Content themes={theme}>{content()}</Content>
                     </AccordionPanelContent>
                   </AccordionPanelItem>
                 </li>
@@ -140,9 +144,7 @@ storiesOf('AccordionPanel', module)
               <AccordionPanelItem key={i} name={`expandable-multiply-${i}`}>
                 <AccordionPanelTrigger>Expandable Multiply {i}</AccordionPanelTrigger>
                 <AccordionPanelContent>
-                  <Content themes={theme}>
-                    <div>{lorem}</div>
-                  </Content>
+                  <Content themes={theme}>{content()}</Content>
                 </AccordionPanelContent>
               </AccordionPanelItem>
             ))}
@@ -154,9 +156,7 @@ storiesOf('AccordionPanel', module)
               <AccordionPanelItem key={i} name={`default-expanded-${i}`}>
                 <AccordionPanelTrigger>Default Expanded {i}</AccordionPanelTrigger>
                 <AccordionPanelContent>
-                  <Content themes={theme}>
-                    <div>{lorem}</div>
-                  </Content>
+                  <Content themes={theme}>{content()}</Content>
                 </AccordionPanelContent>
               </AccordionPanelItem>
             ))}
@@ -176,9 +176,7 @@ storiesOf('AccordionPanel', module)
               <AccordionPanelItem key={i} name={`expandable-multiply-${i}`}>
                 <AccordionPanelTrigger>Expandable Multiply {i}</AccordionPanelTrigger>
                 <AccordionPanelContent>
-                  <Content themes={theme}>
-                    <div>{lorem}</div>
-                  </Content>
+                  <Content themes={theme}>{content()}</Content>
                 </AccordionPanelContent>
               </AccordionPanelItem>
             ))}
@@ -195,25 +193,30 @@ storiesOf('AccordionPanel', module)
 const Wrapper = styled.div`
   padding: 24px;
 
-  > *:not(:first-child) {
+  > * + * {
     margin-top: 24px;
   }
 `
-const BorderList = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => css`
+const BorderList = styled.ul<{ themes: Theme }>(
+  ({ themes: { color } }) => css`
     margin: 0;
     padding: 0;
     list-style: none;
 
-    > li:not(:first-child) {
-      border-top: 1px solid ${themes.palette.BORDER};
+    > li + li {
+      border-top: 1px solid ${color.BORDER};
     }
-  `}
-`
-const Content = styled.div<{ themes: Theme }>`
-  ${({ themes }) => css`
+  `,
+)
+const Content = styled.div<{ themes: Theme }>(
+  ({ themes: { color } }) => css`
+    background-color: ${color.BACKGROUND};
     padding: 16px;
-    background-color: ${themes.palette.BACKGROUND};
     font-size: 14px;
-  `}
+  `,
+)
+const Stack = styled.div`
+  > * + * {
+    margin-top: 12px;
+  }
 `

--- a/src/components/AccordionPanel/AccordionPanelContent.tsx
+++ b/src/components/AccordionPanel/AccordionPanelContent.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, RefObject, VFC, useCallback, useContext, useRef } from 'react'
+import React, { HTMLAttributes, VFC, useCallback, useContext, useRef } from 'react'
 import styled from 'styled-components'
 import { Transition } from 'react-transition-group'
 
@@ -13,10 +13,7 @@ type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-const updateNodeHeight = (node: HTMLElement, wrapperRef: RefObject<HTMLDivElement>) => {
-  const wrapperHeight = wrapperRef.current ? wrapperRef.current.clientHeight : 0
-  node.style.height = `${wrapperHeight}px`
-}
+const duration = 200
 
 export const AccordionPanelContent: VFC<Props & ElementProps> = ({
   children,
@@ -29,47 +26,33 @@ export const AccordionPanelContent: VFC<Props & ElementProps> = ({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const classNames = useClassNames()
 
-  const handleEntering = useCallback(
+  const recalculateHeight = useCallback(
     (node: HTMLElement) => {
-      updateNodeHeight(node, wrapperRef)
+      const wrapperHeight = wrapperRef.current ? wrapperRef.current.clientHeight : 0
+      node.style.height = `${wrapperHeight}px`
     },
     [wrapperRef],
   )
 
   const handleEntered = (node: HTMLElement) => {
     node.style.height = 'auto'
+    node.style.visibility = 'visible'
   }
-
-  const handleExit = useCallback(
-    (node: HTMLElement) => {
-      updateNodeHeight(node, wrapperRef)
-    },
-    [wrapperRef],
-  )
-
-  const handleExiting = useCallback(
-    (node: HTMLElement) => {
-      updateNodeHeight(node, wrapperRef)
-    },
-    [wrapperRef],
-  )
 
   const handleExited = (node: HTMLElement) => {
     node.style.height = '0px'
+    node.style.visibility = 'hidden'
   }
 
   return (
     <Transition
       in={isInclude}
-      onEntering={handleEntering}
+      onEntering={recalculateHeight}
       onEntered={handleEntered}
-      onExit={handleExit}
-      onExiting={handleExiting}
+      onExit={recalculateHeight}
+      onExiting={recalculateHeight}
       onExited={handleExited}
-      timeout={{
-        enter: 300,
-        exit: 0,
-      }}
+      timeout={duration}
     >
       {(status) => (
         <CollapseContainer
@@ -86,13 +69,15 @@ export const AccordionPanelContent: VFC<Props & ElementProps> = ({
   )
 }
 
-const CollapseContainer = styled.div`
+const CollapseContainer = styled.section`
   height: 0;
   overflow: hidden;
-  transition: height 0.3s ease;
+  transition: height ${duration}ms ease;
+  visibility: hidden;
 
   &.entered {
     height: auto;
     overflow: visible;
+    visibility: visible;
   }
 `

--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -3,23 +3,26 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { getIsInclude, mapToKeyArray } from '../../libs/map'
-import { isTouchDevice } from '../../libs/ua'
 import { getNewExpandedItems } from './accordionPanelHelper'
 import { AccordionPanelContext } from './AccordionPanel'
 import { AccordionPanelItemContext } from './AccordionPanelItem'
 import { useClassNames } from './useClassNames'
-
+import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { FaCaretDownIcon } from '../Icon'
 
 type Props = {
   children: React.ReactNode
   className?: string
+  headingType?: HeadingTypes
+  headingTag?: HeadingTagTypes
 }
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof Props>
 
 export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
   children,
   className = '',
+  headingType = 'blockTitle',
+  headingTag,
   ...props
 }) => {
   const theme = useTheme()
@@ -56,48 +59,49 @@ export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
   const caretIcon = <Icon className={iconClassNames} $theme={theme} />
 
   return (
-    <Button
-      id={`${name}-trigger`}
-      className={buttonClassNames}
-      aria-expanded={isExpanded}
-      aria-controls={`${name}-content`}
-      themes={theme}
-      onClick={handleClick}
-      type="button"
-      {...props}
-    >
-      {displayIcon && iconPosition === 'left' && caretIcon}
-      {children}
-      {displayIcon && iconPosition === 'right' && caretIcon}
-    </Button>
+    <Heading tag={headingTag} type={headingType}>
+      <Button
+        id={`${name}-trigger`}
+        className={buttonClassNames}
+        aria-expanded={isExpanded}
+        aria-controls={`${name}-content`}
+        themes={theme}
+        onClick={handleClick}
+        type="button"
+        data-component="AccordionHeaderButton"
+        {...props}
+      >
+        {displayIcon && iconPosition === 'left' && caretIcon}
+        {children}
+        {displayIcon && iconPosition === 'right' && caretIcon}
+      </Button>
+    </Heading>
   )
 }
 
 const resetButtonStyle = css`
   background-color: transparent;
   border: none;
-  outline: none;
   padding: 0;
   appearance: none;
 `
 const Button = styled.button<{ themes: Theme }>`
   ${resetButtonStyle}
   ${({ themes }) => {
-    const { size, palette, interaction } = themes
+    const { color, fontSize, spacing } = themes
 
     return css`
       display: flex;
       align-items: center;
       width: 100%;
-      padding: ${size.pxToRem(12)} ${size.pxToRem(size.space.XS)};
-      color: ${palette.TEXT_BLACK};
-      font-size: ${size.pxToRem(size.font.TALL)};
-      text-align: left;
+      padding: ${fontSize.pxToRem(12)} ${fontSize.pxToRem(spacing.XS)};
       cursor: pointer;
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      font-size: inherit;
+      outline-color: ${color.OUTLINE};
 
-      &:hover {
-        background-color: ${palette.hoverColor('#fff')};
+      &:hover,
+      &:focus {
+        background-color: ${color.hoverColor('#fff')};
       }
       &.right {
         justify-content: space-between;
@@ -110,11 +114,11 @@ const Button = styled.button<{ themes: Theme }>`
 `
 const Icon = styled(FaCaretDownIcon)<{ $theme: Theme }>`
   ${({ $theme }) => {
-    const { size } = $theme
+    const { fontSize, spacing } = $theme
 
     return css`
       display: inline-flex;
-      margin-right: ${size.pxToRem(size.space.XXS)};
+      margin-right: ${fontSize.pxToRem(spacing.XXS)};
       transition: transform 0.3s;
 
       &.left {
@@ -125,7 +129,7 @@ const Icon = styled(FaCaretDownIcon)<{ $theme: Theme }>`
 
       &.right {
         margin-right: 0;
-        margin-left: ${size.pxToRem(size.space.XXS)};
+        margin-left: ${fontSize.pxToRem(spacing.XXS)};
 
         &.expanded {
           transform: rotate(180deg);

--- a/src/components/AccordionPanel/accordionPanelHelper.ts
+++ b/src/components/AccordionPanel/accordionPanelHelper.ts
@@ -15,3 +15,56 @@ export const getNewExpandedItems = (
 
   return newState
 }
+
+export const keycodes = {
+  SPACE: 32,
+  ENTER: 13,
+  HOME: 36,
+  END: 35,
+  UP: 38,
+  RIGHT: 39,
+  DOWN: 40,
+  LEFT: 37,
+}
+
+export const getSiblingButtons = (parent: HTMLDivElement): HTMLElement[] => {
+  return Array.from(parent.querySelectorAll('[data-component="AccordionHeaderButton"]'))
+}
+
+export const focusFirstSibling = (parent: HTMLDivElement): void => {
+  const siblings = getSiblingButtons(parent)
+  const first = siblings[0]
+  first.focus()
+}
+
+export const focusLastSibling = (parent: HTMLDivElement): void => {
+  const siblings = getSiblingButtons(parent)
+  const last = siblings[siblings.length - 1]
+  last.focus()
+}
+
+export const focusNextSibling = (item: HTMLElement, parent: HTMLDivElement): void => {
+  const siblings = getSiblingButtons(parent)
+  const current = siblings.indexOf(item)
+
+  if (current === siblings.length - 1) {
+    const first = siblings[0]
+    first.focus()
+  } else if (current !== -1) {
+    const next = siblings[current + 1]
+    next.focus()
+  }
+}
+
+export const focusPreviousSibling = (item: HTMLElement, parent: HTMLDivElement): void => {
+  const siblings = getSiblingButtons(parent)
+  const current = siblings.indexOf(item)
+
+  if (current === 0) {
+    const last = siblings[siblings.length - 1]
+    last.focus()
+  } else if (current !== -1) {
+    const previous = siblings[current - 1]
+    previous.focus()
+  }
+}


### PR DESCRIPTION
## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

[WAI-ARIA プラクティス](https://waic.jp/docs/2019/NOTE-wai-aria-practices-1.1-20190207/#accordion)にならい、AccordionPanel のキーボード操作ができるようにした。

- パネルヘッダーボタン（Trigger）を `Heading` で囲い、`headingType` や `headingTag` は外から渡せるようにした
  - スペースやエンターでパネルを開閉
  - タブでパネルヘッダーおよび開いたパネル内のコントロールにフォーカス
  - 矢印キーで同 AccordionPanel 内でヘッダーのフォーカスを移動
  - Home / End で最初 / 最後のヘッダーにフォーカスを移動
- `outline: none` をやめる
- `focus` 時にも `hover` と同じスタイルを追加
- `transition` が lazy だったので `0.2s` に変更
- 閉じているパネルは `aria-hidden` ではなく `hidden` にしてキーボード操作不可にした
- Storybook のサンプルでフォーカスの挙動を確認するため FieldSet を追加
