### PR TITLE
fix!: DatePicker (SHRUI-178)

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -34,6 +34,10 @@ storiesOf('DatePicker', module)
             }}
           />
         </dd>
+        <dt>Disabled</dt>
+        <dd>
+          <DatePicker disabled />
+        </dd>
         <dt>Extending style (width: 50%)</dt>
         <dd>
           <ExtendingDatePicker onChangeDate={action('change date')} />

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -13,24 +13,24 @@ storiesOf('DatePicker', module)
     },
   })
   .add('all', () => {
-    const [date, setDate] = React.useState<Date | null>(new Date(2020, 0, 1))
+    const [value, setValue] = React.useState<string>(new Date(2020, 0, 1).toDateString())
     return (
       <List>
         <dt>DatePicker</dt>
         <dd>
-          <DatePicker onChangeDate={action('change date')} onChangeValue={action('change value')} />
+          <DatePicker onChangeDate={action('change')} />
         </dd>
         <dt>Custom format (ex. Date.toDateString)</dt>
         <dd>
           <DatePicker
-            date={date}
-            onChangeDate={(_date) => {
-              action('change date')(_date)
-              setDate(_date)
-            }}
+            value={value}
             formatDate={(_date) => {
               if (!_date) return ''
               return _date.toDateString()
+            }}
+            onChangeDate={(_date, _value) => {
+              action('change')(_date, _value)
+              setValue(_value)
             }}
           />
         </dd>
@@ -40,7 +40,7 @@ storiesOf('DatePicker', module)
         </dd>
         <dt>Extending style (width: 50%)</dt>
         <dd>
-          <ExtendingDatePicker onChangeDate={action('change date')} />
+          <ExtendingDatePicker onChangeDate={action('change')} />
         </dd>
       </List>
     )

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -18,7 +18,7 @@ storiesOf('DatePicker', module)
       <List>
         <dt>DatePicker</dt>
         <dd>
-          <DatePicker onChangeDate={action('change date')} />
+          <DatePicker onChangeDate={action('change date')} onChangeValue={action('change value')} />
         </dd>
         <dt>Custom format (ex. Date.toDateString)</dt>
         <dd>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -126,7 +126,7 @@ export const DatePicker: FC<Props> = ({
   }, [value, isInputFocused, dateToString, stringToDate])
 
   useOuterClick(
-    [inputWrapperRef.current, calendarRef.current],
+    [inputWrapperRef, calendarRef],
     useCallback(() => {
       switchCalendarVisibility(false)
     }, [switchCalendarVisibility]),

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -112,7 +112,7 @@ export const DatePicker: FC<Props> = ({
     }
     /**
      * Do not format the given value in the following cases
-     * - while input element is forcused.
+     * - while input element is focused.
      * - if the given value is not date formattable.
      */
     if (!isInputFocused) {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -18,6 +18,7 @@ type Props = {
   parseInput?: (input: string) => Date | null
   formatDate?: (date: Date | null) => string
   name?: string
+  error?: boolean
   className?: string
 }
 
@@ -28,6 +29,7 @@ export const DatePicker: FC<Props> = ({
   parseInput,
   formatDate,
   name,
+  error,
   className,
 }) => {
   const themes = useTheme()
@@ -208,7 +210,7 @@ export const DatePicker: FC<Props> = ({
               </CalendarIconWrapper>
             </CalendarIconLayout>
           }
-          error={shouldShowError}
+          error={error || shouldShowError}
           ref={inputRef}
         />
       </InputWrapper>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -18,6 +18,7 @@ type Props = {
   parseInput?: (input: string) => Date | null
   formatDate?: (date: Date | null) => string
   name?: string
+  disabled?: boolean
   error?: boolean
   className?: string
 }
@@ -29,6 +30,7 @@ export const DatePicker: FC<Props> = ({
   parseInput,
   formatDate,
   name,
+  disabled,
   error,
   className,
 }) => {
@@ -153,7 +155,7 @@ export const DatePicker: FC<Props> = ({
     <Container
       className={className}
       onClick={() => {
-        if (!isCalendarShown) {
+        if (!disabled && !isCalendarShown) {
           switchCalendarVisibility(true)
         }
       }}
@@ -210,6 +212,7 @@ export const DatePicker: FC<Props> = ({
               </CalendarIconWrapper>
             </CalendarIconLayout>
           }
+          disabled={disabled}
           error={error || shouldShowError}
           ref={inputRef}
         />

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -90,8 +90,8 @@ export const DatePicker: FC<Props> = ({
     setIsCalendarShown(true)
     const rect = inputWrapperRef.current.getBoundingClientRect()
     setCalendarPosition({
-      top: rect.top + rect.height - 4,
-      left: rect.left,
+      top: rect.top + rect.height - 4 + window.pageYOffset,
+      left: rect.left + window.pageXOffset,
     })
   }, [])
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -17,6 +17,7 @@ type Props = {
   parsingErrorMessage?: string
   parseInput?: (input: string) => Date | null
   formatDate?: (date: Date | null) => string
+  name?: string
   className?: string
 }
 
@@ -26,6 +27,7 @@ export const DatePicker: FC<Props> = ({
   parsingErrorMessage = '非対応な入力形式です',
   parseInput,
   formatDate,
+  name,
   className,
 }) => {
   const themes = useTheme()
@@ -167,6 +169,7 @@ export const DatePicker: FC<Props> = ({
       <InputWrapper ref={inputWrapperRef}>
         <StyledInput
           type="text"
+          name={name}
           onChange={() => {
             if (isCalendarShown) {
               switchCalendarVisibility(false)

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -14,6 +14,7 @@ import { parseJpnDateString } from './datePickerHelper'
 type Props = {
   date?: Date | null
   onChangeDate?: (date: Date | null) => void
+  onChangeValue?: (value: string) => void
   parsingErrorMessage?: string
   parseInput?: (input: string) => Date | null
   formatDate?: (date: Date | null) => string
@@ -26,6 +27,7 @@ type Props = {
 export const DatePicker: FC<Props> = ({
   date = null,
   onChangeDate,
+  onChangeValue,
   parsingErrorMessage = '非対応な入力形式です',
   parseInput,
   formatDate,
@@ -75,12 +77,14 @@ export const DatePicker: FC<Props> = ({
       if (!inputRef.current) {
         return
       }
-      inputRef.current.value = dateToString(newDate)
+      const newDateString = dateToString(newDate)
+      inputRef.current.value = newDateString
       setSelectedDate(newDate)
       setExistsParsingError(false)
       onChangeDate && onChangeDate(newDate)
+      onChangeValue && onChangeValue(newDateString)
     },
-    [selectedDate, dateToString, onChangeDate],
+    [selectedDate, dateToString, onChangeDate, onChangeValue],
   )
 
   const switchCalendarVisibility = useCallback((isVisible: boolean) => {
@@ -174,10 +178,11 @@ export const DatePicker: FC<Props> = ({
         <StyledInput
           type="text"
           name={name}
-          onChange={() => {
+          onChange={(e) => {
             if (isCalendarShown) {
               switchCalendarVisibility(false)
             }
+            onChangeValue && onChangeValue(e.target.value)
           }}
           onKeyPress={(e) => {
             if (e.key === 'Enter') {

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -6,11 +6,13 @@ import { DatePicker } from 'smarthr-ui'
 
 ```tsx
 <DatePicker
-  date={date}
+  value={value}
   onChangeDate={handleChangeDate}
-  parsingErrorMessage="custom parsing error message"
   parseInput={customParser}
   formatDate={customFormatter}
+  name={name}
+  disabled={disabled}
+  error={error}
 />
 ```
 
@@ -18,11 +20,13 @@ import { DatePicker } from 'smarthr-ui'
 
 ### DatePicker
 
-| Name                | Required | Type                                | DefaultValue           | Description                                |
-| ------------------- | -------- | ----------------------------------- | ---------------------- | ------------------------------------------ |
-| date                | -        | **Date**                            | null                   | Date value.                                |
-| onChangeDate        | -        | **(date: Date \| null) => void**    | -                      | Fired when date is changed.                |
-| parsingErrorMessage | -        | **string**                          | '非対応な入力形式です' | Error message of parsing date string.      |
-| parseInput          | -        | **(input: string) => Date \| null** | -                      | Custom parsing function for input.         |
-| formatDate          | -        | **(date: Date \| null) => string**  | -                      | Custom formatting function to displa date. |
-| className           | -        | **string**                          | -                      | `className` of component.                  |
+| Name         | Required | Type                                            | DefaultValue | Description                                |
+| ------------ | -------- | ----------------------------------------------- | ------------ | ------------------------------------------ |
+| value        | -        | **string \| null**                              | null         | `value` of input.                          |
+| onChangeDate | -        | **(date: Date \| null, value: string) => void** | -            | Fired when date is changed.                |
+| parseInput   | -        | **(input: string) => Date \| null**             | -            | Custom parsing function for input.         |
+| formatDate   | -        | **(date: Date \| null) => string**              | -            | Custom formatting function to displa date. |
+| name         | -        | **string**                                      | -            | `name` of input.                           |
+| disabled     | -        | **boolean**                                     | -            | `disabled` of input.                       |
+| error        | -        | **boolean**                                     | -            | `error` of input.                          |
+| className    | -        | **string**                                      | -            | `className` of component.                  |

--- a/src/components/DatePicker/useOuterClick.ts
+++ b/src/components/DatePicker/useOuterClick.ts
@@ -1,12 +1,12 @@
-import { useCallback, useEffect } from 'react'
+import { RefObject, useCallback, useEffect } from 'react'
 
 export function useOuterClick(
-  targets: Array<HTMLElement | null>,
+  targets: Array<RefObject<HTMLElement>>,
   callback: (e: MouseEvent) => void,
 ) {
   const handleOuterClick = useCallback(
     (e: MouseEvent) => {
-      if (targets.some((target) => isEventIncludedParent(e, target))) {
+      if (targets.some((target) => isEventIncludedParent(e, target.current))) {
         return
       }
       callback(e)


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-178
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`DatePicker`を全体的に修正します
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* valueの指定の仕方を`Date`から`string`に変更
  * 非Date formattableな文字列も受け取れるようにするため
* `onChangeDate`で、inputのvalueも受け取れるように変更
* `name`, `disabled`, `error` propsの追加
* invalid date error表示の削除
  * アプリケーションによって様々なバリデーションが有り得、そのメッセージを表示する場合`DatePicker`自体のエラー表示とバッティングしてしまう。そこで`DatePicker`の役割を「parseできない場合はinvalid dateで扱う」ように限定し、そのハンドリングはアプリケーション側に任せるように変更する
* `Calendar`の表示位置がスクロール量を考慮できていなかったので修正
* custom hook内のrefの扱い方がまずかったので修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
