### PR TITLE
fix: Textarea outline style

### DIFF
--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -73,7 +73,6 @@ const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: 
       border-radius: ${frame.border.radius.m};
       width: ${textAreaWidth};
       background-color: #fff;
-      outline: none;
       border: ${frame.border.default};
       box-sizing: border-box;
       ${error


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- Textareaにfocusしてもoutlineが表示されず、状態がわからないため修正したい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- `outline: none` を削除

## Capture

<!--
Please attach a capture if it looks different.
-->
<img width="214" alt="スクリーンショット 2021-03-15 12 33 46" src="https://user-images.githubusercontent.com/773467/111100270-b5fa6880-858a-11eb-964f-167177169e20.png">
