### PR TITLE
fix: add disabled to the current button of pagenation

### DIFF
--- a/src/components/Pagination/PaginationItem.tsx
+++ b/src/components/Pagination/PaginationItem.tsx
@@ -23,6 +23,7 @@ export const PaginationItem: FC<Props> = ({ page, currentPage, onClick }) => {
         themes={theme}
         aria-current="page"
         aria-label={`${page}ページ目、現在のページ`}
+        disabled
       >
         {page}
       </ItemButton>


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-299

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Currently, the current button of pagenation can be pressed by clicking. So I want to add a disabled attribute so that it cannot be pressed.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Added `disabled` attribute to the current button of pagenation.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
