### PR TITLE
fix: pass undefined to accept instead of blank string

### DIFF
--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -18,7 +18,7 @@ const overrideEventDefault = (e: DragEvent<HTMLElement>) => {
   e.stopPropagation()
 }
 
-export const DropZone: React.FC<DropZoneProps> = ({ children, onSelectFiles, accept = '' }) => {
+export const DropZone: React.FC<DropZoneProps> = ({ children, onSelectFiles, accept }) => {
   const theme = useTheme()
   const fileRef = useRef<HTMLInputElement>(null)
   const [filesDraggedOver, setFilesDraggedOver] = useState(false)


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-191

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- passing `''` to accept field is invalid on [Nu Html Checker](https://validator.w3.org/nu/)

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- fixed to pass `undefined` to accept instead of `''`

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
