### PR TITLE
fix: consider reset css in BackgroundJobsPanel (SHRUI-213)

### DIFF
--- a/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
+++ b/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
@@ -153,9 +153,9 @@ const Job = styled.li<{ themes: Theme }>(({ themes }) => {
   const { pxToRem, space } = themes.size
   return css`
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     flex-wrap: nowrap;
-    line-height: 1rem;
+    line-height: normal;
     :not(:first-child) {
       margin-top: ${pxToRem(space.XS)};
     }
@@ -163,6 +163,7 @@ const Job = styled.li<{ themes: Theme }>(({ themes }) => {
 })
 const JobIconWrapper = styled.div`
   flex-shrink: 0;
+  line-height: 0;
 `
 const JobName = styled(OmittableJobText)<{ themes: Theme }>(({ themes }) => {
   const { font, pxToRem, space } = themes.size

--- a/src/components/BackgroundJobsPanel/JobIcon.tsx
+++ b/src/components/BackgroundJobsPanel/JobIcon.tsx
@@ -12,7 +12,7 @@ export const JobIcon: FC<Props> = ({ status }) => {
   const name = getIconName(status)
   const color = useIconColor(status)
 
-  return <Icon name={name} color={color} />
+  return <Icon name={name} color={color} size={16} />
 }
 
 function getIconName(status: Status): ComponentProps<typeof Icon>['name'] {

--- a/src/components/BackgroundJobsPanel/OmittableJobText.tsx
+++ b/src/components/BackgroundJobsPanel/OmittableJobText.tsx
@@ -35,6 +35,7 @@ const Wrapper = styled.div`
   overflow: hidden;
 `
 const Tooltip = styled(LightTooltip)`
+  display: block;
   text-overflow: ellipsis;
   overflow: hidden;
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-213
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Modify styles of `BackgroundJobsPanel` not to collapse styles with reset css 

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Adjust `line-height` and `align-items` of Job row.
- Set `display: block` to Tooltip to ignore own line-height.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
![スクリーンショット 2020-10-21 12 11 05](https://user-images.githubusercontent.com/270422/96668938-354a8e00-1397-11eb-8106-8e9478873fd9.png)

<!--
Please attach a capture if it looks different.
-->
