### PR TITLE
Fix mobile Safari not showing all options for Select component  (SHRUI-392)

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -19,10 +19,10 @@ storiesOf('Select', module)
         <Text>default</Text>
         <Select
           options={[
-            { label: 'apple', value: 'apple' },
-            { label: 'orange', value: 'orange' },
-            { label: 'banana', value: 'banana' },
-            { label: 'melon', value: 'melon', disabled: true },
+            { label: 'Apple', value: 'apple' },
+            { label: 'Orange', value: 'orange' },
+            { label: 'Banana', value: 'banana' },
+            { label: 'Melon', value: 'melon', disabled: true },
           ]}
         />
       </li>
@@ -31,9 +31,9 @@ storiesOf('Select', module)
         <Select
           value="orange"
           options={[
-            { label: 'apple', value: 'apple' },
-            { label: 'orange', value: 'orange' },
-            { label: 'banana', value: 'banana' },
+            { label: 'Apple', value: 'apple' },
+            { label: 'Orange', value: 'orange' },
+            { label: 'Banana', value: 'banana' },
           ]}
         />
       </li>
@@ -42,9 +42,9 @@ storiesOf('Select', module)
         <Select
           error
           options={[
-            { label: 'apple', value: 'apple' },
-            { label: 'orange', value: 'orange' },
-            { label: 'banana', value: 'banana' },
+            { label: 'Apple', value: 'apple' },
+            { label: 'Orange', value: 'orange' },
+            { label: 'Banana', value: 'banana' },
           ]}
         />
       </li>
@@ -53,9 +53,9 @@ storiesOf('Select', module)
         <Select
           disabled
           options={[
-            { label: 'apple', value: 'apple' },
-            { label: 'orange', value: 'orange' },
-            { label: 'banana', value: 'banana' },
+            { label: 'Apple', value: 'apple' },
+            { label: 'Orange', value: 'orange' },
+            { label: 'Banana', value: 'banana' },
           ]}
         />
       </li>
@@ -65,9 +65,9 @@ storiesOf('Select', module)
           value=""
           options={[
             { label: 'Select fruit', value: '' },
-            { label: 'apple', value: 'apple' },
-            { label: 'orange', value: 'orange' },
-            { label: 'banana', value: 'banana' },
+            { label: 'Apple', value: 'apple' },
+            { label: 'Orange', value: 'orange' },
+            { label: 'Banana', value: 'banana' },
           ]}
         />
       </li>
@@ -77,23 +77,23 @@ storiesOf('Select', module)
           value="orange"
           options={[
             { label: 'Select fruit', value: '' },
-            { label: 'apple', value: 'apple' },
+            { label: 'Apple', value: 'apple' },
             {
               label: 'citrus',
               options: [
-                { label: 'orange', value: 'orange' },
-                { label: 'lemon', value: 'lemon' },
-                { label: 'grapefruit', value: 'grapefruit' },
+                { label: 'Orange', value: 'orange' },
+                { label: 'Lemon', value: 'lemon' },
+                { label: 'Grapefruit', value: 'grapefruit' },
               ],
             },
-            { label: 'banana', value: 'banana' },
+            { label: 'Banana', value: 'banana' },
             {
-              label: 'fruit vegetables',
+              label: 'Fruit vegetables',
               disabled: true,
               options: [
-                { label: 'strawberry', value: 'strawberry' },
-                { label: 'melon', value: 'melon' },
-                { label: 'water melon', value: 'water melon' },
+                { label: 'Strawberry', value: 'strawberry' },
+                { label: 'Melon', value: 'melon' },
+                { label: 'Water melon', value: 'water melon' },
               ],
             },
           ]}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -53,7 +53,11 @@ export const Select: FC<Props> = ({
         {hasBlank && <option value="">{blankLabel}</option>}
         {options.map((option) => {
           if ('value' in option) {
-            return <option key={option.value} {...option} />
+            return (
+              <option key={option.value} {...option}>
+                {option.label}
+              </option>
+            )
           }
 
           const { options: groupedOptions, ...optgroup } = option
@@ -61,7 +65,9 @@ export const Select: FC<Props> = ({
           return (
             <optgroup key={optgroup.label} {...optgroup}>
               {groupedOptions.map((groupedOption) => (
-                <option key={groupedOption.value} {...groupedOption} />
+                <option key={groupedOption.value} {...groupedOption}>
+                  {groupedOption.label}
+                </option>
               ))}
             </optgroup>
           )


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-392

## Overview

Mobile Safari で Select コンポーネントのアイテム名が表示されない問題を修正したい

## What I did

- Select.stories.tsx
  - label と value の判別がつくように異なる名称にした
- Select.tsx
  - option 要素の children にも label を渡すようにした

## Capture

|Before|After|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5195381/114871469-451dc900-9e34-11eb-93c1-8f8058bcffad.png) | ![image](https://user-images.githubusercontent.com/5195381/114871413-39320700-9e34-11eb-892a-06faa724eb74.png)|

