### PR TITLE
feat: export props of FieldSet component

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -8,7 +8,7 @@ import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { StatusLabel } from '../StatusLabel'
 import { Icon } from '../Icon'
 
-type Props = Omit<InputProps, 'error'> & {
+export type Props = Omit<InputProps, 'error'> & {
   label: string
   labelType?: HeadingTypes
   labelTagType?: HeadingTagTypes

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export {
   DropdownScrollArea,
   FilterDropdown,
 } from './components/Dropdown'
-export { FieldSet } from './components/FieldSet'
+export { FieldSet, Props as FieldSetProps } from './components/FieldSet'
 export { FlashMessage } from './components/FlashMessage'
 export { Input, CurrencyInput } from './components/Input'
 export { Textarea } from './components/Textarea'


### PR DESCRIPTION
## Related URL

None

## Overview

Sometimes we need to re-build customized `FieldSet` component, which wraps the original the `FieldSet` component. In the case, we'd like to re-use the props of the `FieldSet`, but it is not exported now. So now we have to redefine all the props and explicitly pass them to the `FieldSet` to achieve that goal.

```tsx
// CustomizedFieldSet.tsx
import { FieldSet } from 'smarthr-ui'

interface Props {
  label: string
  labelType?: HeadingTypes
  labelTagType?: HeadingTagTypes
  errorMessage?: string | string[]
  helpMessage?: string
  labelSuffix?: ReactNode
  className?: string
}

const CustomizedFieldSet: React.FC<Props> = (props) => (
  <FieldSet
    label={props.label}
    labelType={props.labelType}
    labelTagType={props.labelTagType}
    ...
  />
)
```

In order to avoid this workaround, export the props officially. This change makes the above code simplify:

```tsx
// CustomizedFieldSet.tsx
import { FieldSet, FieldSetProps } from 'smarthr-ui'

const CustomizedFieldSet: React.FC<FieldSetProps> = (props) => (
  <FieldSet {...props} />
)
```

## What I did

- Export `Props` type in `src/components/FieldSet/FieldSet.tsx`
- Export `FieldSetProps` type in `src/index.ts`

## Capture

None
