### PR TITLE
docs: replace old color code of storybook to theme in ProgressBar

### DIFF
--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,28 +1,34 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
+import { Theme, useTheme } from '../../hooks/useTheme'
 import { Icon } from '../Icon'
 
-storiesOf('[TBD] ProgressBar', module).add('all', () => (
-  <Wrapper>
-    <Title>To Be Developed</Title>
-    <Description>This component will develop in the near future.</Description>
-    <Link
-      href="https://smarthr.invisionapp.com/share/ADUDJ8BW74C#/391861064_progress_Bar"
-      target="_blank"
-    >
-      <LinkText>Design of ProgressBar (InVision)</LinkText>
-      <LinkIcon name="fa-external-link-alt" size={14} />
-    </Link>
-  </Wrapper>
-))
+storiesOf('[TBD] ProgressBar', module).add('all', () => {
+  const themes = useTheme()
 
-const Wrapper = styled.div`
+  return (
+    <Wrapper themes={themes}>
+      <Title>To Be Developed</Title>
+      <Description>This component will develop in the near future.</Description>
+      <Link
+        themes={themes}
+        href="https://smarthr.invisionapp.com/share/ADUDJ8BW74C#/391861064_progress_Bar"
+        target="_blank"
+      >
+        <LinkText>Design of ProgressBar (InVision)</LinkText>
+        <LinkIcon name="fa-external-link-alt" size={14} />
+      </Link>
+    </Wrapper>
+  )
+})
+
+const Wrapper = styled.div<{ themes: Theme }>`
   box-sizing: border-box;
   padding: 24px;
   border-radius: 6px;
   box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
-  color: #333;
+  color: ${({ themes }) => themes.palette.TEXT_BLACK};
   font-size: 14px;
   text-align: center;
   line-height: 1;
@@ -43,8 +49,8 @@ const Description = styled.div`
   margin-bottom: 16px;
 `
 
-const Link = styled.a`
-  color: #007bc2;
+const Link = styled.a<{ themes: Theme }>`
+  color: ${({ themes }) => themes.palette.TEXT_LINK};
 `
 const LinkText = styled.span`
   vertical-align: middle;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

Replace old color code in storybook to use theme

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- Replace 
  - `#333` => `palette.TEXT_BLACK`

## Capture

<!--
Please attach a capture if it looks different.
-->
