### PR TITLE
fix: アコーディオンパネルの展開時に overflow を既定値に戻す

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelContent.tsx
+++ b/src/components/AccordionPanel/AccordionPanelContent.tsx
@@ -85,5 +85,6 @@ const CollapseContainer = styled.div`
 
   &.entered {
     height: auto;
+    overflow: visible;
   }
 `


### PR DESCRIPTION
## Overview

アコーディオンパネルの開閉に `overflow: hidden` を利用しているが、`hidden` のままだと展開時に内部コンテンツが見切れる可能性がある。
例えばラジオボタンやチェックボックスを配置した場合に「アウトラインだけ見切れる」という事象が発生する。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

アコーディオンパネルのコンテナ要素の展開時 `.enterd` に対して `overflow` の既定値 `visible` を設定した。

## Capture

<!--
Please attach a capture if it looks different.
-->

見た目の変更はないのでありません。