### PR TITLE
fix: add Segmented control ARIA (SHRUI-242)

### DIFF
--- a/src/components/SegmentedControl/README.md
+++ b/src/components/SegmentedControl/README.md
@@ -37,3 +37,11 @@ import { SegmentedControl } from 'smarthr-ui'
 | content   | ✓        | **React.ReactNode** | -            | Content of option button.                             |
 | ariaLabel | -        | **string**          | -            | Value of aria-label.                                  |
 | disabled  | -        | **boolean**         | -            | Whether makes button disabled.                        |
+
+## Accessibility
+
+### ARIA
+
+- `SegmentedControl` is `role=toolbar` with `role=radiogroup` inside.
+- The buttons in `SegmentedControl` are `role=radio`.
+- `SegmentedControl` should be labelled by `aria-label` or `aria-labelledby`.

--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -23,14 +23,14 @@ storiesOf('SegmentedControl', module)
 
     const options = [
       { value: 'segment1', ariaLabel: 'segment1' },
-      { value: 'segment2', ariaLabel: 'segment1' },
-      { value: 'segment3', ariaLabel: 'segment1' },
-      { value: 'segment4', ariaLabel: 'segment1' },
-      { value: 'segment5', ariaLabel: 'segment1' },
+      { value: 'segment2', ariaLabel: 'segment2' },
+      { value: 'segment3', ariaLabel: 'segment3' },
+      { value: 'segment4', ariaLabel: 'segment4' },
+      { value: 'segment5', ariaLabel: 'segment5' },
     ]
     return (
       <List>
-        <dt>Default</dt>
+        <dt id="dt-default">Default</dt>
         <dd>
           <SegmentedControl
             options={options.map((option) => ({ ...option, content: 'Button' }))}
@@ -39,9 +39,10 @@ storiesOf('SegmentedControl', module)
               action('clicked')(value)
               setValue1(value)
             }}
+            aria-labelledby="dt-default"
           />
         </dd>
-        <dt>Small</dt>
+        <dt id="dt-small">Small</dt>
         <dd>
           <SegmentedControl
             options={options.map((option) => ({ ...option, content: 'Button' }))}
@@ -51,9 +52,10 @@ storiesOf('SegmentedControl', module)
               setValue2(value)
             }}
             size="s"
+            aria-labelledby="dt-small"
           />
         </dd>
