### PR TITLE
[WIP] fix: Dialog: suppressing scroll

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -54,7 +54,7 @@ export const Default: Story = () => {
   const themes = useTheme()
 
   return (
-    <>
+    <Wrapper>
       <SecondaryButton onClick={onClickOpen} aria-haspopup="dialog" aria-controls="dialog-default">
         Dialog
       </SecondaryButton>
@@ -65,50 +65,60 @@ export const Default: Story = () => {
         id="dialog-default"
         ariaLabel="Dialog"
       >
-        <Title themes={themes}>Dialog</Title>
-        <Description>
-          The value of isOpen must be managed by you, but you can customize content freely.
-        </Description>
-        <Content>
-          <DatePicker
-            value={date?.toDateString()}
-            formatDate={(_date) => (_date ? _date.toDateString() : '')}
-            onChangeDate={(_date) => setDate(_date)}
-          />
-        </Content>
-        <RadioList>
-          <li>
-            <RadioButtonLabel
-              name="Apple"
-              label="Apple"
-              checked={value === 'Apple'}
-              onChange={onChangeValue}
+        <Scroller>
+          <Title themes={themes}>Dialog</Title>
+          <Description>
+            The value of isOpen must be managed by you, but you can customize content freely.
+          </Description>
+          <Content>
+            <DatePicker
+              value={date?.toDateString()}
+              formatDate={(_date) => (_date ? _date.toDateString() : '')}
+              onChangeDate={(_date) => setDate(_date)}
             />
-          </li>
-          <li>
-            <RadioButtonLabel
-              name="Orange"
-              label="Orange"
-              checked={value === 'Orange'}
-              onChange={onChangeValue}
-            />
-          </li>
-          <li>
-            <RadioButtonLabel
-              name="Grape"
-              label="Grape"
-              checked={value === 'Grape'}
-              onChange={onChangeValue}
-            />
-          </li>
-        </RadioList>
-        <Footer themes={themes}>
-          <SecondaryButton onClick={onClickClose}>close</SecondaryButton>
-        </Footer>
+          </Content>
+          <RadioList>
+            <li>
+              <RadioButtonLabel
+                name="Apple"
+                label="Apple"
+                checked={value === 'Apple'}
+                onChange={onChangeValue}
+              />
+            </li>
+            <li>
+              <RadioButtonLabel
+                name="Orange"
+                label="Orange"
+                checked={value === 'Orange'}
+                onChange={onChangeValue}
+              />
+            </li>
+            <li>
+              <RadioButtonLabel
+                name="Grape"
+                label="Grape"
+                checked={value === 'Grape'}
+                onChange={onChangeValue}
+              />
+            </li>
+          </RadioList>
+          <Footer themes={themes}>
+            <SecondaryButton onClick={onClickClose}>close</SecondaryButton>
+          </Footer>
+        </Scroller>
       </Dialog>
-    </>
+    </Wrapper>
   )
 }
+
+const Wrapper = styled.div`
+  min-height: 110vh;
+`
+const Scroller = styled.div`
+  max-height: 300px;
+  overflow-y: scroll;
+`
 
 const dummyText = (
   <>

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, VFC, useCallback, useRef } from 'react'
+import React, { ReactNode, VFC, useCallback, useEffect, useRef } from 'react'
 import styled, { createGlobalStyle, css } from 'styled-components'
 import { CSSTransition } from 'react-transition-group'
 
@@ -6,6 +6,11 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { useHandleEscape } from '../../hooks/useHandleEscape'
 import { DialogPositionProvider } from './DialogPositionProvider'
 import { FocusTrap } from './FocusTrap'
+
+const suppressingScroll = (e) => e.preventDefault()
+const SUPPRESSING_SCROLL_OPTIONS = { passive: false }
+const addDocumentEventLister = document.addEventListener.bind(document)
+const removeDocumentEventLister = document.removeEventListener.bind(document)
 
 export type DialogContentInnerProps = {
   /**
@@ -97,6 +102,13 @@ export const DialogContentInner: VFC<DialogContentInnerProps> = ({
     onClickOverlay && onClickOverlay()
   }, [isOpen, onClickOverlay])
 
+  useEffect(() => {
+    const method = isOpen ? addDocumentEventLister : removeDocumentEventLister
+
+    method('mousewheel', suppressingScroll, SUPPRESSING_SCROLL_OPTIONS)
+    method('touchmove', suppressingScroll, SUPPRESSING_SCROLL_OPTIONS)
+  }, [isOpen])
+
   return (
     <DialogPositionProvider top={props.top} bottom={props.bottom}>
       <CSSTransition
@@ -127,7 +139,6 @@ export const DialogContentInner: VFC<DialogContentInnerProps> = ({
             </Inner>
           </FocusTrap>
           {/* Suppresses scrolling of body while modal is displayed */}
-          <ScrollSuppressing />
         </Wrapper>
       </CSSTransition>
     </DialogPositionProvider>
@@ -213,9 +224,4 @@ const Background = styled.div<{ themes: Theme }>`
       background-color: ${themes.palette.SCRIM};
     `
   }}
-`
-const ScrollSuppressing = createGlobalStyle`
-  body {
-    overflow: hidden;
-  }
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- Dialog の表示・非表示でbodyのscrollが切り替えられてしまい、画面幅が変わることでガタツキが発生してしまう場合がある
- styleに頼らずscriptでscrollを制御することでガタつかないようにしたい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- mousewheel, touchmove イベントでscrollをキャンセルする処理を追加
  - passive を false にすることでjsによるブロッキングを回避しました 

## Capture

<!--
Please attach a capture if it looks different.
-->
