### PR TITLE
chore: replace from FC to VFC in Dropdown (SHRUI-321)

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React, {
-  FC,
   MutableRefObject,
   ReactNode,
+  VFC,
   createContext,
   useContext,
   useEffect,
@@ -26,7 +26,7 @@ type DropdownContextType = {
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
   onClickTrigger: (rect: Rect) => void
   onClickCloser: () => void
-  DropdownContentRoot: FC<{ children: ReactNode }>
+  DropdownContentRoot: VFC<{ children: ReactNode }>
   contentId: string
 }
 
@@ -47,7 +47,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   contentId: '',
 })
 
-export const Dropdown: FC<Props> = ({ children }) => {
+export const Dropdown: VFC<Props> = ({ children }) => {
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
@@ -75,7 +75,7 @@ export const Dropdown: FC<Props> = ({ children }) => {
   }, [isChildPortal, portalRoot])
 
   // This is the root container of a dropdown content located in outside the DOM tree
-  const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(
+  const DropdownContentRoot = useMemo<VFC<{ children: ReactNode }>>(
     () => (props) => {
       if (!active) return null
       return createPortal(props.children, portalRoot)

--- a/src/components/Dropdown/DropdownCloser.tsx
+++ b/src/components/Dropdown/DropdownCloser.tsx
@@ -9,7 +9,7 @@ type Props = {
   className?: string
 }
 
-export const DropdownCloser: React.FC<Props> = ({ children, className = '' }) => {
+export const DropdownCloser: React.VFC<Props> = ({ children, className = '' }) => {
   const { onClickCloser, controllable, scrollable } = useContext(DropdownContentContext)
   const { maxHeight } = useContext(DropdownContentInnerContext)
 

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -19,6 +19,7 @@ type Props = {
   controllable?: boolean
   scrollable?: boolean
   className?: string
+  children?: React.ReactNode
 }
 
 export const DropdownContent: React.VFC<Props> = ({

--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -21,7 +21,7 @@ type Props = {
   className?: string
 }
 
-export const DropdownContent: React.FC<Props> = ({
+export const DropdownContent: React.VFC<Props> = ({
   controllable = false,
   scrollable = true,
   className = '',

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC, createContext, useCallback, useLayoutEffect, useRef, useState } from 'react'
+import React, { VFC, createContext, useCallback, useLayoutEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -23,7 +23,7 @@ export const DropdownContentInnerContext = createContext<DropdownContentInnerCon
   maxHeight: '',
 })
 
-export const DropdownContentInner: FC<Props> = ({
+export const DropdownContentInner: VFC<Props> = ({
   triggerRect,
   scrollable,
   children,

--- a/src/components/Dropdown/DropdownScrollArea.tsx
+++ b/src/components/Dropdown/DropdownScrollArea.tsx
@@ -6,7 +6,7 @@ type Props = {
   children: ReactNode
 }
 
-export const DropdownScrollArea: React.FC<Props> = ({ children, className = '' }) => (
+export const DropdownScrollArea: React.VFC<Props> = ({ children, className = '' }) => (
   <Wrapper className={className}>{children}</Wrapper>
 )
 

--- a/src/components/Dropdown/DropdownTrigger.tsx
+++ b/src/components/Dropdown/DropdownTrigger.tsx
@@ -9,7 +9,7 @@ type Props = {
   className?: string
 }
 
-export const DropdownTrigger: React.FC<Props> = ({ children, className = '' }) => {
+export const DropdownTrigger: React.VFC<Props> = ({ children, className = '' }) => {
   const { active, onClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)
 
   useEffect(() => {

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
@@ -18,7 +18,7 @@ type Props = {
   children: ReactNode
 }
 
-export const FilterDropdown: FC<Props> = ({
+export const FilterDropdown: VFC<Props> = ({
   isFiltered = false,
   onApply,
   onCancel,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in `Dropdown`.
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- replace `FC`
- fix type error
- check all exported components have `children` props
  - `Dropdown`
  - `DropdownTrigger`
  - `DropdownContent`
  - `DropdownCloser`
  - `DropdownScrollArea`
  - `FilterDropdown`

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
