### PR TITLE
refactor: migrate Icon in Header

### DIFF
--- a/src/components/Header/HeaderCrewDropdown.tsx
+++ b/src/components/Header/HeaderCrewDropdown.tsx
@@ -4,7 +4,14 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Dropdown, DropdownContent, DropdownTrigger } from '../Dropdown'
-import { Icon } from '../Icon'
+import {
+  FaCaretDownIcon,
+  FaEditIcon,
+  FaPaperPlaneIcon,
+  FaPlusSquareIcon,
+  FaSyncAltIcon,
+  FaUsersIcon,
+} from '../Icon'
 
 type Props = {
   onClickNew?: () => void
@@ -26,11 +33,11 @@ export const HeaderCrewDropdown: FC<Props> = ({
       <DropdownTrigger>
         <TriggerButton themes={theme} type="button">
           <TriggerIcon themes={theme} role="presentation">
-            <Icon name="fa-users" />
+            <FaUsersIcon />
           </TriggerIcon>
           従業員管理
           <CaretIcon themes={theme} role="presentation">
-            <Icon name="fa-caret-down" color="#fff" />
+            <FaCaretDownIcon color="#fff" />
           </CaretIcon>
         </TriggerButton>
       </DropdownTrigger>
@@ -40,7 +47,7 @@ export const HeaderCrewDropdown: FC<Props> = ({
           <MenuListItem role="menuitem">
             <MenuListItemButton themes={theme} onClick={onClickNew}>
               <MenuListItemIcon themes={theme}>
-                <Icon name="fa-edit" />
+                <FaEditIcon />
               </MenuListItemIcon>
               新規登録する（手入力）
             </MenuListItemButton>
@@ -49,7 +56,7 @@ export const HeaderCrewDropdown: FC<Props> = ({
           <MenuListItem role="menuitem">
             <MenuListItemButton themes={theme} onClick={onClickBulkInsert}>
               <MenuListItemIcon themes={theme}>
-                <Icon name="fa-plus-square" />
+                <FaPlusSquareIcon />
               </MenuListItemIcon>
               新規登録する（ファイル）
             </MenuListItemButton>
@@ -58,7 +65,7 @@ export const HeaderCrewDropdown: FC<Props> = ({
           <MenuListItem role="menuitem">
             <MenuListItemButton themes={theme} onClick={onClickBulkUpdate}>
               <MenuListItemIcon themes={theme}>
-                <Icon name="fa-sync-alt" />
+                <FaSyncAltIcon />
               </MenuListItemIcon>
               更新する（ファイル）
             </MenuListItemButton>
@@ -71,7 +78,7 @@ export const HeaderCrewDropdown: FC<Props> = ({
           <MenuListItem role="menuitem">
             <MenuListItemButton themes={theme} onClick={onClickInvite}>
               <MenuListItemIcon themes={theme}>
-                <Icon name="fa-paper-plane" />
+                <FaPaperPlaneIcon />
               </MenuListItemIcon>
               SmartHR に招待
             </MenuListItemButton>

--- a/src/components/Header/HeaderUserDropdown.tsx
+++ b/src/components/Header/HeaderUserDropdown.tsx
@@ -4,7 +4,14 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Dropdown, DropdownContent, DropdownTrigger } from '../Dropdown'
-import { Icon } from '../Icon'
+import {
+  FaBuildingIcon,
+  FaCaretDownIcon,
+  FaCogIcon,
+  FaGraduationCapIcon,
+  FaPowerOffIcon,
+  FaUserAltIcon,
+} from '../Icon'
 
 type Props = {
   isAdmin: boolean
@@ -47,7 +54,7 @@ export const HeaderUserDropdown: FC<Props> = ({
           )}
           {displayName}
           <CaretIcon themes={theme} role="presentation">
-            <Icon name="fa-caret-down" color="#fff" />
+            <FaCaretDownIcon color="#fff" />
           </CaretIcon>
         </TriggerButton>
       </DropdownTrigger>
@@ -62,7 +69,7 @@ export const HeaderUserDropdown: FC<Props> = ({
             <MenuListItem role="menuitem">
               <MenuListItemButton onClick={onClickProfile} themes={theme}>
                 <MenuListItemIcon themes={theme}>
-                  <Icon name="fa-user-alt" />
+                  <FaUserAltIcon />
                 </MenuListItemIcon>
                 プロフィールの確認
               </MenuListItemButton>
@@ -72,7 +79,7 @@ export const HeaderUserDropdown: FC<Props> = ({
           <MenuListItem role="menuitem">
             <MenuListItemButton onClick={onClickAccount} themes={theme}>
               <MenuListItemIcon themes={theme}>
-                <Icon name="fa-cog" />
+                <FaCogIcon />
               </MenuListItemIcon>
               個人設定
             </MenuListItemButton>
@@ -91,7 +98,7 @@ export const HeaderUserDropdown: FC<Props> = ({
               <MenuListItem role="menuitem">
                 <MenuListItemButton onClick={onClickCompany} themes={theme}>
                   <MenuListItemIcon themes={theme}>
-                    <Icon name="fa-building" />
+                    <FaBuildingIcon />
                   </MenuListItemIcon>
                   共通設定
                 </MenuListItemButton>
@@ -107,7 +114,7 @@ export const HeaderUserDropdown: FC<Props> = ({
             <MenuListItem role="menuitem">
               <MenuListItemButton onClick={onClickSchool} themes={theme}>
                 <MenuListItemIcon themes={theme}>
-                  <Icon name="fa-graduation-cap" />
+                  <FaGraduationCapIcon />
                 </MenuListItemIcon>
                 SmartHR スクール
               </MenuListItemButton>
@@ -117,7 +124,7 @@ export const HeaderUserDropdown: FC<Props> = ({
           <MenuListItem role="menuitem">
             <MenuListItemButton onClick={onClickLogout} themes={theme}>
               <MenuListItemIcon themes={theme}>
-                <Icon name="fa-power-off" />
+                <FaPowerOffIcon />
               </MenuListItemIcon>
               ログアウト
             </MenuListItemButton>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR migrates the Icon component in the Header component, which does not affect anyone, just a refactoring.
HeaderButton is also using Icon components, but it receives an icon name as props, so we have to change I/F to migrate the usage. I'll work on that as another issue.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I've replaced the Icon component with the Fa* component.


<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
