### PR TITLE
fix: improve ARIA of InformationPanel (SHRUI-222)

### DIFF
--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { useId } from '../../hooks/useId'
 
 import { Base } from '../Base'
 import {
@@ -64,6 +65,8 @@ export const InformationPanel: FC<Props> = ({
   }
 
   const [active, setActive] = useState(activeProps)
+  const titleId = useId()
+  const contentId = useId()
 
   const handleClickTrigger = () => {
     if (onClickTrigger) {
@@ -78,9 +81,9 @@ export const InformationPanel: FC<Props> = ({
   }, [activeProps])
 
   return (
-    <Wrapper className={className} themes={theme} role="presentation">
+    <Wrapper className={className} themes={theme} role="region" aria-labelledby={titleId}>
       <Header themes={theme}>
-        <Title themes={theme}>
+        <Title themes={theme} id={titleId}>
           <Icon color={iconColor} $theme={theme} />
           <StyledHeading type="blockTitle" tag={titleTag}>
             {title}
@@ -93,17 +96,16 @@ export const InformationPanel: FC<Props> = ({
               size="s"
               onClick={handleClickTrigger}
               aria-expanded={togglable ? active : undefined}
+              aria-controls={contentId}
             >
               {active ? closeButtonLabel : openButtonLabel}
             </SecondaryButton>
           </div>
         )}
       </Header>
-      {active && (
-        <Content themes={theme} aria-hidden={active}>
-          {children}
-        </Content>
-      )}
+      <Content themes={theme} id={contentId} aria-hidden={!active}>
+        {children}
+      </Content>
     </Wrapper>
   )
 }
@@ -160,6 +162,9 @@ const Content = styled.div<{ themes: Theme }>`
     return css`
       margin-top: ${pxToRem(space.S)};
       font-size: ${pxToRem(font.TALL)};
+      &[aria-hidden='true'] {
+        display: none;
+      }
     `
   }}
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-222
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`InformationPanel` の ARIA を改善します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `role=region` に変更
- `role=region` からタイトルを `aria-labelledby` で参照
- 開閉ボタンからコンテンツを `aria-controls` で参照
- コンテンツ部分の `aria-hidden` が表示と乖離しているのを修正
- コンテンツ部分が非表示時にDOMから除去されないように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
