### PR TITLE
fix: add optional chaining to _isChildPortal

### DIFF
--- a/src/hooks/usePortal.tsx
+++ b/src/hooks/usePortal.tsx
@@ -68,7 +68,7 @@ export function usePortal() {
 
 function _isChildPortal(element: HTMLElement | null, parentPortalSeq: number): boolean {
   if (!element) return false
-  const childOf = element.dataset.portalChildOf || ''
+  const childOf = element.dataset?.portalChildOf || ''
   const includesSeq = childOf.split(',').includes(String(parentPortalSeq))
   return includesSeq || _isChildPortal(element.parentElement, parentPortalSeq)
 }


### PR DESCRIPTION
## Overview

Fixed a potential bug in `usePortal`.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Add optional chaining (`?`) to `element.dataset.portalChildOf` since `dataset` can be undefined.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->