### PR TITLE
fix: change to display focus indicator in Accordion Panel

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -76,7 +76,6 @@ export const AccordionPanelTrigger: VFC<Props & ElementProps> = ({
 const resetButtonStyle = css`
   background-color: transparent;
   border: none;
-  outline: none;
   padding: 0;
   appearance: none;
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-297

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

I fixed the focus indicator not appearing when focusing on the element that triggers the opening and closing of the Accordion Panel.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- remove `outline: none ` 

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
