### PR TITLE
Fix elements using Portal can be operate by keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "author": "SmartHR-UI Team",
   "dependencies": {
     "dayjs": "^1.10.4",
-    "focus-trap": "^6.3.0",
     "lodash.merge": "^4.6.2",
     "lodash.range": "^3.2.0",
     "polished": "^4.1.0",
+    "react-focus-lock": "^2.5.0",
     "react-icons": "^4.1.0",
     "react-transition-group": "^4.4.1"
   },

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -20,6 +20,7 @@ type Props = {
   disabled?: boolean
   error?: boolean
   className?: string
+  focusGroupId?: string
   parseInput?: (input: string) => Date | null
   formatDate?: (date: Date | null) => string
   onChangeDate?: (date: Date | null, value: string) => void
@@ -33,6 +34,7 @@ export const DatePicker: FC<Props & InputAttributes> = ({
   to,
   disabled,
   error,
+  focusGroupId,
   className,
   parseInput,
   formatDate,
@@ -238,7 +240,7 @@ export const DatePicker: FC<Props & InputAttributes> = ({
         />
       </InputWrapper>
       {isCalendarShown && (
-        <Portal inputRect={inputRect} ref={calendarPortalRef}>
+        <Portal focusGroupId={focusGroupId} inputRect={inputRect} ref={calendarPortalRef}>
           <Calendar
             value={selectedDate || undefined}
             from={from}

--- a/src/components/DatePicker/Portal.tsx
+++ b/src/components/DatePicker/Portal.tsx
@@ -9,6 +9,7 @@ import React, {
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
+import FocusLock from 'react-focus-lock'
 
 import { usePortal } from '../../hooks/usePortal'
 import { getPortalPosition } from './datePickerHelper'
@@ -16,38 +17,49 @@ import { getPortalPosition } from './datePickerHelper'
 type Props = {
   inputRect: DOMRect
   children: ReactNode
+  focusGroupId?: string
 }
 
-export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, children }, ref) => {
-  const themes = useTheme()
-  const { portalRoot } = usePortal()
+export const Portal = forwardRef<HTMLDivElement, Props>(
+  ({ focusGroupId, inputRect, children }, ref) => {
+    const themes = useTheme()
+    const { portalRoot } = usePortal()
 
-  const [position, setPosition] = useState({
-    top: 0,
-    left: 0,
-  })
-  const [isReady, setIsReady] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(ref, () => containerRef.current)
-
-  useEffect(() => {
-    // wait for createPortal
-    requestAnimationFrame(() => {
-      if (!containerRef.current) {
-        return
-      }
-      setPosition(getPortalPosition(inputRect, containerRef.current.offsetHeight))
-      setIsReady(true)
+    const [position, setPosition] = useState({
+      top: 0,
+      left: 0,
     })
-  }, [inputRect])
+    const [isReady, setIsReady] = useState(false)
+    const containerRef = useRef<HTMLDivElement>(null)
+    useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+      ref,
+      () => containerRef.current,
+    )
 
-  return createPortal(
-    <Container {...position} themes={themes} className={isReady ? 'ready' : ''} ref={containerRef}>
-      {children}
-    </Container>,
-    portalRoot,
-  )
-})
+    useEffect(() => {
+      // wait for createPortal
+      requestAnimationFrame(() => {
+        if (!containerRef.current) {
+          return
+        }
+        setPosition(getPortalPosition(inputRect, containerRef.current.offsetHeight))
+        setIsReady(true)
+      })
+    }, [inputRect])
+
+    return createPortal(
+      <Container
+        {...position}
+        themes={themes}
+        className={isReady ? 'ready' : ''}
+        ref={containerRef}
+      >
+        {focusGroupId ? <FocusLock group={focusGroupId}>{children}</FocusLock> : children}
+      </Container>,
+      portalRoot,
+    )
+  },
+)
 
 const Container = styled.div<{ top: number; left: number; themes: Theme }>(
   ({ top, left, themes }) => css`

--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { SecondaryButton } from '../Button'
 import { RadioButtonLabel } from '../RadioButtonLabel'
+import { DatePicker } from '../DatePicker'
+
 import { ActionDialog, Dialog, MessageDialog } from '.'
 import readme from './README.md'
 
@@ -17,6 +19,8 @@ const DialogController: React.FC<{ themes: Theme }> = ({ themes }) => {
   const onClickClose = () => setIsOpen(false)
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
   const onChangeText = (txt: string) => setText(txt)
+
+  const FOCUS_GROUP_ID = 'dialog-controller-date-picker'
 
   return (
     <div>
@@ -33,11 +37,15 @@ const DialogController: React.FC<{ themes: Theme }> = ({ themes }) => {
         onPressEscape={onClickClose}
         id="dialog-controllable-1"
         ariaLabel="Dialog"
+        focusGroupId={FOCUS_GROUP_ID}
       >
         <DialogControllerTitle themes={themes}>Dialog</DialogControllerTitle>
         <DialogControllerText>
           The value of isOpen must be managed by you, but you can customize content freely.
         </DialogControllerText>
+        <DialogItemWrapper>
+          <DatePicker focusGroupId={FOCUS_GROUP_ID} />
+        </DialogItemWrapper>
         <DialogControllerBox>
           <li>
             <RadioButtonLabel
@@ -64,7 +72,14 @@ const DialogController: React.FC<{ themes: Theme }> = ({ themes }) => {
             />
           </li>
           <li>
-            <input name="test" value={text} onChange={(e) => onChangeText(e.currentTarget.value)} />
+            <label>
+              label:
+              <input
+                name="test"
+                value={text}
+                onChange={(e) => onChangeText(e.currentTarget.value)}
+              />
+            </label>
           </li>
         </DialogControllerBox>
         <DialogControllerBottom themes={themes}>
@@ -218,6 +233,9 @@ const DialogControllerTitle = styled.p<{ themes: Theme }>`
   font-size: 18px;
   line-height: 1;
   border-bottom: ${({ themes }) => themes.frame.border.default};
+`
+const DialogItemWrapper = styled.div`
+  padding: 16px 24px;
 `
 const DialogControllerText = styled.p`
   padding: 16px 24px 0 24px;

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,7 +1,7 @@
-import React, { FC, ReactNode, useCallback, useEffect, useRef } from 'react'
+import React, { FC, ReactNode, useCallback, useRef } from 'react'
 import styled, { createGlobalStyle, css } from 'styled-components'
 import { CSSTransition } from 'react-transition-group'
-import { Options as CreateFocusTrapOptions, createFocusTrap } from 'focus-trap'
+import FocusLock from 'react-focus-lock'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useHandleEscape } from '../../hooks/useHandleEscape'
@@ -18,6 +18,7 @@ export type DialogContentInnerProps = {
   id?: string
   ariaLabel?: string
   ariaLabelledby?: string
+  focusGroupId?: string
   children: ReactNode
 }
 
@@ -41,6 +42,7 @@ export const DialogContentInner: FC<DialogContentInnerProps> = ({
   id,
   ariaLabel,
   ariaLabelledby,
+  focusGroupId,
   children,
   ...props
 }) => {
@@ -57,22 +59,7 @@ export const DialogContentInner: FC<DialogContentInnerProps> = ({
     }, [isOpen, onPressEscape]),
   )
 
-  useEffect(() => {
-    const focusTrapOption: CreateFocusTrapOptions = {
-      allowOutsideClick: true,
-      initialFocus: focusTarget.current ? focusTarget.current : undefined,
-    }
-    const focusTrap =
-      innerRef.current !== null ? createFocusTrap(innerRef.current, focusTrapOption) : undefined
-
-    if (isOpen) {
-      focusTrap?.activate()
-    }
-
-    return () => {
-      focusTrap?.deactivate()
-    }
-  }, [isOpen])
+  // Todo @masuP9 back focus to trigger element
 
   return (
     <DialogPositionProvider top={props.top} bottom={props.bottom}>
@@ -98,8 +85,10 @@ export const DialogContentInner: FC<DialogContentInnerProps> = ({
           <Background onClick={onClickOverlay} themes={theme} />
           <Inner ref={innerRef} themes={theme} role="dialog" aria-modal="true" {...props}>
             {/* dummy element for focus management. */}
-            <div ref={focusTarget} tabIndex={-1} aria-label={ariaLabel}></div>
-            {children}
+            <FocusLock group={focusGroupId}>
+              <div ref={focusTarget} tabIndex={-1} aria-label={ariaLabel}></div>
+              {children}
+            </FocusLock>
           </Inner>
           {/* Suppresses scrolling of body while modal is displayed */}
           <ScrollSuppressing />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7545,13 +7545,6 @@ focus-lock@^0.8.1:
   dependencies:
     tslib "^1.9.3"
 
-focus-trap@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.3.0.tgz#31c08f0b6099705f71f6e0a16d88fbcc4c012586"
-  integrity sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==
-  dependencies:
-    tabbable "^5.1.5"
-
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
@@ -12838,7 +12831,7 @@ react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@^2.1.0:
+react-focus-lock@^2.1.0, react-focus-lock@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
   integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==
@@ -14877,11 +14870,6 @@ symbol.prototype.description@^1.0.0:
     es-abstract "^1.18.0-next.1"
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
-
-tabbable@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.5.tgz#efec48ede268d511c261e3b81facbb4782a35147"
-  integrity sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA==
 
 table@^6.0.4:
   version "6.0.4"


### PR DESCRIPTION
## Overview

> `<Dialog>` 内に Portal な要素を配置するとその要素はキーボードでフォーカスできないことが判明。
> Portal な要素はダイアログ自体と DOM ツリー上の親子関係は無いので、 focus-trap が外側の要素と判定してフォーカスを抑止する模様。

I fixed it.

## What I did

- use [react-focus-lock](https://github.com/theKashey/react-focus-lock) instead of focus-trap.
- use group of react-focus-lock to make elements using Portal target of focus trap.

## Capture

<details open>
<summary>Capture by keyboard operation</summary>
<img src="https://user-images.githubusercontent.com/6724665/107739698-d09fae80-6d4c-11eb-8f0c-e1c4480fa2f1.gif" alt="" />
</details>
