### PR TITLE
test: add maxWorkers option in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
       # run tests!
       - run: yarn audit --groups dependencies
       - run: yarn lint
-      - run: yarn test
+      - run: yarn test -w 1
       - run: yarn test:build-assets
   # visual regression testing
   run-reg-suit:


### PR DESCRIPTION
## Related URL
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
CI の jest でメモリを使い切っている雰囲気があるので、 maxWorkers の制限を入れる
* https://jestjs.io/docs/ja/cli#--maxworkersnumstring
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
* CI の jest に `-w 1` を設定
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
