### PR TITLE
fix: modify to be able to scroll Dropdown in IE (SHRUI-236)

### DIFF
--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -92,13 +92,13 @@ export const DropdownContentInner: FC<Props> = ({
     <Wrapper
       ref={wrapperRef}
       contentBox={contentBox}
-      scrollable={scrollable}
       className={`${className} ${isActive ? 'active' : ''}`}
-      controllable={controllable}
       themes={theme}
     >
       {controllable ? (
-        children
+        <ControllableWrapper scrollable={scrollable} contentBox={contentBox}>
+          {children}
+        </ControllableWrapper>
       ) : (
         <DropdownContentInnerContext.Provider value={{ maxHeight: contentBox.maxHeight }}>
           <DropdownCloser>{children}</DropdownCloser>
@@ -111,13 +111,12 @@ export const DropdownContentInner: FC<Props> = ({
 const Wrapper = styled.div<{
   themes: Theme
   contentBox: ContentBoxStyle
-  scrollable: boolean
-  controllable: boolean
 }>`
-  ${({ contentBox, themes, scrollable, controllable }) => {
+  ${({ contentBox, themes }) => {
     const { frame, zIndex } = themes
 
     return css`
+      display: flex;
       visibility: hidden;
       z-index: ${zIndex.OVERLAP};
       position: absolute;
@@ -128,22 +127,25 @@ const Wrapper = styled.div<{
       background-color: #fff;
       white-space: nowrap;
 
-      ${controllable
-        ? `
-          display: flex;
-          flex-direction: column;
-          `
-        : ''}
-
-      ${contentBox.maxHeight && scrollable && controllable
+      &.active {
+        visibility: visible;
+      }
+    `
+  }}
+`
+const ControllableWrapper = styled.div<{
+  contentBox: ContentBoxStyle
+  scrollable: boolean
+}>`
+  ${({ contentBox, scrollable }) => {
+    return css`
+      display: flex;
+      flex-direction: column;
+      ${contentBox.maxHeight && scrollable
         ? `
           max-height: ${contentBox.maxHeight};
           `
         : ''}
-
-      &.active {
-        visibility: visible;
-      }
     `
   }}
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-236
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
IEで `Dropdown` コンポーネント内にスクロールが必要になった場合に正しくスクロールできない問題を解消する
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `max-height` を設定している要素が `display: flex` でwrapされるように構造を変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/101316254-80652580-389f-11eb-8768-1b1f2ec8e08b.png) | ![image](https://user-images.githubusercontent.com/270422/101316289-91159b80-389f-11eb-9094-66277d784bd3.png) |
<!--
Please attach a capture if it looks different.
-->
