### PR TITLE
chore(deps): update dependency prettier to ^2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint-staged": "^10.2.13",
     "memory-fs": "^0.5.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.0.5",
+    "prettier": "^2.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-test-renderer": "16.13.1",

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -103,25 +103,19 @@ const Wrapper = styled.span<{
     border: ${frame.border.default};
     box-sizing: border-box;
     cursor: text;
-    ${
-      isFocused &&
-      css`
-        border-color: ${palette.hoverColor(palette.MAIN)};
-      `
-    }
-    ${
-      error &&
-      css`
-        border-color: ${palette.DANGER};
-      `
-    }
-    ${
-      disabled &&
-      css`
-        background-color: ${palette.COLUMN};
-        pointer-events: none;
-      `
-    }
+    ${isFocused &&
+    css`
+      border-color: ${palette.hoverColor(palette.MAIN)};
+    `}
+    ${error &&
+    css`
+      border-color: ${palette.DANGER};
+    `}
+    ${disabled &&
+    css`
+      background-color: ${palette.COLUMN};
+      pointer-events: none;
+    `}
   `
 })
 const StyledInput = styled.input<Props & { themes: Theme }>`

--- a/yarn.lock
+++ b/yarn.lock
@@ -13112,10 +13112,10 @@ prettier@^1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+prettier@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
+  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
 
 pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Related URL

- https://github.com/kufu/smarthr-ui/pull/971

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- update prettier from `^2.0.5` to `^2.1.1`
- apply updated format rule to code

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- update prettier (exactly same change as https://github.com/kufu/smarthr-ui/pull/971 )
- run `eslint --fix`

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