-        <dt>Icon</dt>
+        <dt id="dt-icon">Icon</dt>
         <dd>
           <SegmentedControl
             options={options.map((option) => ({
@@ -66,9 +68,10 @@ storiesOf('SegmentedControl', module)
               setValue3(value)
             }}
             isSquare
+            aria-labelledby="dt-icon"
           />
         </dd>
-        <dt>Small icon</dt>
+        <dt id="dt-small-icon">Small icon</dt>
         <dd>
           <SegmentedControl
             options={options.map((option) => ({
@@ -82,9 +85,10 @@ storiesOf('SegmentedControl', module)
             }}
             size="s"
             isSquare
+            aria-labelledby="dt-small-icon"
           />
         </dd>
-        <dt>Disabled</dt>
+        <dt id="dt-disabled">Disabled</dt>
         <dd>
           <SegmentedControl
             options={options.map((option, i) => ({
@@ -97,6 +101,7 @@ storiesOf('SegmentedControl', module)
               action('clicked')(value)
               setValue5(value)
             }}
+            aria-labelledby="dt-disabled"
           />
         </dd>
       </List>

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -32,27 +32,29 @@ export const SegmentedControl: FC<Props> = ({
   const themes = useTheme()
 
   return (
-    <Container {...props} className={className} role="radiogroup">
-      {options.map((option) => {
-        const isSelected = !!value && value === option.value
-        const Button = isSelected ? SelectedButton : DefaultButton
-        const onClick = onClickOption ? () => onClickOption(option.value) : undefined
-        return (
-          <Button
-            aria-label={option.ariaLabel}
-            key={option.value}
-            disabled={option.disabled}
-            onClick={onClick}
-            size={size}
-            square={isSquare}
-            themes={themes}
-            role="radio"
-            aria-checked={isSelected}
-          >
-            {option.content}
-          </Button>
-        )
-      })}
+    <Container {...props} className={className} role="toolbar">
+      <div role="radiogroup">
+        {options.map((option) => {
+          const isSelected = !!value && value === option.value
+          const Button = isSelected ? SelectedButton : DefaultButton
+          const onClick = onClickOption ? () => onClickOption(option.value) : undefined
+          return (
+            <Button
+              aria-label={option.ariaLabel}
+              key={option.value}
+              disabled={option.disabled}
+              onClick={onClick}
+              size={size}
+              square={isSquare}
+              themes={themes}
+              role="radio"
+              aria-checked={isSelected}
+            >
+              {option.content}
+            </Button>
+          )
+        })}
+      </div>
     </Container>
   )
 }

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -35,13 +35,13 @@ export const SegmentedControl: FC<Props> = ({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (!isFocused || !containerRef.current) {
+      if (!isFocused || !containerRef.current || !document.activeElement) {
         return
       }
       const radios = Array.from(
         containerRef.current.querySelectorAll('[role="radio"]:not(:disabled)'),
       )
-      if (radios.length < 2 || !document.activeElement) {
+      if (radios.length < 2) {
         return
       }
       const focusedIndex = radios.indexOf(document.activeElement)

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -27,11 +27,12 @@ export const SegmentedControl: FC<Props> = ({
   size = 'default',
   isSquare = false,
   className,
+  ...props
 }) => {
   const themes = useTheme()
 
   return (
-    <Container className={className}>
+    <Container {...props} className={className} role="radiogroup">
       {options.map((option) => {
         const isSelected = !!value && value === option.value
         const Button = isSelected ? SelectedButton : DefaultButton
@@ -45,6 +46,8 @@ export const SegmentedControl: FC<Props> = ({
             size={size}
             square={isSquare}
             themes={themes}
+            role="radio"
+            aria-checked={isSelected}
           >
             {option.content}
           </Button>

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, useCallback, useEffect, useRef, useState } from '
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { PrimaryButton, SecondaryButton } from '../Button'
+import { SecondaryButton } from '../Button'
 
 export type Option = {
   value: string
@@ -106,7 +106,6 @@ export const SegmentedControl: FC<Props> = ({
       <div role="radiogroup">
         {options.map((option, i) => {
           const isSelected = !!value && value === option.value
-          const Button = isSelected ? SelectedButton : DefaultButton
           const onClick = onClickOption ? () => onClickOption(option.value) : undefined
           return (
             <Button
@@ -133,12 +132,20 @@ export const SegmentedControl: FC<Props> = ({
 const Container = styled.div`
   display: inline-flex;
 `
-const buttonStyle = css<{ themes: Theme }>(({ themes }) => {
-  const { border } = themes.frame
+const Button = styled(SecondaryButton)<{ themes: Theme }>(({ themes }) => {
+  const { palette, frame } = themes
+  const { border } = frame
   return css`
     border: ${border.default};
     border-radius: 0;
 
+    &[aria-checked='true'] {
+      color: #fff;
+      background-color: ${palette.MAIN};
+      &.hover {
+        background-color: ${palette.hoverColor(palette.MAIN)};
+      }
+    }
     &:first-child {
       border-top-left-radius: ${border.radius.m};
       border-bottom-left-radius: ${border.radius.m};
@@ -152,9 +159,3 @@ const buttonStyle = css<{ themes: Theme }>(({ themes }) => {
     }
   `
 })
-const DefaultButton = styled(SecondaryButton)<{ themes: Theme }>`
-  ${buttonStyle}
-`
-const SelectedButton = styled(PrimaryButton)<{ themes: Theme }>`
-  ${buttonStyle}
-`

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -86,12 +86,15 @@ export const SegmentedControl: FC<Props> = ({
   const includesSelected = value && options.some((option) => option.value === value)
   const getRovingTabIndex = useCallback(
     (option: Option, index: number) => {
+      if (isFocused) {
+        return -1
+      }
       if (!includesSelected) {
         return index === 0 ? 0 : -1
       }
       return option.value === value ? 0 : -1
     },
-    [includesSelected, value],
+    [includesSelected, isFocused, value],
   )
 
   return (


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-242
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
This PR adds ARIA attributes and keyboard navigation into `SegmentedControl` component.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* Add ARIA attributes
  * `role=toolbar`, `role=radiogroup`, `role=radio`, `aria-checked`
* Add keyboard navigation
  * `Tab` : focus on / blur the `radiogroup`
    * If the `radiogroup` includes an active radio button, focus the active radio button. If not, focus the first radio button in `radiogroup`.
  * `→`, `↓` : move focus to next radio button
  * `←`, `↑` : move focus to previous radio button
    * The focus movement by arrow keys loops within `radiogruop`.
* Update README
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
