### PR TITLE
refactor: migrate Icon in DropZone

### DIFF
--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { SecondaryButton } from '../Button'
-import { Icon } from '../Icon'
+import { FaFolderOpenIcon } from '../Icon'
 
 type DropZoneProps = {
   onSelectFiles: (
@@ -64,7 +64,7 @@ export const DropZone: React.FC<DropZoneProps> = ({ children, onSelectFiles, acc
       onDragLeave={onDragLeave}
     >
       {children}
-      <SecondaryButton prefix={<Icon size={14} name="fa-folder-open" />} onClick={onClickButton}>
+      <SecondaryButton prefix={<FaFolderOpenIcon size={14} />} onClick={onClickButton}>
         ファイルを選択
       </SecondaryButton>
       <input ref={fileRef} type="file" multiple accept={accept} onChange={onChange} />


### PR DESCRIPTION
## Related URL



<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR migrates the Icon component in the DropZone component, which does not affect anyone, just a refactoring.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I've replaced the Icon component with the Fa* component.


<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
