### PR TITLE
fix: improve scroll suppression in Dialog (SHRUI-380)

### DIFF
--- a/src/components/Dialog/BodyScrollSuppressor.tsx
+++ b/src/components/Dialog/BodyScrollSuppressor.tsx
@@ -1,16 +1,16 @@
-import React, { VFC } from 'react'
+import React, { VFC, useEffect, useState } from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 
 export const BodyScrollSuppressor: VFC = () => {
-  const [originalWidth, setOriginalWidth] = React.useState<number | null>(null)
-  const [paddingRightValue, setPaddingRightValue] = React.useState('0px')
-  const [scrollbarWidth, setScrollbarWidth] = React.useState(0)
+  const [originalWidth, setOriginalWidth] = useState<number | null>(null)
+  const [paddingRightValue, setPaddingRightValue] = useState('0px')
+  const [scrollbarWidth, setScrollbarWidth] = useState(0)
 
-  React.useEffect(() => {
+  useEffect(() => {
     setOriginalWidth(document.body.clientWidth)
   }, [])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (originalWidth === null) {
       return
     }

--- a/src/components/Dialog/BodyScrollSuppressor.tsx
+++ b/src/components/Dialog/BodyScrollSuppressor.tsx
@@ -1,0 +1,46 @@
+import React, { VFC } from 'react'
+import { createGlobalStyle, css } from 'styled-components'
+
+export const BodyScrollSuppressor: VFC = () => {
+  const [initialized, setInitialized] = React.useState(false)
+  const [originalWidth, setOriginalWidth] = React.useState(0)
+  const [widthDiff, setWidthDiff] = React.useState(0)
+
+  React.useEffect(() => {
+    setInitialized(true)
+    return () => setInitialized(false)
+  }, [])
+
+  React.useEffect(() => {
+    if (!initialized) {
+      setOriginalWidth(document.body.clientWidth)
+    }
+  }, [initialized])
+
+  React.useEffect(() => {
+    if (!initialized) {
+      return
+    }
+    const currentWidth = document.body.clientWidth
+    const diff = currentWidth - originalWidth
+    if (diff > 0) {
+      setWidthDiff(diff)
+    }
+  }, [initialized, originalWidth])
+
+  if (!initialized) {
+    return null
+  }
+  return <ScrollSuppressing widthDiff={widthDiff} />
+}
+
+const ScrollSuppressing = createGlobalStyle<{ widthDiff: number }>`
+  body {
+    overflow: hidden;
+    ${({ widthDiff }) =>
+      widthDiff > 0 &&
+      css`
+        padding-right: ${widthDiff}px !important;
+      `}
+  }
+`

--- a/src/components/Dialog/BodyScrollSuppressor.tsx
+++ b/src/components/Dialog/BodyScrollSuppressor.tsx
@@ -3,18 +3,18 @@ import { createGlobalStyle, css } from 'styled-components'
 
 export const BodyScrollSuppressor: VFC = () => {
   const [originalWidth, setOriginalWidth] = React.useState<number | null>(null)
-  const [originalPaddingRight, setOriginalPaddingRight] = React.useState('0px')
+  const [paddingRightValue, setPaddingRightValue] = React.useState('0px')
   const [scrollbarWidth, setScrollbarWidth] = React.useState(0)
 
   React.useEffect(() => {
     setOriginalWidth(document.body.clientWidth)
-    setOriginalPaddingRight(getComputedStyle(document.body).getPropertyValue('padding-right'))
   }, [])
 
   React.useEffect(() => {
     if (originalWidth === null) {
       return
     }
+    setPaddingRightValue(getComputedStyle(document.body).getPropertyValue('padding-right'))
     const currentWidth = document.body.clientWidth
     const widthDiff = currentWidth - originalWidth
     if (widthDiff > 0) {
@@ -25,24 +25,19 @@ export const BodyScrollSuppressor: VFC = () => {
   if (originalWidth === null) {
     return null
   }
-  return (
-    <ScrollSuppressing
-      originalPaddingRight={originalPaddingRight}
-      scrollbarWidth={scrollbarWidth}
-    />
-  )
+  return <ScrollSuppressing paddingRightValue={paddingRightValue} scrollbarWidth={scrollbarWidth} />
 }
 
 const ScrollSuppressing = createGlobalStyle<{
-  originalPaddingRight: string
+  paddingRightValue: string
   scrollbarWidth: number
 }>`
   body {
     overflow: hidden;
-    ${({ originalPaddingRight, scrollbarWidth }) =>
+    ${({ paddingRightValue, scrollbarWidth }) =>
       scrollbarWidth > 0 &&
       css`
-        padding-right: calc(${originalPaddingRight} + ${scrollbarWidth}px) !important;
+        padding-right: calc(${paddingRightValue} + ${scrollbarWidth}px) !important;
       `}
   }
 `

--- a/src/components/Dialog/BodyScrollSuppressor.tsx
+++ b/src/components/Dialog/BodyScrollSuppressor.tsx
@@ -2,42 +2,36 @@ import React, { VFC, useEffect, useState } from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 
 export const BodyScrollSuppressor: VFC = () => {
-  const [originalWidth, setOriginalWidth] = useState<number | null>(null)
-  const [paddingRightValue, setPaddingRightValue] = useState('0px')
-  const [scrollbarWidth, setScrollbarWidth] = useState(0)
+  const [scrollBarWidth, setScrollBarWidth] = useState<number | null>(null)
+  const [paddingRight, setPaddingRight] = useState<number | null>(null)
 
   useEffect(() => {
-    setOriginalWidth(document.body.clientWidth)
+    setScrollBarWidth(window.innerWidth - document.body.clientWidth)
   }, [])
 
   useEffect(() => {
-    if (originalWidth === null) {
+    if (scrollBarWidth === null) {
       return
     }
-    setPaddingRightValue(getComputedStyle(document.body).getPropertyValue('padding-right'))
-    const currentWidth = document.body.clientWidth
-    const widthDiff = currentWidth - originalWidth
-    if (widthDiff > 0) {
-      setScrollbarWidth(widthDiff)
-    }
-  }, [originalWidth])
+    const originalPaddingRight = getComputedStyle(document.body).getPropertyValue('padding-right')
+    setPaddingRight(scrollBarWidth + parseInt(originalPaddingRight, 10))
+  }, [scrollBarWidth])
 
-  if (originalWidth === null) {
+  if (scrollBarWidth === null) {
     return null
   }
-  return <ScrollSuppressing paddingRightValue={paddingRightValue} scrollbarWidth={scrollbarWidth} />
+  return <ScrollSuppressing paddingRight={paddingRight} />
 }
 
 const ScrollSuppressing = createGlobalStyle<{
-  paddingRightValue: string
-  scrollbarWidth: number
+  paddingRight: number | null
 }>`
   body {
     overflow: hidden;
-    ${({ paddingRightValue, scrollbarWidth }) =>
-      scrollbarWidth > 0 &&
+    ${({ paddingRight }) =>
+      paddingRight &&
       css`
-        padding-right: calc(${paddingRightValue} + ${scrollbarWidth}px) !important;
+        padding-right: ${paddingRight}px !important;
       `}
   }
 `

--- a/src/components/Dialog/BodyScrollSuppressor.tsx
+++ b/src/components/Dialog/BodyScrollSuppressor.tsx
@@ -2,45 +2,47 @@ import React, { VFC } from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 
 export const BodyScrollSuppressor: VFC = () => {
-  const [initialized, setInitialized] = React.useState(false)
-  const [originalWidth, setOriginalWidth] = React.useState(0)
-  const [widthDiff, setWidthDiff] = React.useState(0)
+  const [originalWidth, setOriginalWidth] = React.useState<number | null>(null)
+  const [originalPaddingRight, setOriginalPaddingRight] = React.useState('0px')
+  const [scrollbarWidth, setScrollbarWidth] = React.useState(0)
 
   React.useEffect(() => {
-    setInitialized(true)
-    return () => setInitialized(false)
+    setOriginalWidth(document.body.clientWidth)
+    setOriginalPaddingRight(getComputedStyle(document.body).getPropertyValue('padding-right'))
   }, [])
 
   React.useEffect(() => {
-    if (!initialized) {
-      setOriginalWidth(document.body.clientWidth)
-    }
-  }, [initialized])
-
-  React.useEffect(() => {
-    if (!initialized) {
+    if (originalWidth === null) {
       return
     }
     const currentWidth = document.body.clientWidth
-    const diff = currentWidth - originalWidth
-    if (diff > 0) {
-      setWidthDiff(diff)
+    const widthDiff = currentWidth - originalWidth
+    if (widthDiff > 0) {
+      setScrollbarWidth(widthDiff)
     }
-  }, [initialized, originalWidth])
+  }, [originalWidth])
 
-  if (!initialized) {
+  if (originalWidth === null) {
     return null
   }
-  return <ScrollSuppressing widthDiff={widthDiff} />
+  return (
+    <ScrollSuppressing
+      originalPaddingRight={originalPaddingRight}
+      scrollbarWidth={scrollbarWidth}
+    />
+  )
 }
 
-const ScrollSuppressing = createGlobalStyle<{ widthDiff: number }>`
+const ScrollSuppressing = createGlobalStyle<{
+  originalPaddingRight: string
+  scrollbarWidth: number
+}>`
   body {
     overflow: hidden;
-    ${({ widthDiff }) =>
-      widthDiff > 0 &&
+    ${({ originalPaddingRight, scrollbarWidth }) =>
+      scrollbarWidth > 0 &&
       css`
-        padding-right: ${widthDiff}px !important;
+        padding-right: calc(${originalPaddingRight} + ${scrollbarWidth}px) !important;
       `}
   }
 `

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -388,6 +388,54 @@ Position.parameters = {
   },
 }
 
+export const WithScroll: Story = () => {
+  return (
+    <ScrollWrapper>
+      <BorderedWrapper>
+        We can confirm that there is no change in the width of the wrapper for this text before and
+        after opening a dialog.
+      </BorderedWrapper>
+      <DialogWrapper>
+        <DialogTrigger>
+          <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-with-scroll-1">
+            Opne Dialog
+          </SecondaryButton>
+        </DialogTrigger>
+        <DialogContent id="dialog-with-scroll-1">
+          <ContentWrapper>
+            <div>
+              The content behind the opened dialog is not scrollable.
+              <br />
+              Of course the content on the opened dialog is scrollable.
+            </div>
+            <br />
+          </ContentWrapper>
+        </DialogContent>
+      </DialogWrapper>
+    </ScrollWrapper>
+  )
+}
+WithScroll.parameters = { docs: { disable: true } }
+const ScrollWrapper = styled.div`
+  height: 200vh;
+  margin: 1rem;
+  padding: 1rem;
+`
+const BorderedWrapper = styled.div`
+  margin: 1rem 0;
+  padding: 1rem;
+  border: solid 1px gray;
+`
+const ContentWrapper = styled.div`
+  width: 50vh;
+  height: 50vh;
+  overflow: auto;
+  padding: 1rem;
+  & > div {
+    margin-bottom: 100vh;
+  }
+`
+
 export const RegOpendMessage: Story = () => {
   return (
     <MessageDialog

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes, ReactNode, VFC, useCallback, useRef } from 'react'
-import styled, { createGlobalStyle, css } from 'styled-components'
+import styled, { css } from 'styled-components'
 import { CSSTransition } from 'react-transition-group'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -7,6 +7,8 @@ import { useHandleEscape } from '../../hooks/useHandleEscape'
 import { DialogPositionProvider } from './DialogPositionProvider'
 import { FocusTrap } from './FocusTrap'
 import { useClassNames } from './useClassNames'
+
+import { BodyScrollSuppressor } from './BodyScrollSuppressor'
 
 export type DialogContentInnerProps = {
   /**
@@ -146,7 +148,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
             </Inner>
           </FocusTrap>
           {/* Suppresses scrolling of body while modal is displayed */}
-          <ScrollSuppressing />
+          <BodyScrollSuppressor />
         </Wrapper>
       </CSSTransition>
     </DialogPositionProvider>
@@ -232,9 +234,4 @@ const Background = styled.div<{ themes: Theme }>`
       background-color: ${themes.palette.SCRIM};
     `
   }}
-`
-const ScrollSuppressing = createGlobalStyle`
-  body {
-    overflow: hidden;
-  }
 `

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -7,7 +7,6 @@ import { useHandleEscape } from '../../hooks/useHandleEscape'
 import { DialogPositionProvider } from './DialogPositionProvider'
 import { FocusTrap } from './FocusTrap'
 import { useClassNames } from './useClassNames'
-
 import { BodyScrollSuppressor } from './BodyScrollSuppressor'
 
 export type DialogContentInnerProps = {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-380
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Dialog` を開いたとき body のスクロールを抑制するために `overflow: hidden` を設定していますが、 mac などでスクロールバーを常に表示する設定にしている場合、 `overflow: hidden` によりスクロールバーが非表示になることで body の幅が変わり、内側のコンテンツにガタツキが発生してしまいます。
この PR では、スクロールバーが非表示なった分のスペースを `padding` で埋めることで、ガタツキを抑制するように変更します。

修正後の動作については、動作環境の OS で「常にスクロールバーを表示する」設定を行った上で、 `Dialog` の story 内の `Docs` タブにて任意のダイアログを開いたときにガタつかないことで確認できる。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Dialog` 表示時に以下の処理を行う `BodyScrollSuppresscor` を追加
  - 垂直方向のスクロールバーの幅を検出する
  - body の `padding-right` に対して、元々の値と上記の幅を加算した値を設定
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
