### PR TITLE
fix: fix input width for firefox

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -163,6 +163,7 @@ const StyledInput = styled.input<
       color: ${palette.TEXT_BLACK};
       line-height: 1.6;
       outline: none;
+      box-sizing: border-box;
 
       &::placeholder {
         color: ${palette.TEXT_GREY};


### PR DESCRIPTION
## Related URL

🍐 

## Overview

FireFox でのみ再現する表示バグです。
以下の条件を満たす場合に Input コンポーネントの表示が添付したキャプチャのように崩れます。

- Flex ボックスの子要素として Input が置かれている
- Input に width props が number で渡されている

## What I did

Input コンポーネントの input タグに `box-sizing: border-box` をあてることで解決。

## Capture

**Before**

![image](https://user-images.githubusercontent.com/11153463/102969164-9417b980-4538-11eb-8f0c-6899abe09689.png)

**After**

![image](https://user-images.githubusercontent.com/11153463/102969103-78141800-4538-11eb-865c-b7c8c80f498b.png)
