### PR TITLE
fix: enable to ignore Icon what has no labels (SHRUI-148)

### DIFF
--- a/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -299,12 +299,15 @@ exports[`CheckBox should be match snapshot 1`] = `
             size={10}
           >
             <FaCheck
+              aria-hidden={true}
               className=""
               color="#fff"
+              focusable={false}
               role="img"
               size={10}
             >
               <IconBase
+                aria-hidden={true}
                 attr={
                   Object {
                     "viewBox": "0 0 512 512",
@@ -312,12 +315,15 @@ exports[`CheckBox should be match snapshot 1`] = `
                 }
                 className=""
                 color="#fff"
+                focusable={false}
                 role="img"
                 size={10}
               >
                 <svg
+                  aria-hidden={true}
                   color="#fff"
                   fill="currentColor"
+                  focusable={false}
                   height={10}
                   role="img"
                   size={10}

--- a/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
+++ b/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
@@ -384,12 +384,15 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
                       size={10}
                     >
                       <FaCheck
+                        aria-hidden={true}
                         className=""
                         color="#fff"
+                        focusable={false}
                         role="img"
                         size={10}
                       >
                         <IconBase
+                          aria-hidden={true}
                           attr={
                             Object {
                               "viewBox": "0 0 512 512",
@@ -397,12 +400,15 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
                           }
                           className=""
                           color="#fff"
+                          focusable={false}
                           role="img"
                           size={10}
                         >
                           <svg
+                            aria-hidden={true}
                             color="#fff"
                             fill="currentColor"
+                            focusable={false}
                             height={10}
                             role="img"
                             size={10}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -625,13 +625,26 @@ export const Icon: React.FC<Props> = ({
   className = '',
   role = 'img',
   visuallyHiddenText,
+  'aria-hidden': ariaHidden,
+  focusable = false,
   ...props
 }) => {
   const SvgIcon = iconMap[name]
+  const hasLabel =
+    visuallyHiddenText !== undefined ||
+    props['aria-label'] !== undefined ||
+    props['aria-labelledby'] !== undefined
+  const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasLabel
   return (
     <>
       {visuallyHiddenText && <VisuallyHiddenText>{visuallyHiddenText}</VisuallyHiddenText>}
-      <SvgIcon className={className} role={role} {...props} />
+      <SvgIcon
+        className={className}
+        role={role}
+        aria-hidden={isAriaHidden || undefined}
+        focusable={focusable}
+        {...props}
+      />
     </>
   )
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -630,11 +630,11 @@ export const Icon: React.FC<Props> = ({
   ...props
 }) => {
   const SvgIcon = iconMap[name]
-  const hasLabel =
+  const hasAltText =
     visuallyHiddenText !== undefined ||
     props['aria-label'] !== undefined ||
     props['aria-labelledby'] !== undefined
-  const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasLabel
+  const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasAltText
   return (
     <>
       {visuallyHiddenText && <VisuallyHiddenText>{visuallyHiddenText}</VisuallyHiddenText>}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-148
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
When the Icon is a visual decoration, it may want to be set `aria-hidden=true` and `focasable=false`.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
In `Icon` component
* set `focusable` **false** by default
* set `aria-hidden` **true** when the `Icon` has no settings of `visuallyHiddenText`, `aria-label` and `aria-labelledby`.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
