### PR TITLE
test: avoid timeout during reg-suit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ esm/
 storybook-static/
 .reg
 actual_images
+reg_storybook

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lint:tsc": "tsc --noEmit",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "prepublishOnly": "run-s clean lint build",
-    "pretest-visual": "storycap --serverCmd \"start-storybook -p 6006 --ci\" http://localhost:6006 -o actual_images  --serverTimeout 3600000",
+    "pretest-visual": "build-storybook -o reg_storybook; storycap --serverCmd \"npx http-server reg_storybook -p 6006\" http://localhost:6006 -o actual_images  --serverTimeout 3600000",
     "release": "standard-version",
     "release:dryrun": "standard-version --dry-run",
     "storybook": "start-storybook -p 6006",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lint:tsc": "tsc --noEmit",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "prepublishOnly": "run-s clean lint build",
-    "pretest-visual": "build-storybook -o reg_storybook; storycap --serverCmd \"npx http-server reg_storybook -p 6006\" http://localhost:6006 -o actual_images  --serverTimeout 3600000",
+    "pretest-visual": "build-storybook -o reg_storybook --quiet; storycap --serverCmd \"npx http-server reg_storybook -p 6006\" http://localhost:6006 -o actual_images  --serverTimeout 3600000",
     "release": "standard-version",
     "release:dryrun": "standard-version --dry-run",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
CI の reg-suit でタイムアウトが頻発する問題に対処します。

### 原因

`storycap` がスクリーンショットを撮るために storybook を起動しアクセスするが、その初回アクセス時に storybook のコンテンツがロードされるまでに30秒以上掛かると `pupeteer` がタイムアウトする。

### 対応策

`start-storybook` コマンドによって storybook を起動した時、初回アクセス時にモジュールビルドが行われ余計に時間がかかってしまう。
そこで、 `build-storybook` コマンドによって予め storybook の静的ファイルを生成してから http サーバを立ち上げることで初回アクセス時の処理時間を短縮し、タイムアウトを回避させる。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* `pretest-visual` スクリプト内における storybook の起動を、`start-storybook` から `build-storybook` + `npx http-server` に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
