### PR TITLE
fix: add "!important" to font-size of InputFile

### DIFF
--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -132,8 +132,15 @@ const FileButtonWrapper = styled.div<{ themes: Theme }>(({ themes }) => {
       left: -10px;
       top: 0;
       margin: 0;
-      font-size: 128px;
+      /*
+      HINT:
+        input[type=file] が button ボタンを覆うようにサイズを調整
+        Hanica のようにデフォルト font-size に !important がついているプロダクトの場合、上書きされてしまうため念のため !important を入れる
+      */
+      font-size: 128px !important;
       opacity: 0;
+      appearance: none;
+      cursor: pointer;
 
       &::-webkit-file-upload-button {
         cursor: pointer;

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -127,10 +127,12 @@ const FileButtonWrapper = styled.div<{ themes: Theme }>(({ themes }) => {
     > input[type='file'] {
       position: absolute;
       height: 100%;
+
       /* Prevent to show caret on the upload button on IE11 */
       left: -10px;
       top: 0;
       margin: 0;
+
       /* HINT: input[type=file] が button ボタンを覆うようにサイズを調整
       Hanica のようにデフォルト font-size に !important がついているプロダクトの場合、上書きされてしまうため念のため !important を入れる */
       font-size: 128px !important;

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -127,16 +127,12 @@ const FileButtonWrapper = styled.div<{ themes: Theme }>(({ themes }) => {
     > input[type='file'] {
       position: absolute;
       height: 100%;
-
       /* Prevent to show caret on the upload button on IE11 */
       left: -10px;
       top: 0;
       margin: 0;
-      /*
-      HINT:
-        input[type=file] が button ボタンを覆うようにサイズを調整
-        Hanica のようにデフォルト font-size に !important がついているプロダクトの場合、上書きされてしまうため念のため !important を入れる
-      */
+      /* HINT: input[type=file] が button ボタンを覆うようにサイズを調整
+      Hanica のようにデフォルト font-size に !important がついているプロダクトの場合、上書きされてしまうため念のため !important を入れる */
       font-size: 128px !important;
       opacity: 0;
       appearance: none;


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-316

## Overview

Hanicaなどではinputのfont-sizeに!importantがついており、上書きされてしまう。
InputFileのfont-sizeが上書きされると、マウスポインターの切り替え位置がずれるため、デフォで !important つける

## What I did

- [x] css に !important を追加
- [x]  appearance と cursor も追加

## Capture
