### PR TITLE
docs: replace old color code of storybook to theme in Dialog

### DIFF
--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -3,12 +3,13 @@ import { action } from '@storybook/addon-actions'
 import React, { useState } from 'react'
 import styled from 'styled-components'
 
+import { Theme, useTheme } from '../../hooks/useTheme'
 import { SecondaryButton } from '../Button'
 import { RadioButtonLabel } from '../RadioButtonLabel'
 import { ActionDialog, Dialog, MessageDialog } from '.'
 import readme from './README.md'
 
-const DialogController: React.FC = () => {
+const DialogController: React.FC<{ themes: Theme }> = ({ themes }) => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = useState('hoge')
   const [text, setText] = useState('')
@@ -33,7 +34,7 @@ const DialogController: React.FC = () => {
         id="dialog-controllable-1"
         ariaLabel="Dialog"
       >
-        <DialogControllerTitle>Dialog</DialogControllerTitle>
+        <DialogControllerTitle themes={themes}>Dialog</DialogControllerTitle>
         <DialogControllerText>
           The value of isOpen must be managed by you, but you can customize content freely.
         </DialogControllerText>
@@ -66,7 +67,7 @@ const DialogController: React.FC = () => {
             <input name="test" value={text} onChange={(e) => onChangeText(e.currentTarget.value)} />
           </li>
         </DialogControllerBox>
-        <DialogControllerBottom>
+        <DialogControllerBottom themes={themes}>
           <SecondaryButton onClick={onClickClose}>close</SecondaryButton>
         </DialogControllerBottom>
       </Dialog>
@@ -184,19 +185,23 @@ storiesOf('Dialog', module)
       sidebar: readme,
     },
   })
-  .add('controllable', () => (
-    <List>
-      <li>
-        <DialogController />
-      </li>
-      <li>
-        <MessageDialogController />
-      </li>
-      <li>
-        <ActionDialogController />
-      </li>
-    </List>
-  ))
+  .add('controllable', () => {
+    const themes = useTheme()
+
+    return (
+      <List>
+        <li>
+          <DialogController themes={themes} />
+        </li>
+        <li>
+          <MessageDialogController />
+        </li>
+        <li>
+          <ActionDialogController />
+        </li>
+      </List>
+    )
+  })
 
 const List = styled.ul`
   margin: 0;
@@ -207,12 +212,12 @@ const List = styled.ul`
     margin: 8px;
   }
 `
-const DialogControllerTitle = styled.p`
+const DialogControllerTitle = styled.p<{ themes: Theme }>`
   padding: 16px 24px;
   margin: 0;
   font-size: 18px;
   line-height: 1;
-  border-bottom: 1px solid #d6d6d6;
+  border-bottom: ${({ themes }) => themes.frame.border.default};
 `
 const DialogControllerText = styled.p`
   padding: 16px 24px 0 24px;
@@ -228,11 +233,11 @@ const DialogControllerBox = styled.ul`
     padding: 0;
   }
 `
-const DialogControllerBottom = styled.div`
+const DialogControllerBottom = styled.div<{ themes: Theme }>`
   display: flex;
   justify-content: flex-end;
   padding: 16px 24px;
-  border-top: 1px solid #d6d6d6;
+  border-top: ${({ themes }) => themes.frame.border.default};
 
   & > *:not(:first-child) {
     margin-left: 16px;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

Replace old color code in storybook to use theme

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- Replace
  - border style => frame.border.default

## Capture

<!--
Please attach a capture if it looks different.
-->
