### PR TITLE
fix: change tertiary link in Bottom Fixed Area to correct HTML

### DIFF
--- a/src/components/BottomFixedArea/TertiaryLink.tsx
+++ b/src/components/BottomFixedArea/TertiaryLink.tsx
@@ -48,7 +48,7 @@ const Button = styled.button<{ themes: Theme }>`
     `
   }}
 `
-const Text = styled.p<{ themes: Theme }>`
+const Text = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
     const { pxToRem, font } = themes.size
     return css`


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-188

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`BottomFixedArea` の `TertiaryLink` ですが、`button` の中に `p` がありHTML エラーなので対応しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `button` の中にある `p` を `span` に変更

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## dev check

- [Nu Html Checker](https://validator.w3.org/nu/) でエラーにならないこと

<!--
Please attach a capture if it looks different.
-->
