### PR TITLE
fix: add background-color white

### DIFF
--- a/src/components/StatusLabel/StatusLabel.stories.tsx
+++ b/src/components/StatusLabel/StatusLabel.stories.tsx
@@ -45,9 +45,8 @@ storiesOf('StatusLabel', module)
   ))
 
 const ListWrapper = styled.div`
-  padding: 0 24px;
+  padding: 24px;
 `
-
 const List = styled.ul`
   display: flex;
   padding: 0;

--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -30,6 +30,7 @@ const Wrapper = styled.span<{ themes: Theme }>`
       margin: 0;
       border: 1px solid transparent;
       padding: ${size.pxToRem(XXXS)} ${size.pxToRem(size.space.XXS)};
+      background-color: #fff;
       text-align: center;
       white-space: nowrap;
       min-width: ${size.pxToRem(60)};

--- a/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`StatusLabel should be match snapshot 1`] = `
   margin: 0;
   border: 1px solid transparent;
   padding: 0.25rem 0.5rem;
+  background-color: #fff;
   text-align: center;
   white-space: nowrap;
   min-width: 3.75rem;


### PR DESCRIPTION
## Related URL

🍐 

## Overview

v12.0.0-0 にて StatusLabel に白背景がつかなくなってしまったので追加したい

## What I did

- `background-color: #fff` を追加
- story を見やすくするために padding を追加

## Capture

(わかりやすくするためにキャプチャ撮る時だけグレー背景を敷いています)

![image](https://user-images.githubusercontent.com/11153463/103185914-e292d280-4901-11eb-835c-526770af0224.png)
