### PR TITLE
余白を px 値で提供する

### DIFF
--- a/src/themes/__tests__/createSpacing.ts
+++ b/src/themes/__tests__/createSpacing.ts
@@ -1,66 +1,54 @@
-import { createSpacing } from '../createSpacing'
-import { createSize } from '../createSize'
+import { createSpacing, createSpacingByChar } from '../createSpacing'
 
 describe('createSpacing', () => {
-  it('returns same spacing theme with createSize', () => {
-    const actual = createSpacing()
-    const expected = createSize()
-
-    expect(actual.XXS).toBe(expected.space.XXS)
-    expect(actual.XS).toBe(expected.space.XS)
-    expect(actual.S).toBe(expected.space.S)
-    expect(actual.M).toBe(expected.space.M)
-    expect(actual.L).toBe(expected.space.L)
-    expect(actual.XL).toBe(expected.space.XL)
-    expect(actual.XXL).toBe(expected.space.XXL)
-  })
-
-  it('returns same spacing theme with createSize when give base size', () => {
-    const actual = createSpacing({
-      baseSize: 17,
-    })
-    const expected = createSize({
-      space: {
-        defaultRem: 17,
-      },
-    })
-
-    expect(actual.XXS).toBe(expected.space.XXS)
-    expect(actual.XS).toBe(expected.space.XS)
-    expect(actual.S).toBe(expected.space.S)
-    expect(actual.M).toBe(expected.space.M)
-    expect(actual.L).toBe(expected.space.L)
-    expect(actual.XL).toBe(expected.space.XL)
-    expect(actual.XXL).toBe(expected.space.XXL)
-  })
-
   it('returns customized spacing theme when give base size', () => {
     const actual = createSpacing({
       baseSize: 13,
     })
 
-    expect(actual.XXS).toBe(13)
-    expect(actual.XS).toBe(13 * 2)
-    expect(actual.S).toBe(13 * 3)
-    expect(actual.M).toBe(13 * 4)
-    expect(actual.L).toBe(13 * 5)
-    expect(actual.XL).toBe(13 * 6)
-    expect(actual.XXL).toBe(13 * 7)
+    expect(actual.X3S).toBe(`${13 / 2}px`)
+    expect(actual.XXS).toBe('13px')
+    expect(actual.XS).toBe(`${13 * 2}px`)
+    expect(actual.S).toBe(`${13 * 3}px`)
+    expect(actual.M).toBe(`${13 * 4}px`)
+    expect(actual.L).toBe(`${13 * 5}px`)
+    expect(actual.XL).toBe(`${13 * 6}px`)
+    expect(actual.XXL).toBe(`${13 * 7}px`)
+    expect(actual.X3L).toBe(`${13 * 8}px`)
   })
 
-  it('returns customized spacing theme when give base size and some tokens', () => {
-    const actual = createSpacing({
-      baseSize: 13,
-      M: 120,
-      XL: 122,
-    })
+  it('returns customized spacingByChar theme when give base size', () => {
+    const actual = createSpacingByChar(createSpacing({ baseSize: 13 }))
 
-    expect(actual.XXS).toBe(13)
-    expect(actual.XS).toBe(13 * 2)
-    expect(actual.S).toBe(13 * 3)
-    expect(actual.M).toBe(120)
-    expect(actual.L).toBe(13 * 5)
-    expect(actual.XL).toBe(122)
-    expect(actual.XXL).toBe(13 * 7)
+    expect(actual['0.5']).toBe(`${13 / 2}px`)
+    expect(actual[1]).toBe('13px')
+    expect(actual[2]).toBe(`${13 * 2}px`)
+    expect(actual[3]).toBe(`${13 * 3}px`)
+    expect(actual[4]).toBe(`${13 * 4}px`)
+    expect(actual[5]).toBe(`${13 * 5}px`)
+    expect(actual[6]).toBe(`${13 * 6}px`)
+    expect(actual[7]).toBe(`${13 * 7}px`)
+    expect(actual[8]).toBe(`${13 * 8}px`)
+  })
+
+  it('returns customized spacingByChar theme when give base size and some tokens', () => {
+    const actual = createSpacingByChar(
+      createSpacing({
+        baseSize: 13,
+        M: '120px',
+        XL: '122px',
+        X3L: '320px',
+      }),
+    )
+
+    expect(actual['0.5']).toBe(`${13 / 2}px`)
+    expect(actual[1]).toBe('13px')
+    expect(actual[2]).toBe(`${13 * 2}px`)
+    expect(actual[3]).toBe(`${13 * 3}px`)
+    expect(actual[4]).toBe('120px')
+    expect(actual[5]).toBe(`${13 * 5}px`)
+    expect(actual[6]).toBe('122px')
+    expect(actual[7]).toBe(`${13 * 7}px`)
+    expect(actual[8]).toBe('320px')
   })
 })

--- a/src/themes/createSize.ts
+++ b/src/themes/createSize.ts
@@ -1,20 +1,9 @@
 import { merge } from '../libs/lodash'
 
 const defaultHtmlFontSize = 16
-const defaultSpaceSize = 8
 
 export interface SizeProperty {
   htmlFontSize?: number
-  space?: {
-    defaultRem?: number
-    XXS?: number
-    XS?: number
-    S?: number
-    M?: number
-    L?: number
-    XL?: number
-    XXL?: number
-  }
   // respect for Starbucks...
   font?: {
     SHORT?: number
@@ -30,15 +19,6 @@ export interface SizeProperty {
 
 export interface CreatedSizeTheme {
   pxToRem: (value: number) => string
-  space: {
-    XXS: number
-    XS: number
-    S: number
-    M: number
-    L: number
-    XL: number
-    XXL: number
-  }
   font: {
     SHORT: number
     TALL: number
@@ -55,41 +35,23 @@ const pxToRem = (value: number) => (font: number) => {
   return `${value / font}rem`
 }
 
-const getSpace = (size: number) => {
-  return {
-    XXS: size,
-    XS: size * 2,
-    S: size * 3,
-    M: size * 4,
-    L: size * 5,
-    XL: size * 6,
-    XXL: size * 7,
-  }
-}
-
 const defaultFontSize = { SHORT: 11, TALL: 14, GRANDE: 18, VENTI: 24 }
 
 const defaultMediaQuery = { SP: 599, TABLET: 959 }
 
-const defaultSpace = getSpace(defaultSpaceSize)
-
 /**
- * @deprecated The defaultSize will be deprecated, please use defaultFontSize, defaultSpacing or defaultBreakPoint instead
+ * @deprecated The defaultSize will be deprecated, please use defaultFontSize or defaultBreakPoint instead
  */
 export const defaultSize: CreatedSizeTheme = {
   pxToRem: (value: number) => pxToRem(value)(defaultHtmlFontSize),
   font: defaultFontSize,
-  space: defaultSpace,
   mediaQuery: defaultMediaQuery,
 }
 
 export const createSize = (userSize: SizeProperty = {}) => {
-  const space = userSize.space || {}
-  const XXS = space.defaultRem || defaultSpaceSize
   const created: CreatedSizeTheme = merge(
     {
       pxToRem: (value: number) => pxToRem(value)(userSize.htmlFontSize || defaultHtmlFontSize),
-      space: getSpace(XXS),
       font: { ...defaultFontSize },
       mediaQuery: { ...defaultMediaQuery },
     },

--- a/src/themes/createSpacing.ts
+++ b/src/themes/createSpacing.ts
@@ -4,34 +4,66 @@ const defaultBaseSize = 8
 
 export interface SpacingProperty {
   baseSize?: number
-  XXS?: number
-  XS?: number
-  S?: number
-  M?: number
-  L?: number
-  XL?: number
-  XXL?: number
+  X3S?: string
+  XXS?: string
+  XS?: string
+  S?: string
+  M?: string
+  L?: string
+  XL?: string
+  XXL?: string
+  X3L?: string
 }
 
 export interface CreatedSpacingTheme {
-  XXS: number
-  XS: number
-  S: number
-  M: number
-  L: number
-  XL: number
-  XXL: number
+  X3S: string
+  XXS: string
+  XS: string
+  S: string
+  M: string
+  L: string
+  XL: string
+  XXL: string
+  X3L: string
+}
+
+export interface CreatedSpacingByChar {
+  0.5?: string
+  1?: string
+  2?: string
+  3?: string
+  4?: string
+  5?: string
+  6?: string
+  7?: string
+  8?: string
 }
 
 const getSpacing = (baseSize: number) => {
   return {
-    XXS: baseSize,
-    XS: baseSize * 2,
-    S: baseSize * 3,
-    M: baseSize * 4,
-    L: baseSize * 5,
-    XL: baseSize * 6,
-    XXL: baseSize * 7,
+    X3S: `${baseSize / 2}px`,
+    XXS: `${baseSize}px`,
+    XS: `${baseSize * 2}px`,
+    S: `${baseSize * 3}px`,
+    M: `${baseSize * 4}px`,
+    L: `${baseSize * 5}px`,
+    XL: `${baseSize * 6}px`,
+    XXL: `${baseSize * 7}px`,
+    X3L: `${baseSize * 8}px`,
+  }
+}
+
+const getSpacingByChar = (spacing: CreatedSpacingTheme) => {
+  return {
+    0.5: spacing.X3S,
+    1: spacing.XXS,
+    2: spacing.XS,
+    3: spacing.S,
+    4: spacing.M,
+    5: spacing.L,
+    6: spacing.XL,
+    7: spacing.XXL,
+    8: spacing.X3L,
   }
 }
 
@@ -43,3 +75,6 @@ export const createSpacing = (userSpacing: SpacingProperty = {}) => {
 
   return created
 }
+
+export const defaultSpacingByChar = getSpacingByChar(defaultSpacing)
+export const createSpacingByChar = (spacing: CreatedSpacingTheme) => getSpacingByChar(spacing)

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -10,7 +10,13 @@ import { CreatedPaletteTheme, PaletteProperty, createPalette } from './createPal
 import { ColorProperty, CreatedColorTheme, createColor } from './createColor'
 import { CreatedSizeTheme, SizeProperty, createSize } from './createSize'
 import { CreatedFontSizeTheme, FontSizeProperty, createFontSize } from './createFontSize'
-import { CreatedSpacingTheme, SpacingProperty, createSpacing } from './createSpacing'
+import {
+  CreatedSpacingByChar,
+  CreatedSpacingTheme,
+  SpacingProperty,
+  createSpacing,
+  createSpacingByChar,
+} from './createSpacing'
 import { BreakpointProperty, CreatedBreakpointTheme, createBreakpoint } from './createBreakpoint'
 import { CreatedShadowTheme, ShadowProperty, createShadow } from './createShadow'
 import { CreatedZindexTheme, ZIndexProperty, createZIndex } from './createZIndex'
@@ -22,7 +28,7 @@ interface ThemeProperty {
   palette?: PaletteProperty
   color?: ColorProperty
   /**
-   * @deprecated The size property will be deprecated, please use fontSize, spacing or breakpoint property instead
+   * @deprecated The size property will be deprecated, please use fontSize or breakpoint property instead
    */
   size?: SizeProperty
   fontSize?: FontSizeProperty
@@ -46,11 +52,12 @@ export interface CreatedTheme {
   palette: CreatedPaletteTheme
   color: CreatedColorTheme
   /**
-   * @deprecated The size property will be deprecated, please use fontSize, spacing or breakpoint property instead
+   * @deprecated The size property will be deprecated, please use fontSize or breakpoint property instead
    */
   size: CreatedSizeTheme
   fontSize: CreatedFontSizeTheme
   spacing: CreatedSpacingTheme
+  spacingByChar: CreatedSpacingByChar
   breakpoint: CreatedBreakpointTheme
   /**
    * @deprecated The frame property will be deprecated, please use border or radius property instead
@@ -66,12 +73,14 @@ export interface CreatedTheme {
 export const createTheme = (theme: ThemeProperty = {}) => {
   const paletteProperty = getPaletteProperty(theme)
   const colorProperty = getColorProperty(theme)
+  const spacing = createSpacing(theme.spacing)
   const created: CreatedTheme = {
     palette: createPalette(paletteProperty),
     color: createColor(colorProperty),
     size: createSize(getSizeProperty(theme)),
     fontSize: createFontSize(getFontSizeProperty(theme)),
-    spacing: createSpacing(getSpacingProperty(theme)),
+    spacing,
+    spacingByChar: createSpacingByChar(spacing),
     breakpoint: createBreakpoint(getBreakpointProperty(theme)),
     frame: createFrame(getFrameProperty(theme), paletteProperty),
     border: createBorder(getBorderProperty(theme), colorProperty),
@@ -98,16 +107,6 @@ function getColorProperty(theme: ThemeProperty): ColorProperty {
 function getSizeProperty(theme: ThemeProperty): SizeProperty {
   return {
     htmlFontSize: theme.fontSize?.htmlFontSize || theme.size?.htmlFontSize,
-    space: {
-      defaultRem: theme.spacing?.baseSize || theme.size?.space?.defaultRem,
-      XXS: theme.spacing?.XXS || theme.size?.space?.XXS,
-      XS: theme.spacing?.XS || theme.size?.space?.XS,
-      S: theme.spacing?.S || theme.size?.space?.S,
-      M: theme.spacing?.M || theme.size?.space?.M,
-      L: theme.spacing?.L || theme.size?.space?.L,
-      XL: theme.spacing?.XL || theme.size?.space?.XL,
-      XXL: theme.spacing?.XXL || theme.size?.space?.XXL,
-    },
     font: {
       SHORT: theme.fontSize?.SHORT || theme.size?.font?.SHORT,
       TALL: theme.fontSize?.TALL || theme.size?.font?.TALL,
@@ -125,19 +124,6 @@ function getFontSizeProperty(theme: ThemeProperty): FontSizeProperty {
     htmlFontSize: theme.size?.htmlFontSize,
     ...theme.size?.font,
     ...theme.fontSize,
-  }
-}
-function getSpacingProperty(theme: ThemeProperty): SpacingProperty {
-  return {
-    baseSize: theme.size?.space?.defaultRem,
-    XXS: theme.size?.space?.XXS,
-    XS: theme.size?.space?.XS,
-    S: theme.size?.space?.S,
-    M: theme.size?.space?.M,
-    L: theme.size?.space?.L,
-    XL: theme.size?.space?.XL,
-    XXL: theme.size?.space?.XXL,
-    ...theme.spacing,
   }
 }
 function getBreakpointProperty(theme: ThemeProperty): BreakpointProperty {


### PR DESCRIPTION
余白を `pxToRem` を使用しないでも使えるように px 値で提供します。
そのため `theme.spacing` の各値を数値から `px` を含む文字列に変更しました。

既存の `theme.size.space` と `theme.spacing` で数値と文字列が混在してしまうため、すでに非推奨になっている `theme.space` を削除しました。

また `theme.spacing` の S / M / L 値指定だけでなく、ブラウザ標準フォントサイズからの相対値を指定する `theme.spacingByChar` を追加しました。

これを既存アプリに適用する場合の影響範囲はとても大きいです。