### PR TITLE
fix: fix problem with createTheme

### DIFF
--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -48,4 +48,76 @@ describe('createTheme', () => {
     expect(actual.color.TEXT_LINK).toBe('#888')
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
+
+  it('returns theme reflecting settings when given size settings', () => {
+    const actual = createTheme({
+      size: {
+        htmlFontSize: 2,
+        space: {
+          defaultRem: 10,
+          XXS: 11,
+        },
+        font: {
+          SHORT: 100,
+        },
+        mediaQuery: {
+          SP: 1000,
+        },
+      },
+    })
+
+    expect(actual.size.pxToRem(400)).toBe(`${400 / 2}rem`)
+    expect(actual.fontSize.pxToRem(400)).toBe(`${400 / 2}rem`)
+
+    expect(actual.size.space.XXS).toBe(11)
+    expect(actual.size.space.XS).toBe(10 * 2)
+    expect(actual.size.space.S).toBe(10 * 3)
+    expect(actual.spacing.XXS).toBe(11)
+    expect(actual.spacing.XS).toBe(10 * 2)
+    expect(actual.spacing.S).toBe(10 * 3)
+
+    expect(actual.size.font.SHORT).toBe(100)
+    expect(actual.fontSize.SHORT).toBe(100)
+
+    expect(actual.size.mediaQuery.SP).toBe(1000)
+    expect(actual.breakpoint.SP).toBe(1000)
+  })
+
+  it('returns theme reflecting settings when given spacing settings', () => {
+    const actual = createTheme({
+      spacing: {
+        baseSize: 20,
+        XXS: 21,
+      },
+    })
+
+    expect(actual.size.space.XXS).toBe(21)
+    expect(actual.size.space.XS).toBe(20 * 2)
+    expect(actual.size.space.S).toBe(20 * 3)
+    expect(actual.spacing.XXS).toBe(21)
+    expect(actual.spacing.XS).toBe(20 * 2)
+    expect(actual.spacing.S).toBe(20 * 3)
+  })
+
+  it('returns theme reflecting settings when given fontSize settings', () => {
+    const actual = createTheme({
+      fontSize: {
+        SHORT: 30,
+      },
+    })
+
+    expect(actual.size.font.SHORT).toBe(30)
+    expect(actual.fontSize.SHORT).toBe(30)
+  })
+
+  it('returns theme reflecting settings when given breakpoint settings', () => {
+    const actual = createTheme({
+      breakpoint: {
+        SP: 40,
+      },
+    })
+
+    expect(actual.size.mediaQuery.SP).toBe(40)
+    expect(actual.breakpoint.SP).toBe(40)
+  })
 })

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -272,7 +272,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme that reflects "color" settings to "palette"', () => {
+  it('returns theme reflecting "color" settings to "palette"', () => {
     const actual = createTheme({
       color: {
         TEXT_GREY: '#002',
@@ -285,7 +285,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme that prioritizes "color" settings over "palette" when given palette and color settings', () => {
+  it('returns theme prioritizing "color" settings over "palette" when given palette and color settings', () => {
     const actual = createTheme({
       palette: {
         TEXT_BLACK: '#001',
@@ -311,7 +311,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme that reflects "size" settings to "fontSize", "spacing" and "breakpoint"', () => {
+  it('returns theme reflecting "size" settings to "fontSize", "spacing" and "breakpoint"', () => {
     const actual = createTheme({
       size: {
         htmlFontSize: 2,
@@ -349,7 +349,7 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
-  it('returns theme that reflects "spacing" settings to "size.space"', () => {
+  it('returns theme reflecting "spacing" settings to "size.space"', () => {
     const actual = createTheme({
       spacing: {
         baseSize: 20,
@@ -365,7 +365,7 @@ describe('createTheme', () => {
     expect(actual.spacing.S).toBe(20 * 3)
   })
 
-  it('returns theme that reflects "fontSize" settings to "size.fontSize"', () => {
+  it('returns theme reflecting "fontSize" settings to "size.fontSize"', () => {
     const actual = createTheme({
       fontSize: {
         SHORT: 30,
@@ -378,7 +378,7 @@ describe('createTheme', () => {
     expect(actual.fontSize.TALL).toBe(defaultFontSize.TALL)
   })
 
-  it('returns theme that reflects "breakpoint" settings to "size.mediaQuery"', () => {
+  it('returns theme reflecting "breakpoint" settings to "size.mediaQuery"', () => {
     const actual = createTheme({
       breakpoint: {
         SP: 40,
@@ -391,7 +391,7 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
-  it('returns theme that prioritizes "spacing", "fontSize" and "breakpoint" settings over "size" when given size, spacing, fontSize and breakpoint settings', () => {
+  it('returns theme prioritizing "spacing", "fontSize" and "breakpoint" settings over "size" when given size, spacing, fontSize and breakpoint settings', () => {
     const actual = createTheme({
       size: {
         htmlFontSize: 2,
@@ -443,7 +443,7 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(2000)
   })
 
-  it('returns theme that reflects "frame" settings to "border" and "radius"', () => {
+  it('returns theme reflecting "frame" settings to "border" and "radius"', () => {
     const actual = createTheme({
       frame: {
         border: {
@@ -469,7 +469,7 @@ describe('createTheme', () => {
     expect(actual.radius.m).toBe(defaultRadius.m)
   })
 
-  it('returns theme that reflects "border" settings to "frame.border"', () => {
+  it('returns theme reflecting "border" settings to "frame.border"', () => {
     const actual = createTheme({
       border: {
         lineWidth: 'dummy_width',
@@ -485,7 +485,7 @@ describe('createTheme', () => {
     expect(actual.border.lineStyle).toBe(defaultBorder.lineStyle)
   })
 
-  it('returns theme that reflects "radius" settings to "frame.border.radius"', () => {
+  it('returns theme reflecting "radius" settings to "frame.border.radius"', () => {
     const actual = createTheme({
       radius: {
         s: 'dummy_s',
@@ -498,7 +498,7 @@ describe('createTheme', () => {
     expect(actual.radius.m).toBe(defaultRadius.m)
   })
 
-  it('returns theme that prioritizes "border" and "radius" settings over "frame" when given frame, border and radius settings', () => {
+  it('returns theme prioritizing "border" and "radius" settings over "frame" when given frame, border and radius settings', () => {
     const actual = createTheme({
       frame: {
         border: {

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -120,4 +120,51 @@ describe('createTheme', () => {
     expect(actual.size.mediaQuery.SP).toBe(40)
     expect(actual.breakpoint.SP).toBe(40)
   })
+
+  it('returns theme reflecting settings when given frame settings', () => {
+    const actual = createTheme({
+      frame: {
+        border: {
+          lineWidth: 'dummy_width',
+          default: 'dummy_default',
+          radius: {
+            s: 'dummy_s',
+          },
+        },
+      },
+    })
+
+    expect(actual.frame.border.lineWidth).toBe('dummy_width')
+    expect(actual.frame.border.default).toBe('dummy_default')
+    expect(actual.border.lineWidth).toBe('dummy_width')
+    expect(actual.border.shorthand).toBe('dummy_default')
+
+    expect(actual.frame.border.radius.s).toBe('dummy_s')
+    expect(actual.radius.s).toBe('dummy_s')
+  })
+
+  it('returns theme reflecting settings when given border settings', () => {
+    const actual = createTheme({
+      border: {
+        lineWidth: 'dummy_width',
+        shorthand: 'dummy_shorthand',
+      },
+    })
+
+    expect(actual.frame.border.lineWidth).toBe('dummy_width')
+    expect(actual.frame.border.default).toBe('dummy_shorthand')
+    expect(actual.border.lineWidth).toBe('dummy_width')
+    expect(actual.border.shorthand).toBe('dummy_shorthand')
+  })
+
+  it('returns theme reflecting settings when given radius settings', () => {
+    const actual = createTheme({
+      radius: {
+        s: 'dummy_s',
+      },
+    })
+
+    expect(actual.frame.border.radius.s).toBe('dummy_s')
+    expect(actual.radius.s).toBe('dummy_s')
+  })
 })

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -6,6 +6,260 @@ import { defaultBorder } from '../createBorder'
 import { defaultRadius } from '../createRadius'
 
 describe('createTheme', () => {
+  it('returns theme reflecting "palette" settings', () => {
+    const actual = createTheme({
+      palette: {
+        TEXT_BLACK: '#001',
+        TEXT_GREY: '#002',
+        TEXT_DISABLED: '#003',
+        TEXT_LINK: '#004',
+        BORDER: '#005',
+        ACTION_BACKGROUND: '#006',
+        BACKGROUND: '#007',
+        COLUMN: '#008',
+        OVER_BACKGROUND: '#009',
+        HEAD: '#010',
+        BASE_GREY: '#011',
+        MAIN: '#012',
+        DANGER: '#013',
+        WARNING: '#014',
+        SCRIM: '#015',
+        OVERLAY: '#016',
+        OUTLINE: '#017',
+      },
+    })
+    expect(actual.palette.TEXT_BLACK).toBe('#001')
+    expect(actual.palette.TEXT_GREY).toBe('#002')
+    expect(actual.palette.TEXT_DISABLED).toBe('#003')
+    expect(actual.palette.TEXT_LINK).toBe('#004')
+    expect(actual.palette.BORDER).toBe('#005')
+    expect(actual.palette.ACTION_BACKGROUND).toBe('#006')
+    expect(actual.palette.BACKGROUND).toBe('#007')
+    expect(actual.palette.COLUMN).toBe('#008')
+    expect(actual.palette.OVER_BACKGROUND).toBe('#009')
+    expect(actual.palette.HEAD).toBe('#010')
+    expect(actual.palette.BASE_GREY).toBe('#011')
+    expect(actual.palette.MAIN).toBe('#012')
+    expect(actual.palette.DANGER).toBe('#013')
+    expect(actual.palette.WARNING).toBe('#014')
+    expect(actual.palette.SCRIM).toBe('#015')
+    expect(actual.palette.OVERLAY).toBe('#016')
+    expect(actual.palette.OUTLINE).toBe('#017')
+  })
+
+  it('returns theme reflecting "color" settings', () => {
+    const actual = createTheme({
+      color: {
+        TEXT_BLACK: '#001',
+        TEXT_GREY: '#002',
+        TEXT_DISABLED: '#003',
+        TEXT_LINK: '#004',
+        BORDER: '#005',
+        ACTION_BACKGROUND: '#006',
+        BACKGROUND: '#007',
+        COLUMN: '#008',
+        OVER_BACKGROUND: '#009',
+        HEAD: '#010',
+        BASE_GREY: '#011',
+        MAIN: '#012',
+        DANGER: '#013',
+        WARNING: '#014',
+        SCRIM: '#015',
+        OVERLAY: '#016',
+        OUTLINE: '#017',
+      },
+    })
+    expect(actual.color.TEXT_BLACK).toBe('#001')
+    expect(actual.color.TEXT_GREY).toBe('#002')
+    expect(actual.color.TEXT_DISABLED).toBe('#003')
+    expect(actual.color.TEXT_LINK).toBe('#004')
+    expect(actual.color.BORDER).toBe('#005')
+    expect(actual.color.ACTION_BACKGROUND).toBe('#006')
+    expect(actual.color.BACKGROUND).toBe('#007')
+    expect(actual.color.COLUMN).toBe('#008')
+    expect(actual.color.OVER_BACKGROUND).toBe('#009')
+    expect(actual.color.HEAD).toBe('#010')
+    expect(actual.color.BASE_GREY).toBe('#011')
+    expect(actual.color.MAIN).toBe('#012')
+    expect(actual.color.DANGER).toBe('#013')
+    expect(actual.color.WARNING).toBe('#014')
+    expect(actual.color.SCRIM).toBe('#015')
+    expect(actual.color.OVERLAY).toBe('#016')
+    expect(actual.color.OUTLINE).toBe('#017')
+  })
+
+  it('returns theme reflecting "size" settings', () => {
+    const actual1 = createTheme({
+      size: {
+        htmlFontSize: 10,
+        space: {
+          XXS: 11,
+          XS: 12,
+          S: 13,
+          M: 14,
+          L: 15,
+          XL: 16,
+          XXL: 17,
+        },
+        font: {
+          SHORT: 18,
+          TALL: 19,
+          GRANDE: 20,
+          VENTI: 21,
+        },
+        mediaQuery: {
+          SP: 22,
+          TABLET: 23,
+        },
+      },
+    })
+
+    expect(actual1.size.pxToRem(400)).toBe(`${400 / 10}rem`)
+    expect(actual1.size.space.XXS).toBe(11)
+    expect(actual1.size.space.XS).toBe(12)
+    expect(actual1.size.space.S).toBe(13)
+    expect(actual1.size.space.M).toBe(14)
+    expect(actual1.size.space.L).toBe(15)
+    expect(actual1.size.space.XL).toBe(16)
+    expect(actual1.size.space.XXL).toBe(17)
+    expect(actual1.size.font.SHORT).toBe(18)
+    expect(actual1.size.font.TALL).toBe(19)
+    expect(actual1.size.font.GRANDE).toBe(20)
+    expect(actual1.size.font.VENTI).toBe(21)
+    expect(actual1.size.mediaQuery.SP).toBe(22)
+    expect(actual1.size.mediaQuery.TABLET).toBe(23)
+
+    const actual2 = createTheme({
+      size: {
+        space: {
+          defaultRem: 13,
+        },
+      },
+    })
+
+    expect(actual2.size.space.XXS).toBe(13)
+    expect(actual2.size.space.XS).toBe(13 * 2)
+    expect(actual2.size.space.S).toBe(13 * 3)
+    expect(actual2.size.space.M).toBe(13 * 4)
+    expect(actual2.size.space.L).toBe(13 * 5)
+    expect(actual2.size.space.XL).toBe(13 * 6)
+    expect(actual2.size.space.XXL).toBe(13 * 7)
+  })
+
+  it('returns theme reflecting "spacing" settings', () => {
+    const actual1 = createTheme({
+      spacing: {
+        XXS: 21,
+        XS: 22,
+        S: 23,
+        M: 24,
+        L: 25,
+        XL: 26,
+        XXL: 27,
+      },
+    })
+
+    expect(actual1.spacing.XXS).toBe(21)
+    expect(actual1.spacing.XS).toBe(22)
+    expect(actual1.spacing.S).toBe(23)
+    expect(actual1.spacing.M).toBe(24)
+    expect(actual1.spacing.L).toBe(25)
+    expect(actual1.spacing.XL).toBe(26)
+    expect(actual1.spacing.XXL).toBe(27)
+
+    const actual2 = createTheme({
+      spacing: {
+        baseSize: 17,
+      },
+    })
+
+    expect(actual2.spacing.XXS).toBe(17)
+    expect(actual2.spacing.XS).toBe(17 * 2)
+    expect(actual2.spacing.S).toBe(17 * 3)
+    expect(actual2.spacing.M).toBe(17 * 4)
+    expect(actual2.spacing.L).toBe(17 * 5)
+    expect(actual2.spacing.XL).toBe(17 * 6)
+    expect(actual2.spacing.XXL).toBe(17 * 7)
+  })
+
+  it('returns theme reflecting "fontSize" settings', () => {
+    const actual = createTheme({
+      fontSize: {
+        htmlFontSize: 11,
+        SHORT: 12,
+        TALL: 13,
+        GRANDE: 14,
+        VENTI: 15,
+      },
+    })
+
+    expect(actual.fontSize.pxToRem(55)).toBe(`${55 / 11}rem`)
+    expect(actual.fontSize.SHORT).toBe(12)
+    expect(actual.fontSize.TALL).toBe(13)
+    expect(actual.fontSize.GRANDE).toBe(14)
+    expect(actual.fontSize.VENTI).toBe(15)
+  })
+
+  it('returns theme reflecting "breakpoint" settings', () => {
+    const actual = createTheme({
+      breakpoint: {
+        SP: 21,
+        TABLET: 22,
+      },
+    })
+
+    expect(actual.breakpoint.SP).toBe(21)
+    expect(actual.breakpoint.TABLET).toBe(22)
+  })
+
+  it('returns theme reflecting "frame" settings', () => {
+    const actual = createTheme({
+      frame: {
+        border: {
+          lineWidth: 'dummy_width_2',
+          lineStyle: 'dummy_style_2',
+          default: 'dummy_default_2',
+          radius: {
+            s: 'dummy_s_2',
+            m: 'dummy_m_2',
+          },
+        },
+      },
+    })
+
+    expect(actual.frame.border.lineWidth).toBe('dummy_width_2')
+    expect(actual.frame.border.lineStyle).toBe('dummy_style_2')
+    expect(actual.frame.border.default).toBe('dummy_default_2')
+    expect(actual.frame.border.radius.s).toBe('dummy_s_2')
+    expect(actual.frame.border.radius.m).toBe('dummy_m_2')
+  })
+
+  it('returns theme reflecting "border" settings', () => {
+    const actual = createTheme({
+      border: {
+        lineWidth: 'dummy_width_3',
+        lineStyle: 'dummy_style_3',
+        shorthand: 'dummy_shorthand_3',
+      },
+    })
+
+    expect(actual.border.lineWidth).toBe('dummy_width_3')
+    expect(actual.border.lineStyle).toBe('dummy_style_3')
+    expect(actual.border.shorthand).toBe('dummy_shorthand_3')
+  })
+
+  it('returns theeme reflecting "radius" settings', () => {
+    const actual = createTheme({
+      radius: {
+        s: 'dummy_s_4',
+        m: 'dummy_m_4',
+      },
+    })
+
+    expect(actual.radius.s).toBe('dummy_s_4')
+    expect(actual.radius.m).toBe('dummy_m_4')
+  })
+
   it('returns theme that reflects "palette" settings to "color"', () => {
     const actual = createTheme({
       palette: {

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -45,6 +45,9 @@ describe('createTheme', () => {
     expect(actual.palette.SCRIM).toBe('#015')
     expect(actual.palette.OVERLAY).toBe('#016')
     expect(actual.palette.OUTLINE).toBe('#017')
+    expect(actual.frame.border.default).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #005`,
+    )
   })
 
   it('returns theme reflecting "color" settings', () => {
@@ -86,6 +89,9 @@ describe('createTheme', () => {
     expect(actual.color.SCRIM).toBe('#015')
     expect(actual.color.OVERLAY).toBe('#016')
     expect(actual.color.OUTLINE).toBe('#017')
+    expect(actual.border.shorthand).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #005`,
+    )
   })
 
   it('returns theme reflecting "size" settings', () => {
@@ -264,25 +270,39 @@ describe('createTheme', () => {
     const actual = createTheme({
       palette: {
         TEXT_BLACK: '#001',
+        BORDER: '#999',
       },
     })
     expect(actual.palette.TEXT_BLACK).toBe('#001')
-    expect(actual.palette.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.palette.BACKGROUND).toBe(defaultColor.BACKGROUND)
+    expect(actual.frame.border.default).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #999`,
+    )
     expect(actual.color.TEXT_BLACK).toBe('#001')
-    expect(actual.color.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.color.BACKGROUND).toBe(defaultColor.BACKGROUND)
+    expect(actual.border.shorthand).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #999`,
+    )
   })
 
   it('returns theme reflecting "color" settings to "palette"', () => {
     const actual = createTheme({
       color: {
         TEXT_GREY: '#002',
+        BORDER: '#998',
       },
     })
 
     expect(actual.palette.TEXT_GREY).toBe('#002')
-    expect(actual.palette.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.palette.BACKGROUND).toBe(defaultColor.BACKGROUND)
+    expect(actual.frame.border.default).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #998`,
+    )
     expect(actual.color.TEXT_GREY).toBe('#002')
-    expect(actual.color.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.color.BACKGROUND).toBe(defaultColor.BACKGROUND)
+    expect(actual.border.shorthand).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #998`,
+    )
   })
 
   it('returns theme prioritizing "color" settings over "palette" when given palette and color settings', () => {
@@ -292,10 +312,12 @@ describe('createTheme', () => {
         TEXT_GREY: '#002',
         TEXT_DISABLED: '#003',
         TEXT_LINK: '#004',
+        BORDER: '#997',
       },
       color: {
         TEXT_GREY: '#999',
         TEXT_LINK: '#888',
+        BORDER: '#996',
       },
     })
 
@@ -303,12 +325,18 @@ describe('createTheme', () => {
     expect(actual.palette.TEXT_GREY).toBe('#999')
     expect(actual.palette.TEXT_DISABLED).toBe('#003')
     expect(actual.palette.TEXT_LINK).toBe('#888')
-    expect(actual.palette.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.palette.BACKGROUND).toBe(defaultColor.BACKGROUND)
+    expect(actual.frame.border.default).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #996`,
+    )
     expect(actual.color.TEXT_BLACK).toBe('#001')
     expect(actual.color.TEXT_GREY).toBe('#999')
     expect(actual.color.TEXT_DISABLED).toBe('#003')
     expect(actual.color.TEXT_LINK).toBe('#888')
-    expect(actual.color.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.color.BACKGROUND).toBe(defaultColor.BACKGROUND)
+    expect(actual.border.shorthand).toBe(
+      `${defaultBorder.lineWidth} ${defaultBorder.lineStyle} #996`,
+    )
   })
 
   it('returns theme reflecting "size" settings to "fontSize", "spacing" and "breakpoint"', () => {

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -1,0 +1,51 @@
+import { createTheme } from '../createTheme'
+import { defaultColor } from '../createColor'
+
+describe('createTheme', () => {
+  it('returns theme reflecting settings when given palette settings', () => {
+    const actual = createTheme({
+      palette: {
+        TEXT_BLACK: '#001',
+      },
+    })
+    expect(actual.palette.TEXT_BLACK).toBe('#001')
+    expect(actual.color.TEXT_BLACK).toBe('#001')
+  })
+
+  it('returns theme reflecting settings when given color settings', () => {
+    const actual = createTheme({
+      color: {
+        TEXT_GREY: '#002',
+      },
+    })
+
+    expect(actual.palette.TEXT_GREY).toBe('#002')
+    expect(actual.color.TEXT_GREY).toBe('#002')
+  })
+
+  it('returns theme reflecting "color" settings as the priority when given both pelette and color settings', () => {
+    const actual = createTheme({
+      palette: {
+        TEXT_BLACK: '#001',
+        TEXT_GREY: '#002',
+        TEXT_DISABLED: '#003',
+        TEXT_LINK: '#004',
+      },
+      color: {
+        TEXT_GREY: '#999',
+        TEXT_LINK: '#888',
+      },
+    })
+
+    expect(actual.palette.TEXT_BLACK).toBe('#001')
+    expect(actual.palette.TEXT_GREY).toBe('#999')
+    expect(actual.palette.TEXT_DISABLED).toBe('#003')
+    expect(actual.palette.TEXT_LINK).toBe('#888')
+    expect(actual.palette.BORDER).toBe(defaultColor.BORDER)
+    expect(actual.color.TEXT_BLACK).toBe('#001')
+    expect(actual.color.TEXT_GREY).toBe('#999')
+    expect(actual.color.TEXT_DISABLED).toBe('#003')
+    expect(actual.color.TEXT_LINK).toBe('#888')
+    expect(actual.color.BORDER).toBe(defaultColor.BORDER)
+  })
+})

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -6,7 +6,7 @@ import { defaultBorder } from '../createBorder'
 import { defaultRadius } from '../createRadius'
 
 describe('createTheme', () => {
-  it('returns theme reflecting settings when given palette settings', () => {
+  it('returns theme that reflects "palette" settings to "color"', () => {
     const actual = createTheme({
       palette: {
         TEXT_BLACK: '#001',
@@ -18,7 +18,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme reflecting settings when given color settings', () => {
+  it('returns theme that reflects "color" settings to "palette"', () => {
     const actual = createTheme({
       color: {
         TEXT_GREY: '#002',
@@ -31,7 +31,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme that preferentially reflects new settings when given palette and color settings', () => {
+  it('returns theme that prioritizes "color" settings over "palette" when given palette and color settings', () => {
     const actual = createTheme({
       palette: {
         TEXT_BLACK: '#001',
@@ -57,7 +57,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme reflecting settings when given size settings', () => {
+  it('returns theme that reflects "size" settings to "fontSize", "spacing" and "breakpoint"', () => {
     const actual = createTheme({
       size: {
         htmlFontSize: 2,
@@ -95,7 +95,7 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
-  it('returns theme reflecting settings when given spacing settings', () => {
+  it('returns theme that reflects "spacing" settings to "size.space"', () => {
     const actual = createTheme({
       spacing: {
         baseSize: 20,
@@ -111,7 +111,7 @@ describe('createTheme', () => {
     expect(actual.spacing.S).toBe(20 * 3)
   })
 
-  it('returns theme reflecting settings when given fontSize settings', () => {
+  it('returns theme that reflects "fontSize" settings to "size.fontSize"', () => {
     const actual = createTheme({
       fontSize: {
         SHORT: 30,
@@ -124,7 +124,7 @@ describe('createTheme', () => {
     expect(actual.fontSize.TALL).toBe(defaultFontSize.TALL)
   })
 
-  it('returns theme reflecting settings when given breakpoint settings', () => {
+  it('returns theme that reflects "breakpoint" settings to "size.mediaQuery"', () => {
     const actual = createTheme({
       breakpoint: {
         SP: 40,
@@ -137,7 +137,7 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
-  it('returns theme that preferentially reflects new settings when given size, spacing, fontSize and breakpoint settings', () => {
+  it('returns theme that prioritizes "spacing", "fontSize" and "breakpoint" settings over "size" when given size, spacing, fontSize and breakpoint settings', () => {
     const actual = createTheme({
       size: {
         htmlFontSize: 2,
@@ -189,7 +189,7 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(2000)
   })
 
-  it('returns theme reflecting settings when given frame settings', () => {
+  it('returns theme that reflects "frame" settings to "border" and "radius"', () => {
     const actual = createTheme({
       frame: {
         border: {
@@ -215,7 +215,7 @@ describe('createTheme', () => {
     expect(actual.radius.m).toBe(defaultRadius.m)
   })
 
-  it('returns theme reflecting settings when given border settings', () => {
+  it('returns theme that reflects "border" settings to "frame.border"', () => {
     const actual = createTheme({
       border: {
         lineWidth: 'dummy_width',
@@ -231,7 +231,7 @@ describe('createTheme', () => {
     expect(actual.border.lineStyle).toBe(defaultBorder.lineStyle)
   })
 
-  it('returns theme reflecting settings when given radius settings', () => {
+  it('returns theme that reflects "radius" settings to "frame.border.radius"', () => {
     const actual = createTheme({
       radius: {
         s: 'dummy_s',
@@ -244,7 +244,7 @@ describe('createTheme', () => {
     expect(actual.radius.m).toBe(defaultRadius.m)
   })
 
-  it('returns theme that preferentially reflects new settings when given frame, border and radius settings', () => {
+  it('returns theme that prioritizes "border" and "radius" settings over "frame" when given frame, border and radius settings', () => {
     const actual = createTheme({
       frame: {
         border: {

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -1,5 +1,9 @@
 import { createTheme } from '../createTheme'
 import { defaultColor } from '../createColor'
+import { defaultFontSize } from '../createFontSize'
+import { defaultBreakpoint } from '../createBreakpoint'
+import { defaultBorder } from '../createBorder'
+import { defaultRadius } from '../createRadius'
 
 describe('createTheme', () => {
   it('returns theme reflecting settings when given palette settings', () => {
@@ -9,7 +13,9 @@ describe('createTheme', () => {
       },
     })
     expect(actual.palette.TEXT_BLACK).toBe('#001')
+    expect(actual.palette.BORDER).toBe(defaultColor.BORDER)
     expect(actual.color.TEXT_BLACK).toBe('#001')
+    expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
   it('returns theme reflecting settings when given color settings', () => {
@@ -20,7 +26,9 @@ describe('createTheme', () => {
     })
 
     expect(actual.palette.TEXT_GREY).toBe('#002')
+    expect(actual.palette.BORDER).toBe(defaultColor.BORDER)
     expect(actual.color.TEXT_GREY).toBe('#002')
+    expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
   it('returns theme reflecting "color" settings as the priority when given both pelette and color settings', () => {
@@ -77,10 +85,14 @@ describe('createTheme', () => {
     expect(actual.spacing.S).toBe(10 * 3)
 
     expect(actual.size.font.SHORT).toBe(100)
+    expect(actual.size.font.TALL).toBe(defaultFontSize.TALL)
     expect(actual.fontSize.SHORT).toBe(100)
+    expect(actual.fontSize.TALL).toBe(defaultFontSize.TALL)
 
     expect(actual.size.mediaQuery.SP).toBe(1000)
+    expect(actual.size.mediaQuery.TABLET).toBe(defaultBreakpoint.TABLET)
     expect(actual.breakpoint.SP).toBe(1000)
+    expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
   it('returns theme reflecting settings when given spacing settings', () => {
@@ -107,7 +119,9 @@ describe('createTheme', () => {
     })
 
     expect(actual.size.font.SHORT).toBe(30)
+    expect(actual.size.font.TALL).toBe(defaultFontSize.TALL)
     expect(actual.fontSize.SHORT).toBe(30)
+    expect(actual.fontSize.TALL).toBe(defaultFontSize.TALL)
   })
 
   it('returns theme reflecting settings when given breakpoint settings', () => {
@@ -118,7 +132,9 @@ describe('createTheme', () => {
     })
 
     expect(actual.size.mediaQuery.SP).toBe(40)
+    expect(actual.size.mediaQuery.TABLET).toBe(defaultBreakpoint.TABLET)
     expect(actual.breakpoint.SP).toBe(40)
+    expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
   it('returns theme reflecting settings when given frame settings', () => {
@@ -136,11 +152,15 @@ describe('createTheme', () => {
 
     expect(actual.frame.border.lineWidth).toBe('dummy_width')
     expect(actual.frame.border.default).toBe('dummy_default')
+    expect(actual.frame.border.lineStyle).toBe(defaultBorder.lineStyle)
     expect(actual.border.lineWidth).toBe('dummy_width')
     expect(actual.border.shorthand).toBe('dummy_default')
+    expect(actual.border.lineStyle).toBe(defaultBorder.lineStyle)
 
     expect(actual.frame.border.radius.s).toBe('dummy_s')
+    expect(actual.frame.border.radius.m).toBe(defaultRadius.m)
     expect(actual.radius.s).toBe('dummy_s')
+    expect(actual.radius.m).toBe(defaultRadius.m)
   })
 
   it('returns theme reflecting settings when given border settings', () => {
@@ -153,8 +173,10 @@ describe('createTheme', () => {
 
     expect(actual.frame.border.lineWidth).toBe('dummy_width')
     expect(actual.frame.border.default).toBe('dummy_shorthand')
+    expect(actual.frame.border.lineStyle).toBe(defaultBorder.lineStyle)
     expect(actual.border.lineWidth).toBe('dummy_width')
     expect(actual.border.shorthand).toBe('dummy_shorthand')
+    expect(actual.border.lineStyle).toBe(defaultBorder.lineStyle)
   })
 
   it('returns theme reflecting settings when given radius settings', () => {
@@ -165,6 +187,8 @@ describe('createTheme', () => {
     })
 
     expect(actual.frame.border.radius.s).toBe('dummy_s')
+    expect(actual.frame.border.radius.m).toBe(defaultRadius.m)
     expect(actual.radius.s).toBe('dummy_s')
+    expect(actual.radius.m).toBe(defaultRadius.m)
   })
 })

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -31,7 +31,7 @@ describe('createTheme', () => {
     expect(actual.color.BORDER).toBe(defaultColor.BORDER)
   })
 
-  it('returns theme reflecting "color" settings as the priority when given both pelette and color settings', () => {
+  it('returns theme that preferentially reflects new settings when given palette and color settings', () => {
     const actual = createTheme({
       palette: {
         TEXT_BLACK: '#001',
@@ -137,6 +137,58 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
+  it('returns theme that preferentially reflects new settings when given size, spacing, fontSize and breakpoint settings', () => {
+    const actual = createTheme({
+      size: {
+        htmlFontSize: 2,
+        space: {
+          defaultRem: 10,
+          XXS: 11,
+          XS: 12,
+        },
+        font: {
+          SHORT: 100,
+          TALL: 101,
+        },
+        mediaQuery: {
+          SP: 1000,
+          TABLET: 1001,
+        },
+      },
+      spacing: {
+        baseSize: 13,
+        XS: 14,
+      },
+      fontSize: {
+        htmlFontSize: 8,
+        TALL: 200,
+      },
+      breakpoint: {
+        TABLET: 2000,
+      },
+    })
+
+    expect(actual.size.pxToRem(400)).toBe(`${400 / 8}rem`)
+    expect(actual.fontSize.pxToRem(400)).toBe(`${400 / 8}rem`)
+
+    expect(actual.size.space.XXS).toBe(11)
+    expect(actual.size.space.XS).toBe(14)
+    expect(actual.size.space.S).toBe(13 * 3)
+    expect(actual.spacing.XXS).toBe(11)
+    expect(actual.spacing.XS).toBe(14)
+    expect(actual.spacing.S).toBe(13 * 3)
+
+    expect(actual.size.font.SHORT).toBe(100)
+    expect(actual.size.font.TALL).toBe(200)
+    expect(actual.fontSize.SHORT).toBe(100)
+    expect(actual.fontSize.TALL).toBe(200)
+
+    expect(actual.size.mediaQuery.SP).toBe(1000)
+    expect(actual.size.mediaQuery.TABLET).toBe(2000)
+    expect(actual.breakpoint.SP).toBe(1000)
+    expect(actual.breakpoint.TABLET).toBe(2000)
+  })
+
   it('returns theme reflecting settings when given frame settings', () => {
     const actual = createTheme({
       frame: {
@@ -190,5 +242,36 @@ describe('createTheme', () => {
     expect(actual.frame.border.radius.m).toBe(defaultRadius.m)
     expect(actual.radius.s).toBe('dummy_s')
     expect(actual.radius.m).toBe(defaultRadius.m)
+  })
+
+  it('returns theme that preferentially reflects new settings when given frame, border and radius settings', () => {
+    const actual = createTheme({
+      frame: {
+        border: {
+          lineWidth: 'dummy_width',
+          default: 'dummy_default',
+          radius: {
+            s: 'dummy_s',
+            m: 'dummy_m',
+          },
+        },
+      },
+      border: {
+        shorthand: 'dummy_shorthand',
+      },
+      radius: {
+        m: 'dummy_radius_m',
+      },
+    })
+
+    expect(actual.frame.border.lineWidth).toBe('dummy_width')
+    expect(actual.frame.border.default).toBe('dummy_shorthand')
+    expect(actual.border.lineWidth).toBe('dummy_width')
+    expect(actual.border.shorthand).toBe('dummy_shorthand')
+
+    expect(actual.frame.border.radius.s).toBe('dummy_s')
+    expect(actual.frame.border.radius.m).toBe('dummy_radius_m')
+    expect(actual.radius.s).toBe('dummy_s')
+    expect(actual.radius.m).toBe('dummy_radius_m')
   })
 })

--- a/src/themes/createBreakpoint.ts
+++ b/src/themes/createBreakpoint.ts
@@ -13,6 +13,6 @@ export interface CreatedBreakpointTheme {
 export const defaultBreakpoint = { SP: 599, TABLET: 959 }
 
 export const createBreakpoint = (userBreakpoint: BreakpointProperty = {}) => {
-  const created: CreatedBreakpointTheme = merge(defaultBreakpoint, userBreakpoint)
+  const created: CreatedBreakpointTheme = merge({ ...defaultBreakpoint }, userBreakpoint)
   return created
 }

--- a/src/themes/createFrame.ts
+++ b/src/themes/createFrame.ts
@@ -52,6 +52,7 @@ export const createFrame = (userFrame: FrameProperty = {}, userPalette: PaletteP
       border: {
         ...defaultFrame.border,
         default: `${lineWidth} ${lineStyle} ${color}`,
+        radius: { ...defaultFrame.border.radius },
       },
     },
     userFrame,

--- a/src/themes/createRadius.ts
+++ b/src/themes/createRadius.ts
@@ -16,6 +16,6 @@ export const defaultRadius: CreatedRadiusTheme = {
 }
 
 export const createRadius = (userRadius: RadiusProperty = {}) => {
-  const created: CreatedRadiusTheme = merge(defaultRadius, userRadius)
+  const created: CreatedRadiusTheme = merge({ ...defaultRadius }, userRadius)
   return created
 }

--- a/src/themes/createSize.ts
+++ b/src/themes/createSize.ts
@@ -90,8 +90,8 @@ export const createSize = (userSize: SizeProperty = {}) => {
     {
       pxToRem: (value: number) => pxToRem(value)(userSize.htmlFontSize || defaultHtmlFontSize),
       space: getSpace(XXS),
-      font: defaultFontSize,
-      mediaQuery: defaultMediaQuery,
+      font: { ...defaultFontSize },
+      mediaQuery: { ...defaultMediaQuery },
     },
     userSize,
   )

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -67,10 +67,10 @@ export const createTheme = (theme: ThemeProperty = {}) => {
   const created: CreatedTheme = {
     palette: createPalette(getPaletteProperty(theme)),
     color: createColor(getColorProperty(theme)),
-    size: createSize(theme.size),
-    fontSize: createFontSize(theme.fontSize),
-    spacing: createSpacing(theme.spacing),
-    breakpoint: createBreakpoint(theme.breakpoint),
+    size: createSize(getSizeProperty(theme)),
+    fontSize: createFontSize(getFontSizeProperty(theme)),
+    spacing: createSpacing(getSpacingProperty(theme)),
+    breakpoint: createBreakpoint(getBreakpointProperty(theme)),
     frame: createFrame(theme.frame, theme.palette),
     border: createBorder(theme.border, theme.color),
     radius: createRadius(theme.radius),
@@ -91,5 +91,56 @@ function getColorProperty(theme: ThemeProperty): ColorProperty {
   return {
     ...theme.palette,
     ...theme.color,
+  }
+}
+function getSizeProperty(theme: ThemeProperty): SizeProperty {
+  return {
+    htmlFontSize: theme.size?.htmlFontSize || theme.fontSize?.htmlFontSize,
+    space: {
+      defaultRem: theme.size?.space?.defaultRem || theme.spacing?.baseSize,
+      XXS: theme.size?.space?.XXS || theme.spacing?.XXS,
+      XS: theme.size?.space?.XS || theme.spacing?.XS,
+      S: theme.size?.space?.S || theme.spacing?.S,
+      M: theme.size?.space?.M || theme.spacing?.M,
+      L: theme.size?.space?.L || theme.spacing?.L,
+      XL: theme.size?.space?.XL || theme.spacing?.XL,
+      XXL: theme.size?.space?.XXL || theme.spacing?.XXL,
+    },
+    font: {
+      SHORT: theme.size?.font?.SHORT || theme.fontSize?.SHORT,
+      TALL: theme.size?.font?.TALL || theme.fontSize?.TALL,
+      GRANDE: theme.size?.font?.GRANDE || theme.fontSize?.GRANDE,
+      VENTI: theme.size?.font?.VENTI || theme.fontSize?.VENTI,
+    },
+    mediaQuery: {
+      ...theme.size?.mediaQuery,
+      ...theme.breakpoint,
+    },
+  }
+}
+function getFontSizeProperty(theme: ThemeProperty): FontSizeProperty {
+  return {
+    htmlFontSize: theme.size?.htmlFontSize,
+    ...theme.size?.font,
+    ...theme.fontSize,
+  }
+}
+function getSpacingProperty(theme: ThemeProperty): SpacingProperty {
+  return {
+    baseSize: theme.size?.space?.defaultRem,
+    XXS: theme.size?.space?.XXS,
+    XS: theme.size?.space?.XS,
+    S: theme.size?.space?.S,
+    M: theme.size?.space?.M,
+    L: theme.size?.space?.L,
+    XL: theme.size?.space?.XL,
+    XXL: theme.size?.space?.XXL,
+    ...theme.spacing,
+  }
+}
+function getBreakpointProperty(theme: ThemeProperty): BreakpointProperty {
+  return {
+    ...theme.size?.mediaQuery,
+    ...theme.breakpoint,
   }
 }

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -65,8 +65,8 @@ export interface CreatedTheme {
 
 export const createTheme = (theme: ThemeProperty = {}) => {
   const created: CreatedTheme = {
-    palette: createPalette(theme.palette),
-    color: createColor(theme.color),
+    palette: createPalette(getPaletteProperty(theme)),
+    color: createColor(getColorProperty(theme)),
     size: createSize(theme.size),
     fontSize: createFontSize(theme.fontSize),
     spacing: createSpacing(theme.spacing),
@@ -79,4 +79,17 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     zIndex: createZIndex(theme.zIndex),
   }
   return created
+}
+
+function getPaletteProperty(theme: ThemeProperty): PaletteProperty {
+  return {
+    ...theme.palette,
+    ...theme.color,
+  }
+}
+function getColorProperty(theme: ThemeProperty): ColorProperty {
+  return {
+    ...theme.palette,
+    ...theme.color,
+  }
 }

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -97,22 +97,22 @@ function getColorProperty(theme: ThemeProperty): ColorProperty {
 }
 function getSizeProperty(theme: ThemeProperty): SizeProperty {
   return {
-    htmlFontSize: theme.size?.htmlFontSize || theme.fontSize?.htmlFontSize,
+    htmlFontSize: theme.fontSize?.htmlFontSize || theme.size?.htmlFontSize,
     space: {
-      defaultRem: theme.size?.space?.defaultRem || theme.spacing?.baseSize,
-      XXS: theme.size?.space?.XXS || theme.spacing?.XXS,
-      XS: theme.size?.space?.XS || theme.spacing?.XS,
-      S: theme.size?.space?.S || theme.spacing?.S,
-      M: theme.size?.space?.M || theme.spacing?.M,
-      L: theme.size?.space?.L || theme.spacing?.L,
-      XL: theme.size?.space?.XL || theme.spacing?.XL,
-      XXL: theme.size?.space?.XXL || theme.spacing?.XXL,
+      defaultRem: theme.spacing?.baseSize || theme.size?.space?.defaultRem,
+      XXS: theme.spacing?.XXS || theme.size?.space?.XXS,
+      XS: theme.spacing?.XS || theme.size?.space?.XS,
+      S: theme.spacing?.S || theme.size?.space?.S,
+      M: theme.spacing?.M || theme.size?.space?.M,
+      L: theme.spacing?.L || theme.size?.space?.L,
+      XL: theme.spacing?.XL || theme.size?.space?.XL,
+      XXL: theme.spacing?.XXL || theme.size?.space?.XXL,
     },
     font: {
-      SHORT: theme.size?.font?.SHORT || theme.fontSize?.SHORT,
-      TALL: theme.size?.font?.TALL || theme.fontSize?.TALL,
-      GRANDE: theme.size?.font?.GRANDE || theme.fontSize?.GRANDE,
-      VENTI: theme.size?.font?.VENTI || theme.fontSize?.VENTI,
+      SHORT: theme.fontSize?.SHORT || theme.size?.font?.SHORT,
+      TALL: theme.fontSize?.TALL || theme.size?.font?.TALL,
+      GRANDE: theme.fontSize?.GRANDE || theme.size?.font?.GRANDE,
+      VENTI: theme.fontSize?.VENTI || theme.size?.font?.VENTI,
     },
     mediaQuery: {
       ...theme.size?.mediaQuery,
@@ -149,9 +149,9 @@ function getBreakpointProperty(theme: ThemeProperty): BreakpointProperty {
 function getFrameProperty(theme: ThemeProperty): FrameProperty {
   return {
     border: {
-      lineWidth: theme.frame?.border?.lineWidth || theme.border?.lineWidth,
-      lineStyle: theme.frame?.border?.lineStyle || theme.border?.lineStyle,
-      default: theme.frame?.border?.default || theme.border?.shorthand,
+      lineWidth: theme.border?.lineWidth || theme.frame?.border?.lineWidth,
+      lineStyle: theme.border?.lineStyle || theme.frame?.border?.lineStyle,
+      default: theme.border?.shorthand || theme.frame?.border?.default,
       radius: {
         ...theme.frame?.border?.radius,
         ...theme.radius,
@@ -161,9 +161,9 @@ function getFrameProperty(theme: ThemeProperty): FrameProperty {
 }
 function getBorderProperty(theme: ThemeProperty): BorderProperty {
   return {
-    lineWidth: theme.frame?.border?.lineWidth || theme.border?.lineWidth,
-    lineStyle: theme.frame?.border?.lineStyle || theme.border?.lineStyle,
-    shorthand: theme.frame?.border?.default || theme.border?.shorthand,
+    lineWidth: theme.border?.lineWidth || theme.frame?.border?.lineWidth,
+    lineStyle: theme.border?.lineStyle || theme.frame?.border?.lineStyle,
+    shorthand: theme.border?.shorthand || theme.frame?.border?.default,
   }
 }
 function getRadiusProperty(theme: ThemeProperty): RadiusProperty {

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -64,16 +64,18 @@ export interface CreatedTheme {
 }
 
 export const createTheme = (theme: ThemeProperty = {}) => {
+  const paletteProperty = getPaletteProperty(theme)
+  const colorProperty = getColorProperty(theme)
   const created: CreatedTheme = {
-    palette: createPalette(getPaletteProperty(theme)),
-    color: createColor(getColorProperty(theme)),
+    palette: createPalette(paletteProperty),
+    color: createColor(colorProperty),
     size: createSize(getSizeProperty(theme)),
     fontSize: createFontSize(getFontSizeProperty(theme)),
     spacing: createSpacing(getSpacingProperty(theme)),
     breakpoint: createBreakpoint(getBreakpointProperty(theme)),
-    frame: createFrame(theme.frame, theme.palette),
-    border: createBorder(theme.border, theme.color),
-    radius: createRadius(theme.radius),
+    frame: createFrame(getFrameProperty(theme), paletteProperty),
+    border: createBorder(getBorderProperty(theme), colorProperty),
+    radius: createRadius(getRadiusProperty(theme)),
     interaction: createInteraction(theme.interaction),
     shadow: createShadow(theme.shadow),
     zIndex: createZIndex(theme.zIndex),
@@ -142,5 +144,31 @@ function getBreakpointProperty(theme: ThemeProperty): BreakpointProperty {
   return {
     ...theme.size?.mediaQuery,
     ...theme.breakpoint,
+  }
+}
+function getFrameProperty(theme: ThemeProperty): FrameProperty {
+  return {
+    border: {
+      lineWidth: theme.frame?.border?.lineWidth || theme.border?.lineWidth,
+      lineStyle: theme.frame?.border?.lineStyle || theme.border?.lineStyle,
+      default: theme.frame?.border?.default || theme.border?.shorthand,
+      radius: {
+        ...theme.frame?.border?.radius,
+        ...theme.radius,
+      },
+    },
+  }
+}
+function getBorderProperty(theme: ThemeProperty): BorderProperty {
+  return {
+    lineWidth: theme.frame?.border?.lineWidth || theme.border?.lineWidth,
+    lineStyle: theme.frame?.border?.lineStyle || theme.border?.lineStyle,
+    shorthand: theme.frame?.border?.default || theme.border?.shorthand,
+  }
+}
+function getRadiusProperty(theme: ThemeProperty): RadiusProperty {
+  return {
+    ...theme.frame?.border?.radius,
+    ...theme.radius,
   }
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
この PR では、theme 構造の見直し (#1256) に起因して発生している `createTheme` の問題を修正する。

問題を例示すると、
```typescript
const theme = createTheme({
  size: {
    space: {
      XXS: 10,
    },
  },
  spacing: {
    XXS: 20,
  },
})
```
とした時、`theme.size.space.XXS` は `10` になるが `theme.spacing.XXS` は `20` となり、どちらを参照しているかによってズレが生じてしまう問題がある。

これを解消するには、上記の例で言えば、`createTheme` 内で引数の `size.space` と `spacing` をマージ（新規の方を優先）して扱う必要があると思われる。そうした場合、 `theme.size.space.XXS` と `theme.spacing.XXS` はどちらも `20` になりズレは発生しなくなる。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `createTheme` 時に新旧 theme の設定値をマージするように修正
- `lodash` の `merge` によってオブジェクトが破壊されることで既定値が変わってしまう問題を修正
- `createTheme` のテストを追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
