### PR TITLE
chore: authenticate docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,16 +45,25 @@ jobs:
   node-v10:
     docker:
       - image: circleci/node:10
+        auth:
+          username: smarthrinc
+          password: $DOCKER_HUB_ACCESS_TOKEN
     steps:
       - run-npm-test
   node-v12:
     docker:
       - image: circleci/node:12
+        auth:
+          username: smarthrinc
+          password: $DOCKER_HUB_ACCESS_TOKEN
     steps:
       - run-npm-test
   reg-suit:
     docker:
       - image: regviz/node-xcb
+        auth:
+          username: smarthrinc
+          password: $DOCKER_HUB_ACCESS_TOKEN
     working_directory: ~/repo
     steps:
       - run-reg-suit


### PR DESCRIPTION
## Related URL

https://smarthr-inc.docbase.io/posts/1585443#docker-hub-%E3%81%AE%E4%BB%B6-tknzk

## Overview

- Docker Hub の無料プランにおける image の pull の回数制限が始まりました
- これを受けて弊社で Docker Hub への課金が始まりました
  - https://smarthr-inc.docbase.io/posts/1585443#docker-hub-%E3%81%AE%E4%BB%B6-tknzk
- CircleCI の設定で docker pull するところで認証を通さなきゃいけなくなりました

## What I did

- CircleCI の `config.yml` で認証情報を追加

## Capture

🍐 
