### PR TITLE
feat: control z-index of portals by context

### DIFF
--- a/src/components/DatePicker/Portal.tsx
+++ b/src/components/DatePicker/Portal.tsx
@@ -2,6 +2,8 @@ import React, { FC, ReactNode, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 
+import { usePortalZIndex } from '../../hooks/usePortalZIndex'
+
 type Props = {
   top: number
   left: number
@@ -9,6 +11,8 @@ type Props = {
 }
 
 export const Portal: FC<Props> = ({ top, left, children }) => {
+  const zIndex = usePortalZIndex()
+
   const root = useRef(document.createElement('div')).current
   useEffect(() => {
     document.body.appendChild(root)
@@ -19,17 +23,18 @@ export const Portal: FC<Props> = ({ top, left, children }) => {
   }, [root])
 
   return createPortal(
-    <Container top={top} left={left}>
+    <Container top={top} left={left} zIndex={zIndex}>
       {children}
     </Container>,
     root,
   )
 }
 
-const Container = styled.div<{ top: number; left: number }>(
-  ({ top, left }) => css`
+const Container = styled.div<{ top: number; left: number; zIndex: number }>(
+  ({ top, left, zIndex }) => css`
     position: absolute;
     top: ${top}px;
     left: ${left}px;
+    z-index: ${zIndex};
   `,
 )

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -5,6 +5,7 @@ import { CSSTransition } from 'react-transition-group'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useHandleEscape } from '../../hooks/useHandleEscape'
 import { DialogPositionProvider } from './DialogPositionProvider'
+import { usePortalZIndex } from '../../hooks/usePortalZIndex'
 
 type Props = {
   onClickOverlay?: () => void
@@ -39,6 +40,7 @@ export const DialogContentInner: FC<Props> = ({
 }) => {
   const theme = useTheme()
   const domRef = useRef(null)
+  const zIndex = usePortalZIndex()
   useHandleEscape(onPressEscape)
 
   return (
@@ -56,7 +58,7 @@ export const DialogContentInner: FC<Props> = ({
         appear
         unmountOnExit
       >
-        <Wrapper ref={domRef}>
+        <Wrapper zIndex={zIndex} ref={domRef}>
           <Background onClick={onClickOverlay} themes={theme} />
           <Inner themes={theme} {...props}>
             {children}
@@ -69,8 +71,8 @@ export const DialogContentInner: FC<Props> = ({
   )
 }
 
-const Wrapper = styled.div`
-  z-index: 10000;
+const Wrapper = styled.div<{ zIndex: number }>`
+  z-index: ${({ zIndex }) => zIndex};
   position: fixed;
   top: 0;
   left: 0;
@@ -119,7 +121,6 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
 
     return css`
       position: absolute;
-      z-index: 10100;
       top: ${positionTop};
       right: ${positionRight};
       bottom: ${positionBottom};

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -5,6 +5,7 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { ContentBoxStyle, Rect, getContentBoxStyle } from './dropdownHelper'
 import { DropdownCloser } from './DropdownCloser'
+import { usePortalZIndex } from '../../hooks/usePortalZIndex'
 
 type Props = {
   triggerRect: Rect
@@ -41,6 +42,7 @@ export const DropdownContentInner: FC<Props> = ({
   useEffect(() => {
     setIsMounted(true)
   }, [])
+  const zIndex = usePortalZIndex()
 
   useEffect(() => {
     if (isMounted && wrapperRef.current) {
@@ -72,6 +74,7 @@ export const DropdownContentInner: FC<Props> = ({
       scrollable={scrollable}
       className={`${className} ${isActive ? 'active' : ''}`}
       controllable={controllable}
+      zIndex={zIndex}
       themes={theme}
     >
       {controllable ? (
@@ -90,11 +93,12 @@ const Wrapper = styled.div<{
   contentBox: ContentBoxStyle
   scrollable: boolean
   controllable: boolean
+  zIndex: number
 }>`
-  ${({ contentBox, themes, scrollable, controllable }) => {
+  ${({ contentBox, themes, scrollable, controllable, zIndex }) => {
     return css`
       visibility: hidden;
-      z-index: 99999;
+      z-index: ${zIndex};
       position: absolute;
       top: ${contentBox.top};
       left: ${contentBox.left};

--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode, useLayoutEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { getTooltipRect } from './tooltipHelper'
+import { usePortalZIndex } from '../../hooks/usePortalZIndex'
 
 type Props = {
   id: string
@@ -50,8 +51,10 @@ export const TooltipPortal: FC<Props> = ({
     )
   }, [horizontal, isIcon, isMultiLine, parentRect, vertical])
 
+  const zIndex = usePortalZIndex()
+
   return (
-    <Container id={id} ref={portalRef} {...rect}>
+    <Container id={id} ref={portalRef} zIndex={zIndex} {...rect}>
       {children}
     </Container>
   )
@@ -62,8 +65,9 @@ const Container = styled.div<{
   left: number
   width: number
   height: number
+  zIndex: number
 }>(
-  ({ top, left, width, height }) => css`
+  ({ top, left, width, height, zIndex }) => css`
     position: absolute;
     top: ${top}px;
     left: ${left}px;
@@ -75,6 +79,6 @@ const Container = styled.div<{
     css`
       height: ${height}px;
     `}
-    z-index: 9000;
+    z-index: ${zIndex};
   `,
 )

--- a/src/hooks/usePortalZIndex.tsx
+++ b/src/hooks/usePortalZIndex.tsx
@@ -1,0 +1,26 @@
+import React, { FC, ReactNode, createContext, useContext } from 'react'
+
+interface PortalZIndexValue {
+  zIndex: number
+}
+
+const defaultContext: PortalZIndexValue = {
+  zIndex: 10000,
+}
+
+const PortalZIndexContext = createContext<PortalZIndexValue>(defaultContext)
+
+export function usePortalZIndex() {
+  const context = useContext(PortalZIndexContext)
+  return context.zIndex
+}
+export const PortalZIndexProvider: FC<{ increment?: number; children: ReactNode }> = ({
+  increment = 0,
+  children,
+}) => {
+  const zIndex = usePortalZIndex()
+  const value: PortalZIndexValue = {
+    zIndex: zIndex + increment,
+  }
+  return <PortalZIndexContext.Provider value={value}>{children}</PortalZIndexContext.Provider>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,3 +91,4 @@ export { FONT_FAMILY, VISUALLY_HIDDEN_STYLE } from './constants'
 
 // utils
 export { SequencePrefixIdProvider } from './hooks/useId'
+export { PortalZIndexProvider } from './hooks/usePortalZIndex'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
portalの`z-index`をcontextによって管理する方法を模索します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- portalのz-indexを管理するContext, hookの追加

#### この対応で可能になること
  - 親子関係を取るportal同士（portal in portal）の重なりの破綻の解消
    - `createPortal()`で追加されるコンポーネントの`z-index`を、contextから与えるようにする
      - これによりportalの`z-Index`が基本同値となるため、react上で親子関係を取るportal同士はDOM追加順の関係で前後関係が崩れない
    - ちなみにcontextの初期値は`z-index: 10000`（暫定）
      - portalの基準`z-index`を表す
#### この対応でやらないこと
  - 兄弟要素のportal同士の前後の重なりの規定
    - 例えば横に並んでいる`DatePicker`と`DropDown`のどっちが前かは決めない
    - `PortalZIndexProvider`を用いることで調整可能にする
      - 使用側で適宜設定する
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
