### PR TITLE
feat: add sync icon to InformationPanel

### DIFF
--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -12,6 +12,7 @@ import {
   FaExclamationCircleIcon,
   FaExclamationTriangleIcon,
   FaInfoCircleIcon,
+  FaSyncAltIcon,
 } from '../Icon'
 import { Heading, HeadingTagTypes } from '../Heading'
 import { SecondaryButton } from '../Button'
@@ -19,7 +20,7 @@ import { SecondaryButton } from '../Button'
 type Props = {
   title: string
   titleTag?: HeadingTagTypes
-  type?: 'success' | 'info' | 'warning' | 'error' | ''
+  type?: 'success' | 'info' | 'warning' | 'error' | 'sync' | ''
   togglable?: boolean
   openButtonLabel?: string
   closeButtonLabel?: string
@@ -62,6 +63,10 @@ export const InformationPanel: FC<Props> = ({
     case 'error':
       Icon = ErrorTitleIcon
       iconColor = theme.palette.DANGER
+      break
+    case 'sync':
+      Icon = SyncIcon
+      iconColor = theme.palette.MAIN
   }
 
   const [active, setActive] = useState(activeProps)
@@ -154,6 +159,7 @@ const SuccessTitleIcon = createTitleIcon(FaCheckCircleIcon)
 const InfoTitleIcon = createTitleIcon(FaInfoCircleIcon)
 const WarningTitleIcon = createTitleIcon(FaExclamationTriangleIcon)
 const ErrorTitleIcon = createTitleIcon(FaExclamationCircleIcon)
+const SyncIcon = createTitleIcon(FaSyncAltIcon)
 
 const Content = styled.div<{ themes: Theme }>`
   ${({ themes }) => {

--- a/src/components/InformationPanel/README.md
+++ b/src/components/InformationPanel/README.md
@@ -12,7 +12,7 @@ import { InformationPanel } from 'smarthr-ui'
 | ---------------- | -------- | --------------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
 | title            | ✓        | **string**                                                                                    | -            | The title of component                                                              |
 | titleTag         | -        | **enum** <br/> 'h1' &#124; 'h2' &#124; 'h3' &#124; 'h4' &#124; 'h5' &#124; 'h6' &#124; 'span' | 'span'       | HTML tag of title                                                                   |
-| type             | -        | **enum** <br/> 'success' &#124; 'info' &#124; 'warning' &#124; 'error'                        | 'info'       | Can be set type of component                                                        |
+| type             | -        | **enum** <br/> 'success' &#124; 'info' &#124; 'warning' &#124; 'error' &#124; 'sync'          | 'info'       | Can be set type of component                                                        |
 | togglable        | -        | **boolean** | `true`  | Show open / close button |
 | openButtonLabel  | -        | **string**                                                                                    | '開く'       | Label of open button                                                                |
 | closeButtonLabel | -        | **string**                                                                                    | '閉じる'     | Label of close button                                                               |


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Add an icon variation to Information Panel.
Now you can choose sync icon for the panel.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I fixed the InformationPanel to show the FaSyncAlt icon as an icon.
I also updated the docs.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

![スクリーンショット 2021-03-31 11 35 55](https://user-images.githubusercontent.com/13192318/113082429-69af5980-9215-11eb-8c98-64c756971617.png)


<!--
Please attach a capture if it looks different.
-->
