### PR TITLE
fix: add role attribute to tooltip

### DIFF
--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -53,7 +53,7 @@ export const TooltipPortal: FC<Props> = ({
   }, [horizontal, isIcon, isMultiLine, parentRect, vertical])
 
   return (
-    <Container id={id} ref={portalRef} themes={theme} {...rect}>
+    <Container id={id} ref={portalRef} themes={theme} role="tooltip" {...rect}>
       {children}
     </Container>
   )


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-172

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Tooltipを晴眼者しか見ることができず、[達成基準 1.3.1 情報及び関係性](https://waic.jp/docs/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html)に不適合なので対応しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Tooltipのコンテナ要素に、 `role=tooltip` を追加
  - https://waic.jp/docs/2019/NOTE-wai-aria-practices-1.1-20190207/#tooltip
  - (トリガーとなる要素に `aria-describedby` の記述があり、Tooltip要素を参照するようになっていたので `aria-describedby` は追加していません)

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
