### PR TITLE
fix: fallback parentElement of svg element for IE

### DIFF
--- a/src/hooks/usePortal.tsx
+++ b/src/hooks/usePortal.tsx
@@ -66,9 +66,22 @@ export function usePortal() {
   }
 }
 
-function _isChildPortal(element: HTMLElement | null, parentPortalSeq: number): boolean {
+function _isChildPortal(
+  element: HTMLElement | SVGElement | null,
+  parentPortalSeq: number,
+): boolean {
   if (!element) return false
   const childOf = element.dataset?.portalChildOf || ''
   const includesSeq = childOf.split(',').includes(String(parentPortalSeq))
-  return includesSeq || _isChildPortal(element.parentElement, parentPortalSeq)
+  const parent =
+    element.parentElement ||
+    (() => {
+      // In IE11, parentElement is undefined for SVGEelement, whereas parentNode is defined
+      const node = element.parentNode
+      if (node instanceof HTMLElement || node instanceof SVGElement) {
+        return node
+      }
+      return null
+    })()
+  return includesSeq || _isChildPortal(parent, parentPortalSeq)
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
IEにおいて`SVGElement.parentElement`が`undefined`であるという問題があるので、`parentNode`でフォールバックを行う
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `instanceof`で型ガードしつつフォールバック
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
