### PR TITLE
fix: fix styles of Calendar when using reset style (SHRUI-160)

### DIFF
--- a/src/components/Calendar/CalendarTable.tsx
+++ b/src/components/Calendar/CalendarTable.tsx
@@ -80,11 +80,12 @@ const Table = styled.table<{ themes: Theme }>(({ themes }) => {
     color: ${palette.TEXT_BLACK};
     font-size: ${size.pxToRem(size.font.TALL)};
     border-spacing: 0;
-    padding: 4px 8px 13px;
+    margin: 4px 8px 13px;
 
     th {
       height: 37px;
       padding: 0;
+      vertical-align: middle;
       text-align: center;
       font-weight: normal;
       color: ${palette.TEXT_GREY};
@@ -93,6 +94,7 @@ const Table = styled.table<{ themes: Theme }>(({ themes }) => {
       width: 43px;
       height: 35px;
       padding: 0;
+      vertical-align: middle;
     }
   `
 })


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
When using reset CSS like [styled-reset](https://github.com/zacanger/styled-reset), there is a problem of design collapse.
It needs to be modified to work fine with reset CSS.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* Set `vertical-align: middle;` to every table cell
* Change from `padding` to `margin` of table because `padding` is not working when `border-collapse: collapse;` is set.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

| before | after |
| --- | --- |
| ![スクリーンショット 2020-08-31 17 38 11](https://user-images.githubusercontent.com/270422/91701111-cb411400-ebb1-11ea-8fe7-dc9ec38c88a9.png) | ![スクリーンショット 2020-08-31 17 37 48](https://user-images.githubusercontent.com/270422/91701133-d1cf8b80-ebb1-11ea-9440-da98e2d1d58b.png) |



<!--
Please attach a capture if it looks different.
-->
