### PR TITLE
feat: enable to be able to make anchor button disabled (SHRUI-363)

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -46,10 +46,6 @@ export type BaseProps = {
    * If `true`, the component shape changes width is 100%
    */
   wide?: boolean
-  /**
-   * If `true`, the button becomes disabled.
-   */
-  disabled?: boolean
 }
 
 export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
@@ -173,32 +169,8 @@ const tagStore = {
 export const BaseButton: VFC<ButtonProps> = buttonFactory<ButtonProps>('button')
 
 const AnchorButton: VFC<AnchorProps> = buttonFactory<AnchorProps>('a')
-
-export const BaseButtonAnchor: VFC<AnchorProps> = ({ disabled, href, onClick, ...props }) => {
-  const controlledHref = React.useMemo(() => {
-    // When disabled, make href undefined
-    return disabled ? undefined : href
-  }, [disabled, href])
-
-  const controlledOnClick = React.useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (disabled) {
-        // When disabled, do not fire click event
-        e.preventDefault()
-        e.stopPropagation()
-        return
-      }
-      onClick && onClick(e)
-    },
-    [disabled, onClick],
-  )
-
-  return (
-    <AnchorButton
-      {...props}
-      href={controlledHref}
-      onClick={controlledOnClick}
-      disabled={disabled}
-    />
-  )
-}
+export const BaseButtonAnchor = styled(AnchorButton)`
+  &:not([href]) {
+    cursor: not-allowed;
+  }
+`

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -46,6 +46,10 @@ export type BaseProps = {
    * If `true`, the component shape changes width is 100%
    */
   wide?: boolean
+  /**
+   * If `true`, the button becomes disabled.
+   */
+  disabled?: boolean
 }
 
 export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
@@ -167,4 +171,34 @@ const tagStore = {
 }
 
 export const BaseButton: VFC<ButtonProps> = buttonFactory<ButtonProps>('button')
-export const BaseButtonAnchor: VFC<AnchorProps> = buttonFactory<AnchorProps>('a')
+
+const AnchorButton: VFC<AnchorProps> = buttonFactory<AnchorProps>('a')
+
+export const BaseButtonAnchor: VFC<AnchorProps> = ({ disabled, href, onClick, ...props }) => {
+  const controlledHref = React.useMemo(() => {
+    // When disabled, make href undefined
+    return disabled ? undefined : href
+  }, [disabled, href])
+
+  const controlledOnClick = React.useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (disabled) {
+        // When disabled, do not fire click event
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+      onClick && onClick(e)
+    },
+    [disabled, onClick],
+  )
+
+  return (
+    <AnchorButton
+      {...props}
+      href={controlledHref}
+      onClick={controlledOnClick}
+      disabled={disabled}
+    />
+  )
+}

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -81,9 +81,14 @@ AnchorButton.parameters = {
 }
 
 export const Disabled: Story = () => (
-  <PrimaryButton disabled onClick={action('clicked')}>
-    Disabled
-  </PrimaryButton>
+  <Wrapper onClick={() => console.log('wapper')}>
+    <PrimaryButton disabled onClick={action('clicked')}>
+      Button
+    </PrimaryButton>
+    <PrimaryButtonAnchor disabled href="#" onClick={action('clicked')}>
+      Anchor
+    </PrimaryButtonAnchor>
+  </Wrapper>
 )
 Disabled.parameters = {
   docs: {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -85,7 +85,7 @@ export const Disabled: Story = () => (
     <PrimaryButton disabled onClick={action('clicked')}>
       Button
     </PrimaryButton>
-    <PrimaryButtonAnchor disabled href="#" onClick={action('clicked')}>
+    <PrimaryButtonAnchor href={undefined} onClick={action('clicked')}>
       Anchor
     </PrimaryButtonAnchor>
   </Wrapper>

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -47,17 +47,24 @@ const dangerStyle = css`
       &.hover {
         background-color: ${palette.hoverColor(palette.DANGER)};
       }
-
-      &[disabled] {
-        background-color: ${palette.disableColor(palette.DANGER)};
-        color: ${palette.disableColor('#fff')};
-      }
     `
   }}
 `
+const disabledStyle = css`
+  ${({ themes: { color } }: { themes: Theme }) => css`
+    background-color: ${color.disableColor(color.DANGER)};
+    color: ${color.disableColor('#fff')};
+  `}
+`
 const DangerStyleButton = styled(BaseButton)`
   ${dangerStyle}
+  &[disabled] {
+    ${disabledStyle}
+  }
 `
 const DangerStyleButtonAnchor = styled(BaseButtonAnchor)`
   ${dangerStyle}
+  &:not([href]) {
+    ${disabledStyle}
+  }
 `

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -57,17 +57,24 @@ const primaryStyle = css`
         background-color: ${palette.hoverColor(palette.MAIN)};
         color: #fff;
       }
