### PR TITLE
chore: replace from FC to VFC in Dialog (SHRUI-321)

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -11,7 +11,7 @@ type Props = ActionDialogContentInnerProps & {
     'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
   >
 
-export const ActionDialog: React.FC<Props> = ({
+export const ActionDialog: React.VFC<Props> = ({
   children,
   title,
   closeText,

--- a/src/components/Dialog/ActionDialogContent.tsx
+++ b/src/components/Dialog/ActionDialogContent.tsx
@@ -6,7 +6,7 @@ import { ActionDialogContentInner, BaseProps } from './ActionDialogContentInner'
 
 type Props = BaseProps & Pick<DialogContentInnerProps, 'top' | 'right' | 'bottom' | 'left' | 'id'>
 
-export const ActionDialogContent: React.FC<Props> = ({
+export const ActionDialogContent: React.VFC<Props> = ({
   children,
   title,
   closeText,

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react'
+import React, { VFC, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -21,7 +21,7 @@ export type ActionDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
 }
 
-export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
+export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   children,
   title,
   closeText,

--- a/src/components/Dialog/Dialog.controllable.stories.tsx
+++ b/src/components/Dialog/Dialog.controllable.stories.tsx
@@ -10,7 +10,7 @@ import { DatePicker } from '../DatePicker'
 import { ActionDialog, Dialog, MessageDialog } from '.'
 import readme from './README.md'
 
-const DialogController: React.FC<{ themes: Theme }> = ({ themes }) => {
+const DialogController: React.VFC<{ themes: Theme }> = ({ themes }) => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = useState('hoge')
   const [date, setDate] = useState<Date | null>(null)
@@ -79,7 +79,7 @@ const DialogController: React.FC<{ themes: Theme }> = ({ themes }) => {
   )
 }
 
-const MessageDialogController: React.FC = () => {
+const MessageDialogController: React.VFC = () => {
   const [isOpen, setIsOpen] = useState(false)
   const onClickOpen = () => setIsOpen(true)
   const onClickClose = () => setIsOpen(false)
@@ -121,7 +121,7 @@ const MessageDialogController: React.FC = () => {
   )
 }
 
-const ActionDialogController: React.FC = () => {
+const ActionDialogController: React.VFC = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = React.useState('hoge')
   const onClickOpen = () => setIsOpen(true)

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -5,7 +5,7 @@ import { DialogContentInner, DialogContentInnerProps } from './DialogContentInne
 
 type Props = DialogContentInnerProps
 
-export const Dialog: React.FC<Props> = ({ children, ...props }) => {
+export const Dialog: React.VFC<Props> = ({ children, ...props }) => {
   const element = useRef(document.createElement('div')).current
 
   useEffect(() => {

--- a/src/components/Dialog/Dialog.uncontrollable.stories.tsx
+++ b/src/components/Dialog/Dialog.uncontrollable.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from '.'
 import readme from './README.md'
 
-const FormDialog: React.FC = () => {
+const FormDialog: React.VFC = () => {
   const [value, setValue] = useState('hoge')
   const [text, setText] = useState('')
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)

--- a/src/components/Dialog/DialogCloser.tsx
+++ b/src/components/Dialog/DialogCloser.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { DialogContentContext } from './DialogContent'
 
-export const DialogCloser: React.FC = ({ children }) => {
+export const DialogCloser: React.VFC = ({ children }) => {
   const { onClickClose } = useContext(DialogContentContext)
   return <Wrapper onClick={onClickClose}>{children}</Wrapper>
 }

--- a/src/components/Dialog/DialogCloser.tsx
+++ b/src/components/Dialog/DialogCloser.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { DialogContentContext } from './DialogContent'
 
-export const DialogCloser: React.VFC = ({ children }) => {
+export const DialogCloser: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
   const { onClickClose } = useContext(DialogContentContext)
   return <Wrapper onClick={onClickClose}>{children}</Wrapper>
 }

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -18,7 +18,7 @@ type Props = Pick<
   'top' | 'right' | 'bottom' | 'left' | 'id' | 'ariaLabel' | 'ariaLabelledby'
 >
 
-export const DialogContent: React.FC<Props> = ({ children, ...props }) => {
+export const DialogContent: React.VFC<Props> = ({ children, ...props }) => {
   const { DialogContentRoot, onClickClose, active } = useContext(DialogContext)
 
   return (

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -15,7 +15,7 @@ export const DialogContentContext = createContext<DialogContentContextType>({
 
 type Props = Pick<
   DialogContentInnerProps,
-  'top' | 'right' | 'bottom' | 'left' | 'id' | 'ariaLabel' | 'ariaLabelledby'
+  'top' | 'right' | 'bottom' | 'left' | 'id' | 'ariaLabel' | 'ariaLabelledby' | 'children'
 >
 
 export const DialogContent: React.VFC<Props> = ({ children, ...props }) => {

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useCallback, useRef } from 'react'
+import React, { ReactNode, VFC, useCallback, useRef } from 'react'
 import styled, { createGlobalStyle, css } from 'styled-components'
 import { CSSTransition } from 'react-transition-group'
 
@@ -32,7 +32,7 @@ function exist(value: any) {
   return value !== undefined && value !== null
 }
 
-export const DialogContentInner: FC<DialogContentInnerProps> = ({
+export const DialogContentInner: VFC<DialogContentInnerProps> = ({
   onClickOverlay,
   onPressEscape = () => {
     /* noop */

--- a/src/components/Dialog/DialogPositionProvider.tsx
+++ b/src/components/Dialog/DialogPositionProvider.tsx
@@ -7,7 +7,7 @@ type PositionContextType = {
 
 export const PositionContext = createContext<PositionContextType>({})
 
-export const DialogPositionProvider: React.FC<PositionContextType> = ({
+export const DialogPositionProvider: React.VFC<PositionContextType> = ({
   top,
   bottom,
   children,

--- a/src/components/Dialog/DialogPositionProvider.tsx
+++ b/src/components/Dialog/DialogPositionProvider.tsx
@@ -7,11 +7,9 @@ type PositionContextType = {
 
 export const PositionContext = createContext<PositionContextType>({})
 
-export const DialogPositionProvider: React.VFC<PositionContextType> = ({
-  top,
-  bottom,
-  children,
-}) => {
+export const DialogPositionProvider: React.VFC<
+  PositionContextType & { children?: React.ReactNode }
+> = ({ top, bottom, children }) => {
   return (
     <PositionContext.Provider
       value={{

--- a/src/components/Dialog/DialogTrigger.tsx
+++ b/src/components/Dialog/DialogTrigger.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { DialogContext } from './DialogWrapper'
 
-export const DialogTrigger: React.FC = ({ children }) => {
+export const DialogTrigger: React.VFC = ({ children }) => {
   const { onClickTrigger } = useContext(DialogContext)
   return (
     <Wrapper onClick={onClickTrigger} aria-haspopup="dialog">

--- a/src/components/Dialog/DialogTrigger.tsx
+++ b/src/components/Dialog/DialogTrigger.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { DialogContext } from './DialogWrapper'
 
-export const DialogTrigger: React.VFC = ({ children }) => {
+export const DialogTrigger: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
   const { onClickTrigger } = useContext(DialogContext)
   return (
     <Wrapper onClick={onClickTrigger} aria-haspopup="dialog">

--- a/src/components/Dialog/DialogWrapper.tsx
+++ b/src/components/Dialog/DialogWrapper.tsx
@@ -19,7 +19,7 @@ export const DialogContext = createContext<DialogContextType>({
   active: false,
 })
 
-export const DialogWrapper: React.VFC = ({ children }) => {
+export const DialogWrapper: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
   const [active, setActive] = useState(false)
   const element = useRef(document.createElement('div')).current
 

--- a/src/components/Dialog/DialogWrapper.tsx
+++ b/src/components/Dialog/DialogWrapper.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom'
 type DialogContextType = {
   onClickTrigger: () => void
   onClickClose: () => void
-  DialogContentRoot: React.FC<{ children: React.ReactNode }>
+  DialogContentRoot: React.VFC<{ children: React.ReactNode }>
   active: boolean
 }
 
@@ -19,7 +19,7 @@ export const DialogContext = createContext<DialogContextType>({
   active: false,
 })
 
-export const DialogWrapper: React.FC = ({ children }) => {
+export const DialogWrapper: React.VFC = ({ children }) => {
   const [active, setActive] = useState(false)
   const element = useRef(document.createElement('div')).current
 
@@ -32,7 +32,7 @@ export const DialogWrapper: React.FC = ({ children }) => {
   }, [element])
 
   // This is the root container of a dialog content located in outside the DOM tree
-  const DialogContentRoot = useMemo<React.FC<{ children: React.ReactNode }>>(
+  const DialogContentRoot = useMemo<React.VFC<{ children: React.ReactNode }>>(
     () => (props) => {
       return createPortal(props.children, element)
     },

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -13,7 +13,7 @@ type Props = MessageDialogContentInnerProps &
     'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
   >
 
-export const MessageDialog: React.FC<Props> = ({
+export const MessageDialog: React.VFC<Props> = ({
   title,
   description,
   closeText,

--- a/src/components/Dialog/MessageDialogContent.tsx
+++ b/src/components/Dialog/MessageDialogContent.tsx
@@ -6,7 +6,7 @@ import { BaseProps, MessageDialogContentInner } from './MessageDialogContentInne
 
 type Props = BaseProps & Pick<DialogContentInnerProps, 'top' | 'right' | 'bottom' | 'left' | 'id'>
 
-export const MessageDialogContent: React.FC<Props> = ({
+export const MessageDialogContent: React.VFC<Props> = ({
   title,
   description,
   closeText,

--- a/src/components/Dialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -16,7 +16,7 @@ export type MessageDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
 }
 
-export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
+export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
   title,
   description,
   closeText,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in `Dialog`.
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- replace `FC`
- fix type error
- check presence of `children` props in exported components
  - necessary
    - `Dialog`
    - `ActionDialog`
    - `DialogWrapper`
    - `DialogTrigger`
    - `DialogCloser`
    - `DialogContent`
    - `ActionDialogContent`
  - unnecessary
    - `MessageDialog`
    - `MessageDialogContent`
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
