### PR TITLE
fix: TabBar outline style

### DIFF
--- a/src/components/TabBar/TabItem.tsx
+++ b/src/components/TabBar/TabItem.tsx
@@ -43,7 +43,6 @@ const resetButtonStyle = css`
   background-color: transparent;
   border: none;
   cursor: pointer;
-  outline: none;
   padding: 0;
   appearance: none;
 `

--- a/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`TabBar should be match snapshot 1`] = `
   background-color: transparent;
   border: none;
   cursor: pointer;
-  outline: none;
   padding: 0;
   -webkit-appearance: none;
   -moz-appearance: none;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- TabBarのアイテムにfocusしてもoutlineが表示されず、状態がわからないため修正したい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- `outline: none` を削除

## Capture

<!--
Please attach a capture if it looks different.
-->
<img width="400" alt="スクリーンショット 2021-03-15 12 29 24" src="https://user-images.githubusercontent.com/773467/111100007-1937cb00-858a-11eb-9b16-5eba324bded5.png">
