### PR TITLE
Change caret direction of `<AccordionPanel>`

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -88,7 +88,7 @@ const resetButtonStyle = css`
 const Button = styled.button<{ themes: Theme }>`
   ${resetButtonStyle}
   ${({ themes }) => {
-    const { color, fontSize, spacing } = themes
+    const { color, fontSize, spacing, shadow } = themes
 
     return css`
       display: flex;
@@ -97,12 +97,17 @@ const Button = styled.button<{ themes: Theme }>`
       padding: ${fontSize.pxToRem(12)} ${fontSize.pxToRem(spacing.XS)};
       cursor: pointer;
       font-size: inherit;
-      outline-color: ${color.OUTLINE};
       text-align: left;
 
-      &:hover,
       &:focus {
+        outline: none;
+        box-shadow: ${shadow.OUTLINE};
+      }
+
+      &:hover,
+      &:focus:not(:focus-visible) {
         background-color: ${color.hoverColor('#fff')};
+        box-shadow: none;
       }
 
       /* TODO replace if impremented Layout component */

--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -8,7 +8,7 @@ import { AccordionPanelContext } from './AccordionPanel'
 import { AccordionPanelItemContext } from './AccordionPanelItem'
 import { useClassNames } from './useClassNames'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
-import { FaCaretDownIcon } from '../Icon'
+import { FaCaretRightIcon, FaCaretUpIcon } from '../Icon'
 
 type Props = {
   children: React.ReactNode
@@ -67,9 +67,9 @@ export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
         data-component="AccordionHeaderButton"
         {...props}
       >
-        {displayIcon && iconPosition === 'left' && <Icon />}
+        {displayIcon && iconPosition === 'left' && <LeftIcon />}
         <TriggerTitle>{children}</TriggerTitle>
-        {displayIcon && iconPosition === 'right' && <Icon />}
+        {displayIcon && iconPosition === 'right' && <RightIcon />}
       </Button>
     </Heading>
   )
@@ -117,14 +117,18 @@ const Button = styled.button<{ themes: Theme }>`
     `
   }}
 `
-const Icon = styled(FaCaretDownIcon)`
+const LeftIcon = styled(FaCaretRightIcon)`
   transition: transform 0.3s;
 
   [aria-expanded='true'] > & {
-    transform: rotate(-180deg);
+    transform: rotate(90deg);
   }
+`
 
