### PR TITLE
fix: remove that blank optgroup is displayed for IE

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FC, SelectHTMLAttributes, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
+import { isMobileSafari, isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Icon } from '../Icon'
@@ -75,7 +75,7 @@ export const Select: FC<Props> = ({
         })}
         {
           // Support for not omitting labels in Mobile Safari
-          <BlankOptgroup />
+          isMobileSafari && <BlankOptgroup />
         }
       </SelectBox>
       <IconWrap>

--- a/src/libs/ua.ts
+++ b/src/libs/ua.ts
@@ -23,3 +23,7 @@ export const isPc = !isSp && !isTablet
 
 export const isTouchDevice = isSp || isTablet
 export const isMouseDevice = isPc
+export const isMobileSafari =
+  (ua.indexOf('iphone') !== -1 || ua.indexOf('ipod') !== -1) &&
+  ua.indexOf('safari') !== -1 &&
+  ua.indexOf('apple') !== -1


### PR DESCRIPTION
## Related URL

## Overview
The blank <optgroup> is displayed for IE. 👇 
<img width="283" alt="image" src="https://user-images.githubusercontent.com/17189098/100830737-a8234a80-34a7-11eb-8fdb-11b8a126187b.png">

So, add the blank <optogroup> only on Safari Mobile
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Add mobile safari detection flag to is libs/ua.ts
- Add blank <optgroup> only on mobile safari by above flag

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
