### PR TITLE
fix: calculate Calendar position in DatePicker (SHRUI-212)

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -42,6 +42,10 @@ storiesOf('DatePicker', module)
         <dd>
           <ExtendingDatePicker onChangeDate={action('change')} />
         </dd>
+        <dt className="bottom">Place on the page bottom</dt>
+        <dd>
+          <DatePicker onChangeDate={action('change')} />
+        </dd>
       </List>
     )
   })
@@ -52,6 +56,9 @@ const List = styled.dl`
 
   dd {
     margin: 10px 0 20px;
+  }
+  dt.bottom {
+    margin-top: 1000px;
   }
 `
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -60,10 +60,7 @@ export const DatePicker: FC<Props> = ({
   const inputRef = useRef<HTMLInputElement>(null)
   const inputWrapperRef = useRef<HTMLDivElement>(null)
   const calendarRef = useRef<HTMLDivElement>(null)
-  const [calendarPosition, setCalendarPosition] = useState({
-    top: 0,
-    left: 0,
-  })
+  const [inputRect, setInputRect] = useState<DOMRect>(new DOMRect())
   const [isInputFocused, setIsInputFocused] = useState(false)
   const [isCalendarShown, setIsCalendarShown] = useState(false)
 
@@ -99,11 +96,7 @@ export const DatePicker: FC<Props> = ({
       return
     }
     setIsCalendarShown(true)
-    const rect = inputWrapperRef.current.getBoundingClientRect()
-    setCalendarPosition({
-      top: rect.top + rect.height - 4 + window.pageYOffset,
-      left: rect.left + window.pageXOffset,
-    })
+    setInputRect(inputWrapperRef.current.getBoundingClientRect())
   }, [])
 
   useEffect(() => {
@@ -236,7 +229,7 @@ export const DatePicker: FC<Props> = ({
         />
       </InputWrapper>
       {isCalendarShown && (
-        <Portal {...calendarPosition}>
+        <Portal inputRect={inputRect}>
           <Calendar
             value={selectedDate || undefined}
             onSelectDate={(_, selected) => {

--- a/src/components/DatePicker/Portal.tsx
+++ b/src/components/DatePicker/Portal.tsx
@@ -1,9 +1,10 @@
-import React, { FC, ReactNode, useEffect } from 'react'
+import React, { FC, ReactNode, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { usePortal } from '../../hooks/usePortal'
+import { getPortalPosition } from './datePickerHelper'
 
 type Props = {
   inputRect: DOMRect
@@ -21,11 +22,26 @@ export const Portal: FC<Props> = ({ inputRect, children }) => {
     }
   }, [portalRoot])
 
-  const top = inputRect.top + inputRect.height - 4 + window.pageYOffset
-  const left = inputRect.left + window.pageXOffset
+  const [position, setPosition] = useState({
+    top: 0,
+    left: 0,
+  })
+  const [isReady, setIsReady] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    // wait for createPortal
+    requestAnimationFrame(() => {
+      if (!containerRef.current) {
+        return
+      }
+      setPosition(getPortalPosition(inputRect, containerRef.current.offsetHeight))
+      setIsReady(true)
+    })
+  }, [inputRect])
 
   return createPortal(
-    <Container top={top} left={left} themes={themes}>
+    <Container {...position} themes={themes} className={isReady ? 'ready' : ''} ref={containerRef}>
       {children}
     </Container>,
     portalRoot,
@@ -38,5 +54,10 @@ const Container = styled.div<{ top: number; left: number; themes: Theme }>(
     top: ${top}px;
     left: ${left}px;
     z-index: ${themes.zIndex.OVERLAP};
+
+    visibility: hidden;
+    &.ready {
+      visibility: visible;
+    }
   `,
 )

--- a/src/components/DatePicker/Portal.tsx
+++ b/src/components/DatePicker/Portal.tsx
@@ -6,12 +6,11 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { usePortal } from '../../hooks/usePortal'
 
 type Props = {
-  top: number
-  left: number
+  inputRect: DOMRect
   children: ReactNode
 }
 
-export const Portal: FC<Props> = ({ top, left, children }) => {
+export const Portal: FC<Props> = ({ inputRect, children }) => {
   const themes = useTheme()
   const { portalRoot } = usePortal()
   useEffect(() => {
@@ -21,6 +20,9 @@ export const Portal: FC<Props> = ({ top, left, children }) => {
       document.body.removeChild(portalRoot)
     }
   }, [portalRoot])
+
+  const top = inputRect.top + inputRect.height - 4 + window.pageYOffset
+  const left = inputRect.left + window.pageXOffset
 
   return createPortal(
     <Container top={top} left={left} themes={themes}>

--- a/src/components/DatePicker/datePickerHelper.ts
+++ b/src/components/DatePicker/datePickerHelper.ts
@@ -80,3 +80,25 @@ export function parseJpnDateString(dateString: string): Date {
 
   return dayjs(converted).toDate()
 }
+
+export function getPortalPosition(inputRect: DOMRect, contentHeihgt: number) {
+  const margin = 4
+  const { innerHeight, pageYOffset } = window
+
+  const left = pageXOffset + inputRect.left
+
+  const hasNoSpaceOnBottomSide = inputRect.bottom + contentHeihgt > innerHeight
+  const isTopSideSpaceBiggerThanBottomSide = inputRect.top > innerHeight - inputRect.bottom
+  if (hasNoSpaceOnBottomSide && isTopSideSpaceBiggerThanBottomSide) {
+    // display on top side
+    return {
+      top: pageYOffset + inputRect.top - contentHeihgt + margin,
+      left,
+    }
+  }
+  // display on bottom side
+  return {
+    top: pageYOffset + inputRect.bottom - margin,
+    left,
+  }
+}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-212
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`body`にスクロール制限がかかっている時、`DatePicker`の`Calendar`がページ下方にはみ出した時にスクロールして表示することができなくなる問題を解消する。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 特定の条件下で、`Calendar`をinputの上側に表示するように変更
  - input下側に`Calendar`を表示するための十分なスペースがなく、且つ、input下側のスペースより上側のスペースのほうが大きい場合
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
![image](https://user-images.githubusercontent.com/270422/96425179-b3dbea00-1236-11eb-91e9-ccec3049c935.png)

<!--
Please attach a capture if it looks different.
-->