-  [aria-expanded='true'] &:last-child {
-    transform: rotate(180deg);
+const RightIcon = styled(FaCaretUpIcon)`
+  transition: transform 0.3s;
+
+  [aria-expanded='true'] & {
+    transform: rotate(-180deg);
   }
 `

--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -9,6 +9,7 @@ import { AccordionPanelItemContext } from './AccordionPanelItem'
 import { useClassNames } from './useClassNames'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { FaCaretRightIcon, FaCaretUpIcon } from '../Icon'
+import { radiusMap } from '../Base'
 
 type Props = {
   children: React.ReactNode
@@ -98,6 +99,14 @@ const Button = styled.button<{ themes: Theme }>`
       cursor: pointer;
       font-size: inherit;
       text-align: left;
+
+      .smarthr-ui-AccordionPanel > * > *:first-child & {
+        border-radius: ${radiusMap.m} ${radiusMap.m} 0 0;
+      }
+
+      .smarthr-ui-AccordionPanel > * > *:last-child & {
+        border-radius: 0 0 ${radiusMap.m} ${radiusMap.m};
+      }
 
       &:focus {
         outline: none;

--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -38,9 +38,7 @@ export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
   const classNames = useClassNames()
 
   const isExpanded = getIsInclude(expandedItems, name)
-  const expandedClassName = isExpanded ? 'expanded' : ''
-  const buttonClassNames = `${className} ${expandedClassName} ${iconPosition} ${classNames.trigger}`
-  const iconClassNames = `${expandedClassName} ${iconPosition}`
+  const buttonClassNames = `${className} ${classNames.trigger}`
 
   const handleClick = useCallback(() => {
     if (onClickTrigger) onClickTrigger(name, !isExpanded)
@@ -56,8 +54,6 @@ export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
     }
   }, [onClickTrigger, name, isExpanded, onClickProps, expandedItems, expandableMultiply])
 
-  const caretIcon = <Icon className={iconClassNames} $theme={theme} />
-
   return (
     <Heading tag={headingTag} type={headingType}>
       <Button
@@ -71,13 +67,17 @@ export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
         data-component="AccordionHeaderButton"
         {...props}
       >
-        {displayIcon && iconPosition === 'left' && caretIcon}
-        {children}
-        {displayIcon && iconPosition === 'right' && caretIcon}
+        {displayIcon && iconPosition === 'left' && <Icon />}
+        <TriggerTitle>{children}</TriggerTitle>
+        {displayIcon && iconPosition === 'right' && <Icon />}
       </Button>
     </Heading>
   )
 }
+
+const TriggerTitle = styled.span`
+  flex-grow: 1;
+`
 
 const resetButtonStyle = css`
   background-color: transparent;
@@ -98,43 +98,28 @@ const Button = styled.button<{ themes: Theme }>`
       cursor: pointer;
       font-size: inherit;
       outline-color: ${color.OUTLINE};
+      text-align: left;
 
       &:hover,
       &:focus {
         background-color: ${color.hoverColor('#fff')};
       }
-      &.right {
-        justify-content: space-between;
-      }
-      &.left {
-        justify-content: left;
+
+      /* TODO replace if impremented Layout component */
+      & > * + * {
+        margin-left: ${fontSize.pxToRem(spacing.XXS)};
       }
     `
   }}
 `
-const Icon = styled(FaCaretDownIcon)<{ $theme: Theme }>`
-  ${({ $theme }) => {
-    const { fontSize, spacing } = $theme
+const Icon = styled(FaCaretDownIcon)`
+  transition: transform 0.3s;
 
-    return css`
-      display: inline-flex;
-      margin-right: ${fontSize.pxToRem(spacing.XXS)};
-      transition: transform 0.3s;
+  [aria-expanded='true'] > & {
+    transform: rotate(-180deg);
+  }
 
-      &.left {
-        &.expanded {
-          transform: rotate(-180deg);
-        }
-      }
-
-      &.right {
-        margin-right: 0;
-        margin-left: ${fontSize.pxToRem(spacing.XXS)};
-
-        &.expanded {
-          transform: rotate(180deg);
-        }
-      }
-    `
-  }}
+  [aria-expanded='true'] &:last-child {
+    transform: rotate(180deg);
+  }
 `

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -9,7 +9,7 @@ type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-const radiusMap = {
+export const radiusMap = {
   s: '6px',
   m: '8px',
 }

--- a/src/components/Base/index.ts
+++ b/src/components/Base/index.ts
@@ -1,2 +1,2 @@
-export { Base } from './Base'
+export { Base, radiusMap } from './Base'
 export { DialogBase } from './DialogBase'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

The rules for icons representing expansion and collapse are now as follows.

- Put an icon to the left of the trigger's text label.
- Use the caret right icon when target is expanded, and the caret down icon when target is collapsed.
- It is also acceptable to place the icon to the right of the trigger's text label, but in that case, use caret down when the target is open and caret up when it is closed so that the icon does not indicate transition.
- Do not mix icons with different positions in the same page.

展開・折りたたみを表すアイコンのルールは以下の通りとなりました。

- トリガーのテキストラベルの左にアイコンを置いてください。
- ターゲットが展開されているときはcaret_rightを、ターゲットが折りたたまれているときはcaret_downアイコンを使用します。
- アイコンをラベルの右におくこともできますが、その場合はアイコンが遷移を示唆しないようにターゲットが開いているときは caret_down を、閉じているときは caret_up アイコンを利用してください。
- 同じページ内でアイコンの位置が違うものを混在させないでください。

## What I did

- refactor: replace deprecated theme params
- refactor: layout `<AccortionPanelTrigger>` without className
- fix: make AccordionPanelTrigger focus indicator
- feat: change AccordionPanel caret direction

## Capture

|before|after|
|----|----|
|![capture of AccordionPanel in smarthr-ui app)](https://user-images.githubusercontent.com/6724665/113383524-14af4700-93bf-11eb-93f1-b79e1fa23577.png)|![capture of AccordionPanel in local env](https://user-images.githubusercontent.com/6724665/113383533-1b3dbe80-93bf-11eb-8148-424fe23b0ce1.png)|