### PR TITLE
フォントサイズと余白を rem で扱いたい

### DIFF
--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -1,0 +1,12 @@
+A Stack component.
+
+要素を縦方向に積み上げるためのコンポーネントです。[Every Layout の Stack](https://every-layout.dev/layouts/stack/) を参考にしています。
+
+<details>
+<summary>how to import</summary>
+
+```tsx
+import { Stack } from 'smarthr-ui'
+```
+
+</details>

--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+import { Story } from '@storybook/react'
+
+import { useTheme } from '../../hooks/useTheme'
+import { Stack } from '.'
+import { Base as shrBase } from '../Base'
+import { Heading } from '../Heading'
+
+import readme from './README.md'
+
+export default {
+  title: 'Stack',
+  component: Stack,
+  parameters: {
+    docs: {
+      description: { component: readme },
+    },
+  },
+}
+
+export const Default: Story = () => (
+  <LineUp>
+    <Content>
+      <Stack recursive>
+        <Base>
+          <P>各要素の間隔は 1rem が標準です。</P>
+        </Base>
+        <Base>
+          <P>spaceLength を使って間隔を変えられます。</P>
+        </Base>
+        <Base>
+          <P>recursive を使うと子孫要素に対して再帰的に影響を与えます。</P>
+
+          <Stack spaceLength={0.5}>
+            <Heading type="blockTitle">入れ子にすることができます</Heading>
+            <InnerBase>
+              <P>同じ要素である必要もありません。</P>
+            </InnerBase>
+          </Stack>
+        </Base>
+      </Stack>
+    </Content>
+    <SideAreaStack splitAfter={2}>
+      <Base>
+        <P>各要素の間隔は 1rem が標準です</P>
+      </Base>
+      <Base>
+        <P>各要素の間隔は 1rem が標準です</P>
+      </Base>
+      <Base>
+        <P>splitAfter を使うと分割することができます。</P>
+      </Base>
+      <Base>
+        <P>この場合、Stack の高さは対峙する要素より高さが必要です。</P>
+      </Base>
+    </SideAreaStack>
+  </LineUp>
+)
+
+const LineUp = styled.div(() => {
+  const { space } = useTheme()
+
+  return css`
+    display: flex;
+
+    > * + * {
+      margin-left: ${space(2)};
+    }
+  `
+})
+const SideAreaStack = styled(Stack)`
+  flex: 1;
+`
+const Content = styled.div`
+  flex: 3;
+  min-height: 30vw;
+`
+const Base = styled(shrBase)(() => {
+  const { space } = useTheme()
+  return css`
+    padding: ${space(1.5)};
+  `
+})
+const InnerBase = styled(shrBase)(() => {
+  const { color, space } = useTheme()
+  return css`
+    background-color: ${color.OVER_BACKGROUND};
+    padding: ${space(1)};
+  `
+})
+const P = styled.p`
+  margin-top: 0;
+  margin-bottom: 0;
+`

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,0 +1,32 @@
+import styled, { css } from 'styled-components'
+import { SpaceLength } from '../../themes/createSpace'
+import { useSpace } from '../../hooks/useSpace'
+
+/**
+ * @param recursive 直下の要素だけでなく再帰的に適用するかどうかの指定
+ * @param spaceLength 間隔の指定（rem の値）
+ * @param splitAfter 分割する位置の指定（nth-child に渡す値）
+ */
+export const Stack = styled.div<{
+  recursive?: boolean
+  spaceLength?: SpaceLength
+  splitAfter?: number | string
+}>(({ recursive = false, spaceLength = 1, splitAfter }) => {
+  return css`
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+
+    ${!recursive && '>'} * + * {
+      margin-top: ${useSpace(spaceLength)};
+      margin-bottom: 0;
+    }
+
+    ${splitAfter &&
+    `
+      ${!recursive && '>'} :nth-child(${splitAfter}) {
+        margin-bottom: auto;
+      }
+    `}
+  `
+})

--- a/src/components/Stack/index.ts
+++ b/src/components/Stack/index.ts
@@ -1,0 +1,1 @@
+export { Stack } from './Stack'

--- a/src/hooks/useSpace.ts
+++ b/src/hooks/useSpace.ts
@@ -1,0 +1,51 @@
+import { useTheme } from '../hooks/useTheme'
+import { space } from '../themes/createSpace'
+import { defaultBaseSize } from '../themes/createSpacing'
+
+const calcBaseSpace = defaultBaseSize * 2
+
+export const useSpace: typeof space = (length, options) => {
+  const {
+    shinTheme,
+    spacing,
+    fontSize: { pxToRem },
+  } = useTheme()
+
+  if (!shinTheme) {
+    // 旧テーマが space に対応していないのでマッピング
+    switch (length) {
+      case 0:
+      default:
+        return 0
+      case 0.25:
+      case '1/4':
+        return pxToRem(calcBaseSpace * 0.25)
+      case 0.5:
+      case '1/2':
+        return pxToRem(spacing.XXS)
+      case 0.75:
+      case '3/4':
+        return pxToRem(calcBaseSpace * 0.75)
+      case 1:
+        return pxToRem(spacing.XS)
+      case 1.25:
+      case '5/4':
+        return pxToRem(calcBaseSpace * 1.25)
+      case 1.5:
+      case '3/2':
+        return pxToRem(spacing.S)
+      case 2:
+        return pxToRem(spacing.M)
+      case 2.5:
+        return pxToRem(spacing.L)
+      case 3:
+        return pxToRem(spacing.XL)
+      case 4:
+        return pxToRem(calcBaseSpace * 4)
+      case 8:
+        return pxToRem(calcBaseSpace * 8)
+    }
+  }
+
+  return space(length, options)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export { defaultBorder } from './themes/createBorder'
 export { defaultRadius } from './themes/createRadius'
 export { defaultSize } from './themes/createSize'
 export { defaultFontSize } from './themes/createFontSize'
+export { defaultRemSize } from './themes/createRemSize'
 export { defaultSpacing } from './themes/createSpacing'
 export { defaultBreakpoint } from './themes/createBreakpoint'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export {
 } from './components/BackgroundJobsPanel'
 export { MultiComboBox } from './components/MultiComboBox'
 export { SideNav } from './components/SideNav'
+export { Stack } from './components/Stack'
 
 // themes
 export { createTheme } from './themes/createTheme'

--- a/src/themes/__tests__/createRemSize.ts
+++ b/src/themes/__tests__/createRemSize.ts
@@ -1,0 +1,68 @@
+import { createRemSize, createRemSizeForPxToRem } from '../createRemSize'
+
+describe('createRemSize', () => {
+  it('returns same font size theme with createRemSize', () => {
+    const actual = createRemSize()
+    const expected = {
+      XXS: `${6 / 9}rem`,
+      XS: `${6 / 8}rem`,
+      S: `${6 / 7}rem`,
+      M: `${6 / 6}rem`,
+      L: `${6 / 5}rem`,
+      XL: `${6 / 4}rem`,
+      XXL: `${6 / 3}rem`,
+    }
+
+    expect(actual.XXS).toBe(expected.XXS)
+    expect(actual.XS).toBe(expected.XS)
+    expect(actual.S).toBe(expected.S)
+    expect(actual.M).toBe(expected.M)
+    expect(actual.L).toBe(expected.L)
+    expect(actual.XL).toBe(expected.XL)
+    expect(actual.XXS).toBe(expected.XXS)
+  })
+
+  it('returns customized rem size theme when give user font factor', () => {
+    const actual = createRemSize(8)
+    const expected = {
+      XXS: `${8 / 11}rem`,
+      XS: `${8 / 10}rem`,
+      S: `${8 / 9}rem`,
+      M: `${8 / 8}rem`,
+      L: `${8 / 7}rem`,
+      XL: `${8 / 6}rem`,
+      XXL: `${8 / 5}rem`,
+    }
+
+    expect(actual.XXS).toBe(expected.XXS)
+    expect(actual.XS).toBe(expected.XS)
+    expect(actual.S).toBe(expected.S)
+    expect(actual.M).toBe(expected.M)
+    expect(actual.L).toBe(expected.L)
+    expect(actual.XL).toBe(expected.XL)
+    expect(actual.XXS).toBe(expected.XXS)
+  })
+})
+
+describe('createRemSizeForPxToRem', () => {
+  it('returns same font size theme with createRemSizeForPxToRem', () => {
+    const actual = createRemSizeForPxToRem()
+    const expected = {
+      XXS: 16 * (6 / 9),
+      XS: 16 * (6 / 8),
+      S: 16 * (6 / 7),
+      M: 16 * (6 / 6),
+      L: 16 * (6 / 5),
+      XL: 16 * (6 / 4),
+      XXL: 16 * (6 / 3),
+    }
+
+    expect(actual.XXS).toBe(expected.XXS)
+    expect(actual.XS).toBe(expected.XS)
+    expect(actual.S).toBe(expected.S)
+    expect(actual.M).toBe(expected.M)
+    expect(actual.L).toBe(expected.L)
+    expect(actual.XL).toBe(expected.XL)
+    expect(actual.XXS).toBe(expected.XXS)
+  })
+})

--- a/src/themes/__tests__/createSpace.ts
+++ b/src/themes/__tests__/createSpace.ts
@@ -1,0 +1,45 @@
+import { space } from '../createSpace'
+
+describe('createSpacing', () => {
+  it('returns same space theme with createSpace', () => {
+    expect(space(0)).toBe(0)
+    expect(space(0.25)).toBe('0.25rem')
+    expect(space(0.5)).toBe('0.5rem')
+    expect(space(0.75)).toBe('0.75rem')
+    expect(space(1)).toBe('1rem')
+    expect(space(1.25)).toBe('1.25rem')
+    expect(space(1.5)).toBe('1.5rem')
+    expect(space(2)).toBe('2rem')
+    expect(space(2.5)).toBe('2.5rem')
+    expect(space(3)).toBe('3rem')
+    expect(space(4)).toBe('4rem')
+    expect(space(8)).toBe('8rem')
+
+    expect(space('1/4')).toBe('0.25rem')
+    expect(space('1/2')).toBe('0.5rem')
+    expect(space('3/4')).toBe('0.75rem')
+    expect(space('5/4')).toBe('1.25rem')
+    expect(space('3/2')).toBe('1.5rem')
+  })
+
+  it('returns same space theme with createSpace when give onlyNumber option', () => {
+    expect(space(0, { onlyNumber: true })).toBe(0)
+    expect(space(0.25, { onlyNumber: true })).toBe(0.25)
+    expect(space(0.5, { onlyNumber: true })).toBe(0.5)
+    expect(space(0.75, { onlyNumber: true })).toBe(0.75)
+    expect(space(1, { onlyNumber: true })).toBe(1)
+    expect(space(1.25, { onlyNumber: true })).toBe(1.25)
+    expect(space(1.5, { onlyNumber: true })).toBe(1.5)
+    expect(space(2, { onlyNumber: true })).toBe(2)
+    expect(space(2.5, { onlyNumber: true })).toBe(2.5)
+    expect(space(3, { onlyNumber: true })).toBe(3)
+    expect(space(4, { onlyNumber: true })).toBe(4)
+    expect(space(8, { onlyNumber: true })).toBe(8)
+
+    expect(space('1/4', { onlyNumber: true })).toBe(0.25)
+    expect(space('1/2', { onlyNumber: true })).toBe(0.5)
+    expect(space('3/4', { onlyNumber: true })).toBe(0.75)
+    expect(space('5/4', { onlyNumber: true })).toBe(1.25)
+    expect(space('3/2', { onlyNumber: true })).toBe(1.5)
+  })
+})

--- a/src/themes/createRemSize.ts
+++ b/src/themes/createRemSize.ts
@@ -1,0 +1,43 @@
+const defaultHtmlFontSize = 16
+
+export interface RemSizeProperty {
+  XXS: string | number
+  XS: string | number
+  S: string | number
+  M: string | number
+  L: string | number
+  XL: string | number
+  XXL: string | number
+}
+
+const fontSize = ({ factor = 6, harmonic = 0, forLegacy = false }) => {
+  const result = factor / (factor - harmonic)
+
+  if (forLegacy) {
+    return defaultHtmlFontSize * result
+  }
+
+  return `${result}rem`
+}
+
+export const createRemSize = (factor = 6) => ({
+  XXS: String(fontSize({ factor, harmonic: -3 })),
+  XS: String(fontSize({ factor, harmonic: -2 })),
+  S: String(fontSize({ factor, harmonic: -1 })),
+  M: String(fontSize({ factor, harmonic: 0 })),
+  L: String(fontSize({ factor, harmonic: 1 })),
+  XL: String(fontSize({ factor, harmonic: 2 })),
+  XXL: String(fontSize({ factor, harmonic: 3 })),
+})
+
+export const defaultRemSize = createRemSize()
+
+export const createRemSizeForPxToRem = (factor = 6, forLegacy = true) => ({
+  XXS: Number(fontSize({ factor, harmonic: -3, forLegacy })),
+  XS: Number(fontSize({ factor, harmonic: -2, forLegacy })),
+  S: Number(fontSize({ factor, harmonic: -1, forLegacy })),
+  M: Number(fontSize({ factor, harmonic: 0, forLegacy })),
+  L: Number(fontSize({ factor, harmonic: 1, forLegacy })),
+  XL: Number(fontSize({ factor, harmonic: 2, forLegacy })),
+  XXL: Number(fontSize({ factor, harmonic: 3, forLegacy })),
+})

--- a/src/themes/createSpace.ts
+++ b/src/themes/createSpace.ts
@@ -17,11 +17,12 @@ const primitiveToken = {
   4: 4,
   8: 8,
 }
+export type SpaceLength = keyof typeof primitiveToken
 
-export const space: (
-  length: keyof typeof primitiveToken,
-  options?: { onlyNumber: boolean },
-) => string | number = (length, { onlyNumber } = { onlyNumber: false }) => {
+export const space: (length: SpaceLength, options?: { onlyNumber: boolean }) => string | number = (
+  length,
+  { onlyNumber } = { onlyNumber: false },
+) => {
   if (length === 0) {
     return 0
   }

--- a/src/themes/createSpace.ts
+++ b/src/themes/createSpace.ts
@@ -1,0 +1,32 @@
+const primitiveToken = {
+  0: 0,
+  0.25: 0.25,
+  '1/4': 0.25,
+  0.5: 0.5,
+  '1/2': 0.5,
+  0.75: 0.75,
+  '3/4': 0.75,
+  1: 1,
+  1.25: 1.25,
+  '5/4': 1.25,
+  1.5: 1.5,
+  '3/2': 1.5,
+  2: 2,
+  2.5: 2.5,
+  3: 3,
+  4: 4,
+  8: 8,
+}
+
+export const space: (
+  length: keyof typeof primitiveToken,
+  options?: { onlyNumber: boolean },
+) => string | number = (length, { onlyNumber } = { onlyNumber: false }) => {
+  if (length === 0) {
+    return 0
+  }
+
+  const result = primitiveToken[length]
+
+  return onlyNumber ? Number(result) : `${result}rem`
+}

--- a/src/themes/createSpacing.ts
+++ b/src/themes/createSpacing.ts
@@ -1,6 +1,6 @@
 import { merge } from '../libs/lodash'
 
-const defaultBaseSize = 8
+export const defaultBaseSize = 8
 
 export interface SpacingProperty {
   baseSize?: number

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -12,6 +12,7 @@ import { CreatedSizeTheme, SizeProperty, createSize } from './createSize'
 import { CreatedFontSizeTheme, FontSizeProperty, createFontSize } from './createFontSize'
 import { RemSizeProperty, createRemSize, createRemSizeForPxToRem } from './createRemSize'
 import { CreatedSpacingTheme, SpacingProperty, createSpacing } from './createSpacing'
+import { space } from './createSpace'
 import { BreakpointProperty, CreatedBreakpointTheme, createBreakpoint } from './createBreakpoint'
 import { CreatedShadowTheme, ShadowProperty, createShadow } from './createShadow'
 import { CreatedZindexTheme, ZIndexProperty, createZIndex } from './createZIndex'
@@ -55,6 +56,7 @@ export interface CreatedTheme {
   remSize: RemSizeProperty
   remSizeForPxToRem: RemSizeProperty
   spacing: CreatedSpacingTheme
+  space: typeof space
   breakpoint: CreatedBreakpointTheme
   /**
    * @deprecated The frame property will be deprecated, please use border or radius property instead
@@ -76,6 +78,7 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     remSize: createRemSize(theme.fontSizeFactor),
     remSizeForPxToRem: createRemSizeForPxToRem(theme.fontSizeFactor),
     spacing: createSpacing(theme.spacing),
+    space,
     breakpoint: createBreakpoint(theme.breakpoint),
     frame: createFrame(theme.frame, theme.palette),
     border: createBorder(theme.border, theme.color),

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -40,6 +40,7 @@ interface ThemeProperty {
   interaction?: InteractionProperty
   shadow?: ShadowProperty
   zIndex?: ZIndexProperty
+  shinTheme?: boolean
 }
 
 export interface CreatedTheme {
@@ -67,6 +68,7 @@ export interface CreatedTheme {
   interaction: CreatedInteractionTheme
   shadow: CreatedShadowTheme
   zIndex: CreatedZindexTheme
+  shinTheme: boolean
 }
 
 export const createTheme = (theme: ThemeProperty = {}) => {
@@ -86,6 +88,7 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     interaction: createInteraction(theme.interaction),
     shadow: createShadow(theme.shadow),
     zIndex: createZIndex(theme.zIndex),
+    shinTheme: !!theme.shinTheme,
   }
   return created
 }

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -10,6 +10,7 @@ import { CreatedPaletteTheme, PaletteProperty, createPalette } from './createPal
 import { ColorProperty, CreatedColorTheme, createColor } from './createColor'
 import { CreatedSizeTheme, SizeProperty, createSize } from './createSize'
 import { CreatedFontSizeTheme, FontSizeProperty, createFontSize } from './createFontSize'
+import { RemSizeProperty, createRemSize, createRemSizeForPxToRem } from './createRemSize'
 import { CreatedSpacingTheme, SpacingProperty, createSpacing } from './createSpacing'
 import { BreakpointProperty, CreatedBreakpointTheme, createBreakpoint } from './createBreakpoint'
 import { CreatedShadowTheme, ShadowProperty, createShadow } from './createShadow'
@@ -26,6 +27,7 @@ interface ThemeProperty {
    */
   size?: SizeProperty
   fontSize?: FontSizeProperty
+  fontSizeFactor?: number
   spacing?: SpacingProperty
   breakpoint?: BreakpointProperty
   /**
@@ -50,6 +52,8 @@ export interface CreatedTheme {
    */
   size: CreatedSizeTheme
   fontSize: CreatedFontSizeTheme
+  remSize: RemSizeProperty
+  remSizeForPxToRem: RemSizeProperty
   spacing: CreatedSpacingTheme
   breakpoint: CreatedBreakpointTheme
   /**
@@ -69,6 +73,8 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     color: createColor(theme.color),
     size: createSize(theme.size),
     fontSize: createFontSize(theme.fontSize),
+    remSize: createRemSize(theme.fontSizeFactor),
+    remSizeForPxToRem: createRemSizeForPxToRem(theme.fontSizeFactor),
     spacing: createSpacing(theme.spacing),
     breakpoint: createBreakpoint(theme.breakpoint),
     frame: createFrame(theme.frame, theme.palette),


### PR DESCRIPTION
## Overview

下記を実現したい。

```tsx
const { remSize, space } = useTheme()

return css`
  font-size: ${remSize.M};

  > * + * {
    margin-top: ${space(1)};
  }
`
```

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- createResize を追加
- createSpace を追加

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## 懸念

既存の `fontSize` や `spacing` とどう棲み分けていくか?
- SmartHR UI は theme を渡せば使える
  - 新規開発などプロダクト側で標準フォントサイズを変えられるプロジェクトは問題ない
  - remSizeForPxToRem はそのためにある（pxToRem に投げ込めるようになってる）
- theme を変えない既存との共存が問題
  - 新しいコンポーネントを rem で記述した場合に利用できない?
  - すべてのコンポーネントの rem 対応が必要?
<!--
Please attach a capture if it looks different.
-->
