### PR TITLE
fix: fix position of visually hidden text (SHRUI-317)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,10 @@ import { css } from 'styled-components'
 
 export const VISUALLY_HIDDEN_STYLE = css`
   position: absolute;
+  top: -1px;
+  left: 0;
   width: 1px;
   height: 1px;
-  margin: -1px;
   border: 0;
   padding: 0;
   white-space: nowrap;


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-317
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`VISUALLY_HIDDEN_STYLE` の位置が直近の祖先の相対位置になることに起因して意図しないスクロールが発生してしまう問題に対応する。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* `top`, `left` 位置を指定して基準座標付近（1px上）に配することで、このスタイルを持った要素の表示に伴うスクロールが生じないように修正
  * ページ上の特定の箇所に 1px の absolute 表示の要素が存在しうることになるが、`clip` スタイルを用いていることによりその領域はクリック等のマウス操作に影響を及ぼさないことを確認したので、特に支障は無いと思われる
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
