### PR TITLE
Fix indicate `<FilterDropdown>` isFiltered state without color

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -1,4 +1,4 @@
-import { storiesOf } from '@storybook/react'
+import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
@@ -10,105 +10,112 @@ import { Input } from '../../Input'
 
 import readme from './README.md'
 
-storiesOf('Dropdown', module)
-  .addParameters({
-    readme: {
-      sidebar: readme,
+export default {
+  title: 'FilterDropdown',
+  Component: FilterDropdown,
+  parameters: {
+    docs: {
+      description: { component: readme },
+      source: {
+        type: 'code',
+      },
     },
-  })
-  .add('filter', () => {
-    const [value, setValue] = React.useState('hoge')
-    const [text, setText] = React.useState('')
-    const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
-    const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.currentTarget.value)
-    const themes = useTheme()
-    const [isFiltered, setIsFiltered] = React.useState(false)
-    const [isFiltered2, setIsFiltered2] = React.useState(true)
-    const [isFiltered3, setIsFiltered3] = React.useState(true)
+  },
+}
 
-    return (
-      <Wrapper themes={themes}>
-        <List>
-          <dt>nonFiltered</dt>
-          <dd>
-            <FilterDropdown
-              onApply={() => setIsFiltered(true)}
-              onCancel={() => setIsFiltered(false)}
-              onReset={() => {
-                setValue('hoge')
-                setText('')
-              }}
-              isFiltered={isFiltered}
-            >
-              <Text themes={themes}>
-                `FilterDropdown` provide specific interface to be able to filter data.
-                <br />
-                You can control inputs for filtering conditions as children components.
-              </Text>
-              <RadioButtonList>
-                <li>
-                  <RadioButtonLabel
-                    name="hoge"
-                    label="hoge"
-                    checked={value === 'hoge'}
-                    onChange={onChangeValue}
-                  />
-                </li>
-                <li>
-                  <RadioButtonLabel
-                    name="fuga"
-                    label="fuga"
-                    checked={value === 'fuga'}
-                    onChange={onChangeValue}
-                  />
-                </li>
-                <li>
-                  <RadioButtonLabel
-                    name="piyo"
-                    label="piyo"
-                    checked={value === 'piyo'}
-                    onChange={onChangeValue}
-                  />
-                </li>
-                <li>
-                  <Input name="test" value={text} onChange={onChangeText} />
-                </li>
-              </RadioButtonList>
-              <Description>
-                ↓<br />↓
-              </Description>
-              <Text themes={themes}>Children content is scrollable.</Text>
-            </FilterDropdown>
-          </dd>
-          <dt>Filtered</dt>
-          <dd>
-            <FilterDropdown
-              isFiltered={isFiltered2}
-              onApply={() => setIsFiltered2(true)}
-              onReset={() => setIsFiltered2(false)}
-            >
-              <Text themes={themes}>
-                You can change border color of the trigger button by setting `isFiltered`.
-              </Text>
-            </FilterDropdown>
-          </dd>
-          <dt>Filtered has status text</dt>
-          <dd>
-            <FilterDropdown
-              isFiltered={isFiltered3}
-              onApply={() => setIsFiltered3(true)}
-              onReset={() => setIsFiltered3(false)}
-              hasStatusText
-            >
-              <Text themes={themes}>
-                You can change border text and color of the trigger button by setting `isFiltered`.
-              </Text>
-            </FilterDropdown>
-          </dd>
-        </List>
-      </Wrapper>
-    )
-  })
+export const Default: Story = () => {
+  const [value, setValue] = React.useState('hoge')
+  const [text, setText] = React.useState('')
+  const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
+  const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.currentTarget.value)
+  const themes = useTheme()
+  const [isFiltered, setIsFiltered] = React.useState(false)
+  const [isFiltered2, setIsFiltered2] = React.useState(true)
+  const [isFiltered3, setIsFiltered3] = React.useState(true)
+
+  return (
+    <Wrapper themes={themes}>
+      <List>
+        <dt>nonFiltered</dt>
+        <dd>
+          <FilterDropdown
+            onApply={() => setIsFiltered(true)}
+            onCancel={() => setIsFiltered(false)}
+            onReset={() => {
+              setValue('hoge')
+              setText('')
+            }}
+            isFiltered={isFiltered}
+          >
+            <Text themes={themes}>
+              `FilterDropdown` provide specific interface to be able to filter data.
+              <br />
+              You can control inputs for filtering conditions as children components.
+            </Text>
+            <RadioButtonList>
+              <li>
+                <RadioButtonLabel
+                  name="hoge"
+                  label="hoge"
+                  checked={value === 'hoge'}
+                  onChange={onChangeValue}
+                />
+              </li>
+              <li>
+                <RadioButtonLabel
+                  name="fuga"
+                  label="fuga"
+                  checked={value === 'fuga'}
+                  onChange={onChangeValue}
+                />
+              </li>
+              <li>
+                <RadioButtonLabel
+                  name="piyo"
+                  label="piyo"
+                  checked={value === 'piyo'}
+                  onChange={onChangeValue}
+                />
+              </li>
+              <li>
+                <Input name="test" value={text} onChange={onChangeText} />
+              </li>
+            </RadioButtonList>
+            <Description>
+              ↓<br />↓
+            </Description>
+            <Text themes={themes}>Children content is scrollable.</Text>
+          </FilterDropdown>
+        </dd>
+        <dt>Filtered</dt>
+        <dd>
+          <FilterDropdown
+            isFiltered={isFiltered2}
+            onApply={() => setIsFiltered2(true)}
+            onReset={() => setIsFiltered2(false)}
+          >
+            <Text themes={themes}>
+              You can change border color of the trigger button by setting `isFiltered`.
+            </Text>
+          </FilterDropdown>
+        </dd>
+        <dt>Filtered has status text</dt>
+        <dd>
+          <FilterDropdown
+            isFiltered={isFiltered3}
+            onApply={() => setIsFiltered3(true)}
+            onReset={() => setIsFiltered3(false)}
+            hasStatusText
+          >
+            <Text themes={themes}>
+              You can change border text and color of the trigger button by setting `isFiltered`.
+            </Text>
+          </FilterDropdown>
+        </dd>
+      </List>
+    </Wrapper>
+  )
+}
 
 const Wrapper = styled.div<{ themes: Theme }>`
   padding: 24px;

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -1,5 +1,4 @@
 import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 import * as React from 'react'
 import styled from 'styled-components'
 
@@ -23,19 +22,23 @@ storiesOf('Dropdown', module)
     const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
     const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.currentTarget.value)
     const themes = useTheme()
+    const [isFiltered, setIsFiltered] = React.useState(false)
+    const [isFiltered2, setIsFiltered2] = React.useState(true)
+    const [isFiltered3, setIsFiltered3] = React.useState(true)
 
     return (
       <Wrapper themes={themes}>
         <List>
-          <dt>Controlled</dt>
+          <dt>nonFiltered</dt>
           <dd>
             <FilterDropdown
-              onApply={action('apply')}
-              onCancel={action('cancel')}
+              onApply={() => setIsFiltered(true)}
+              onCancel={() => setIsFiltered(false)}
               onReset={() => {
                 setValue('hoge')
                 setText('')
               }}
+              isFiltered={isFiltered}
             >
               <Text themes={themes}>
                 `FilterDropdown` provide specific interface to be able to filter data.
@@ -79,9 +82,26 @@ storiesOf('Dropdown', module)
           </dd>
           <dt>Filtered</dt>
           <dd>
-            <FilterDropdown isFiltered onApply={action('apply')} onReset={action('reset')}>
+            <FilterDropdown
+              isFiltered={isFiltered2}
+              onApply={() => setIsFiltered2(true)}
+              onReset={() => setIsFiltered2(false)}
+            >
               <Text themes={themes}>
                 You can change border color of the trigger button by setting `isFiltered`.
+              </Text>
+            </FilterDropdown>
+          </dd>
+          <dt>Filtered has status text</dt>
+          <dd>
+            <FilterDropdown
+              isFiltered={isFiltered3}
+              onApply={() => setIsFiltered3(true)}
+              onReset={() => setIsFiltered3(false)}
+              hasStatusText
+            >
+              <Text themes={themes}>
+                You can change border text and color of the trigger button by setting `isFiltered`.
               </Text>
             </FilterDropdown>
           </dd>
@@ -92,7 +112,7 @@ storiesOf('Dropdown', module)
 
 const Wrapper = styled.div<{ themes: Theme }>`
   padding: 24px;
