### PR TITLE
chore: pass props to Row and Cell components

### DIFF
--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useContext } from 'react'
+import React, { FC, HTMLAttributes, ReactNode, useContext } from 'react'
 import styled, { css } from 'styled-components'
 
 import { isTouchDevice } from '../../libs/ua'
@@ -15,8 +15,9 @@ export type Props = {
   className?: string
   onClick?: () => void
 }
+type ElementProps = Omit<HTMLAttributes<HTMLTableDataCellElement>, keyof Props>
 
-export const Cell: FC<Props> = ({
+export const Cell: FC<Props & ElementProps> = ({
   className = '',
   children,
   onClick,
@@ -24,6 +25,7 @@ export const Cell: FC<Props> = ({
   rowSpan,
   highlighted = false,
   nullable = false,
+  ...elementProps
 }) => {
   const theme = useTheme()
   const { group } = useContext(TableGroupContext)
@@ -37,6 +39,7 @@ export const Cell: FC<Props> = ({
     rowSpan,
     className: classNames,
     themes: theme,
+    ...elementProps,
   }
 
   if (group === 'head') {

--- a/src/components/Table/Row.tsx
+++ b/src/components/Table/Row.tsx
@@ -1,10 +1,13 @@
-import * as React from 'react'
+import React, { HTMLAttributes } from 'react'
 
 export type Props = {
   children?: React.ReactNode
   className?: string
 }
+type ElementProps = Omit<HTMLAttributes<HTMLTableRowElement>, keyof Props>
 
-export const Row: React.FC<Props> = ({ className = '', children }) => (
-  <tr className={className}>{children}</tr>
+export const Row: React.FC<Props & ElementProps> = ({ className = '', children, ...props }) => (
+  <tr className={className} {...props}>
+    {children}
+  </tr>
 )


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- E2E の自動テストを実施する際、独自のデータ属性（ `data-spec` など）を埋め込みたかったのですが、props として受け取れるようになっていなかったので、受け取れるようにし、受け取ったものを return する要素に渡すようにしました。


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 対応したコンポーネント
  - `Row`
  - `Cell`

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
