### PR TITLE
feat: backport Shin Color to v11 (SHRUI-232)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,12 +6,13 @@ import { withA11y } from '@storybook/addon-a11y'
 import { addReadme } from 'storybook-readme'
 
 import { createTheme } from '../src/themes/createTheme'
+import { shinColorPalette } from '../src/themes/createPalette'
 import { ThemeProvider } from '../src/themes/ThemeProvider'
 
 const req = require.context('../src/components', true, /.stories.tsx$/)
 
 function loadStories() {
-  req.keys().forEach(filename => req(filename))
+  req.keys().forEach((filename) => req(filename))
 }
 
 addParameters({
@@ -29,7 +30,10 @@ addParameters({ viewport: { viewports: INITIAL_VIEWPORTS } })
 
 addDecorator(withA11y)
 addDecorator(addReadme)
-addDecorator(Story => <ThemeProvider theme={createTheme()}><Story /></ThemeProvider>)
+addDecorator((Story) => (
+  <ThemeProvider theme={createTheme({ palette: shinColorPalette })}>
+    <Story />
+  </ThemeProvider>
+))
 
 configure(loadStories, module)
-

--- a/src/components/BottomFixedArea/TertiaryLink.tsx
+++ b/src/components/BottomFixedArea/TertiaryLink.tsx
@@ -33,7 +33,7 @@ const Button = styled.button<{ themes: Theme }>`
     const { pxToRem } = themes.size
 
     return css`
-      color: #007bc2;
+      color: ${themes.palette.TEXT_LINK};
       display: flex;
       align-items: center;
 

--- a/src/components/Calendar/CalendarTable.tsx
+++ b/src/components/Calendar/CalendarTable.tsx
@@ -135,7 +135,7 @@ const CellButton = styled(ResetButton)<{ themes: Theme }>(
     :not(:disabled) {
       &:hover {
         ${DateCell} {
-          background-color: #f5f5f5;
+          background-color: ${themes.palette.BASE_GREY};
           color: ${themes.palette.TEXT_BLACK};
         }
       }

--- a/src/components/Calendar/YearPicker.tsx
+++ b/src/components/Calendar/YearPicker.tsx
@@ -119,8 +119,10 @@ const YearButton = styled(ResetButton)<{ themes: Theme }>`
   cursor: pointer;
   &:hover {
     ${YearWrapper} {
-      color: ${(props) => props.themes.palette.TEXT_BLACK};
-      background-color: #f5f5f5;
+      ${({ themes }) => css`
+        color: ${themes.palette.TEXT_BLACK};
+        background-color: ${themes.palette.BASE_GREY};
+      `}
     }
   }
 `

--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
+import { useTheme } from '../../hooks/useTheme'
 import { Loader } from './Loader'
 import readme from './README.md'
 
@@ -11,28 +12,31 @@ storiesOf('Loader', module)
       sidebar: readme,
     },
   })
-  .add('all', () => (
-    <>
-      <GrayWrapper>
-        <Text>You can choose the size.</Text>
-        <Inner>
-          <Loader size="s" />
-          <Loader size="m" />
-          <Loader size="l" />
-        </Inner>
-      </GrayWrapper>
+  .add('all', () => {
+    const theme = useTheme()
+    return (
+      <>
+        <GrayWrapper>
+          <Text>You can choose the size.</Text>
+          <Inner>
+            <Loader size="s" />
+            <Loader size="m" />
+            <Loader size="l" />
+          </Inner>
+        </GrayWrapper>
 
-      <Wrapper>
-        <Text>You can choose the color.</Text>
-        <Inner>
-          <Loader color="#00a5ab" />
-          <Loader color="#007bc2" />
-          <Loader color="#ff8800" />
-          <Loader color="#ef475b" />
-        </Inner>
-      </Wrapper>
-    </>
-  ))
+        <Wrapper>
+          <Text>You can choose the color.</Text>
+          <Inner>
+            <Loader color={theme.palette.BRAND} />
+            <Loader color={theme.palette.TEXT_LINK} />
+            <Loader color={theme.palette.WARNING} />
+            <Loader color={theme.palette.DANGER} />
+          </Inner>
+        </Wrapper>
+      </>
+    )
+  })
 
 const Wrapper = styled.div`
   padding: 24px;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -112,8 +112,8 @@ const Wrapper = styled.div<{
     `}
     ${disabled &&
     css`
-      border-color: #f5f5f5;
-      background-color: #f5f5f5;
+      border-color: ${palette.BASE_GREY};
+      background-color: ${palette.BASE_GREY};
     `}
   `
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export { MultiComboBox } from './components/MultiComboBox'
 // themes
 export { createTheme } from './themes/createTheme'
 export { ThemeProvider } from './themes/ThemeProvider'
-export { defaultPalette } from './themes/createPalette'
+export { defaultPalette, shinColorPalette } from './themes/createPalette'
 export { defaultInteraction } from './themes/createInteraction'
 export { defaultFrame } from './themes/createFrame'
 export { defaultSize } from './themes/createSize'

--- a/src/themes/createPalette.ts
+++ b/src/themes/createPalette.ts
@@ -10,6 +10,7 @@ export interface PaletteProperty {
   BORDER?: string
   BACKGROUND?: string
   COLUMN?: string
+  BASE_GREY?: string
   MAIN?: string
   DANGER?: string
   WARNING?: string
@@ -28,6 +29,7 @@ export interface CreatedPaletteTheme {
   BORDER: string
   BACKGROUND: string
   COLUMN: string
+  BASE_GREY: string
   MAIN: string
   DANGER: string
   WARNING: string
@@ -46,12 +48,30 @@ export const defaultPalette = {
   BORDER: '#d6d6d6',
   BACKGROUND: '#f5f6fa',
   COLUMN: '#f9f9f9',
+  BASE_GREY: '#f5f5f5',
   MAIN: '#00a5ab',
   DANGER: '#ef475b',
   WARNING: '#ff8800',
   SCRIM: 'rgba(0,0,0,0.5)',
   OVERLAY: 'rgba(0,0,0,0.15)',
   HEADER_GREEN: '#57d0d5',
+  BRAND: '#00c4cc',
+}
+
+export const shinColorPalette = {
+  TEXT_BLACK: '#23221f',
+  TEXT_GREY: '#76736a',
+  TEXT_DISABLED: '#c1bdb7',
+  TEXT_LINK: '#0077c7',
+  BORDER: '#d6d3d0',
+  BACKGROUND: '#f8f7f6',
+  COLUMN: '#f9f8f7',
+  BASE_GREY: '#f5f4f3',
+  MAIN: '#0077c7',
+  DANGER: '#e01e5a',
+  WARNING: '#ff8800',
+  SCRIM: 'rgba(0,0,0,0.5)',
+  OVERLAY: 'rgba(0,0,0,0.15)',
   BRAND: '#00c4cc',
 }
 


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-232

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
v11に新カラーをバックポートする

タグ`v11.1.0`から切った`v11-release`ブランチにマージする
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- cherry-pick 1c8063ac92543f54b4046efc7d9f12a177cb891b
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