-  color: ${({ themes }) => themes.palette.TEXT_BLACK};
+  color: ${({ themes }) => themes.color.TEXT_BLACK};
 `
 const List = styled.dl`
   margin: 0;
@@ -109,7 +129,7 @@ const List = styled.dl`
 const Text = styled.p<{ themes: Theme }>`
   margin: 0;
   font-size: 14px;
-  color: ${({ themes }) => themes.palette.TEXT_BLACK};
+  color: ${({ themes }) => themes.color.TEXT_BLACK};
 `
 const Description = styled.p`
   margin: 0;

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, VFC } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
 import { Dropdown } from '../Dropdown'
@@ -8,7 +8,7 @@ import { DropdownContent } from '../DropdownContent'
 import { DropdownCloser } from '../DropdownCloser'
 import { DropdownScrollArea } from '../DropdownScrollArea'
 import { PrimaryButton, SecondaryButton, TextButton } from '../../Button'
-import { FaCaretDownIcon, FaUndoAltIcon } from '../../Icon'
+import { FaCheckCircleIcon, FaFilterIcon, FaUndoAltIcon } from '../../Icon'
 
 type Props = {
   isFiltered?: boolean
@@ -16,6 +16,7 @@ type Props = {
   onCancel?: () => void
   onReset?: () => void
   children: ReactNode
+  hasStatusText?: boolean
 }
 
 export const FilterDropdown: VFC<Props> = ({
@@ -24,16 +25,29 @@ export const FilterDropdown: VFC<Props> = ({
   onCancel,
   onReset,
   children,
+  hasStatusText,
 }: Props) => {
   const themes = useTheme()
 
   return (
     <Dropdown>
-      <TriggerButtonWrapper themes={themes} isFiltered={isFiltered}>
-        <DropdownTrigger>
-          <SecondaryButton suffix={<FaCaretDownIcon />}>絞り込み</SecondaryButton>
-        </DropdownTrigger>
-      </TriggerButtonWrapper>
+      <DropdownTrigger>
+        <>
+          <SecondaryButton
+            suffix={
+              <IsFilteredIconWrapper isFiltered={isFiltered} themes={themes}>
+                <FaFilterIcon size={13} />
+                {isFiltered ? (
+                  <FaCheckCircleIcon size={8} aria-label={hasStatusText ? undefined : '適用中'} />
+                ) : null}
+              </IsFilteredIconWrapper>
+            }
+          >
+            絞り込み
+          </SecondaryButton>
+          {hasStatusText && isFiltered ? <StatusText themes={themes}>適用中</StatusText> : null}
+        </>
+      </DropdownTrigger>
       <DropdownContent controllable>
         <DropdownScrollArea>
           <ContentLayout>{children}</ContentLayout>
@@ -60,16 +74,23 @@ export const FilterDropdown: VFC<Props> = ({
   )
 }
 
-const TriggerButtonWrapper = styled.div<{ themes: Theme; isFiltered: boolean }>`
-  ${({ themes, isFiltered }) =>
-    isFiltered &&
-    css`
-      button {
-        border-color: ${themes.palette.WARNING};
-      }
-    `}
-`
+const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean; themes: Theme }>`
+  position: relative;
+  color: ${({ isFiltered, themes }) => {
+    return isFiltered ? themes.color.MAIN : themes.color.TEXT_BLACK
+  }};
+  line-height: 1;
 
+  & > [role='img'] + [role='img'] {
+    position: absolute;
+    right: -4px;
+    bottom: 2px;
+  }
+`
+const StatusText = styled.span<{ themes: Theme }>`
+  margin-left: ${({ themes }) => themes.spacing.XXS}px;
+  font-size: ${({ themes }) => themes.size.pxToRem(themes.fontSize.SHORT)};
+`
 const ContentLayout = styled.div`
   padding: 24px;
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-366?atlOrigin=eyJpIjoiNzBlMzNjY2QxNjEwNDQ1MTliY2RiYzMzY2NkNjkwZGMiLCJwIjoiaiJ9

## Overview

FilterDropdown is indicate filtered status with only border color. So users that can’t percept difference color can’t percept FilterDropdown status.

絞り込みされている状態 `isFiltered` を示すのが border の色変更のみとなっており、色が知覚できないユーザーには絞り込み状態を知覚することができない。

## What I did

- Set `FaFilterIcon` with `FaCheckIcon` when FilterDropdown is filtered.
- Add `hasStatusLabel` for indicate status with text
- Change color that indicate filtered to MAIN color.

## Capture

<img width="255" alt="capture FilterDropdown stories, non filtered, filtered, filtered with text" src="https://user-images.githubusercontent.com/6724665/114008589-5c414180-989d-11eb-9d17-e03de0cfb446.png">
