### PR TITLE
refactor: migrate Icon in AccordionPanel and BackgroundJobsPanel

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -8,7 +8,7 @@ import { getNewExpandedItems } from './accordionPanelHelper'
 import { AccordionPanelContext } from './AccordionPanel'
 import { AccordionPanelItemContext } from './AccordionPanelItem'
 
-import { Icon as IconComponent } from '../Icon'
+import { FaCaretDownIcon } from '../Icon'
 
 type Props = {
   children: React.ReactNode
@@ -46,7 +46,7 @@ export const AccordionPanelTrigger: FC<Props> = ({ children, className = '' }) =
     }
   }, [onClickTrigger, name, isExpanded, onClickProps, expandedItems, expandableMultiply])
 
-  const caretIcon = <Icon className={iconClassNames} name="fa-caret-down" $theme={theme} />
+  const caretIcon = <Icon className={iconClassNames} $theme={theme} />
 
   return (
     <Button
@@ -100,7 +100,7 @@ const Button = styled.button<{ themes: Theme }>`
     `
   }}
 `
-const Icon = styled(IconComponent)<{ $theme: Theme }>`
+const Icon = styled(FaCaretDownIcon)<{ $theme: Theme }>`
   ${({ $theme }) => {
     const { size } = $theme
 

--- a/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
+++ b/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
@@ -6,7 +6,7 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { Base } from '../Base'
 import { SecondaryButton } from '../Button'
 import { ResetButton } from '../Button/ResetButton'
-import { Icon } from '../Icon'
+import { FaMinusIcon, FaTimesIcon, FaWindowMaximizeIcon } from '../Icon'
 import { JobIcon } from './JobIcon'
 import { OmittableJobText } from './OmittableJobText'
 
@@ -70,10 +70,10 @@ export const BackgroundJobsPanel: FC<Props> = ({
             aria-expanded={isExpanded}
             aria-controls={jobListId}
           >
-            <Icon name={isExpanded ? 'fa-minus' : 'fa-window-maximize'} size={13} />
+            {isExpanded ? <FaMinusIcon size={13} /> : <FaWindowMaximizeIcon size={13} />}
           </SecondaryButton>
           <SecondaryButton type="button" size="s" square onClick={onClickClose}>
-            <Icon name="fa-times" size={13} aria-label="Close" />
+            <FaTimesIcon size={13} aria-label="Close" />
           </SecondaryButton>
         </HeaderButtonLayout>
       </Header>

--- a/src/components/BackgroundJobsPanel/JobIcon.tsx
+++ b/src/components/BackgroundJobsPanel/JobIcon.tsx
@@ -1,32 +1,39 @@
-import React, { ComponentProps, FC } from 'react'
+import React, { FC } from 'react'
 
 import { useTheme } from '../../hooks/useTheme'
 import { Status } from './BackgroundJobsPanel'
-import { Icon } from '../Icon'
+import {
+  FaCheckCircleIcon,
+  FaCloudDownloadAltIcon,
+  FaExclamationTriangleIcon,
+  FaSyncAltIcon,
+  FaTimesCircleIcon,
+  IconProps,
+} from '../Icon'
 
 type Props = {
   status: Status
 }
 
 export const JobIcon: FC<Props> = ({ status }) => {
-  const name = getIconName(status)
+  const Icon = getIcon(status)
   const color = useIconColor(status)
 
-  return <Icon name={name} color={color} size={16} />
+  return <Icon color={color} size={16} />
 }
 
-function getIconName(status: Status): ComponentProps<typeof Icon>['name'] {
+function getIcon(status: Status): React.ComponentType<IconProps> {
   switch (status) {
     case 'processing':
-      return 'fa-sync-alt'
+      return FaSyncAltIcon
     case 'downloading':
-      return 'fa-cloud-download-alt'
+      return FaCloudDownloadAltIcon
     case 'warning':
-      return 'fa-exclamation-triangle'
+      return FaExclamationTriangleIcon
     case 'error':
-      return 'fa-times-circle'
+      return FaTimesCircleIcon
     case 'done':
-      return 'fa-check-circle'
+      return FaCheckCircleIcon
   }
 }
 


### PR DESCRIPTION
## Related URL

A part of SHRUI-238.

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR migrates the Icon component in AccordionPanel and BackgroundJobsPanel, which does not affect anyone, just a refactoring.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I've replaced the Icon component with each Icon components like `FaCaretDownIcon`.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
