### PR TITLE
chore: move PR creation to the end of publishRelease job

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -41,15 +41,6 @@ jobs:
       - run: echo NEW_TAG=$(git describe) >> $GITHUB_ENV
       - run: git push origin $NEW_TAG
       - run: npx ts-node ./scripts/getLatestChangelog.ts > ${{ env.CHANGELOG_PATH }}
-      - name: cherry-pick release commit
-        run: |
-          git checkout master
-          git cherry-pick $NEW_TAG
-      - name: craete pull request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          title: 'chore(release): ${{ env.NEW_TAG }}'
-          branch: 'merge-release-${{ env.NEW_TAG }}'
       - name: create release on GitHub
         uses: actions/create-release@v1
         env:
@@ -64,3 +55,12 @@ jobs:
         uses: peter-evans/close-issue@v1
       - name: delete branch
         run: git push origin :release-candidate
+      - name: cherry-pick release commit
+        run: |
+          git checkout master
+          git cherry-pick $NEW_TAG
+      - name: craete pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: 'chore(release): ${{ env.NEW_TAG }}'
+          branch: 'merge-release-${{ env.NEW_TAG }}'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
自動リリースで PR を作成する際に、 `cherry-pick` でコンフリクトが発生してワークフローが中断する可能性があるため、残作業を最小限にするために PR 作成の step を job の最後尾に移動する
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `cherry-pick` および `create-pull-request` の step を最後尾に移動
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
