### PR TITLE
fix: change to add aria-label to icon

### DIFF
--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -40,11 +40,12 @@ export const MessageScreen: FC<Props> = ({ title, links, children, className = '
                 <Link
                   href={link.url}
                   {...(link.target ? { target: link.target } : {})}
-                  {...(link.target === '_blank' ? { 'aria-label': '別タブで開く' } : {})}
                   themes={theme}
                 >
                   {link.label}
-                  {link.target === '_blank' && <ExternalIcon color={theme.palette.TEXT_LINK} />}
+                  {link.target === '_blank' && (
+                    <ExternalIcon color={theme.palette.TEXT_LINK} aria-label="別タブで開く" />
+                  )}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-223

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`MessageScreen` コンポーネントの `aria-label = "別タブで開く"` がアイコンではなくリンク自体についているので修正しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- リンクではなくアイコンに `aria-label = "別タブで開く"` を付与。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
