### PR TITLE
fix: fix DatePicker for IE11 (SHRUI-391)

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -67,7 +67,7 @@ export const DatePicker: VFC<Props & InputAttributes> = ({
   const inputRef = useRef<HTMLInputElement>(null)
   const inputWrapperRef = useRef<HTMLDivElement>(null)
   const calendarPortalRef = useRef<HTMLDivElement>(null)
-  const [inputRect, setInputRect] = useState<DOMRect>(new DOMRect())
+  const [inputRect, setInputRect] = useState<DOMRect | null>(null)
   const [isInputFocused, setIsInputFocused] = useState(false)
   const [isCalendarShown, setIsCalendarShown] = useState(false)
 
@@ -237,7 +237,7 @@ export const DatePicker: VFC<Props & InputAttributes> = ({
           ref={inputRef}
         />
       </InputWrapper>
-      {isCalendarShown && (
+      {isCalendarShown && inputRect && (
         <Portal inputRect={inputRect} ref={calendarPortalRef}>
           <Calendar
             value={selectedDate || undefined}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-391
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
The `DatePicker` component is not working on IE11. The reason is that `new DOMRect()` is not supported for IE11.

This PR will modify not to do `new DOMRect()`, and make `DatePicker` can work on IE11.
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace blank `DOMRect` to `null`
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
