### PR TITLE
feat: ActionDialog にレスポンスメッセージエリアを追加

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -19,6 +19,7 @@ export const ActionDialog: React.VFC<Props> = ({
   actionTheme,
   onClickAction,
   onClickClose,
+  responseMessage,
   actionDisabled = false,
   closeDisabled,
   ...props
@@ -58,6 +59,7 @@ export const ActionDialog: React.VFC<Props> = ({
         closeDisabled={closeDisabled}
         onClickClose={handleClickClose}
         onClickAction={handleClickAction}
+        responseMessage={responseMessage}
       >
         {children}
       </ActionDialogContentInner>

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -79,7 +79,7 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   if (actionTheme === 'secondary') ActionButton = SecondaryButton
   if (actionTheme === 'danger') ActionButton = DangerButton
 
-  const requestProcessing = responseMessage && responseMessage.status === 'processing'
+  const isRequestProcessing = responseMessage && responseMessage.status === 'processing'
 
   return (
     <>
@@ -89,14 +89,19 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
       <Body offsetHeight={offsetHeight}>{children}</Body>
       <ActionArea themes={theme} ref={bottomRef}>
         <ButtonArea themes={theme}>
-          <SecondaryButton onClick={onClickClose} disabled={closeDisabled || requestProcessing}>
+          <SecondaryButton onClick={onClickClose} disabled={closeDisabled || isRequestProcessing}>
             {closeText}
           </SecondaryButton>
-          <ActionButton onClick={handleClickAction} disabled={actionDisabled || requestProcessing}>
+          <ActionButton
+            onClick={handleClickAction}
+            disabled={actionDisabled || isRequestProcessing}
+          >
             {actionText}
           </ActionButton>
         </ButtonArea>
-        <ResponseMessage themes={theme} responseMessage={responseMessage} />
+        <div role="alert">
+          <ResponseMessage themes={theme} responseMessage={responseMessage} />
+        </div>
       </ActionArea>
     </>
   )

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -5,6 +5,8 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { useOffsetHeight } from './dialogHelper'
 import { DangerButton, PrimaryButton, SecondaryButton } from '../Button'
+import { FaCheckCircleIcon, FaExclamationTriangleIcon } from '../Icon'
+import { Loader } from '../Loader'
 
 export type BaseProps = {
   /**
@@ -42,11 +44,17 @@ export type BaseProps = {
   closeDisabled?: boolean
 }
 
+type responseMessageType = {
+  status: 'success' | 'error' | 'processing'
+  text: string
+}
+
 export type ActionDialogContentInnerProps = BaseProps & {
   /**
    * Handler function when clicking on close button.
    */
   onClickClose: () => void
+  responseMessage?: responseMessageType
 }
 
 export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
@@ -57,6 +65,7 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   actionTheme,
   onClickAction,
   onClickClose,
+  responseMessage,
   actionDisabled = false,
   closeDisabled,
 }) => {
@@ -70,33 +79,37 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   if (actionTheme === 'secondary') ActionButton = SecondaryButton
   if (actionTheme === 'danger') ActionButton = DangerButton
 
+  const requestProcessing = responseMessage && responseMessage.status === 'processing'
+
   return (
     <>
       <Title themes={theme} ref={titleRef}>
         {title}
       </Title>
       <Body offsetHeight={offsetHeight}>{children}</Body>
-      <Bottom themes={theme} ref={bottomRef}>
-        <SecondaryButton onClick={onClickClose} disabled={closeDisabled}>
-          {closeText}
-        </SecondaryButton>
-        <ActionButton onClick={handleClickAction} disabled={actionDisabled}>
-          {actionText}
-        </ActionButton>
-      </Bottom>
+      <ActionArea themes={theme} ref={bottomRef}>
+        <ButtonArea themes={theme}>
+          <SecondaryButton onClick={onClickClose} disabled={closeDisabled || requestProcessing}>
+            {closeText}
+          </SecondaryButton>
+          <ActionButton onClick={handleClickAction} disabled={actionDisabled || requestProcessing}>
+            {actionText}
+          </ActionButton>
+        </ButtonArea>
+        <ResponseMessage themes={theme} responseMessage={responseMessage} />
+      </ActionArea>
     </>
   )
 }
 
 const Title = styled.p<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space, font } = themes.size
-    const { border } = themes.frame
+  ${({ themes: { fontSize, border, spacing } }) => {
+    const { pxToRem } = fontSize
     return css`
       margin: 0;
-      padding: ${pxToRem(space.XS)} ${pxToRem(space.S)};
-      border-bottom: ${border.default};
-      font-size: ${pxToRem(font.GRANDE)};
+      padding: ${pxToRem(spacing.XS)} ${pxToRem(spacing.S)};
+      border-bottom: ${border.shorthand};
+      font-size: ${pxToRem(fontSize.GRANDE)};
       line-height: 1;
     `
   }}
@@ -109,20 +122,80 @@ const Body = styled.div<{ offsetHeight: number }>`
     `
   }}
 `
-const Bottom = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-    const { border } = themes.frame
-    return css`
-      display: flex;
-      justify-content: flex-end;
-      margin: 0;
-      padding: ${pxToRem(space.XS)} ${pxToRem(space.S)};
-      border-top: ${border.default};
+const ActionArea = styled.div<{ themes: Theme }>(({ themes: { fontSize, spacing, border } }) => {
+  const { pxToRem } = fontSize
 
-      & > *:not(:first-child) {
-        margin: 0 0 0 ${pxToRem(space.XS)};
+  return css`
+    display: flex;
+    flex-direction: column;
+    border-top: ${border.shorthand};
+    padding: ${pxToRem(spacing.XS)} ${pxToRem(spacing.S)};
+
+    &&& > * + * {
+      margin-top: 0.5rem;
+    }
+  `
+})
+const ResponseMessage: React.VFC<{
+  themes: Theme
+  responseMessage?: responseMessageType
+}> = ({ themes, responseMessage }) => {
+  if (!responseMessage) {
+    return null
+  }
+
+  const {
+    color,
+    fontSize: { pxToRem, TALL },
+  } = themes
+  const { status, text } = responseMessage
+  const Wrapper = styled.p`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: ${pxToRem(TALL)};
+  `
+  const Spinner = styled(Loader)`
+    &&& {
+      > div {
+        width: 1rem;
+        height: 1rem;
       }
-    `
-  }}
-`
+
+      > div > div {
+        border-color: ${color.TEXT_GREY};
+      }
+    }
+  `
+  const Icon =
+    status === 'success' ? (
+      <FaCheckCircleIcon color={color.MAIN} />
+    ) : status === 'error' ? (
+      <FaExclamationTriangleIcon color={color.DANGER} />
+    ) : (
+      <Spinner size="s" />
+    )
+  const Message = styled.span`
+    margin-left: 0.25rem;
+  `
+
+  return (
+    <Wrapper>
+      {Icon}
+      <Message>{text}</Message>
+    </Wrapper>
+  )
+}
+const ButtonArea = styled.div<{ themes: Theme }>(({ themes: { fontSize, spacing } }) => {
+  const { pxToRem } = fontSize
+  return css`
+    display: flex;
+    justify-content: flex-end;
+
+    > * + * {
+      margin-left: ${pxToRem(spacing.XS)};
+    }
+  `
+})

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -165,7 +165,10 @@ export const Action_Dialog: Story = () => {
     text: string
   }>()
   const onClickOpen = () => setIsOpen(true)
