### PR TITLE
feat: support multiline text of CheckboxLabel

### DIFF
--- a/src/components/CheckBoxLabel/CheckBoxLabel.stories.tsx
+++ b/src/components/CheckBoxLabel/CheckBoxLabel.stories.tsx
@@ -76,6 +76,21 @@ storiesOf('CheckBoxLabel', module)
           </li>
         </List>
       </li>
+
+      <li>
+        <Text>multiline text</Text>
+        <List>
+          <li>
+            <CheckBoxLabel
+              label="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+              name="name9"
+              checked={true}
+              mixed={true}
+              onChange={onChange}
+            />
+          </li>
+        </List>
+      </li>
     </Group>
   ))
 
@@ -85,10 +100,6 @@ const List = styled.ul`
   & > li {
     display: inline-block;
     padding: 16px;
-
-    &:not(:first-child) {
-      margin-left: 16px;
-    }
   }
 `
 const Group = styled.ul`

--- a/src/components/CheckBoxLabel/CheckBoxLabel.tsx
+++ b/src/components/CheckBoxLabel/CheckBoxLabel.tsx
@@ -9,9 +9,15 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 type Props = CheckBoxProps & {
   label: string
+  lineHeight?: number
 }
 
-export const CheckBoxLabel: VFC<Props & ElementProps> = ({ label, className = '', ...props }) => {
+export const CheckBoxLabel: VFC<Props & ElementProps> = ({
+  label,
+  lineHeight = 1.5,
+  className = '',
+  ...props
+}) => {
   const theme = useTheme()
   const classNames = useClassNames()
 
@@ -19,7 +25,7 @@ export const CheckBoxLabel: VFC<Props & ElementProps> = ({ label, className = ''
     <Wrapper className={`${className} ${classNames.wrapper}`}>
       <Label className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`} themes={theme}>
         <CheckBox {...props} />
-        <Txt className={classNames.text} themes={theme}>
+        <Txt className={classNames.text} lineHeight={lineHeight} themes={theme}>
           {label}
         </Txt>
       </Label>
@@ -32,27 +38,39 @@ const Wrapper = styled.div`
 `
 const Label = styled.label<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette } = themes
+    const { color } = themes
+
+    // 複数行テキストに対応させるため flex-start にする
     return css`
       display: flex;
-      align-items: center;
-      color: ${palette.TEXT_BLACK};
+      align-items: flex-start;
+      color: ${color.TEXT_BLACK};
       cursor: pointer;
 
       &.disabled {
-        color: ${palette.TEXT_DISABLED};
+        color: ${color.TEXT_DISABLED};
         cursor: default;
         pointer-events: none;
       }
     `
   }}
 `
-const Txt = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
+const Txt = styled.span<{ themes: Theme; lineHeight: number }>`
+  ${({ themes, lineHeight }) => {
+    const { fontSize, spacing } = themes
+
+    // checkbox と text の位置がずれるため、line-height 分を調整する疑似要素を作る
     return css`
-      margin: 0 0 0 ${size.pxToRem(size.space.XXS)};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      margin: 0 0 0 ${fontSize.pxToRem(spacing.XXS)};
+      font-size: ${fontSize.pxToRem(fontSize.TALL)};
+      line-height: ${lineHeight};
+      &::before {
+        content: '';
+        display: block;
+        height: 0;
+        width: 0;
+        margin-top: calc((1 - ${lineHeight}) * 0.3em);
+      }
     `
   }}
 `

--- a/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
+++ b/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
@@ -87,10 +87,10 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   color: #23221f;
   cursor: pointer;
 }
@@ -104,6 +104,15 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
 .c6 {
   margin: 0 0 0 0.5rem;
   font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.c6::before {
+  content: '';
+  display: block;
+  height: 0;
+  width: 0;
+  margin-top: calc((1 - 1.5) * 0.3em);
 }
 
 <div


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-354

## Overview

Added support for align the opening when multiline text are position in ChekboxLabel.

## What I did

- [x] Using a pseudo-element to set the negative margin

## Capture

![image](https://user-images.githubusercontent.com/5885283/109449210-339e7e80-7a8b-11eb-832e-5f71452e12fc.png)

