### PR TITLE
docs: change the color of FieldSet in storybook to shin color

### DIFF
--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -64,7 +64,7 @@ storiesOf('FieldSet', module)
             label="labelSuffix"
             labelSuffix={
               <Suffix>
-                <Icon name="fa-exclamation-circle" size={12} color="#767676" />
+                <Icon name="fa-exclamation-circle" size={12} color={themes.palette.TEXT_GREY} />
                 <SuffixText>suffix text</SuffixText>
               </Suffix>
             }
@@ -82,7 +82,7 @@ storiesOf('FieldSet', module)
             helpMessage="This is help message."
             labelSuffix={
               <Suffix>
-                <Icon name="fa-exclamation-circle" size={12} color="#767676" />
+                <Icon name="fa-exclamation-circle" size={12} color={themes.palette.TEXT_GREY} />
                 <SuffixText>suffix text</SuffixText>
               </Suffix>
             }

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -15,7 +15,7 @@ storiesOf('FieldSet', module)
     },
   })
   .add('all', () => {
-    const theme = useTheme()
+    const themes = useTheme()
 
     return (
       <List>
@@ -72,7 +72,7 @@ storiesOf('FieldSet', module)
         </li>
         <li>
           <FieldSet label="custom field">
-            <CustomTag theme={theme}>It is a field where tags can be freely inserted.</CustomTag>
+            <CustomTag themes={themes}>It is a field where tags can be freely inserted.</CustomTag>
           </FieldSet>
         </li>
         <li>
@@ -88,7 +88,7 @@ storiesOf('FieldSet', module)
             }
             required
           >
-            <CustomTag theme={theme}>It is a field where tags can be freely inserted.</CustomTag>
+            <CustomTag themes={themes}>It is a field where tags can be freely inserted.</CustomTag>
           </FieldSet>
         </li>
       </List>
@@ -115,11 +115,11 @@ const SuffixText = styled.p`
   margin: 0;
   font-size: 11px;
 `
-const CustomTag = styled.div<{ theme: Theme }>`
-  ${({ theme }) => {
+const CustomTag = styled.div<{ themes: Theme }>`
+  ${({ themes }) => {
     return css`
       padding: 10px;
-      border: 1px solid ${theme.palette.BORDER};
+      border: 1px solid ${themes.palette.BORDER};
       border-radius: 5px;
     `
   }}

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -2,6 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
+import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Icon } from '../Icon'
 import { FieldSet } from './FieldSet'
@@ -13,82 +14,86 @@ storiesOf('FieldSet', module)
       sidebar: readme,
     },
   })
