### PR TITLE
fix: change input error style (SHRUI-327)

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -51,6 +51,11 @@ storiesOf('Input', module).add('all', () => {
         <Input error={true} />
       </li>
       <li>
+        <Txt>disabled and error</Txt>
+        <Input disabled={true} error={true} />
+        <Note>`disabled` takes precedence over `error`</Note>
+      </li>
+      <li>
         <Txt>prefix</Txt>
         <Input prefix={<FaSearchIcon color={theme.palette.BORDER} />} />
       </li>
@@ -79,4 +84,9 @@ const Txt = styled.p`
 `
 const StyledInput = styled(Input)`
   width: 50%;
+`
+const Note = styled.div`
+  margin-top: 8px;
+  font-size: 12px;
+  color: #767676;
 `

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,9 +1,9 @@
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-import { useTheme } from '../../hooks/useTheme'
+import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Input } from './Input'
 import { FaSearchIcon } from '../Icon'
@@ -53,7 +53,7 @@ storiesOf('Input', module).add('all', () => {
       <li>
         <Txt>disabled and error</Txt>
         <Input disabled={true} error={true} />
-        <Note>`disabled` takes precedence over `error`</Note>
+        <Note themes={theme}>`disabled` takes precedence over `error`</Note>
       </li>
       <li>
         <Txt>prefix</Txt>
@@ -85,8 +85,11 @@ const Txt = styled.p`
 const StyledInput = styled(Input)`
   width: 50%;
 `
-const Note = styled.div`
-  margin-top: 8px;
-  font-size: 12px;
-  color: #767676;
+const Note = styled.div<{ themes: Theme }>`
+  ${({ themes }) => css`
+    margin-top: 8px;
+    font-size: 12px;
+    font-size: 14px;
+    color: ${themes.palette.TEXT_GREY};
+  `}
 `

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -131,7 +131,8 @@ const Wrapper = styled.span<{
     css`
       border-color: ${palette.hoverColor(palette.MAIN)};
     `}
-    ${error &&
+    ${!$disabled &&
+    error &&
     css`
       border-color: ${palette.DANGER};
     `}


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/KOBAN-4970
- https://smarthr.atlassian.net/browse/SHRUI-327

## Overview

- Input コンポーネントで error と disabled 双方の props が指定されている場合は、disabled の style を当てたい

## What I did

- Input error の style は !disabled のときのみ適用するようにした

## Capture

|Before|After|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5195381/105024803-dd075300-5a8f-11eb-830b-abdf3c7c2e7d.png) | ![image](https://user-images.githubusercontent.com/5195381/105024325-4f2b6800-5a8f-11eb-859f-d915a2813295.png) |


