### PR TITLE
fix:  invalid html width attribute

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -32,7 +32,7 @@ export const FieldSet: FC<Props> = ({
   const theme = useTheme()
 
   return (
-    <Wrapper width={props.width || 'auto'} className={className}>
+    <Wrapper $width={props.width || 'auto'} className={className}>
       <Title themes={theme}>
         <TitleText type={labelType} tag={labelTagType}>
           {label}
@@ -58,10 +58,10 @@ export const FieldSet: FC<Props> = ({
   )
 }
 
-const Wrapper = styled.div<{ width: string | number }>`
-  ${({ width }) => css`
+const Wrapper = styled.div<{ $width: string | number }>`
+  ${({ $width }) => css`
     display: inline-block;
-    width: ${typeof width === 'number' ? `${width}px` : width};
+    width: ${typeof $width === 'number' ? `${$width}px` : $width};
   `}
 `
 const Title = styled.div<{ themes: Theme }>`

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -35,7 +35,7 @@ export type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> & {
 }
 
 export const Input = forwardRef<HTMLInputElement, Props>(
-  ({ onFocus, onBlur, autoFocus, prefix, suffix, className, ...props }, ref) => {
+  ({ onFocus, onBlur, autoFocus, prefix, suffix, className, width, ...props }, ref) => {
     const theme = useTheme()
     const innerRef = useRef<HTMLInputElement>(null)
     const [isFocused, setIsFocused] = useState(false)
@@ -64,7 +64,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     return (
       <Wrapper
         themes={theme}
-        width={props.width}
+        $width={width}
         isFocused={isFocused}
         disabled={props.disabled}
         error={props.error}
@@ -87,16 +87,16 @@ export const Input = forwardRef<HTMLInputElement, Props>(
 
 const Wrapper = styled.span<{
   themes: Theme
-  width?: string | number
+  $width?: string | number
   isFocused: boolean
   disabled?: boolean
   error?: boolean
-}>(({ themes, width = 'auto', isFocused, disabled, error }) => {
+}>(({ themes, $width = 'auto', isFocused, disabled, error }) => {
   const { frame, palette, size } = themes
   return css`
     display: inline-flex;
     align-items: stretch;
-    width: ${typeof width === 'number' ? `${width}px` : width};
+    width: ${typeof $width === 'number' ? `${$width}px` : $width};
     padding: 0 ${size.pxToRem(size.space.XXS)};
     background-color: #fff;
     border-radius: ${frame.border.radius.m};


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-194

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- htmlにinvalidなwidth属性が指定される場合があったため対応したい

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

以下のコンポーネントで不正なwidth属性を取り除いた

- FieldSet
- Input
- MessageScreen

widthをTransient propsに変更しています

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
