### PR TITLE
refactor: migrate Icon in InputFile

### DIFF
--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { isTouchDevice } from '../../libs/ua'
 import { TextButton } from '../Button'
-import { Icon } from '../Icon'
+import { FaFolderOpenIcon, FaTrashAltIcon } from '../Icon'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 type Size = 'default' | 's'
@@ -59,7 +59,7 @@ export const InputFile: FC<Props> = ({
                 <span>{file.name}</span>
                 <span>
                   <TextButton
-                    prefix={<Icon size={14} name="fa-trash-alt" />}
+                    prefix={<FaTrashAltIcon size={14} />}
                     onClick={() => handleDelete(index)}
                   >
                     削除
@@ -86,7 +86,7 @@ export const InputFile: FC<Props> = ({
         >
           <label htmlFor={id}>
             <Prefix themes={theme}>
-              <Icon size={14} name="fa-folder-open" />
+              <FaFolderOpenIcon size={14} />
             </Prefix>
             {label}
           </label>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR migrates the Icon component in the InputFile component, which does not affect anyone, just a refactoring.


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I've replaced the Icon component with the Fa* component.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
