### PR TITLE
fix: change the value of min props in the calendar component

### DIFF
--- a/src/components/Calendar/calendarHelper.test.ts
+++ b/src/components/Calendar/calendarHelper.test.ts
@@ -2,15 +2,15 @@ import { getFromDate, getMonthArray, getToDate, isBetween } from './calendarHelp
 
 describe('calendarHelper', () => {
   describe('getFromDate', () => {
-    it('returns given date when date is after 1970-01-01', () => {
+    it('returns given date when date is after 1900-01-01', () => {
       const actual = getFromDate(new Date(2020, 5, 15))
       expect(actual.getFullYear()).toBe(2020)
       expect(actual.getMonth()).toBe(5)
       expect(actual.getDate()).toBe(15)
     })
-    it('returns 1970-01-01 when date is before 1970-01-01', () => {
+    it('returns 1900-01-01 when date is before 1900-01-01', () => {
       const actual = getFromDate(new Date(1000, 5, 15))
-      expect(actual.getFullYear()).toBe(1970)
+      expect(actual.getFullYear()).toBe(1900)
       expect(actual.getMonth()).toBe(0)
       expect(actual.getDate()).toBe(1)
     })

--- a/src/components/Calendar/calendarHelper.ts
+++ b/src/components/Calendar/calendarHelper.ts
@@ -3,10 +3,17 @@ import dayjs from 'dayjs'
 export const daysInWeek = ['日', '月', '火', '水', '木', '金', '土']
 
 export function getFromDate(date?: Date): Date {
-  const min = new Date(1970, 0, 1)
-  if (!date || isNaN(date.getTime()) || date.getTime() < 0) {
+  const defaultDate = new Date(1970, 0, 1)
+  const min = new Date(1900, 0, 1)
+
+  if (!date || isNaN(date.getTime())) {
+    return defaultDate
+  }
+
+  if (date.getTime() < min.getTime()) {
     return min
   }
+
   return date
 }
 


### PR DESCRIPTION
## Related URL

なし

## Overview

Calendar コンポーネントの用途として生年月日の選択などがあるが、現状だと最低値が1970年1月1日なので、これを1900年1月1日まで下げたい。
1900年1月1日という値は特に明確な理由はなく、 SmartHR のユースケースにおいてはこれより下の年月日を選択したい時はなさそうという感じです。
from props を渡さなかった場合のデフォルトの値は変わらず1970年1月1日のままです。

## What I did

- from props の min の値を変更

## Capture

なし
