### PR TITLE
docs: modify overwriting styles in Story of FlashMessage

### DIFF
--- a/src/components/FlashMessage/FlashMessage.stories.tsx
+++ b/src/components/FlashMessage/FlashMessage.stories.tsx
@@ -146,7 +146,7 @@ const List = styled.ul`
 
   /* overwrite FlashMessage style */
   & > li > div {
-    bottom: auto;
-    left: auto;
+    position: static;
+    display: inline-flex;
   }
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`FlashMessage` の Story において、画面端に接している部分の影のグラデーションが回帰テストで差分検出されがちなので、コンポーネントが画面端に到達しないように修正。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Story におけるスタイルの上書き方法を修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
