### PR TITLE
chore: enable to prerelease from actions

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHANGELOG_PATH: /tmp/CHANGELOG.md
+      IS_PRERELEASE: ${{ contains(github.event.issue.labels.*.name, 'prerelease') }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -26,7 +27,15 @@ jobs:
           git config user.name "github-actions[bot]"
       - run: yarn install
       - run: yarn release
+        if: ${{ env.IS_PRERELEASE == 'false' }}
+      - run: yarn release --prerelease
+        if: ${{ env.IS_PRERELEASE == 'true' }}
       - run: npm publish
+        if: ${{ env.IS_PRERELEASE == 'false' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --tag prerelease
+        if: ${{ env.IS_PRERELEASE == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: echo NEW_TAG=$(git describe) >> $GITHUB_ENV
@@ -50,6 +59,7 @@ jobs:
           release_name: ${{ env.NEW_TAG }}
           body_path: ${{ env.CHANGELOG_PATH }}
           commitish: master
+          prerelease: ${{ env.IS_PRERELEASE }}
       - name: close issue
         uses: peter-evans/close-issue@v1
       - name: delete branch

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -2,12 +2,19 @@ name: start release
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Input release mode, "normal" or "prerelease".'
+        required: true
+        default: ''
 
 jobs:
   start_release:
+    if: github.event.inputs.mode == 'normal' || github.event.inputs.mode == 'prerelease'
     runs-on: ubuntu-latest
     env:
       RESULT_PATH: /tmp/result.txt
+      IS_PRERELEASE: ${{ github.event.inputs.mode == 'prerelease' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -26,18 +33,30 @@ jobs:
           git merge --no-edit ${{ github.ref }}
       - run: yarn install
       - name: release dry run
+        if: ${{ env.IS_PRERELEASE == 'false' }}
+        run: yarn release:dryrun > ${{ env.RESULT_PATH }}
+      - name: prerelease dry run
+        if: ${{ env.IS_PRERELEASE == 'true' }}
+        run: yarn release:dryrun --prerelease > ${{ env.RESULT_PATH }}
+      - name: wrap dry run log
         run: |
           echo "Dry Run Log:
           \`\`\`
-          $(yarn release:dryrun)
-          \`\`\`" >> ${{ env.RESULT_PATH }}
+          $(cat ${{ env.RESULT_PATH }})
+          \`\`\`" > ${{ env.RESULT_PATH }}
       - name: push branch
         run: |
           git checkout -b release-candidate
           git push origin release-candidate
+      - name: release issue labels
+        if: ${{ env.IS_PRERELEASE == 'false' }}
+        run: echo ISSUE_LABELS='release candidate' >> $GITHUB_ENV
+      - name: prerelease issue labels
+        if: ${{ env.IS_PRERELEASE == 'true' }}
+        run: echo ISSUE_LABELS='release candidate, prerelease' >> $GITHUB_ENV
       - name: create issue
         uses: peter-evans/create-issue-from-file@v2
         with:
           title: Release candidate
           content-filepath: ${{ env.RESULT_PATH }}
-          labels: release candidate
+          labels: ${{ env.ISSUE_LABELS }}

--- a/scripts/getLatestChangelog.ts
+++ b/scripts/getLatestChangelog.ts
@@ -11,7 +11,7 @@ stream.on('data', (chunk) => {
   buffer += chunk.toString('utf8')
   // The changelog after the second release header is for old version.
   // Therefore, the part before that is considered as the changelog for latest release.
-  const matched = buffer.match(/\n#+\s\[?\d+\.\d+.\d+\]?/g)
+  const matched = buffer.match(/\n#+\s\[?\d+\.\d+.\d+(-\d+)?\]?/g)
   if (matched === null || matched.length < 2) {
     return
   }


### PR DESCRIPTION
## Related URL
#1446 
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Actions からプレリリースが行えるように、ワークフローを修正します
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- リリースモード選択のための入力フィールド追加
- リリースモードによって各処理の分岐
- `getLatestChangelog` 内でプレリリースのヘッダにマッチするように正規表現を修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
