### PR TITLE
refactor: migrate Icon in FieldSet

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -7,7 +7,7 @@ import { useId } from '../../hooks/useId'
 import { Input, Props as InputProps } from '../Input'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { StatusLabel } from '../StatusLabel'
-import { Icon } from '../Icon'
+import { FaExclamationCircleIcon } from '../Icon'
 
 type Props = Omit<InputProps, 'error'> & {
   label: string
@@ -54,7 +54,7 @@ export const FieldSet: FC<Props> = ({
       {errorMessage &&
         (typeof errorMessage === 'string' ? [errorMessage] : errorMessage).map((message) => (
           <Error themes={theme} key={message}>
-            <ErrorIcon name="fa-exclamation-circle" color={theme.palette.DANGER} />
+            <ErrorIcon color={theme.palette.DANGER} />
             <ErrorText>{message}</ErrorText>
           </Error>
         ))}
@@ -103,7 +103,7 @@ const Error = styled.div<{ themes: Theme }>`
     line-height: 1;
   `}
 `
-const ErrorIcon = styled(Icon)`
+const ErrorIcon = styled(FaExclamationCircleIcon)`
   margin-right: 0.4rem;
   vertical-align: middle;
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR migrates the Icon component in the FieldSet component, which does not affect anyone, just a refactoring.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I've replaced the Icon component with the Fa* component.


<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