-  const onClickClose = () => setIsOpen(false)
+  const onClickClose = () => {
+    setIsOpen(false)
+    setResponseMessage(undefined)
+  }
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
 
   const Buttons = styled.div`
@@ -190,6 +193,7 @@ export const Action_Dialog: Story = () => {
         actionTheme="primary"
         onClickAction={(closeDialog) => {
           action('executed')()
+          setResponseMessage(undefined)
           closeDialog()
         }}
         onClickClose={onClickClose}

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -160,9 +160,22 @@ Message_Dialog.parameters = {
 export const Action_Dialog: Story = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = React.useState('Apple')
+  const [responseMessage, setResponseMessage] = useState<{
+    status: 'success' | 'error' | 'processing'
+    text: string
+  }>()
   const onClickOpen = () => setIsOpen(true)
   const onClickClose = () => setIsOpen(false)
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
+
+  const Buttons = styled.div`
+    margin-top: -2rem;
+    padding: 1rem 1.5rem;
+
+    > button + button {
+      margin-left: 0.5rem;
+    }
+  `
 
   return (
     <>
@@ -182,6 +195,7 @@ export const Action_Dialog: Story = () => {
         onClickClose={onClickClose}
         onClickOverlay={onClickClose}
         onPressEscape={onClickClose}
+        responseMessage={responseMessage}
         id="dialog-action"
       >
         <RadioList>
@@ -210,6 +224,39 @@ export const Action_Dialog: Story = () => {
             />
           </li>
         </RadioList>
+        <Buttons>
+          <p>切り替えボタン：</p>
+          <SecondaryButton
+            onClick={() =>
+              setResponseMessage({
+                status: 'success',
+                text: '保存しました。',
+              })
+            }
+          >
+            保存
+          </SecondaryButton>
+          <SecondaryButton
+            onClick={() =>
+              setResponseMessage({
+                status: 'error',
+                text: '何らかのエラーが発生しました。',
+              })
+            }
+          >
+            エラー
+          </SecondaryButton>
+          <SecondaryButton
+            onClick={() =>
+              setResponseMessage({
+                status: 'processing',
+                text: '保存中',
+              })
+            }
+          >
+            保存中
+          </SecondaryButton>
+        </Buttons>
       </ActionDialog>
     </>
   )


### PR DESCRIPTION
## 概要

ActoinDialog のボタン上部にレスポンスメッセージを表示したい。
プライマリボタンを押したあとのフィードバックをボタンのすぐ近くで行いたい。
入力要素ごとのメッセージは各入力要素の近くで見ればよい。

https://user-images.githubusercontent.com/19403400/110281694-8beff600-8020-11eb-9fde-eb5c64bf74ee.mp4

## 懸念

レスポンスメッセージを表示するときに「ガタン」が発生する。
以下の代案が考えられるが、一旦このままプロダクトに適用して調整したい。
- プライマリボタンの右横に吹き出し的な UI で表現
- ボタンを中央や左に寄せ、プライマリボタンの右横に構成
- レスポンスメッセージ表示時のみ上部にマイナス margin して調整
- あらかじめメッセージ分余白を取っておく