-  .add('all', () => (
-    <List>
-      <li>
-        <FieldSet label="string" defaultValue="string" />
-      </li>
-      <li>
-        <FieldSet type="number" label="number" defaultValue={1} />
-      </li>
-      <li>
-        <FieldSet type="password" label="password" defaultValue="password" />
-      </li>
-      <li>
-        <FieldSet
-          name="sample"
-          label="long title.........................................."
-          defaultValue="string"
-        />
-      </li>
-      <li>
-        <FieldSet label="required" defaultValue="string" required />
-      </li>
-      <li>
-        <FieldSet label="disabled" disabled />
-      </li>
-      <li>
-        <FieldSet label="width" defaultValue="width: 100%" width="100%" />
-      </li>
-      <li>
-        <FieldSet label="placeholder" placeholder="placeholder" />
-      </li>
-      <li>
-        <FieldSet label="onChange" onChange={action('onChange!!')} />
-      </li>
-      <li>
-        <FieldSet label="onBlur" onBlur={action('onBlur!!')} />
-      </li>
-      <li>
-        <FieldSet label="help message" helpMessage="This is help message." width={400} />
-      </li>
-      <li>
-        <FieldSet label="error message" errorMessage="An error occurred" />
-      </li>
-      <li>
-        <FieldSet
-          label="labelSuffix"
-          labelSuffix={
-            <Suffix>
-              <Icon name="fa-exclamation-circle" size={12} color="#767676" />
-              <SuffixText>suffix text</SuffixText>
-            </Suffix>
-          }
-        />
-      </li>
-      <li>
-        <FieldSet label="custom field">
-          <CustomTag>It is a field where tags can be freely inserted.</CustomTag>
-        </FieldSet>
-      </li>
-      <li>
-        <FieldSet
-          label="many parts"
-          errorMessage={['First error message.', 'Second error message.']}
-          helpMessage="This is help message."
-          labelSuffix={
-            <Suffix>
-              <Icon name="fa-exclamation-circle" size={12} color="#767676" />
-              <SuffixText>suffix text</SuffixText>
-            </Suffix>
-          }
-          required
-        >
-          <CustomTag>It is a field where tags can be freely inserted.</CustomTag>
-        </FieldSet>
-      </li>
-    </List>
-  ))
+  .add('all', () => {
+    const theme = useTheme()
+
+    return (
+      <List>
+        <li>
+          <FieldSet label="string" defaultValue="string" />
+        </li>
+        <li>
+          <FieldSet type="number" label="number" defaultValue={1} />
+        </li>
+        <li>
+          <FieldSet type="password" label="password" defaultValue="password" />
+        </li>
+        <li>
+          <FieldSet
+            name="sample"
+            label="long title.........................................."
+            defaultValue="string"
+          />
+        </li>
+        <li>
+          <FieldSet label="required" defaultValue="string" required />
+        </li>
+        <li>
+          <FieldSet label="disabled" disabled />
+        </li>
+        <li>
+          <FieldSet label="width" defaultValue="width: 100%" width="100%" />
+        </li>
+        <li>
+          <FieldSet label="placeholder" placeholder="placeholder" />
+        </li>
+        <li>
+          <FieldSet label="onChange" onChange={action('onChange!!')} />
+        </li>
+        <li>
+          <FieldSet label="onBlur" onBlur={action('onBlur!!')} />
+        </li>
+        <li>
+          <FieldSet label="help message" helpMessage="This is help message." width={400} />
+        </li>
+        <li>
+          <FieldSet label="error message" errorMessage="An error occurred" />
+        </li>
+        <li>
+          <FieldSet
+            label="labelSuffix"
+            labelSuffix={
+              <Suffix>
+                <Icon name="fa-exclamation-circle" size={12} color="#767676" />
+                <SuffixText>suffix text</SuffixText>
+              </Suffix>
+            }
+          />
+        </li>
+        <li>
+          <FieldSet label="custom field">
+            <CustomTag theme={theme}>It is a field where tags can be freely inserted.</CustomTag>
+          </FieldSet>
+        </li>
+        <li>
+          <FieldSet
+            label="many parts"
+            errorMessage={['First error message.', 'Second error message.']}
+            helpMessage="This is help message."
+            labelSuffix={
+              <Suffix>
+                <Icon name="fa-exclamation-circle" size={12} color="#767676" />
+                <SuffixText>suffix text</SuffixText>
+              </Suffix>
+            }
+            required
+          >
+            <CustomTag theme={theme}>It is a field where tags can be freely inserted.</CustomTag>
+          </FieldSet>
+        </li>
+      </List>
+    )
+  })
 
 const List = styled.ul`
   padding: 0 24px;
@@ -110,8 +115,12 @@ const SuffixText = styled.p`
   margin: 0;
   font-size: 11px;
 `
-const CustomTag = styled.div`
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
+const CustomTag = styled.div<{ theme: Theme }>`
+  ${({ theme }) => {
+    return css`
+      padding: 10px;
+      border: 1px solid ${theme.palette.BORDER};
+      border-radius: 5px;
+    `
+  }}
 `

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Icon } from '../Icon'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://smarthr.atlassian.net/browse/SHRUI-314

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

FieldSetのstorybookのカラーをシン・カラーに変更しました。

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

- theme参照に変更
- シン・カラーに変更
