### PR TITLE
chore: change e2e test trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ name: e2e
 on:
   pull_request:
     branches:
-      - master
+      - ie
 
 jobs:
   e2e-win-matrix:


### PR DESCRIPTION
## Related URL

🍐 

## Overview

IE 向けの E2E テストの動作が不安定なので、安定するまでは一旦 GitHub Actions のトリガーを master ブランチへの PR ではなく、 ie ブランチへの PR にしたい

## What I did

- GitHub Actions の設定ファイルの修正
  - `master` -> `ie`

## Capture

🍐 