-
-      &[disabled] {
-        background-color: ${palette.disableColor(palette.MAIN)};
-        color: ${palette.disableColor('#fff')};
-      }
     `
   }}
 `
+const disabledStyle = css`
+  ${({ themes: { color } }: { themes: Theme }) => css`
+    background-color: ${color.disableColor(color.MAIN)};
+    color: ${color.disableColor('#fff')};
+  `}
+`
 const PrimaryStyleButton = styled(BaseButton)`
   ${primaryStyle}
+  &[disabled] {
+    ${disabledStyle}
+  }
 `
 const PrimaryStyleButtonAnchor = styled(BaseButtonAnchor)`
   ${primaryStyle}
+  &:not([href]) {
+    ${disabledStyle}
+  }
 `

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -59,17 +59,24 @@ const secondaryStyle = css`
         background-color: ${palette.hoverColor('#fff')};
         color: ${palette.TEXT_BLACK};
       }
-
-      &[disabled] {
-        background-color: ${palette.COLUMN};
-        color: ${palette.TEXT_DISABLED};
-      }
     `
   }}
 `
+const disabledStyle = css`
+  ${({ themes: { color } }: { themes: Theme }) => css`
+    background-color: ${color.COLUMN};
+    color: ${color.TEXT_DISABLED};
+  `}
+`
 const SecondaryStyleButton = styled(BaseButton)`
   ${secondaryStyle}
+  &[disabled] {
+    ${disabledStyle}
+  }
 `
 const SecondaryStyleButtonAnchor = styled(BaseButtonAnchor)`
   ${secondaryStyle}
+  &:not([href]) {
+    ${disabledStyle}
+  }
 `

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -49,17 +49,24 @@ const skeletonStyle = css`
         background-color: ${palette.OVERLAY};
         color: #fff;
       }
-
-      &[disabled] {
-        background-color: transparent;
-        color: ${palette.disableColor('#fff')};
-      }
     `
   }}
 `
+const disabledStyle = css`
+  ${({ themes: { color } }: { themes: Theme }) => css`
+    background-color: transparent;
+    color: ${color.disableColor('#fff')};
+  `}
+`
 const SkeletonStyleButton = styled(BaseButton)`
   ${skeletonStyle}
+  &[disabled] {
+    ${disabledStyle}
+  }
 `
 const SkeletonStyleButtonAnchor = styled(BaseButtonAnchor)`
   ${skeletonStyle}
+  &:not([href]) {
+    ${disabledStyle}
+  }
 `

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -57,17 +57,24 @@ const textStyle = css`
         background-color: ${palette.hoverColor('#fff')};
         color: ${palette.TEXT_BLACK};
       }
-
-      &[disabled] {
-        background-color: transparent;
-        color: ${palette.disableColor(palette.TEXT_DISABLED)};
-      }
     `
   }}
 `
+const disabledStyle = css`
+  ${({ themes: { color } }: { themes: Theme }) => css`
+    background-color: transparent;
+    color: ${color.disableColor(color.TEXT_DISABLED)};
+  `}
+`
 const TextStyleButton = styled(BaseButton)`
   ${textStyle}
+  &[disabled] {
+    ${disabledStyle}
+  }
 `
 const TextStyleButtonAnchor = styled(BaseButtonAnchor)`
   ${textStyle}
+  &:not([href]) {
+    ${disabledStyle}
+  }
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-363
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Each anchor button in `Button` can not be `disabled`, but it is useful that we can, so this PR enables to be able to make anchor button disabled.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Make to be able to set `disable` prop to anchor button.
- Modify `href` and `onClick` of `BaseButtonAnchor` not to button operate when button is disabled.
- Add disabled anchor button in Story.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
![image](https://user-images.githubusercontent.com/270422/115006796-3d1d6200-9ee4-11eb-8c62-11412f3971bd.png)

<!--
Please attach a capture if it looks different.
-->
