### PR TITLE
fix: DatePicker bugs

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -64,7 +64,7 @@ export const DatePicker: FC<Props> = ({
   const [selectedDate, setSelectedDate] = useState<Date | null>(stringToDate(value))
   const inputRef = useRef<HTMLInputElement>(null)
   const inputWrapperRef = useRef<HTMLDivElement>(null)
-  const calendarRef = useRef<HTMLDivElement>(null)
+  const calendarPortalRef = useRef<HTMLDivElement>(null)
   const [inputRect, setInputRect] = useState<DOMRect>(new DOMRect())
   const [isInputFocused, setIsInputFocused] = useState(false)
   const [isCalendarShown, setIsCalendarShown] = useState(false)
@@ -124,7 +124,7 @@ export const DatePicker: FC<Props> = ({
   }, [value, isInputFocused, dateToString, stringToDate])
 
   useOuterClick(
-    [inputWrapperRef, calendarRef],
+    [inputWrapperRef, calendarPortalRef],
     useCallback(() => {
       switchCalendarVisibility(false)
     }, [switchCalendarVisibility]),
@@ -132,10 +132,10 @@ export const DatePicker: FC<Props> = ({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || !inputRef.current || !calendarRef.current) {
+      if (e.key !== 'Tab' || !inputRef.current || !calendarPortalRef.current) {
         return
       }
-      const calendarButtons = calendarRef.current.querySelectorAll('button')
+      const calendarButtons = calendarPortalRef.current.querySelectorAll('button')
       if (calendarButtons.length === 0) {
         return
       }
@@ -234,7 +234,7 @@ export const DatePicker: FC<Props> = ({
         />
       </InputWrapper>
       {isCalendarShown && (
-        <Portal inputRect={inputRect}>
+        <Portal inputRect={inputRect} ref={calendarPortalRef}>
           <Calendar
             value={selectedDate || undefined}
             from={from}
@@ -247,7 +247,6 @@ export const DatePicker: FC<Props> = ({
               })
               inputRef.current && inputRef.current.focus()
             }}
-            ref={calendarRef}
           />
         </Portal>
       )}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -26,7 +26,7 @@ type Props = {
 }
 
 export const DatePicker: FC<Props> = ({
-  value = null,
+  value,
   name,
   from,
   to,
@@ -105,7 +105,7 @@ export const DatePicker: FC<Props> = ({
   }, [])
 
   useEffect(() => {
-    if (!value || !inputRef.current) {
+    if (value === undefined || !inputRef.current) {
       return
     }
     /**
@@ -117,10 +117,12 @@ export const DatePicker: FC<Props> = ({
       const newDate = stringToDate(value)
       if (newDate && dayjs(newDate).isValid()) {
         inputRef.current.value = dateToString(newDate)
+        setSelectedDate(newDate)
         return
       }
+      setSelectedDate(null)
     }
-    inputRef.current.value = value
+    inputRef.current.value = value || ''
   }, [value, isInputFocused, dateToString, stringToDate])
 
   useOuterClick(

--- a/src/components/DatePicker/Portal.tsx
+++ b/src/components/DatePicker/Portal.tsx
@@ -1,4 +1,11 @@
-import React, { FC, ReactNode, useEffect, useRef, useState } from 'react'
+import React, {
+  ReactNode,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -11,7 +18,7 @@ type Props = {
   children: ReactNode
 }
 
-export const Portal: FC<Props> = ({ inputRect, children }) => {
+export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, children }, ref) => {
   const themes = useTheme()
   const { portalRoot } = usePortal()
 
@@ -21,6 +28,7 @@ export const Portal: FC<Props> = ({ inputRect, children }) => {
   })
   const [isReady, setIsReady] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(ref, () => containerRef.current)
 
   useEffect(() => {
     // wait for createPortal
@@ -39,7 +47,7 @@ export const Portal: FC<Props> = ({ inputRect, children }) => {
     </Container>,
     portalRoot,
   )
-}
+})
 
 const Container = styled.div<{ top: number; left: number; themes: Theme }>(
   ({ top, left, themes }) => css`
@@ -47,6 +55,7 @@ const Container = styled.div<{ top: number; left: number; themes: Theme }>(
     top: ${top}px;
     left: ${left}px;
     z-index: ${themes.zIndex.OVERLAP};
+    line-height: 1;
 
     visibility: hidden;
     &.ready {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`DatePicker`のバグを2点修正します

* `Calendar`が上側表示される際の input との重なり具合を修正
* `value`propに`null`を設定した時、正しく input に値が反映されない不具合を修正
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* `value`propに`null`が入ったときもinputへの反映用の`useEffect`が発火するように修正
  * 同時に、適切に`selectedDate`が更新されるように修正
* `Calendar`の portal の位置及び外側クリック判定対象を修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![スクリーンショット 2020-10-22 18 08 15](https://user-images.githubusercontent.com/270422/96850317-a0788b00-1491-11eb-957f-323e9600e016.png) | ![スクリーンショット 2020-10-22 18 07 21](https://user-images.githubusercontent.com/270422/96850328-a53d3f00-1491-11eb-8630-f3a92d0b48a3.png) |
<!--
Please attach a capture if it looks different.
-->
