### PR TITLE
fix: reflect feedback of SideNav (SHRUI-320)

### DIFF
--- a/src/components/SideNav/SideNav.stories.tsx
+++ b/src/components/SideNav/SideNav.stories.tsx
@@ -10,8 +10,6 @@ import { Heading } from '../Heading'
 import readme from './README.md'
 
 const Label = styled(StatusLabel)`
-  margin-right: 8px;
-
   &.done {
     background-color: #fff;
   }

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { OnClick, SideNavItem, SideNavSizeType } from './SideNavItem'
+import { useClassNames } from './useClassNames'
 
 type SideNavItemProps = Omit<ComponentProps<typeof SideNavItem>, 'size' | 'onClick'>
 
@@ -15,9 +16,10 @@ type Props = {
 
 export const SideNav: FC<Props> = ({ items, size = 'default', onClick, className }) => {
   const theme = useTheme()
+  const classNames = useClassNames()
 
   return (
-    <Wrapper themes={theme} className={className}>
+    <Wrapper themes={theme} className={`${className} ${classNames.wrapper}`}>
       {items.map((item) => (
         <SideNavItem
           id={item.id}

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -14,7 +14,7 @@ type Props = {
   className?: string
 }
 
-export const SideNav: FC<Props> = ({ items, size = 'default', onClick, className }) => {
+export const SideNav: FC<Props> = ({ items, size = 'default', onClick, className = '' }) => {
   const theme = useTheme()
   const classNames = useClassNames()
 

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -33,7 +33,7 @@ export const SideNavItem: FC<Props> = ({
   return (
     <Wrapper className={isSelected ? 'selected' : ''} themes={theme}>
       <Button className={size} themes={theme} onClick={handleClick}>
-        {prefix && <span>{prefix}</span>}
+        {prefix && <PrefixWrapper themes={theme}>{prefix}</PrefixWrapper>}
         {title}
       </Button>
     </Wrapper>
@@ -92,6 +92,15 @@ const Button = styled(ResetButton)<{ themes: Theme }>`
         padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
         font-size: ${size.pxToRem(size.font.SHORT)};
       }
+    `
+  }}
+`
+const PrefixWrapper = styled.span<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { size } = themes
+
+    return css`
+      margin-right: ${size.pxToRem(size.space.XXS)};
     `
   }}
 `

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -85,6 +85,7 @@ const Button = styled(ResetButton)<{ themes: Theme }>`
       width: 100%;
       line-height: 1;
       box-sizing: border-box;
+      cursor: pointer;
 
       &.default {
         padding: ${size.pxToRem(size.space.XS)};

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { isTouchDevice } from '../../libs/ua'
 import { ResetButton } from '../Button/ResetButton'
+import { useClassNames } from './useClassNames'
 
 export type SideNavSizeType = 'default' | 's'
 export type OnClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => void
@@ -26,15 +27,17 @@ export const SideNavItem: FC<Props> = ({
   onClick,
 }) => {
   const theme = useTheme()
+  const classNames = useClassNames()
   const handleClick = onClick
     ? (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => onClick(e, id)
     : undefined
 
+  const itemClassName = `${isSelected ? 'selected' : ''} ${classNames.item}`
   return (
-    <Wrapper className={isSelected ? 'selected' : ''} themes={theme}>
+    <Wrapper className={itemClassName} themes={theme}>
       <Button className={size} themes={theme} onClick={handleClick}>
         {prefix && <PrefixWrapper themes={theme}>{prefix}</PrefixWrapper>}
-        {title}
+        <span className={classNames.itemTitle}>{title}</span>
       </Button>
     </Wrapper>
   )

--- a/src/components/SideNav/useClassNames.ts
+++ b/src/components/SideNav/useClassNames.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator('SideNav')
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+      item: generate('item'),
+      itemTitle: generate('itemTitle'),
+    }),
+    [generate],
+  )
+}

--- a/src/hooks/useClassNameGenerator.ts
+++ b/src/hooks/useClassNameGenerator.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react'
+
+const PREFIX = 'smarthr-ui'
+
+export function useClassNameGenerator(componentName: string) {
+  return useCallback(
+    (partName?: string) => {
+      if (!partName) {
+        return `${PREFIX}-${componentName}`
+      }
+      return `${PREFIX}-${componentName}-${partName}`
+    },
+    [componentName],
+  )
+}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-320
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
このPRはプレリリース`v12.0.0-0`に対する hotfix です

`SideNav`コンポーネントに対して以下の修正を行います。
- 外側から各アイテム、アイテムタイトルを特定できるようにする
- prefix - title 間のマージン設定の責務をprefix側で担保
- 各ボタンに`cursor: pointer`スタイルを付与
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 特定用のclass名を付与
  - 共用hookとして`useClassNameGenerator`を追加
    - コンポーネント名とパーツ名からclass名を生成する関数
    - 命名ルールとしては、`smarthr-ui-SideNav-itemTitle` という風になる想定としました
      - ケバブケースとキャメルケースが混じってやや違和感がありますが、`{コンポーネント名}-{パーツ名}`を明確に表現するためにはこれが良いのではないかと判断しました
  - `SideNav`用のhookとして`useClassNames`を追加
    - 意図としては、同コンポーネント内におけるコンポーネント名指定の揺れを防ぐためと、コンポーネント内で使っているclass名を一覧できるようにしたほうが良さそうだと思ったからです
    - もしこれが冗長であれば消すことも可能です
  - wrapper, 各アイテム, 各アイテムのタイトルにclass名を付与
- prefix に `margin-right` を設定
- ボタンに `cursor: pointer` を設定

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
