### PR TITLE
fix: modify not to apply hover or focus style from other css to Button (SHRUI-244)

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -105,6 +105,11 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       &.prefix {
         justify-content: left;
       }
+
+      &:hover,
+      &:focus {
+        text-decoration: none;
+      }
     `
   }}
 `

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -32,11 +32,12 @@ const primaryStyle = css`
       color: #fff;
       border: none;
       background-color: ${palette.MAIN};
-      color: #fff;
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
-      &.hover {
+      &.hover,
+      &:focus {
         background-color: ${palette.hoverColor(palette.MAIN)};
+        color: #fff;
       }
 
       &[disabled] {

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -32,8 +32,10 @@ const secondaryStyle = css`
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       border: ${frame.border.default};
 
-      &.hover {
+      &.hover,
+      &:focus {
         background-color: ${palette.hoverColor('#fff')};
+        color: ${palette.TEXT_BLACK};
       }
 
       &[disabled] {

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -26,8 +26,10 @@ const skeletonStyle = css`
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       border: ${frame.border.lineWidth} ${frame.border.lineStyle} #fff;
 
-      &.hover {
+      &.hover,
+      &:focus {
         background-color: ${palette.OVERLAY};
+        color: #fff;
       }
 
       &[disabled] {

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -34,8 +34,10 @@ const textStyle = css`
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       border: ${frame.border.lineWidth} ${frame.border.lineStyle} transparent;
 
-      &.hover {
+      &.hover,
+      &:focus {
         background-color: ${palette.hoverColor('#fff')};
+        color: ${palette.TEXT_BLACK};
       }
 
       &[disabled] {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-244
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Button`コンポーネントに対して、別ライブラリなどで指定されたaタグに対するホバーやフォーカスのスタイルが当たらないように修正する
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Button`コンポーネントの`:hover`, `:focus`に対して`text-decoration`, `color` のスタイルを明示しておく
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
