### PR TITLE
New focus appearance

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -78,7 +78,7 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { frame, size, interaction } = themes
+    const { frame, size, interaction, shadow } = themes
 
     return css`
       display: inline-flex;
@@ -134,6 +134,11 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       &:hover,
       &:focus {
         text-decoration: none;
+      }
+
+      &:focus {
+        outline: 0;
+        box-shadow: ${shadow.OUTLINE};
       }
     `
   }}

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -84,7 +84,7 @@ const Box = styled.span<{ themes: Theme }>`
 `
 const Input = styled.input<{ themes: Theme }>`
   ${({ themes }) => {
-    const { MAIN, OUTLINE } = themes.palette
+    const { shadow, color } = themes
     return css`
       opacity: 0;
       position: absolute;
@@ -98,10 +98,10 @@ const Input = styled.input<{ themes: Theme }>`
         pointer-events: none;
       }
       &:hover + span {
-        box-shadow: 0 0 0 2px ${transparentize(0.78, MAIN)};
+        box-shadow: 0 0 0 2px ${transparentize(0.78, color.MAIN)};
       }
       &:focus + span {
-        box-shadow: 0 0 0 2px ${OUTLINE};
+        box-shadow: ${shadow.OUTLINE};
       }
     `
   }}

--- a/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/src/components/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`CheckBox should be match snapshot 1`] = `
 }
 
 .c1:focus + span {
-  box-shadow: 0 0 0 2px rgba(0,119,199,0.5);
+  box-shadow: 0 0 0 2px white,0 0 0 4px #0077c7;
 }
 
 .c3 {

--- a/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
+++ b/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
 }
 
 .c3:focus + span {
-  box-shadow: 0 0 0 2px rgba(0,119,199,0.5);
+  box-shadow: 0 0 0 2px white,0 0 0 4px #0077c7;
 }
 
 .c5 {

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -86,7 +86,7 @@ const Box = styled.span<{ themes: Theme }>`
 `
 const Input = styled.input<{ themes: Theme }>`
   ${({ themes }) => {
-    const { OUTLINE } = themes.palette
+    const { OUTLINE } = themes.shadow
 
     return css`
       opacity: 0;
@@ -103,7 +103,7 @@ const Input = styled.input<{ themes: Theme }>`
       }
 
       &:focus + span {
-        box-shadow: 0 0 0 2px ${OUTLINE};
+        box-shadow: ${OUTLINE};
       }
     `
   }}

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -30,7 +30,7 @@ export type CreatedColorTheme = Palette & {
   disableColor: (value: string) => string
 }
 
-export const defaultColor = {
+const baseColor = {
   TEXT_BLACK: '#23221f',
   TEXT_GREY: '#706d65',
   TEXT_DISABLED: '#c1bdb7',
@@ -50,13 +50,14 @@ export const defaultColor = {
   BRAND: '#00c4cc',
 }
 
+export const defaultColor = { ...baseColor, OUTLINE: baseColor.MAIN }
+
 export const createColor = (userColor: ColorProperty = {}) => {
   const created: CreatedColorTheme = merge(
     {
       hoverColor: (value: string, darkenAmount: 0.05 | 0.15 = 0.05): string =>
         darken(darkenAmount, value),
       disableColor: (value: string): string => rgba(value, 0.5),
-      OUTLINE: transparentize(0.5, defaultColor.MAIN),
       ...defaultColor,
     },
     userColor,

--- a/src/themes/createPalette.ts
+++ b/src/themes/createPalette.ts
@@ -1,5 +1,5 @@
 import { merge } from '../libs/lodash'
-import { darken, rgba, transparentize } from 'polished'
+import { darken, rgba } from 'polished'
 
 // Allow deviations from the JavaScript naming convention to match SmartHR design guidelines
 export interface PaletteProperty {
@@ -74,13 +74,11 @@ export const createPalette = (userPalette: PaletteProperty = {}) => {
       hoverColor: (value: string, darkenAmount: 0.05 | 0.15 = 0.05): string =>
         darken(darkenAmount, value),
       disableColor: (value: string): string => rgba(value, 0.5),
-      OUTLINE: transparentize(0.5, defaultPalette.MAIN),
+      OUTLINE: defaultPalette.MAIN,
       ...defaultPalette,
     },
     userPalette,
-    userPalette.OUTLINE == null && userPalette.MAIN != null
-      ? { OUTLINE: transparentize(0.5, userPalette.MAIN) }
-      : null,
+    userPalette.OUTLINE == null && userPalette.MAIN != null ? { OUTLINE: userPalette.MAIN } : null,
   )
   return created
 }

--- a/src/themes/createShadow.ts
+++ b/src/themes/createShadow.ts
@@ -1,26 +1,25 @@
 import { merge } from '../libs/lodash'
+import { defaultColor } from './createColor'
 
 export interface ShadowProperty {
   BASE?: string
   DIALOG?: string
+  OUTLINE?: string
 }
 
 export interface CreatedShadowTheme {
   BASE: string
   DIALOG: string
+  OUTLINE: string
 }
 
 export const defaultShadow = {
   BASE: 'rgba(51, 51, 51, 0.15) 0 0 4px 0',
   DIALOG: 'rgba(51, 51, 51, 0.3) 0 4px 10px 0',
+  OUTLINE: `0 0 0 2px white, 0 0 0 4px ${defaultColor.OUTLINE}`,
 }
 
 export const createShadow = (userShadow: ShadowProperty = {}) => {
-  const created: CreatedShadowTheme = merge(
-    {
-      ...defaultShadow,
-    },
-    userShadow,
-  )
+  const created: CreatedShadowTheme = merge({ ...defaultShadow }, userShadow)
   return created
 }


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-386

## Overview

[WCAG 2.2の達成基準](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum)を満たしたフォーカスの見た目を新しく作成した。

Create the appearance of a focus that meets the [WCAG 2.2 achievement criteria](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum)

### Problem

- テーマに定義されている `OUTLINE` の色が淡く、背景色とのコントラスト比が WCAG 2.2 の 2.4.11, 2.4.12 で提案されているフォーカスの見た目の達成基準（ `3:1` OR `4.5:1` ）を満たせていない。
- Google Chrome のデフォルトフォーカスインジケータの青色とテーマの `MAIN` が類似しており、フォーカスインジケータが視認しにくい。

----

- The color of the `OUTLINE` defined in the theme is pale and the contrast ratio with the background color does not meet the criteria for achieving the focus appearance (`3:1` OR `4.5:1`) proposed in WCAG 2.2, 2.4.11 and 2.4.12.
- The blue color of the default focus indicator in Google Chrome and the theme `MAIN` are similar, making the focus indicator difficult to see.

<details open>
<summary>screenshot of PrimaryButton is focused and not focused by Google Chrome</summary>
<img width="485" alt="" src="https://user-images.githubusercontent.com/6724665/114653628-69d64b80-9d23-11eb-9e8e-569fe32f1e3d.png">
</details>


## What I did

- フォーカスインジケータに使用する色をコントラスト比が確保されている `MAIN` に変更
- テーマの `shadow` に `OUTLINE` を追加
- `<PrimaryButton>` などの `MAIN` が背景色に利用されているフォーカス可能な要素における視認性確保のため、要素とアウトラインの間に擬似的なオフセットを追加
- WCAG 2.2 2.4.11 を達成するためにアウトラインの幅を `2px` に

---

- Changed the color used for the focus indicator to `MAIN`, which ensures a good contrast ratio.
- Added the `OUTLINE` to `shadow` of themes.
- Added a pseudo-offset between the element and the outline for visibility in focusable elements with `MAIN` as background color, such as `<PrimaryButton>`.
- Set outline width to `2px` to achieve WCAG 2.2 2.4.11

## Capture

| `<Button>` | `<Checkbox>` | `<RadioButton>` |
| ---- | ---- | ---- |
|<img width="104" alt="screenshot of focused Button component" src="https://user-images.githubusercontent.com/6724665/114654364-fa615b80-9d24-11eb-9436-f34c08df053d.png">|<img width="117" alt="screenshot of focused Checkbox component" src="https://user-images.githubusercontent.com/6724665/114654379-077e4a80-9d25-11eb-80c5-9a898169da5b.png">|<img width="43" alt="screenshot of focused RadioButton component" src="https://user-images.githubusercontent.com/6724665/114654412-16fd9380-9d25-11eb-86b2-6ef3d1641560.png">|

## TODO

- グローバルなフォーカススタイルを定義するかどうかを検討
- `<Input>` など他のフォーカス可能な要素のスタイル反映
- ポインターを中心に利用するユーザーのための控えめなフォーカスの見た目の検討

----

- Consider whether to define a global focus style.
- Apply styles of other focusable elements such as `<Input>`.
- Consideration of a discreet focus look for users who use the pointer as a centerpiece.