### PR TITLE
fix: input[file] の不要なfocusを削除する

### DIFF
--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -77,7 +77,7 @@ export const InputFile: FC<Props> = ({
           id={id}
           onChange={(e) => handleChange(e)}
           disabled={disabled}
-          tab-index="-1"
+          tabIndex={-1}
         />
         <FileButton
           themes={theme}

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -72,11 +72,12 @@ export const InputFile: FC<Props> = ({
       )}
       <FileButtonWrapper themes={theme} className={FileButtonWrapperClassName}>
         <input
+          {...props}
           type="file"
           id={id}
           onChange={(e) => handleChange(e)}
           disabled={disabled}
-          {...props}
+          tab-index="-1"
         />
         <FileButton
           themes={theme}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

<InputFile> は input[type=”file'] と <button>で実装されているが、隠している input にもフォーカスがあたってしまい、一度フォーカスインジケーターが表示されなくなる。
キーボードで操作している場合には混乱する可能性があるため修正したい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
