### PR TITLE
[WIP] chore: experiment CSF and MDX format with storybook-addon-docs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../**/*.stories.js'],
+  stories: ['../**/*.stories.tsx', '../**/*.stories.mdx'],
   addons: [
     'storybook-readme',
     {
@@ -7,7 +7,6 @@ module.exports = {
       options: {
         // we are not ready to use them yet.
         controls: false,
-        docs: false
       }
     },
     {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,13 +2,7 @@ module.exports = {
   stories: ['../**/*.stories.tsx', '../**/*.stories.mdx'],
   addons: [
     'storybook-readme',
-    {
-      name: '@storybook/addon-essentials',
-      options: {
-        // we are not ready to use them yet.
-        controls: false,
-      }
-    },
+    '@storybook/addon-essentials',
     {
       name: '@storybook/addon-storysource',
       options: {

--- a/src/components/ButtonTest/BaseButton.tsx
+++ b/src/components/ButtonTest/BaseButton.tsx
@@ -1,0 +1,135 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+import { hoverable } from '../../hocs/hoverable'
+import { isTouchDevice } from '../../libs/ua'
+
+type Tag = 'button' | 'a'
+type Size = 'default' | 's'
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+
+export type ButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'size' | 'prefix'> &
+  BaseProps
+export type AnchorProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'prefix'> & BaseProps
+
+export type BaseProps = {
+  size?: Size
+  children?: React.ReactNode
+  className?: string
+  prefix?: React.ReactNode
+  suffix?: React.ReactNode
+  square?: boolean
+  wide?: boolean
+}
+
+export const buttonFactory: <Props extends BaseProps>(tag: Tag) => FC<Props> = (tag) => {
+  const Tag = hoverable()(tagStore[tag])
+
+  return ({
+    size = 'default',
+    className = '',
+    square = false,
+    children = '',
+    prefix = '',
+    suffix = '',
+    ...props
+  }) => {
+    const theme = useTheme()
+
+    // prettier-ignore
+    const classNames = `${size} ${className} ${square ? 'square' : ''} ${prefix ? 'prefix' : ''} ${suffix ? 'suffix' : ''}`
+
+    return (
+      <Tag className={classNames} themes={theme} {...props}>
+        {prefix && <Prefix themes={theme}>{prefix}</Prefix>}
+        {children}
+        {suffix && <Suffix themes={theme}>{suffix}</Suffix>}
+      </Tag>
+    )
+  }
+}
+
+const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
+  ${({ themes, wide }) => {
+    const { frame, size, interaction } = themes
+
+    return css`
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      width: ${wide ? '100%;' : 'auto'};
+      min-width: 2rem;
+      vertical-align: middle;
+      border-radius: ${frame.border.radius.m};
+      font-family: inherit;
+      font-weight: bold;
+      text-align: center;
+      text-decoration: none;
+      box-sizing: border-box;
+      cursor: pointer;
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      white-space: nowrap;
+
+      &.default {
+        font-size: ${size.pxToRem(size.font.TALL)};
+        height: 40px;
+        padding: 0 ${size.pxToRem(size.space.XS)};
+      }
+
+      &.s {
+        font-size: ${size.pxToRem(size.font.SHORT)};
+        height: 27px;
+        padding: 0 ${size.pxToRem(size.space.XXS)};
+      }
+
+      &.square {
+        width: 40px;
+        padding: 0;
+
+        &.s {
+          width: 27px;
+          min-width: 27px;
+        }
+      }
+
+      &[disabled] {
+        cursor: not-allowed;
+      }
+
+      &.suffix {
+        justify-content: space-between;
+      }
+
+      &.prefix {
+        justify-content: left;
+      }
+    `
+  }}
+`
+const Prefix = styled.span<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { pxToRem, space } = themes.size
+    return css`
+      display: inline-flex;
+      margin-right: ${pxToRem(space.XXS)};
+    `
+  }}
+`
+const Suffix = styled.span<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { pxToRem, space } = themes.size
+    return css`
+      display: inline-flex;
+      margin-left: ${pxToRem(space.XXS)};
+    `
+  }}
+`
+const tagStore = {
+  button: Base.withComponent('button'),
+  a: Base.withComponent('a'),
+}
+
+export const BaseButton: FC<ButtonProps> = buttonFactory<ButtonProps>('button')
+export const BaseButtonAnchor: FC<AnchorProps> = buttonFactory<AnchorProps>('a')

--- a/src/components/ButtonTest/BaseButton.tsx
+++ b/src/components/ButtonTest/BaseButton.tsx
@@ -15,12 +15,27 @@ export type ButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 's
 export type AnchorProps = Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'prefix'> & BaseProps
 
 export type BaseProps = {
+  /**
+   * ## The size of button
+   * You can write this comment as Markdown
+   */
   size?: Size
-  children?: React.ReactNode
   className?: string
+  /**
+   * An element placed before the label
+   */
   prefix?: React.ReactNode
+  /**
+   * An element placed after the label
+   */
   suffix?: React.ReactNode
+  /**
+   * A boolean if the button is a square shape
+   */
   square?: boolean
+  /**
+   * A boolean if the button is a wide shape
+   */
   wide?: boolean
 }
 

--- a/src/components/ButtonTest/ButtonTest.stories.mdx
+++ b/src/components/ButtonTest/ButtonTest.stories.mdx
@@ -1,80 +1,83 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Canvas, Description } from '@storybook/addon-docs/blocks';
 import { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
+import { SecondaryButton } from './SecondaryButton'
+import { DangerButton } from './DangerButton'
 import { ArgsTable } from '@storybook/addon-docs/blocks';
 import { Icon } from '../Icon'
 import { action } from '@storybook/addon-actions'
 
-<Meta title="ButtonTest/MDX" component={PrimaryButton} args={{primary: true }} />
+export const Template = (args) => (
+  <>
+    <PrimaryButton onClick={action('clicked')} {...args}>
+      {args.children ?? 'Button'}
+    </PrimaryButton>
+    <SecondaryButton onClick={action('clicked')} {...args}>
+      {args.children ?? 'SecondaryButton'}
+    </SecondaryButton>
+    <DangerButton onClick={action('clicked')} {...args}>
+      {args.children ?? 'DangerButton'}
+    </DangerButton>
+    <PrimaryButtonAnchor href="#" {...args}>
+      {args.children ?? 'Anchor'}
+    </PrimaryButtonAnchor>
+    <PrimaryButton disabled={true} {...args}>
+      {args.children ?? 'Disabled'}
+    </PrimaryButton>
+  </>
+)
 
-# Hello
+<Meta
+  title="ButtonTest/Button(MDX)"
+  component={PrimaryButton}
+  subcomponents={[PrimaryButtonAnchor, SecondaryButton, DangerButton]}
+  argTypes={{
+    prefix: { control: false },
+    suffix: { control: false },
+  }}
+/>
 
-Hello, this is an awesome button.
-- foo
-- bar
-- baz
+# Button(MDX)
 
-<ArgsTable of={PrimaryButton} />
+<Description of={PrimaryButton} />
 
 <Canvas>
   <Story name="Default">
-      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={() => {}}/>
+      {Template.bind({})}
    </Story>
 </Canvas>
 
-you can use this button with an icon
+<ArgsTable of={PrimaryButton} />
+
+You can put an icon before the label text.
+
+## Stories
+
+### With Icon
+
+You can put an icon before the label text
 
 <Canvas>
-  <Story name="WithIcon">
-    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
-        Button
-      </PrimaryButton>
-      <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
-        Anchor
-      </PrimaryButtonAnchor>
-      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
-        Disabled
-      </PrimaryButton>
+  <Story name="WithIcon" args={{ prefix: <Icon size={14} name="fa-plus-circle" /> }}>
+  {Template.bind({})}
   </Story>
 </Canvas>
 
-<Canvas>
-  <Story name="WithIconLeft">
-      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
-        Button
-      </PrimaryButton>
-      <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
-        Anchor
-      </PrimaryButtonAnchor>
-      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
-        Disabled
-      </PrimaryButton>
-    </Story>
-</Canvas>
+### With Icon Right
+
+You can put an icon after the label text
 
 <Canvas>
-  <Story name="WithIconRight">
-      <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
-        Button
-      </PrimaryButton>
-      <PrimaryButtonAnchor suffix={<Icon size={14} name="fa-plus-circle" />} href="#">
-        Anchor
-      </PrimaryButtonAnchor>
-      <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
-        Disabled
-      </PrimaryButton>
-    </Story>
+  <Story name="WithIconRight" args={{ suffix: <Icon size={14} name="fa-plus-circle" /> }}>
+  {Template.bind({})}
+  </Story>
 </Canvas>
 
+### Only Icon
+
+This is an icon button
+
 <Canvas>
-  <Story name="OnlyIcon">
-      <PrimaryButton onClick={action('clicked')} square>
-        <Icon size={16} name="fa-plus-circle" />
-      </PrimaryButton>
-      <PrimaryButtonAnchor href="#" square>
-        <Icon size={16} name="fa-plus-circle" />
-      </PrimaryButtonAnchor>
-      <PrimaryButton disabled={true} square>
-        <Icon size={16} name="fa-plus-circle" />
-      </PrimaryButton>
-    </Story>
+  <Story name="OnlyIcon" args={{ square: true, children: <Icon size={16} name="fa-plus-circle" /> }}>
+  {Template.bind({})}
+  </Story>
 </Canvas>

--- a/src/components/ButtonTest/ButtonTest.stories.mdx
+++ b/src/components/ButtonTest/ButtonTest.stories.mdx
@@ -1,0 +1,80 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+import { Icon } from '../Icon'
+import { action } from '@storybook/addon-actions'
+
+<Meta title="ButtonTest/MDX" component={PrimaryButton} args={{primary: true }} />
+
+# Hello
+
+Hello, this is an awesome button.
+- foo
+- bar
+- baz
+
+<ArgsTable of={PrimaryButton} />
+
+<Canvas>
+  <Story name="Default">
+      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={() => {}}/>
+   </Story>
+</Canvas>
+
+you can use this button with an icon
+
+<Canvas>
+  <Story name="WithIcon">
+    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
+        Button
+      </PrimaryButton>
+      <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
+        Anchor
+      </PrimaryButtonAnchor>
+      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
+        Disabled
+      </PrimaryButton>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="WithIconLeft">
+      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
+        Button
+      </PrimaryButton>
+      <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
+        Anchor
+      </PrimaryButtonAnchor>
+      <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
+        Disabled
+      </PrimaryButton>
+    </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="WithIconRight">
+      <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
+        Button
+      </PrimaryButton>
+      <PrimaryButtonAnchor suffix={<Icon size={14} name="fa-plus-circle" />} href="#">
+        Anchor
+      </PrimaryButtonAnchor>
+      <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
+        Disabled
+      </PrimaryButton>
+    </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="OnlyIcon">
+      <PrimaryButton onClick={action('clicked')} square>
+        <Icon size={16} name="fa-plus-circle" />
+      </PrimaryButton>
+      <PrimaryButtonAnchor href="#" square>
+        <Icon size={16} name="fa-plus-circle" />
+      </PrimaryButtonAnchor>
+      <PrimaryButton disabled={true} square>
+        <Icon size={16} name="fa-plus-circle" />
+      </PrimaryButton>
+    </Story>
+</Canvas>

--- a/src/components/ButtonTest/ButtonTest.stories.tsx
+++ b/src/components/ButtonTest/ButtonTest.stories.tsx
@@ -4,82 +4,80 @@ import { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
 import { SecondaryButton } from './SecondaryButton'
 import { DangerButton } from './DangerButton'
 import { Icon } from '../Icon'
+import { Story } from '@storybook/react'
 export default {
-  title: 'ButtonTest/CSF',
+  title: 'ButtonTest/Button(CSF)',
   component: PrimaryButton,
-  subcomponents: { SecondaryButton, DangerButton },
+  subcomponents: { PrimaryButtonAnchor, SecondaryButton, DangerButton },
   parameters: {
     docs: {
       description: {
-        component: 'this is an awesome button!!',
+        component: 'A Button component',
       },
     },
   },
+  argTypes: {
+    prefix: { control: false },
+    suffix: { control: false },
+  },
 }
-export const Default = () => (
+const Template: Story<React.ComponentProps<typeof PrimaryButton>> = (args) => (
   <>
-    <PrimaryButton onClick={action('clicked')}>Button</PrimaryButton>
-    <PrimaryButtonAnchor href="#">Anchor</PrimaryButtonAnchor>
-    <PrimaryButton disabled={true}>Disabled</PrimaryButton>
-  </>
-)
-export const WithIcon = () => (
-  <>
-    <p>With icon (Left)</p>
-    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
-      Button
+    <PrimaryButton onClick={action('clicked')} {...args}>
+      {args.children ?? 'Button'}
     </PrimaryButton>
-    <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
-      Anchor
+    <SecondaryButton onClick={action('clicked')} {...args}>
+      {args.children ?? 'SecondaryButton'}
+    </SecondaryButton>
+    <DangerButton onClick={action('clicked')} {...args}>
+      {args.children ?? 'DangerButton'}
+    </DangerButton>
+    {/* @ts-expect-error */}
+    <PrimaryButtonAnchor href="#" {...args}>
+      {args.children ?? 'Anchor'}
     </PrimaryButtonAnchor>
-    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
-      Disabled
+    <PrimaryButton disabled={true} {...args}>
+      {args.children ?? 'Disabled'}
     </PrimaryButton>
   </>
 )
+
+export const Default = Template.bind({})
+Default.args = {}
+
+export const WithIcon = Template.bind({})
+WithIcon.args = {
+  prefix: <Icon size={14} name="fa-plus-circle" />,
+}
 WithIcon.parameters = {
   docs: {
     description: {
-      story: 'you can use this button with an icon',
+      story: 'You can put an icon before the label text',
     },
   },
 }
-export const WithIconLeft = () => (
-  <>
-    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
-      Button
-    </PrimaryButton>
-    <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
-      Anchor
-    </PrimaryButtonAnchor>
-    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
-      Disabled
-    </PrimaryButton>
-  </>
-)
-export const WithIconRight = () => (
-  <>
-    <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
-      Button
-    </PrimaryButton>
-    <PrimaryButtonAnchor suffix={<Icon size={14} name="fa-plus-circle" />} href="#">
-      Anchor
-    </PrimaryButtonAnchor>
-    <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
-      Disabled
-    </PrimaryButton>
-  </>
-)
-export const OnlyIcon = () => (
-  <>
-    <PrimaryButton onClick={action('clicked')} square>
-      <Icon size={16} name="fa-plus-circle" />
-    </PrimaryButton>
-    <PrimaryButtonAnchor href="#" square>
-      <Icon size={16} name="fa-plus-circle" />
-    </PrimaryButtonAnchor>
-    <PrimaryButton disabled={true} square>
-      <Icon size={16} name="fa-plus-circle" />
-    </PrimaryButton>
-  </>
-)
+
+export const WithIconRight = Template.bind({})
+WithIconRight.args = {
+  suffix: <Icon size={14} name="fa-plus-circle" />,
+}
+WithIconRight.parameters = {
+  docs: {
+    description: {
+      story: 'You can put an icon after the label text',
+    },
+  },
+}
+
+export const OnlyIcon = Template.bind({})
+OnlyIcon.args = {
+  square: true,
+  children: <Icon size={16} name="fa-plus-circle" />,
+}
+OnlyIcon.parameters = {
+  docs: {
+    description: {
+      story: 'This is an icon button',
+    },
+  },
+}

--- a/src/components/ButtonTest/ButtonTest.stories.tsx
+++ b/src/components/ButtonTest/ButtonTest.stories.tsx
@@ -6,21 +6,10 @@ import { DangerButton } from './DangerButton'
 import { Icon } from '../Icon'
 import { Story } from '@storybook/react'
 
-const description = `A Button component.
-
-**This component is not intended for a navigation link.**
-`
 export default {
   title: 'ButtonTest/Button(CSF)',
   component: PrimaryButton,
   subcomponents: { PrimaryButtonAnchor, SecondaryButton, DangerButton },
-  parameters: {
-    docs: {
-      description: {
-        component: description,
-      },
-    },
-  },
   argTypes: {
     prefix: { control: false },
     suffix: { control: false },

--- a/src/components/ButtonTest/ButtonTest.stories.tsx
+++ b/src/components/ButtonTest/ButtonTest.stories.tsx
@@ -1,0 +1,85 @@
+import { action } from '@storybook/addon-actions'
+import * as React from 'react'
+import { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
+import { SecondaryButton } from './SecondaryButton'
+import { DangerButton } from './DangerButton'
+import { Icon } from '../Icon'
+export default {
+  title: 'ButtonTest/CSF',
+  component: PrimaryButton,
+  subcomponents: { SecondaryButton, DangerButton },
+  parameters: {
+    docs: {
+      description: {
+        component: 'this is an awesome button!!',
+      },
+    },
+  },
+}
+export const Default = () => (
+  <>
+    <PrimaryButton onClick={action('clicked')}>Button</PrimaryButton>
+    <PrimaryButtonAnchor href="#">Anchor</PrimaryButtonAnchor>
+    <PrimaryButton disabled={true}>Disabled</PrimaryButton>
+  </>
+)
+export const WithIcon = () => (
+  <>
+    <p>With icon (Left)</p>
+    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
+      Button
+    </PrimaryButton>
+    <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
+      Anchor
+    </PrimaryButtonAnchor>
+    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
+      Disabled
+    </PrimaryButton>
+  </>
+)
+WithIcon.parameters = {
+  docs: {
+    description: {
+      story: 'you can use this button with an icon',
+    },
+  },
+}
+export const WithIconLeft = () => (
+  <>
+    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
+      Button
+    </PrimaryButton>
+    <PrimaryButtonAnchor prefix={<Icon size={14} name="fa-plus-circle" />} href="#">
+      Anchor
+    </PrimaryButtonAnchor>
+    <PrimaryButton prefix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
+      Disabled
+    </PrimaryButton>
+  </>
+)
+export const WithIconRight = () => (
+  <>
+    <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} onClick={action('clicked')}>
+      Button
+    </PrimaryButton>
+    <PrimaryButtonAnchor suffix={<Icon size={14} name="fa-plus-circle" />} href="#">
+      Anchor
+    </PrimaryButtonAnchor>
+    <PrimaryButton suffix={<Icon size={14} name="fa-plus-circle" />} disabled={true}>
+      Disabled
+    </PrimaryButton>
+  </>
+)
+export const OnlyIcon = () => (
+  <>
+    <PrimaryButton onClick={action('clicked')} square>
+      <Icon size={16} name="fa-plus-circle" />
+    </PrimaryButton>
+    <PrimaryButtonAnchor href="#" square>
+      <Icon size={16} name="fa-plus-circle" />
+    </PrimaryButtonAnchor>
+    <PrimaryButton disabled={true} square>
+      <Icon size={16} name="fa-plus-circle" />
+    </PrimaryButton>
+  </>
+)

--- a/src/components/ButtonTest/ButtonTest.stories.tsx
+++ b/src/components/ButtonTest/ButtonTest.stories.tsx
@@ -5,6 +5,11 @@ import { SecondaryButton } from './SecondaryButton'
 import { DangerButton } from './DangerButton'
 import { Icon } from '../Icon'
 import { Story } from '@storybook/react'
+
+const description = `A Button component.
+
+**This component is not intended for a navigation link.**
+`
 export default {
   title: 'ButtonTest/Button(CSF)',
   component: PrimaryButton,
@@ -12,7 +17,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: 'A Button component',
+        component: description,
       },
     },
   },

--- a/src/components/ButtonTest/DangerButton.tsx
+++ b/src/components/ButtonTest/DangerButton.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { isTouchDevice } from '../../libs/ua'
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
+
+export const DangerButton: FC<ButtonProps> = ({ type = 'button', ...props }) => {
+  const theme = useTheme()
+  return <DangerStyleButton {...props} themes={theme} type={type} />
+}
+
+export const DangerButtonAnchor: FC<AnchorProps> = (props) => {
+  const theme = useTheme()
+  return <DangerStyleButtonAnchor themes={theme} {...props} />
+}
+
+const dangerStyle = css`
+  ${({ themes }: { themes: Theme }) => {
+    const { palette, interaction } = themes
+
+    return css`
+      color: #fff;
+      border: none;
+      background-color: ${palette.DANGER};
+      color: #fff;
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+
+      &.hover {
+        background-color: ${palette.hoverColor(palette.DANGER)};
+      }
+
+      &[disabled] {
+        background-color: ${palette.disableColor(palette.DANGER)};
+        color: ${palette.disableColor('#fff')};
+      }
+    `
+  }}
+`
+const DangerStyleButton = styled(BaseButton)`
+  ${dangerStyle}
+`
+const DangerStyleButtonAnchor = styled(BaseButtonAnchor)`
+  ${dangerStyle}
+`

--- a/src/components/ButtonTest/PrimaryButton.tsx
+++ b/src/components/ButtonTest/PrimaryButton.tsx
@@ -6,6 +6,12 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
 
+/**
+ *
+ * A Button component.
+ *
+ * **This component is not intended for a navigation link.**
+ */
 export const PrimaryButton: FC<ButtonProps> = ({ type = 'button', ...props }) => {
   const theme = useTheme()
   return <PrimaryStyleButton {...props} themes={theme} type={type} />

--- a/src/components/ButtonTest/PrimaryButton.tsx
+++ b/src/components/ButtonTest/PrimaryButton.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { isTouchDevice } from '../../libs/ua'
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
+
+export const PrimaryButton: FC<ButtonProps> = ({ type = 'button', ...props }) => {
+  const theme = useTheme()
+  return <PrimaryStyleButton {...props} themes={theme} type={type} />
+}
+
+// set the displayName explicit.
+// This is for error message of BottomFixedArea component.
+PrimaryButton.displayName = 'PrimaryButton'
+
+export const PrimaryButtonAnchor: FC<AnchorProps> = (props) => {
+  const theme = useTheme()
+  return <PrimaryStyleButtonAnchor themes={theme} {...props} />
+}
+
+// set the displayName explicit.
+// This is for error message of BottomFixedArea component.
+PrimaryButtonAnchor.displayName = 'PrimaryButtonAnchor'
+
+const primaryStyle = css`
+  ${({ themes }: { themes: Theme }) => {
+    const { palette, interaction } = themes
+
+    return css`
+      color: #fff;
+      border: none;
+      background-color: ${palette.MAIN};
+      color: #fff;
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+
+      &.hover {
+        background-color: ${palette.hoverColor(palette.MAIN)};
+      }
+
+      &[disabled] {
+        background-color: ${palette.disableColor(palette.MAIN)};
+        color: ${palette.disableColor('#fff')};
+      }
+    `
+  }}
+`
+const PrimaryStyleButton = styled(BaseButton)`
+  ${primaryStyle}
+`
+const PrimaryStyleButtonAnchor = styled(BaseButtonAnchor)`
+  ${primaryStyle}
+`

--- a/src/components/ButtonTest/README.md
+++ b/src/components/ButtonTest/README.md
@@ -1,0 +1,54 @@
+# Buttons
+
+```tsx
+import { PrimaryButton, PrimaryButtonAnchor } from 'smarthr-ui'
+import { SecondaryButton, SecondaryButtonAnchor } from 'smarthr-ui'
+import { DangerButton, DangerButtonAnchor } from 'smarthr-ui'
+import { SkeletonButton, SkeletonButtonAnchor } from 'smarthr-ui'
+import { TextButton, TextButtonAnchor } from 'smarthr-ui'
+
+<PrimaryButton>Button</PrimaryButton>
+<PrimaryButtonAnchor href="#">Anchor</PrimaryButtonAnchor>
+
+<SecondaryButton>Button</SecondaryButton>
+<SecondaryButtonAnchor href="#">Anchor</SecondaryButtonAnchor>
+
+<DangerButton>Button</DangerButton>
+<DangerButtonAnchor href="#">Anchor</DangerButtonAnchor>
+
+<SkeletonButton>Button</SkeletonButton>
+<SkeletonButtonAnchor href="#">Anchor</SkeletonButtonAnchor>
+
+<TextButton>Button</TextButton>
+<TextButtonAnchor href="#">Anchor</TextButtonAnchor>
+```
+
+## props
+
+### Common to Button and Anchor
+
+| Name      | Required | Type                           | DefaultValue | Description                                                                           |
+| --------- | -------- | ------------------------------ | ------------ | ------------------------------------------------------------------------------------- |
+| size      | -        | **enum** <br> default &#124; s | default      | Size of button.                                                                       |
+| children  | -        | **node**                       | ''           | The content of the component.                                                         |
+| prefix    | -        | **node**                       | ''           | The content of the prefix of button content.<br>Normally, this is for icon insertion. |
+| suffix    | -        | **node**                       | ''           | The content of the suffix of button content.<br>Normally, this is for icon insertion. |
+| square    | -        | **boolean**                    | false        | If `true`, the component shape changes to square. Cannot be used with TextButton.     |
+| wide      | -        | **boolean**                    | false        | If `true`, the component shape changes width is 100%.                                 |
+| className | -        | **string**                     | ''           | `className` of component.                                                             |
+
+### Button
+
+| Name     | Required | Type                                         | DefaultValue | Description                                                         |
+| -------- | -------- | -------------------------------------------- | ------------ | ------------------------------------------------------------------- |
+| onClick  | -        | **function**                                 | -            | Fired when the component is focused. <br><br>`function: () => void` |
+| disabled | -        | **boolean**                                  | false        | If `true`, the component is disabled.                               |
+| type     | -        | **"button" &#124; "submit" &#124; "reset"**  | "button"     | `type` for component.                                               |
+
+### Anchor
+
+| Name   | Required | Type       | DefaultValue | Description             |
+| ------ | -------- | ---------- | ------------ | ----------------------- |
+| href   | ✓        | **string** | ''           | `href` for component.   |
+| target | -        | **string** | ''           | `target` for component. |
+| rel    | -        | **string** | ''           | `rel` for component.    |

--- a/src/components/ButtonTest/ResetButton.tsx
+++ b/src/components/ButtonTest/ResetButton.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+
+export const ResetButton = styled.button`
+  appearance: none;
+  display: inline;
+  align-items: stretch;
+  overflow: visible;
+  cursor: auto;
+  padding: 0;
+  border-style: none;
+  border-width: medium;
+  border-color: currentColor;
+  border-image-source: none;
+  border-image-slice: 100%;
+  border-image-width: 1;
+  border-image-outset: 0;
+  border-image-repeat: stretch;
+  box-sizing: content-box;
+  background-color: transparent;
+  background-image: none;
+  background-origin: padding-box;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  text-align: left;
+  user-select: auto;
+  zoom: auto;
+`

--- a/src/components/ButtonTest/SecondaryButton.tsx
+++ b/src/components/ButtonTest/SecondaryButton.tsx
@@ -1,0 +1,51 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { isTouchDevice } from '../../libs/ua'
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
+
+export const SecondaryButton: FC<ButtonProps> = ({ type = 'button', ...props }) => {
+  const theme = useTheme()
+  return <SecondaryStyleButton {...props} themes={theme} type={type} />
+}
+// set the displayName explicit.
+// This is for error message of BottomFixedArea component.
+SecondaryButton.displayName = 'SecondaryButton'
+
+export const SecondaryButtonAnchor: FC<AnchorProps> = (props) => {
+  const theme = useTheme()
+  return <SecondaryStyleButtonAnchor themes={theme} {...props} />
+}
+// set the displayName explicit.
+// This is for error message of BottomFixedArea component.
+SecondaryButtonAnchor.displayName = 'SecondaryButtonAnchor'
+
+const secondaryStyle = css`
+  ${({ themes }: { themes: Theme }) => {
+    const { palette, interaction, frame } = themes
+
+    return css`
+      background-color: #fff;
+      color: ${palette.TEXT_BLACK};
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      border: ${frame.border.default};
+
+      &.hover {
+        background-color: ${palette.hoverColor('#fff')};
+      }
+
+      &[disabled] {
+        background-color: ${palette.COLUMN};
+        color: ${palette.TEXT_DISABLED};
+      }
+    `
+  }}
+`
+const SecondaryStyleButton = styled(BaseButton)`
+  ${secondaryStyle}
+`
+const SecondaryStyleButtonAnchor = styled(BaseButtonAnchor)`
+  ${secondaryStyle}
+`

--- a/src/components/ButtonTest/SkeletonButton.tsx
+++ b/src/components/ButtonTest/SkeletonButton.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { isTouchDevice } from '../../libs/ua'
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
+
+export const SkeletonButton: FC<ButtonProps> = ({ type = 'button', ...props }) => {
+  const theme = useTheme()
+  return <SkeletonStyleButton {...props} themes={theme} type={type} />
+}
+
+export const SkeletonButtonAnchor: FC<AnchorProps> = (props) => {
+  const theme = useTheme()
+  return <SkeletonStyleButtonAnchor themes={theme} {...props} />
+}
+
+const skeletonStyle = css`
+  ${({ themes }: { themes: Theme }) => {
+    const { palette, interaction, frame } = themes
+
+    return css`
+      background-color: transparent;
+      color: #fff;
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      border: ${frame.border.lineWidth} ${frame.border.lineStyle} #fff;
+
+      &.hover {
+        background-color: ${palette.OVERLAY};
+      }
+
+      &[disabled] {
+        background-color: transparent;
+        color: ${palette.disableColor('#fff')};
+      }
+    `
+  }}
+`
+const SkeletonStyleButton = styled(BaseButton)`
+  ${skeletonStyle}
+`
+const SkeletonStyleButtonAnchor = styled(BaseButtonAnchor)`
+  ${skeletonStyle}
+`

--- a/src/components/ButtonTest/TextButton.tsx
+++ b/src/components/ButtonTest/TextButton.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { isTouchDevice } from '../../libs/ua'
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import {
+  AnchorProps as BaseAnchorProps,
+  BaseButton,
+  BaseButtonAnchor,
+  ButtonProps as BaseButtonProps,
+} from './BaseButton'
+
+type ButtonProps = Omit<BaseButtonProps, 'square'>
+type AnchorProps = Omit<BaseAnchorProps, 'square'>
+
+export const TextButton: FC<ButtonProps> = ({ type = 'button', ...props }) => {
+  const theme = useTheme()
+  return <TextStyleButton {...props} themes={theme} type={type} />
+}
+
+export const TextButtonAnchor: FC<AnchorProps> = (props) => {
+  const theme = useTheme()
+  return <TextStyleButtonAnchor themes={theme} {...props} />
+}
+
+const textStyle = css`
+  ${({ themes }: { themes: Theme }) => {
+    const { palette, interaction, frame } = themes
+
+    return css`
+      background-color: transparent;
+      color: ${palette.TEXT_BLACK};
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      border: ${frame.border.lineWidth} ${frame.border.lineStyle} transparent;
+
+      &.hover {
+        background-color: ${palette.hoverColor('#fff')};
+      }
+
+      &[disabled] {
+        background-color: transparent;
+        color: ${palette.disableColor(palette.TEXT_DISABLED)};
+      }
+    `
+  }}
+`
+const TextStyleButton = styled(BaseButton)`
+  ${textStyle}
+`
+const TextStyleButtonAnchor = styled(BaseButtonAnchor)`
+  ${textStyle}
+`

--- a/src/components/ButtonTest/index.ts
+++ b/src/components/ButtonTest/index.ts
@@ -1,0 +1,5 @@
+export { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
+export { SecondaryButton, SecondaryButtonAnchor } from './SecondaryButton'
+export { DangerButton, DangerButtonAnchor } from './DangerButton'
+export { SkeletonButton, SkeletonButtonAnchor } from './SkeletonButton'
+export { TextButton, TextButtonAnchor } from './TextButton'

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 const readFile = util.promisify(fs.readFile)
 const readdir = util.promisify(fs.readdir)
 
-const IGNORE_DIRS = ['__tests__', 'Downloader', 'ProgressBar']
+const IGNORE_DIRS = ['__tests__', 'Downloader', 'ProgressBar', 'ButtonTest']
 
 describe('index', () => {
   it('should export all components in the components directory from index.ts', async () => {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR is experimental with `storybook-addon-docs`.
We have two options for the format, which are CSF and MDX.

### CSF

- [Preview](https://deploy-preview-1152--smarthr-ui.netlify.app/?path=/docs/buttontest-csf--default)
- [Implementation](https://github.com/kufu/smarthr-ui/blob/experimental-storybook-addon-docs/src/components/ButtonTest/ButtonTest.stories.tsx)

### MDX

- [Preview](https://deploy-preview-1152--smarthr-ui.netlify.app/?path=/docs/buttontest-mdx--default-story)
- [Implementation](https://github.com/kufu/smarthr-ui/blob/experimental-storybook-addon-docs/src/components/ButtonTest/ButtonTest.stories.mdx)
  - [Raw format](https://raw.githubusercontent.com/kufu/smarthr-ui/experimental-storybook-addon-docs/src/components/ButtonTest/ButtonTest.stories.mdx)

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
