### PR TITLE
docs: replace old color code of storybook to theme in Downloader (SHRUI-308)

### DIFF
--- a/src/components/Downloader/Downloader.stories.tsx
+++ b/src/components/Downloader/Downloader.stories.tsx
@@ -7,7 +7,7 @@ import { Icon } from '../Icon'
 storiesOf('[TBD] Downloader', module).add('all', () => {
   const themes = useTheme()
   return (
-    <Wrapper>
+    <Wrapper themes={themes}>
       <Title>To Be Developed</Title>
       <Description>This component will develop in the near future.</Description>
       <Link
@@ -22,13 +22,13 @@ storiesOf('[TBD] Downloader', module).add('all', () => {
   )
 })
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ themes: Theme }>`
   box-sizing: border-box;
   padding: 24px;
   border-radius: 6px;
   box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
-  color: #333;
-  font-size: 14px;
+  color: ${({ themes }) => themes.palette.TEXT_BLACK};
+  font-size: ${({ themes }) => themes.size.font.TALL};
   text-align: center;
   line-height: 1;
   position: absolute;

--- a/src/components/Downloader/Downloader.stories.tsx
+++ b/src/components/Downloader/Downloader.stories.tsx
@@ -1,21 +1,26 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
+import { Theme, useTheme } from '../../hooks/useTheme'
 import { Icon } from '../Icon'
 
-storiesOf('[TBD] Downloader', module).add('all', () => (
-  <Wrapper>
-    <Title>To Be Developed</Title>
-    <Description>This component will develop in the near future.</Description>
-    <Link
-      href="https://smarthr.invisionapp.com/share/ADUDJ8BW74C#/386514188_downloaders"
-      target="_blank"
-    >
-      <LinkText>Design of Downloader (InVision)</LinkText>
-      <LinkIcon name="fa-external-link-alt" size={14} />
-    </Link>
-  </Wrapper>
-))
+storiesOf('[TBD] Downloader', module).add('all', () => {
+  const themes = useTheme()
+  return (
+    <Wrapper>
+      <Title>To Be Developed</Title>
+      <Description>This component will develop in the near future.</Description>
+      <Link
+        themes={themes}
+        href="https://smarthr.invisionapp.com/share/ADUDJ8BW74C#/386514188_downloaders"
+        target="_blank"
+      >
+        <LinkText>Design of Downloader (InVision)</LinkText>
+        <LinkIcon name="fa-external-link-alt" size={14} />
+      </Link>
+    </Wrapper>
+  )
+})
 
 const Wrapper = styled.div`
   box-sizing: border-box;
@@ -43,8 +48,8 @@ const Description = styled.div`
   margin-bottom: 16px;
 `
 
-const Link = styled.a`
-  color: #007bc2;
+const Link = styled.a<{ themes: Theme }>`
+  color: ${({ themes }) => themes.palette.TEXT_LINK};
 `
 const LinkText = styled.span`
   vertical-align: middle;


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-308
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- Replace old color code in storybook to use `theme`
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace
  - `#007bc2` => `palette.TEXT_LINK`
  - `#333` => `palette.TEXT_BLACK`
  - `font-size: 14px` => `size.font.TALL`
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
