### PR TITLE
余白を px で提供する・改

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -89,13 +89,13 @@ const resetButtonStyle = css`
 const Button = styled.button<{ themes: Theme }>`
   ${resetButtonStyle}
   ${({ themes }) => {
-    const { color, fontSize, spacing, shadow } = themes
+    const { color, spacingByChar, shadow } = themes
 
     return css`
       display: flex;
       align-items: center;
       width: 100%;
-      padding: ${fontSize.pxToRem(12)} ${fontSize.pxToRem(spacing.XS)};
+      padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
       cursor: pointer;
       font-size: inherit;
       text-align: left;
@@ -121,7 +121,7 @@ const Button = styled.button<{ themes: Theme }>`
 
       /* TODO replace if impremented Layout component */
       & > * + * {
-        margin-left: ${fontSize.pxToRem(spacing.XXS)};
+        margin-left: ${spacingByChar(0.5)};
       }
     `
   }}

--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -128,18 +128,14 @@ const Wrapper = styled.nav<{ themes: Theme }>`
   }}
 `
 const StatusLabel = styled(StatusLabelComponent)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin-right: ${pxToRem(space.XS)};
+      margin-right: ${spacingByChar(1)};
     `
   }}
 `
 const Buttons = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: flex;
       align-items: center;
@@ -150,7 +146,7 @@ const Buttons = styled.ul<{ themes: Theme }>`
         list-style: none;
 
         &:not(:first-child) {
-          margin-left: ${pxToRem(space.XS)};
+          margin-left: ${spacingByChar(1)};
         }
       }
     `

--- a/src/components/AppNavi/appNaviHelper.tsx
+++ b/src/components/AppNavi/appNaviHelper.tsx
@@ -33,13 +33,11 @@ export const getIconComponent = (
 }
 
 const IconWrapper = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: flex;
       padding: 0;
-      margin: 0 ${pxToRem(space.XXS)} 0 0;
+      margin: 0 ${spacingByChar(0.5)} 0 0;
     `
   }}
 `

--- a/src/components/BackgroundJobsPanel/BackgroundJobsList.tsx
+++ b/src/components/BackgroundJobsPanel/BackgroundJobsList.tsx
@@ -22,8 +22,7 @@ const BackgroundJobsList: VFC<Props & ElementProps> = ({ children, className = '
 }
 
 const Item = styled.li``
-const List = styled.ul<{ themes: Theme }>(({ themes }) => {
-  const { pxToRem, space } = themes.size
+const List = styled.ul<{ themes: Theme }>(({ themes: { spacingByChar } }) => {
   return css`
     position: fixed;
     bottom: 0;
@@ -31,12 +30,12 @@ const List = styled.ul<{ themes: Theme }>(({ themes }) => {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    margin: ${pxToRem(space.XS)};
+    margin: ${spacingByChar(1)};
     list-style: none;
 
     ${Item} {
       :not(:first-child) {
-        margin-top: ${pxToRem(space.XS)};
+        margin-top: ${spacingByChar(1)};
       }
     }
   `

--- a/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
+++ b/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
@@ -125,51 +125,50 @@ const Header = styled.div`
   display: flex;
   align-items: center;
 `
-const Title = styled.div<{ themes: Theme }>(({ themes }) => {
-  const { font, pxToRem, space } = themes.size
+const Title = styled.div<{ themes: Theme }>(({ themes: { size, spacingByChar } }) => {
+  const { font, pxToRem } = size
   return css`
     font-size: ${pxToRem(font.TALL)};
-    padding: ${pxToRem(space.XS)};
+    padding: ${spacingByChar(1)};
   `
 })
-const HeaderButtonLayout = styled.div<{ themes: Theme }>(({ themes }) => {
-  const { pxToRem, space } = themes.size
+const HeaderButtonLayout = styled.div<{ themes: Theme }>(({ themes: { spacingByChar } }) => {
   return css`
     flex-shrink: 0;
     margin-left: auto;
-    padding-right: ${pxToRem(space.XS)};
+    padding-right: ${spacingByChar(1)};
     button:not(:first-child) {
-      margin-left: ${pxToRem(space.XXS)};
+      margin-left: ${spacingByChar(0.5)};
     }
   `
 })
-const JobList = styled.ul<{ isExpanded: boolean; themes: Theme }>(({ isExpanded, themes }) => {
-  const { pxToRem, space } = themes.size
-  return css`
-    margin: 0;
-    list-style: none;
-    padding: ${pxToRem(space.XS)};
-    border-top: ${themes.frame.border.default};
-    ${!isExpanded &&
-    css`
-      height: 0;
-      visibility: hidden;
-      overflow: hidden;
-      padding-top: 0;
-      padding-bottom: 0;
-      border: none;
-    `}
-  `
-})
-const Job = styled.li<{ themes: Theme }>(({ themes }) => {
-  const { pxToRem, space } = themes.size
+const JobList = styled.ul<{ isExpanded: boolean; themes: Theme }>(
+  ({ isExpanded, themes: { frame, spacingByChar } }) => {
+    return css`
+      margin: 0;
+      list-style: none;
+      padding: ${spacingByChar(1)};
+      border-top: ${frame.border.default};
+      ${!isExpanded &&
+      css`
+        height: 0;
+        visibility: hidden;
+        overflow: hidden;
+        padding-top: 0;
+        padding-bottom: 0;
+        border: none;
+      `}
+    `
+  },
+)
+const Job = styled.li<{ themes: Theme }>(({ themes: { spacingByChar } }) => {
   return css`
     display: flex;
     align-items: center;
     flex-wrap: nowrap;
     line-height: normal;
     :not(:first-child) {
-      margin-top: ${pxToRem(space.XS)};
+      margin-top: ${spacingByChar(1)};
     }
   `
 })
@@ -177,30 +176,36 @@ const JobIconWrapper = styled.div`
   flex-shrink: 0;
   line-height: 0;
 `
-const JobName = styled(OmittableJobText)<{ themes: Theme }>(({ themes }) => {
-  const { font, pxToRem, space } = themes.size
-  return css`
-    margin-left: ${pxToRem(space.XXS)};
-    font-size: ${pxToRem(font.TALL)};
-  `
-})
-const JobDesc = styled(OmittableJobText)<{ themes: Theme }>(({ themes }) => {
-  const { font, pxToRem, space } = themes.size
-  return css`
-    margin-left: ${pxToRem(space.XXS)};
-    font-size: ${pxToRem(font.SHORT)};
-  `
-})
-const CancelButton = styled(ResetButton)<{ themes: Theme }>(({ themes }) => {
-  const { font, pxToRem, space } = themes.size
-  return css`
-    flex-shrink: 0;
-    margin-left: ${pxToRem(space.XXS)};
-    font-size: ${pxToRem(font.SHORT)};
-    color: ${themes.palette.TEXT_LINK};
-    cursor: pointer;
-    :hover {
-      text-decoration: underline;
-    }
-  `
-})
+const JobName = styled(OmittableJobText)<{ themes: Theme }>(
+  ({ themes: { size, spacingByChar } }) => {
+    const { font, pxToRem } = size
+    return css`
+      margin-left: ${spacingByChar(0.5)};
+      font-size: ${pxToRem(font.TALL)};
+    `
+  },
+)
+const JobDesc = styled(OmittableJobText)<{ themes: Theme }>(
+  ({ themes: { size, spacingByChar } }) => {
+    const { font, pxToRem } = size
+    return css`
+      margin-left: ${spacingByChar(0.5)};
+      font-size: ${pxToRem(font.SHORT)};
+    `
+  },
+)
+const CancelButton = styled(ResetButton)<{ themes: Theme }>(
+  ({ themes: { color, size, spacingByChar } }) => {
+    const { font, pxToRem } = size
+    return css`
+      flex-shrink: 0;
+      margin-left: ${spacingByChar(0.5)};
+      font-size: ${pxToRem(font.SHORT)};
+      color: ${color.TEXT_LINK};
+      cursor: pointer;
+      :hover {
+        text-decoration: underline;
+      }
+    `
+  },
+)

--- a/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -84,16 +84,14 @@ export const BottomFixedArea: VFC<Props & ElementProps> = ({
 }
 
 const Base = styled(BaseComponent)<{ themes: Theme; zIndex: number }>`
-  ${({ themes, zIndex }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar }, zIndex }) => {
     return css`
       display: flex;
       flex-direction: column;
       position: fixed;
       bottom: 0;
       width: 100%;
-      padding: ${pxToRem(space.S)};
+      padding: ${spacingByChar(1.5)};
       text-align: center;
       z-index: ${zIndex};
     `
@@ -103,18 +101,16 @@ const Text = styled.div`
   margin: 0;
 `
 const ButtonList = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin: ${pxToRem(space.XS)} 0 0 0;
+      margin: ${spacingByChar(1)} 0 0 0;
       padding: 0;
       display: flex;
       justify-content: center;
 
       > li {
         list-style: none;
-        margin-right: ${pxToRem(space.XS)};
+        margin-right: ${spacingByChar(1)};
 
         &:last-of-type {
           margin-right: 0;
@@ -124,18 +120,16 @@ const ButtonList = styled.ul<{ themes: Theme }>`
   }}
 `
 const TertiaryList = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin: ${pxToRem(space.XS)} 0 0 0;
+      margin: ${spacingByChar(1)} 0 0 0;
       padding: 0;
       display: flex;
       justify-content: center;
 
       > li {
         list-style: none;
-        margin-right: ${pxToRem(space.XS)};
+        margin-right: ${spacingByChar(1)};
 
         &:last-of-type {
           margin-right: 0;

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -78,7 +78,7 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { frame, size, interaction, shadow } = themes
+    const { frame, size, spacingByChar, interaction, shadow } = themes
 
     return css`
       display: inline-flex;
@@ -100,13 +100,13 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       &.default {
         font-size: ${size.pxToRem(size.font.TALL)};
         height: 40px;
-        padding: 0 ${size.pxToRem(size.space.XS)};
+        padding: 0 ${spacingByChar(1)};
       }
 
       &.s {
         font-size: ${size.pxToRem(size.font.SHORT)};
         height: 27px;
-        padding: 0 ${size.pxToRem(size.space.XXS)};
+        padding: 0 ${spacingByChar(0.5)};
       }
 
       &.square {
@@ -144,20 +144,18 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   }}
 `
 const Prefix = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-flex;
-      margin-right: ${pxToRem(space.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     `
   }}
 `
 const Suffix = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-flex;
-      margin-left: ${pxToRem(space.XXS)};
+      margin-left: ${spacingByChar(0.5)};
     `
   }}
 `

--- a/src/components/CheckBoxLabel/CheckBoxLabel.tsx
+++ b/src/components/CheckBoxLabel/CheckBoxLabel.tsx
@@ -57,11 +57,11 @@ const Label = styled.label<{ themes: Theme }>`
 `
 const Txt = styled.span<{ themes: Theme; lineHeight: number }>`
   ${({ themes, lineHeight }) => {
-    const { fontSize, spacing } = themes
+    const { fontSize, spacingByChar } = themes
 
     // checkbox と text の位置がずれるため、line-height 分を調整する疑似要素を作る
     return css`
-      margin: 0 0 0 ${fontSize.pxToRem(spacing.XXS)};
+      margin: 0 0 0 ${spacingByChar(0.5)};
       font-size: ${fontSize.pxToRem(fontSize.TALL)};
       line-height: ${lineHeight};
       &::before {

--- a/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
+++ b/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
 }
 
 .c6 {
-  margin: 0 0 0 0.5rem;
+  margin: 0 0 0 8px;
   font-size: 0.875rem;
   line-height: 1.5;
 }

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -258,11 +258,11 @@ export const MultiComboBox: FC<Props> = ({
 
 const Container = styled.div<{ themes: Theme; width: number | string }>`
   ${({ themes, width }) => {
-    const { frame, size, palette, shadow } = themes
+    const { frame, palette, shadow, spacingByChar } = themes
 
     return css`
       display: inline-flex;
-      min-width: calc(62px + 32px + ${size.pxToRem(size.space.XXS)} * 2);
+      min-width: calc(62px + 32px + ${spacingByChar(0.5)} * 2);
       width: ${typeof width === 'number' ? `${width}px` : width};
       min-height: 40px;
       border-radius: ${frame.border.radius.m};
@@ -287,18 +287,14 @@ const Container = styled.div<{ themes: Theme; width: number | string }>`
   }}
 `
 const InputArea = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, spacing } = themes
-
-    return css`
-      /* for IE */
-      /* stylelint-disable-next-line length-zero-no-unit */
-      flex: 1 1 0px;
-      overflow-y: auto;
-      max-height: 300px;
-      padding-left: ${fontSize.pxToRem(spacing.XXS)};
-    `
-  }}
+  ${({ themes: { spacingByChar } }) => css`
+    /* for IE */
+    /* stylelint-disable-next-line length-zero-no-unit */
+    flex: 1 1 0px;
+    overflow-y: auto;
+    max-height: 300px;
+    padding-left: ${spacingByChar(0.5)};
+  `}
 `
 const smallMargin = 6.5
 const borderWidth = 1
@@ -306,7 +302,7 @@ const List = styled.ul<{ themes: Theme }>`
   ${({ themes }) => {
     const {
       fontSize: { pxToRem },
-      spacing,
+      spacingByChar,
     } = themes
 
     return css`
@@ -318,7 +314,7 @@ const List = styled.ul<{ themes: Theme }>`
 
       > li {
         min-height: 27px;
-        margin-right: ${pxToRem(spacing.XXS)};
+        margin-right: ${spacingByChar(0.5)};
         margin-bottom: ${pxToRem(smallMargin - borderWidth)};
       }
     `
@@ -326,12 +322,11 @@ const List = styled.ul<{ themes: Theme }>`
 `
 const SelectedItem = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { border, color, fontSize, spacing } = themes
-    const { pxToRem } = fontSize
+    const { border, color, fontSize, spacingByChar } = themes
 
     return css`
       display: flex;
-      border-radius: calc(${fontSize.SHORT}px + ${pxToRem(spacing.XXS - borderWidth)} * 2);
+      border-radius: calc(${fontSize.SHORT}px + (${spacingByChar(0.5)} - ${borderWidth}px) * 2);
       border: ${border.shorthand};
       background-color: #fff;
       color: ${color.TEXT_BLACK};
@@ -341,27 +336,16 @@ const SelectedItem = styled.div<{ themes: Theme }>`
   }}
 `
 const SelectedItemLabel = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const {
-      fontSize: { pxToRem },
-      spacing,
-    } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      padding: ${pxToRem(spacing.XXS - borderWidth)};
+      padding: calc(${spacingByChar(0.5)} - ${borderWidth}px);
     `
   }}
 `
 const DeleteButton = styled(ResetButton)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const {
-      fontSize: { pxToRem },
-      spacing,
-      shadow,
-    } = themes
-
+  ${({ themes: { spacingByChar, shadow } }) => {
     return css`
-      padding: ${pxToRem(spacing.XXS - borderWidth)};
+      padding: calc(${spacingByChar(0.5)} - ${borderWidth}px);
       border-radius: 50%;
       cursor: pointer;
       line-height: 0;
@@ -377,7 +361,6 @@ const DeleteButton = styled(ResetButton)<{ themes: Theme }>`
     `
   }}
 `
-
 const InputWrapper = styled.li`
   &.hidden {
     position: absolute;
@@ -419,17 +402,14 @@ const Placeholder = styled.p<{ themes: Theme }>`
   }}
 `
 const Suffix = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { spacing, fontSize, border } = themes
-
-    return css`
+  ${({ themes: { spacingByChar, border } }) =>
+    css`
       display: flex;
       justify-content: center;
       align-items: center;
-      margin: ${fontSize.pxToRem(spacing.XXS)} 0;
-      padding: 0 ${fontSize.pxToRem(spacing.XXS)};
+      margin: ${spacingByChar(0.5)} 0;
+      padding: 0 ${spacingByChar(0.5)};
       border-left: ${border.shorthand};
       box-sizing: border-box;
-    `
-  }}
+    `}
 `

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -272,34 +272,34 @@ const StyledInput = styled(Input)`
   }
 `
 const CaretDownLayout = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { fontSize, spacing } = themes
+  const { spacingByChar } = themes
   return css`
     height: 100%;
     box-sizing: border-box;
-    padding: ${fontSize.pxToRem(spacing.XXS)} 0;
+    padding: ${spacingByChar(0.5)} 0;
   `
 })
 const CaretDownWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { border, fontSize, spacing } = themes
+  const { border, spacingByChar } = themes
   return css`
     display: flex;
     align-items: center;
     justify-content: center;
     height: 100%;
     box-sizing: border-box;
-    padding-left: ${fontSize.pxToRem(spacing.XXS)};
+    padding-left: ${spacingByChar(0.5)};
     border-left: ${border.shorthand};
   `
 })
 const ClearButton = styled(ResetButton)<{ themes: Theme }>`
   ${({ themes }) => {
-    const { fontSize, spacing } = themes
+    const { spacingByChar } = themes
     return css`
       display: flex;
       align-items: center;
       justify-content: center;
       height: 100%;
-      padding: 0 ${fontSize.pxToRem(spacing.XXS)};
+      padding: 0 ${spacingByChar(0.5)};
       cursor: pointer;
       &.hidden {
         display: none;

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -230,7 +230,7 @@ export function useListBox({
 
 const Container = styled.div<{ top: number; left: number; width: number; themes: Theme }>(
   ({ top, left, width, themes }) => {
-    const { size, frame } = themes
+    const { spacingByChar, frame } = themes
     return css`
       position: absolute;
       top: ${top}px;
@@ -238,7 +238,7 @@ const Container = styled.div<{ top: number; left: number; width: number; themes:
       overflow-y: auto;
       max-height: 300px;
       width: ${width}px;
-      padding: ${size.pxToRem(size.space.XXS)} 0;
+      padding: ${spacingByChar(0.5)} 0;
       border-radius: ${frame.border.radius.m};
       box-shadow: rgba(51, 51, 51, 0.3) 0 4px 10px 0;
       background-color: #fff;
@@ -253,11 +253,11 @@ const Container = styled.div<{ top: number; left: number; width: number; themes:
 )
 const NoItems = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size } = themes
+    const { size, spacingByChar } = themes
 
     return css`
       margin: 0;
-      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       background-color: #fff;
       font-size: ${size.font.TALL}px;
     `
@@ -265,13 +265,13 @@ const NoItems = styled.p<{ themes: Theme }>`
 `
 const SelectButton = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette } = themes
+    const { size, spacingByChar, palette } = themes
 
     return css`
       display: block;
       width: 100%;
       border: none;
-      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       background-color: #fff;
       font-size: ${size.font.TALL}px;
       text-align: left;

--- a/src/components/CompactInformationPanel/CompactInformationPanel.tsx
+++ b/src/components/CompactInformationPanel/CompactInformationPanel.tsx
@@ -42,12 +42,7 @@ const callIcon = (type: IconType, theme: Theme) => {
 
 const createIcon = (Icon: typeof FaInfoCircleIcon) =>
   styled(Icon)<{ $theme: Theme }>(
-    ({
-      $theme: {
-        spacing,
-        fontSize: { pxToRem },
-      },
-    }) => css`
+    ({ $theme: { spacingByChar } }) => css`
       flex-shrink: 0;
 
       /*
@@ -55,7 +50,7 @@ const createIcon = (Icon: typeof FaInfoCircleIcon) =>
       translate-y 0.25em transform for leading
       */
       transform: translateY(0.25em);
-      margin-right: ${pxToRem(spacing.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     `,
   )
 const InfoIcon = createIcon(FaInfoCircleIcon)
@@ -64,17 +59,11 @@ const WarningIcon = createIcon(FaExclamationTriangleIcon)
 const ErrorIcon = createIcon(FaExclamationCircleIcon)
 
 const Wrapper = styled(Base)<{ themes: Theme }>`
-  ${({
-    themes: {
-      fontSize: { pxToRem },
-      spacing,
-      shadow,
-    },
-  }) => {
+  ${({ themes: { spacingByChar, shadow } }) => {
     return css`
       display: flex;
       box-shadow: ${shadow.DIALOG};
-      padding: ${pxToRem(spacing.XS)};
+      padding: ${spacingByChar(1)};
     `
   }}
 `

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -265,23 +265,22 @@ const InputWrapper = styled.div``
 const StyledInput = styled(Input)`
   width: 100%;
 `
-const CalendarIconLayout = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { size } = themes
+const CalendarIconLayout = styled.span<{ themes: Theme }>(({ themes: { spacingByChar } }) => {
   return css`
     height: 100%;
-    padding: ${size.pxToRem(size.space.XXS)} 0;
+    padding: ${spacingByChar(0.5)} 0;
     box-sizing: border-box;
   `
 })
 const CalendarIconWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { palette, size } = themes
+  const { palette, size, spacingByChar } = themes
   return css`
     display: flex;
     align-items: center;
     justify-content: center;
     box-sizing: border-box;
     height: 100%;
-    padding-left: ${size.pxToRem(size.space.XXS)};
+    padding-left: ${spacingByChar(0.5)};
     border-left: 1px solid ${palette.BORDER};
     font-size: ${size.pxToRem(size.font.TALL)};
   `

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -78,10 +78,9 @@ const Wrapper = styled.dl<{ layout: LayoutType }>`
   }}
 `
 const Item = styled(DefinitionListItem)<{ themes: Theme; layout: LayoutType }>`
-  ${({ themes, layout }) => {
-    const { pxToRem, space } = themes.size
+  ${({ themes: { spacingByChar }, layout }) => {
     const basicStyle = css`
-      margin-bottom: ${pxToRem(space.S)};
+      margin-bottom: ${spacingByChar(1.5)};
     `
 
     switch (layout) {

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -125,7 +125,7 @@ const Title = styled.p<{ themes: Theme }>`
     const { pxToRem } = fontSize
     return css`
       margin: 0;
-      padding: ${pxToRem(spacing.XS)} ${pxToRem(spacing.S)};
+      padding: ${spacing.XS} ${spacing.S};
       border-bottom: ${border.shorthand};
       font-size: ${pxToRem(fontSize.GRANDE)};
       line-height: 1;
@@ -140,14 +140,12 @@ const Body = styled.div<{ offsetHeight: number }>`
     `
   }}
 `
-const ActionArea = styled.div<{ themes: Theme }>(({ themes: { fontSize, spacing, border } }) => {
-  const { pxToRem } = fontSize
-
+const ActionArea = styled.div<{ themes: Theme }>(({ themes: { spacing, border } }) => {
   return css`
     display: flex;
     flex-direction: column;
     border-top: ${border.shorthand};
-    padding: ${pxToRem(spacing.XS)} ${pxToRem(spacing.S)};
+    padding: ${spacing.XS} ${spacing.S};
 
     &&& > * + * {
       margin-top: 0.5rem;
@@ -206,14 +204,13 @@ const ResponseMessage: React.VFC<{
     </Wrapper>
   )
 }
-const ButtonArea = styled.div<{ themes: Theme }>(({ themes: { fontSize, spacing } }) => {
-  const { pxToRem } = fontSize
+const ButtonArea = styled.div<{ themes: Theme }>(({ themes: { spacing } }) => {
   return css`
     display: flex;
     justify-content: flex-end;
 
     > * + * {
-      margin-left: ${pxToRem(spacing.XS)};
+      margin-left: ${spacing.XS};
     }
   `
 })

--- a/src/components/Dialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialogContentInner.tsx
@@ -58,10 +58,10 @@ export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
 
 const Title = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, frame } = themes
+    const { size, spacingByChar, frame } = themes
     return css`
       margin: 0;
-      padding: ${size.pxToRem(size.space.XS)} ${size.pxToRem(size.space.S)};
+      padding: ${spacingByChar(1)} ${spacingByChar(1.5)};
       border-bottom: ${frame.border.default};
       font-size: ${size.pxToRem(size.font.GRANDE)};
       line-height: 1;
@@ -69,12 +69,12 @@ const Title = styled.p<{ themes: Theme }>`
   }}
 `
 const Description = styled.div<{ themes: Theme; offsetHeight: number }>`
-  ${({ themes, offsetHeight }) => {
-    const { pxToRem, space, font } = themes.size
+  ${({ themes: { size, spacingByChar }, offsetHeight }) => {
+    const { pxToRem, font } = size
     return css`
       max-height: calc(100vh - ${offsetHeight}px);
       overflow: auto;
-      padding: 0 ${pxToRem(space.S)};
+      padding: 0 ${spacingByChar(1.5)};
       font-size: ${pxToRem(font.TALL)};
       line-height: 1.5;
     `
@@ -82,11 +82,11 @@ const Description = styled.div<{ themes: Theme; offsetHeight: number }>`
 `
 const Bottom = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, frame } = themes
+    const { spacingByChar, frame } = themes
     return css`
       display: flex;
       justify-content: flex-end;
-      padding: ${size.pxToRem(size.space.XS)} ${size.pxToRem(size.space.S)};
+      padding: ${spacingByChar(1)} ${spacingByChar(1.5)};
       border-top: ${frame.border.default};
     `
   }}

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -84,7 +84,7 @@ export const DropZone: React.VFC<DropZoneProps & ElementProps> = ({
 
 const Wrapper = styled.div<{ theme: Theme; filesDraggedOver: boolean }>`
   ${({ theme, filesDraggedOver }) => {
-    const { palette, frame, size } = theme
+    const { palette, frame, spacingByChar } = theme
     const border = filesDraggedOver
       ? `solid ${frame.border.lineWidth} ${palette.MAIN}`
       : `dashed ${frame.border.lineWidth} ${palette.BORDER}`
@@ -93,7 +93,7 @@ const Wrapper = styled.div<{ theme: Theme; filesDraggedOver: boolean }>`
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      padding: ${size.pxToRem(size.space.L)};
+      padding: ${spacingByChar(2.5)};
       border: ${border};
       background-color: ${palette.COLUMN};
       > input {

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -88,7 +88,7 @@ const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean; themes: Theme }
   }
 `
 const StatusText = styled.span<{ themes: Theme }>`
-  margin-left: ${({ themes }) => themes.spacing.XXS}px;
+  margin-left: ${({ themes }) => themes.spacing.XXS};
   font-size: ${({ themes }) => themes.size.pxToRem(themes.fontSize.SHORT)};
 `
 const ContentLayout = styled.div`

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -86,13 +86,13 @@ const Wrapper = styled.div<{ $width: string | number }>`
   `}
 `
 const Title = styled.div<{ themes: Theme }>`
-  ${({ themes }) => css`
+  ${({ themes: { spacingByChar } }) => css`
     display: flex;
     align-items: center;
-    margin: 0 0 ${themes.size.pxToRem(themes.size.space.XXS)};
+    margin: 0 0 ${spacingByChar(0.5)};
 
     > *:not(:first-child) {
-      margin-left: ${themes.size.pxToRem(themes.size.space.XXS)};
+      margin-left: ${spacingByChar(0.5)};
     }
   `}
 `
@@ -100,17 +100,17 @@ const TitleText = styled(Heading)`
   display: inline-block;
 `
 const Help = styled.div<{ themes: Theme }>`
-  ${({ themes }) => css`
-    margin: ${themes.size.pxToRem(themes.size.space.XXS)} 0 0 0;
-    font-size: ${themes.size.pxToRem(themes.size.font.SHORT)};
+  ${({ themes: { color, size, spacingByChar } }) => css`
+    margin: ${spacingByChar(0.5)} 0 0 0;
+    font-size: ${size.pxToRem(size.font.SHORT)};
     line-height: 1;
-    color: ${themes.palette.TEXT_GREY};
+    color: ${color.TEXT_GREY};
   `}
 `
 const Error = styled.div<{ themes: Theme }>`
-  ${({ themes }) => css`
-    margin: ${themes.size.pxToRem(themes.size.space.XXS)} 0 0 0;
-    font-size: ${themes.size.pxToRem(themes.size.font.SHORT)};
+  ${({ themes: { size, spacingByChar } }) => css`
+    margin: ${spacingByChar(0.5)} 0 0 0;
+    font-size: ${size.pxToRem(size.font.SHORT)};
     line-height: 1;
   `}
 `

--- a/src/components/FlashMessage/FlashMessage.tsx
+++ b/src/components/FlashMessage/FlashMessage.tsx
@@ -134,7 +134,7 @@ const fadeAnimation = keyframes`
 
 const Wrapper = styled.div<{ themes: Theme; animation: Props['animation'] }>`
   ${({ themes, animation }) => {
-    const { size, spacing, radius, color, zIndex } = themes
+    const { spacingByChar, radius, color, zIndex } = themes
 
     let keyframe = bounceAnimation
     switch (animation) {
@@ -153,13 +153,15 @@ const Wrapper = styled.div<{ themes: Theme; animation: Props['animation'] }>`
       z-index: ${zIndex.FLASH_MESSAGE};
       display: flex;
       position: fixed;
-      bottom: ${size.pxToRem(spacing.XXS)};
-      left: ${size.pxToRem(spacing.XXS)};
+      bottom: ${spacingByChar(0.5)};
+      left: ${spacingByChar(0.5)};
       box-sizing: border-box;
       align-items: center;
-      min-width: ${size.pxToRem(200)};
-      padding: ${size.pxToRem(spacing.XXS)} ${size.pxToRem(spacing.XS)};
-      padding-right: ${size.pxToRem(spacing.XXS)};
+
+      /* border + padding + Icon + 10em + Button + margin */
+      min-width: calc(2px + ${spacingByChar(1.5)} + 14px + 8em + 27px + ${spacingByChar(1)});
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
+      padding-right: ${spacingByChar(0.5)};
       background-color: #fff;
       border: 1px solid ${color.BORDER};
       border-radius: ${radius.m};
@@ -171,7 +173,7 @@ const Wrapper = styled.div<{ themes: Theme; animation: Props['animation'] }>`
       }
 
       & > * + * {
-        margin-left: ${size.space.XXS}px;
+        margin-left: ${spacingByChar(0.5)};
       }
     `
   }}

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -59,8 +59,8 @@ export const FloatArea: VFC<Props> = ({
 }
 
 const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string }>`
-  ${({ themes: { spacing, fontSize }, top, bottom, $width, zIndex = 500 }) => {
-    return css`
+  ${({ themes: { spacingByChar }, top, bottom, $width, zIndex = 500 }) =>
+    css`
       display: flex;
       align-items: center;
       position: fixed;
@@ -68,20 +68,18 @@ const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string 
       ${exist(bottom) && `bottom: ${bottom}px;`}
       z-index: ${zIndex};
       width: ${$width};
-      padding: ${fontSize.pxToRem(spacing.XS)};
-    `
-  }}
+      padding: ${spacingByChar(1)};
+    `}
 `
 
 const ActionArea = styled.div<{ themes: Theme }>`
-  ${({ themes: { fontSize, spacing } }) => {
-    return css`
+  ${({ themes: { spacingByChar } }) =>
+    css`
       > button,
       > a {
-        margin-left: ${fontSize.pxToRem(spacing.XS)};
+        margin-left: ${spacingByChar(1)};
       }
-    `
-  }}
+    `}
 `
 const ErrorTextArea = styled.p`
   display: flex;
@@ -91,12 +89,11 @@ const ErrorTextArea = styled.p`
   max-width: 40%;
 `
 const ErrorIcon = styled.div<{ themes: Theme }>`
-  ${({ themes: { fontSize, spacing } }) => {
-    return css`
-      margin-right: ${fontSize.pxToRem(spacing.XXS)};
+  ${({ themes: { spacingByChar } }) =>
+    css`
+      margin-right: ${spacingByChar(0.5)};
       flex-shrink: 0;
-    `
-  }}
+    `}
 `
 
 const ErrorText = styled.div<{ themes: Theme }>`

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -22,19 +22,24 @@ export const Footer: VFC = () => {
 }
 
 const Wrapper = styled.footer<{ themes: Theme }>`
-  ${({ themes }) => css`
+  ${({
+    themes: {
+      color,
+      size: { font, pxToRem },
+      spacingByChar,
+    },
+  }) => css`
     overflow: hidden;
-    padding: ${themes.size.pxToRem(themes.size.space.XS)}
-      ${themes.size.pxToRem(themes.size.space.S)};
-    background-color: ${themes.palette.BRAND};
+    padding: ${spacingByChar(1)} ${spacingByChar(1.5)};
+    background-color: ${color.BRAND};
     color: #fff;
-    font-size: ${themes.size.pxToRem(themes.size.font.TALL)};
+    font-size: ${pxToRem(font.TALL)};
     white-space: nowrap;
   `}
 `
 
 const List = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => css`
+  ${({ themes: { spacingByChar } }) => css`
     float: left;
     display: flex;
     flex-wrap: wrap;
@@ -45,7 +50,7 @@ const List = styled.ul<{ themes: Theme }>`
 
     > li {
       padding: 3px 0;
-      margin-right: ${themes.size.pxToRem(themes.size.space.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     }
   `}
 `

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -101,71 +101,53 @@ const Title = styled(Heading)<{ themes: Theme }>`
 `
 
 const StatusLabels = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, spacing } = themes
-
-    return css`
-      margin-left: ${fontSize.pxToRem(spacing.XXS)};
+  ${({ themes: { spacingByChar } }) =>
+    css`
+      margin-left: ${spacingByChar(0.5)};
       display: inline-block;
       line-height: 1;
-    `
-  }}
+    `}
 `
 
 const StyledStatusLabel = styled(StatusLabel)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize } = themes
-
-    return css`
-      margin-right: ${fontSize.pxToRem(4)};
+  ${({ themes: { spacingByChar } }) =>
+    css`
+      margin-right: ${spacingByChar(0.25)};
       display: inline-block;
-    `
-  }}
+    `}
 `
 
 const HelpMessage = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, spacing } = themes
-
-    return css`
+  ${({ themes: { fontSize, spacingByChar } }) =>
+    css`
       display: block;
-      margin-top: ${fontSize.pxToRem(spacing.XXS)};
+      margin-top: ${spacingByChar(0.5)};
       font-size: ${fontSize.pxToRem(fontSize.TALL)};
-    `
-  }}
+    `}
 `
 
 const ErrorMessage = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, spacing } = themes
-
-    return css`
+  ${({ themes: { fontSize, spacingByChar } }) =>
+    css`
       display: flex;
       align-items: center;
-      margin-top: ${fontSize.pxToRem(spacing.XXS)};
+      margin-top: ${spacingByChar(0.5)};
       font-size: ${fontSize.pxToRem(fontSize.TALL)};
       line-height: 1;
-    `
-  }}
+    `}
 `
 
 const ErrorIcon = styled(FaExclamationCircleIcon)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize } = themes
-
-    return css`
-      margin-right: ${fontSize.pxToRem(4)};
-    `
-  }}
+  ${({ themes: { spacingByChar } }) =>
+    css`
+      margin-right: ${spacingByChar(0.25)};
+    `}
 `
 
 const Body = styled.span<{ themes: Theme; margin: innerMarginType }>`
-  ${({ themes, margin }) => {
-    const { fontSize, spacing } = themes
-
-    return css`
+  ${({ themes: { spacing }, margin }) =>
+    css`
       display: block;
-      margin-top: ${fontSize.pxToRem(spacing[margin])};
-    `
-  }}
+      margin-top: ${spacing[margin]};
+    `}
 `

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -110,15 +110,13 @@ export const Header: VFC<Props> = ({
 }
 
 const Wrapper = styled.header<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size, palette } = themes
-
+  ${({ themes: { spacingByChar, palette } }) => {
     return css`
       display: flex;
       align-items: center;
       justify-content: space-between;
       height: 50px;
-      padding: 0 ${size.pxToRem(size.space.XS)};
+      padding: 0 ${spacingByChar(1)};
       background-color: ${palette.BRAND};
     `
   }}
@@ -148,10 +146,10 @@ const HeaderLogo = styled.button<{ themes: Theme }>`
 `
 const TenantName = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size } = themes
+    const { size, spacingByChar } = themes
 
     return css`
-      margin: 0 0 0 ${size.pxToRem(size.space.XS)};
+      margin: 0 0 0 ${spacingByChar(1)};
       font-size: ${size.pxToRem(size.font.TALL)};
       color: #fff;
     `

--- a/src/components/Header/HeaderButton.tsx
+++ b/src/components/Header/HeaderButton.tsx
@@ -47,13 +47,11 @@ const Wrapper = styled.button<{ themes: Theme }>`
   }}
 `
 const IconWrapper = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-block;
       padding: 0;
-      margin: 0 ${size.pxToRem(size.space.XXS)} 0 0;
+      margin: 0 ${spacingByChar(0.5)} 0 0;
       vertical-align: middle;
     `
   }}

--- a/src/components/Header/HeaderCrewDropdown.tsx
+++ b/src/components/Header/HeaderCrewDropdown.tsx
@@ -113,26 +113,22 @@ const TriggerButton = styled.button<{ themes: Theme }>`
   }}
 `
 const TriggerIcon = styled.figure<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-block;
       height: 14px;
       padding: 0;
-      margin: 0 ${size.pxToRem(size.space.XXS)} 0 0;
+      margin: 0 ${spacingByChar(0.5)} 0 0;
       vertical-align: middle;
     `
   }}
 `
 const CaretIcon = styled.figure<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-block;
       padding: 0;
-      margin: 0 0 0 ${size.pxToRem(size.space.XXS)};
+      margin: 0 0 0 ${spacingByChar(0.5)};
       vertical-align: middle;
     `
   }}
@@ -155,14 +151,12 @@ const MenuListItem = styled.div`
   padding: 0;
 `
 const MenuListItemIcon = styled.figure<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: flex;
       align-items: center;
       padding: 0;
-      margin: 0 ${size.pxToRem(size.space.XXS)} 0 0;
+      margin: 0 ${spacingByChar(0.5)} 0 0;
     `
   }}
 `

--- a/src/components/Header/HeaderUserDropdown.tsx
+++ b/src/components/Header/HeaderUserDropdown.tsx
@@ -159,23 +159,19 @@ const TriggerButton = styled.button<{ themes: Theme }>`
   }}
 `
 const Avatar = styled.img<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       border-radius: 4px;
-      margin-right: ${size.pxToRem(size.space.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     `
   }};
 `
 const CaretIcon = styled.figure<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-block;
       padding: 0;
-      margin: 0 0 0 ${size.pxToRem(size.space.XXS)};
+      margin: 0 0 0 ${spacingByChar(0.5)};
       vertical-align: middle;
     `
   }}
@@ -198,14 +194,12 @@ const MenuListItem = styled.div`
   padding: 0;
 `
 const MenuListItemIcon = styled.figure<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: flex;
       align-items: center;
       padding: 0;
-      margin: 0 ${size.pxToRem(size.space.XXS)} 0 0;
+      margin: 0 ${spacingByChar(0.5)} 0 0;
     `
   }}
 `

--- a/src/components/HeadlineArea/HeadlineArea.tsx
+++ b/src/components/HeadlineArea/HeadlineArea.tsx
@@ -34,10 +34,10 @@ const Wrapper = styled.div`
 `
 const Description = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette } = themes
+    const { size, spacingByChar, palette } = themes
 
     return css`
-      margin-top: ${size.pxToRem(size.space.XS)};
+      margin-top: ${spacingByChar(1)};
       color: ${palette.TEXT_BLACK};
       font-size: ${size.pxToRem(size.font.TALL)};
       line-height: 1.5;

--- a/src/components/IndexNav/IndexNav.tsx
+++ b/src/components/IndexNav/IndexNav.tsx
@@ -47,24 +47,24 @@ const List = styled.ul<{ themes: Theme }>(({ themes }) => {
   `
 })
 const Item = styled.li<{ themes: Theme }>(({ themes }) => {
-  const { size } = themes
+  const { size, spacingByChar } = themes
   return css`
     line-height: 1em;
     &:not(:first-child) {
-      margin-top: ${size.pxToRem(size.space.XS)};
+      margin-top: ${spacingByChar(1)};
     }
     & > ${List} {
-      margin-top: ${size.pxToRem(size.space.XS)};
-      margin-left: ${size.pxToRem(size.space.S)};
+      margin-top: ${spacingByChar(1)};
+      margin-left: ${spacingByChar(1.5)};
       font-size: ${size.pxToRem(size.font.SHORT)};
     }
   `
 })
 const Anchor = styled.a<{ themes: Theme; current?: boolean }>(({ themes, current }) => {
-  const { palette, size } = themes
+  const { palette, spacingByChar } = themes
   return css`
     display: inline-block;
-    padding-left: ${size.pxToRem(size.space.XXS)};
+    padding-left: ${spacingByChar(0.5)};
     border-left: 2px solid;
     border-color: ${current ? palette.MAIN : 'transparent'};
     line-height: 1em;

--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -116,11 +116,9 @@ export const InformationPanel: VFC<Props> = ({
 }
 
 const Wrapper = styled(Base)<{ themes: Theme; role: string }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      padding: ${pxToRem(space.S)};
+      padding: ${spacingByChar(1.5)};
       box-shadow: rgba(51, 51, 51, 0.3) 0 4px 10px 0;
     `
   }}
@@ -146,11 +144,9 @@ const Header = styled.div<{ themes: Theme; togglable: boolean }>(
 const Title = styled.div<{ themes: Theme }>`
   vertical-align: middle;
   line-height: 1;
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin-right: ${pxToRem(space.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     `
   }}
 `
@@ -158,11 +154,9 @@ const Title = styled.div<{ themes: Theme }>`
 const createTitleIcon = (Icon: typeof FaCheckCircleIcon) => {
   return styled(Icon)<{ $theme: Theme }>`
     vertical-align: text-top;
-    ${({ $theme }) => {
-      const { pxToRem, space } = $theme.size
-
+    ${({ $theme: { spacingByChar } }) => {
       return css`
-        margin-right: ${pxToRem(space.XXS)};
+        margin-right: ${spacingByChar(0.5)};
       `
     }}
   `
@@ -174,11 +168,11 @@ const ErrorTitleIcon = createTitleIcon(FaExclamationCircleIcon)
 const SyncIcon = createTitleIcon(FaSyncAltIcon)
 
 const Content = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space, font } = themes.size
+  ${({ themes: { size, spacingByChar } }) => {
+    const { pxToRem, font } = size
 
     return css`
-      margin-top: ${pxToRem(space.S)};
+      margin-top: ${spacingByChar(1.5)};
       font-size: ${pxToRem(font.TALL)};
       &[aria-hidden='true'] {
         display: none;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -143,16 +143,16 @@ const StyledInput = styled.input<
 >`
   ${(props) => {
     const { prefixWidth, suffixWidth, themes } = props
-    const { size, palette, frame } = themes
+    const { size, spacingByChar, palette, frame } = themes
 
     return css`
       flex-grow: 1;
       display: inline-block;
       width: 100%;
-      padding-top: ${size.pxToRem(size.space.XXS)};
-      padding-bottom: ${size.pxToRem(size.space.XXS)};
-      padding-left: ${size.pxToRem(size.space.XXS + prefixWidth)};
-      padding-right: ${size.pxToRem(size.space.XXS + suffixWidth)};
+      padding-top: ${spacingByChar(0.5)};
+      padding-bottom: ${spacingByChar(0.5)};
+      padding-left: calc(${spacingByChar(0.5)} + ${prefixWidth}px);
+      padding-right: calc(${spacingByChar(0.5)} + ${suffixWidth}px);
       border: none;
       border-radius: ${frame.border.radius.m};
       font-size: ${size.pxToRem(size.font.TALL)};
@@ -172,27 +172,27 @@ const StyledInput = styled.input<
     `
   }}
 `
-const Prefix = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { size } = themes
-  return css`
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    display: flex;
-    align-items: center;
-    padding-left: ${size.pxToRem(size.space.XXS)};
-  `
-})
-const Suffix = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { size } = themes
-  return css`
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
-    align-items: center;
-    padding-right: ${size.pxToRem(size.space.XXS)};
-  `
-})
+const Prefix = styled.span<{ themes: Theme }>(
+  ({ themes: { spacingByChar } }) =>
+    css`
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      padding-left: ${spacingByChar(0.5)};
+    `,
+)
+const Suffix = styled.span<{ themes: Theme }>(
+  ({ themes: { spacingByChar } }) =>
+    css`
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      padding-right: ${spacingByChar(0.5)};
+    `,
+)

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -102,11 +102,11 @@ const Wrapper = styled.div`
 `
 
 const FileList = styled.ul<{ themes: Theme }>(({ themes }) => {
-  const { palette, size } = themes
+  const { palette, size, spacingByChar } = themes
   return css`
     font-size: ${size.pxToRem(size.font.TALL)};
-    padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
-    margin-bottom: ${size.pxToRem(size.space.XS)};
+    padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
+    margin-bottom: ${spacingByChar(1)};
     background-color: ${palette.COLUMN};
     list-style: none;
 
@@ -170,7 +170,7 @@ const FileButtonWrapper = styled.div<{ themes: Theme }>(({ themes }) => {
 })
 
 const FileButton = styled.button<{ themes: Theme }>(({ themes }) => {
-  const { frame, palette, size } = themes
+  const { frame, palette, size, spacingByChar } = themes
   return css`
     font-family: inherit;
     font-weight: bold;
@@ -187,13 +187,13 @@ const FileButton = styled.button<{ themes: Theme }>(({ themes }) => {
     &.default {
       font-size: ${size.pxToRem(size.font.TALL)};
       height: 40px;
-      padding: 0 ${size.pxToRem(size.space.XS)};
+      padding: 0 ${spacingByChar(1)};
     }
 
     &.s {
       font-size: ${size.pxToRem(size.font.SHORT)};
       height: 27px;
-      padding: 0 ${size.pxToRem(size.space.XXS)};
+      padding: 0 ${spacingByChar(0.5)};
     }
 
     &.square {
@@ -222,11 +222,10 @@ const FileButton = styled.button<{ themes: Theme }>(({ themes }) => {
 })
 
 const Prefix = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: inline-flex;
-      margin-right: ${pxToRem(space.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     `
   }}
 `

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -183,10 +183,10 @@ const Ticker = styled.div`
 
 const Text = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette, size } = themes
+    const { palette, size, spacingByChar } = themes
 
     return css`
-      margin-top: ${size.pxToRem(size.space.XS)};
+      margin-top: ${spacingByChar(1)};
       font-size: ${size.pxToRem(size.font.TALL)};
       text-align: center;
 

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -85,11 +85,11 @@ const Logo = styled.div`
 `
 const Title = styled.h1<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette } = themes
-    const { pxToRem, space, font } = size
+    const { size, spacingByChar, palette } = themes
+    const { font } = size
 
     return css`
-      margin: ${pxToRem(space.S)} 0 0;
+      margin: ${spacingByChar(1.5)} 0 0;
       background-color: ${palette.BACKGROUND};
       color: ${palette.TEXT_BLACK};
       font-weight: normal;
@@ -99,27 +99,23 @@ const Title = styled.h1<{ themes: Theme }>`
   }}
 `
 const Content = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin-top: ${pxToRem(space.XS)};
+      margin-top: ${spacingByChar(1)};
     `
   }}
 `
 const Links = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin: ${pxToRem(space.XS)} 0 0;
+      margin: ${spacingByChar(1)} 0 0;
       padding: 0;
       list-style: none;
       text-align: center;
       line-height: 1;
 
       > li:not(:first-child) {
-        margin-top: ${pxToRem(space.XS)};
+        margin-top: ${spacingByChar(1)};
       }
     `
   }}
@@ -147,12 +143,10 @@ const ExternalIcon = styled(FaExternalLinkAltIcon).attrs(() => ({
   vertical-align: -1px;
 `
 const FooterArea = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       width: 100%;
-      padding-top: ${space.XS}px;
+      padding-top: ${spacingByChar(1)};
     `
   }}
 `

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -98,24 +98,22 @@ const Wrapper = styled.nav`
   display: inline-block;
 `
 const List = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: flex;
       margin: 0;
       padding: 0;
       > li {
         list-style: none;
-        margin-left: ${pxToRem(space.XXS)};
+        margin-left: ${spacingByChar(0.5)};
         &.prev {
-          margin-right: ${pxToRem(space.XS)};
+          margin-right: ${spacingByChar(1)};
           + li {
             margin-left: 0;
           }
         }
         &.next {
-          margin-left: ${pxToRem(space.XS)};
+          margin-left: ${spacingByChar(1)};
         }
         &.prevDouble {
           margin-left: 0;
@@ -124,14 +122,14 @@ const List = styled.ul<{ themes: Theme }>`
       &.withoutNumbers {
         > li {
           &.prev {
-            margin-left: ${pxToRem(space.XS)};
+            margin-left: ${spacingByChar(1)};
             margin-right: 0;
           }
           &.next {
-            margin-left: ${pxToRem(space.XXS)};
+            margin-left: ${spacingByChar(0.5)};
           }
           &.nextDouble {
-            margin-left: ${pxToRem(space.XS)};
+            margin-left: ${spacingByChar(1)};
           }
         }
       }

--- a/src/components/RadioButtonLabel/RadioButtonLabel.tsx
+++ b/src/components/RadioButtonLabel/RadioButtonLabel.tsx
@@ -43,9 +43,9 @@ const Label = styled.label<{ themes: Theme }>`
 `
 const Txt = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size } = themes
+    const { size, spacingByChar } = themes
     return css`
-      margin: 0 0 0 ${size.pxToRem(size.space.XXS)};
+      margin: 0 0 0 ${spacingByChar(0.5)};
       font-size: ${size.pxToRem(size.font.TALL)};
     `
   }}

--- a/src/components/RightFixedNote/RightFixedNote.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.tsx
@@ -69,11 +69,11 @@ export const RightFixedNote: FC<Props> = ({
 
 const Wrapper = styled.form<{ themes: Theme; $width: number }>`
   ${({ themes, $width }) => {
-    const { size, palette } = themes
+    const { size, spacingByChar, palette } = themes
 
     return css`
       width: ${size.pxToRem($width)};
-      padding: ${size.pxToRem(size.space.XS)};
+      padding: ${spacingByChar(1)};
       background-color: ${palette.COLUMN};
       box-shadow: rgba(0, 0, 0, 0.1) 0 0 8px;
       overflow: hidden scroll;
@@ -86,27 +86,23 @@ const Wrapper = styled.form<{ themes: Theme; $width: number }>`
 `
 
 const Title = styled(Heading)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: block;
-      margin-bottom: ${pxToRem(space.XS)};
+      margin-bottom: ${spacingByChar(1)};
     `
   }}
 `
 
 const TextArea = styled(Textarea)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
       display: block;
       width: 100%;
       max-width: 100%;
       min-width: 100%;
       box-sizing: border-box;
-      margin-bottom: ${pxToRem(space.XS)};
+      margin-bottom: ${spacingByChar(1)};
     `
   }}
 `

--- a/src/components/RightFixedNote/RightFixedNoteItem.tsx
+++ b/src/components/RightFixedNote/RightFixedNoteItem.tsx
@@ -46,22 +46,18 @@ export const RightFixedNoteItem: FC<Props> = ({
 }
 
 const Wrapper = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin-bottom: ${pxToRem(space.S)};
+      margin-bottom: ${spacingByChar(1.5)};
     `
   }}
 `
 
 const TextBase = styled(Base)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, space } = themes.size
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      padding: ${pxToRem(space.XXS)};
-      margin-bottom: ${pxToRem(space.XXS)};
+      padding: ${spacingByChar(0.5)};
+      margin-bottom: ${spacingByChar(0.5)};
       overflow: hidden;
     `
   }}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -128,13 +128,13 @@ const Wrapper = styled.div<{
 })
 const SelectBox = styled.select<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, frame, palette } = themes
+    const { size, spacingByChar, frame, palette } = themes
 
     return css`
       display: inline-block;
       width: 100%;
-      padding: ${size.pxToRem(size.space.XXS)};
-      padding-right: ${size.pxToRem(size.space.M)};
+      padding: ${spacingByChar(0.5)};
+      padding-right: ${spacingByChar(2)};
       border-radius: ${frame.border.radius.m};
       border: none;
       background-color: transparent;

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -79,7 +79,7 @@ const Wrapper = styled.li<{ themes: Theme }>`
 
 const Button = styled(ResetButton)<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size } = themes
+    const { size, spacingByChar } = themes
 
     return css`
       width: 100%;
@@ -88,23 +88,21 @@ const Button = styled(ResetButton)<{ themes: Theme }>`
       cursor: pointer;
 
       &.default {
-        padding: ${size.pxToRem(size.space.XS)};
+        padding: ${spacingByChar(1)};
         font-size: ${size.pxToRem(size.font.TALL)};
       }
 
       &.s {
-        padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
+        padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
         font-size: ${size.pxToRem(size.font.SHORT)};
       }
     `
   }}
 `
 const PrefixWrapper = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      margin-right: ${size.pxToRem(size.space.XXS)};
+      margin-right: ${spacingByChar(0.5)};
     `
   }}
 `

--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -21,15 +21,14 @@ export const StatusLabel: FC<Props> = ({ type = 'done', className = '', children
 
 const Wrapper = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette } = themes
-    const XXXS = size.space.XXS / 2
+    const { size, spacingByChar, palette } = themes
 
     return css`
       box-sizing: border-box;
       display: inline-block;
       margin: 0;
       border: 1px solid transparent;
-      padding: ${size.pxToRem(XXXS)} ${size.pxToRem(size.space.XXS)};
+      padding: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
       background-color: #fff;
       text-align: center;
       white-space: nowrap;

--- a/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`StatusLabel should be match snapshot 1`] = `
   display: inline-block;
   margin: 0;
   border: 1px solid transparent;
-  padding: 0.25rem 0.5rem;
+  padding: 4px 8px;
   background-color: #fff;
   text-align: center;
   white-space: nowrap;

--- a/src/components/TabBar/TabItem.tsx
+++ b/src/components/TabBar/TabItem.tsx
@@ -49,14 +49,14 @@ const resetButtonStyle = css`
 const Wrapper = styled.button<{ themes: Theme }>`
   ${resetButtonStyle}
   ${({ themes }) => {
-    const { size, palette, interaction } = themes
+    const { size, spacingByChar, palette, interaction } = themes
     return css`
       font-weight: bold;
       font-size: ${size.pxToRem(size.font.TALL)};
       color: ${palette.TEXT_GREY};
       height: 40px;
       border-bottom: solid 3px transparent;
-      padding: 0 ${size.pxToRem(size.space.S)};
+      padding: 0 ${spacingByChar(1.5)};
       box-sizing: border-box;
       transition: ${isTouchDevice
         ? 'none'

--- a/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`TabBar should be match snapshot 1`] = `
   color: #706d65;
   height: 40px;
   border-bottom: solid 3px transparent;
-  padding: 0 1.5rem;
+  padding: 0 24px;
   box-sizing: border-box;
   -webkit-transition: background-color .3s ease-out,color .3s ease-out;
   transition: background-color .3s ease-out,color .3s ease-out;

--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -53,13 +53,13 @@ export const Cell: FC<Props & ElementProps> = ({
 
 const Th = styled.th<{ themes: Theme; onClick?: () => void }>`
   ${({ themes, onClick }) => {
-    const { size, palette, interaction } = themes
+    const { size, spacingByChar, palette, interaction } = themes
 
     return css`
       height: ${size.pxToRem(40)};
       font-size: ${size.pxToRem(size.font.SHORT)};
       font-weight: bold;
-      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       color: ${palette.TEXT_BLACK};
       transition: ${isTouchDevice ? 'none' : `background-color ${interaction.hover.animation}`};
       text-align: left;
@@ -91,12 +91,12 @@ const Td = styled.td<{ themes: Theme }>`
   }
 
   ${({ themes }) => {
-    const { size, palette, frame } = themes
+    const { size, spacingByChar, palette, frame } = themes
 
     return css`
       color: ${palette.TEXT_BLACK};
       height: ${size.pxToRem(44)};
-      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       border-top: ${frame.border.default};
       font-size: ${size.pxToRem(size.font.TALL)};
       line-height: 1.5;

--- a/src/components/Table/Head.tsx
+++ b/src/components/Table/Head.tsx
@@ -27,12 +27,12 @@ export const Head: FC<Props> = ({ bulkActionArea, className = '', children }) =>
 }
 
 const BulkActionTD = styled.td<{ themes: Theme }>(({ themes }) => {
-  const { frame, color } = themes
-  const { font, pxToRem, space } = themes.size
+  const { frame, color, spacingByChar } = themes
+  const { font, pxToRem } = themes.size
   return css`
     border-top: ${frame.border.default};
     background-color: ${color.ACTION_BACKGROUND};
-    padding: ${pxToRem(space.XS)};
+    padding: ${spacingByChar(1)};
     font-size: ${pxToRem(font.TALL)};
   `
 })

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -65,10 +65,10 @@ export const Textarea: FC<Props> = ({ autoFocus, maxLength, width, ...props }) =
 const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: string | number }>`
   ${(props) => {
     const { themes, textAreaWidth = 'auto', error } = props
-    const { size, frame, palette } = themes
+    const { size, spacingByChar, frame, palette } = themes
 
     return css`
-      padding: ${size.pxToRem(size.space.XXS)};
+      padding: ${spacingByChar(0.5)};
       font-size: ${size.pxToRem(size.font.TALL)};
       color: ${palette.TEXT_BLACK};
       border-radius: ${frame.border.radius.m};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -151,12 +151,9 @@ const StyledDarkBalloon = StyledLightBalloon.withComponent(DarkBalloon)
 
 const StyledBalloonText = styled.p<{ themes: Theme }>`
   margin: 0;
-  ${(props) => {
-    const { themes } = props
-    const { size } = themes
-
+  ${({ themes: { spacingByChar } }) => {
     return css`
-      padding: ${size.pxToRem(size.space.XXS)} ${size.pxToRem(size.space.XS)};
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
     `
   }}
 `

--- a/src/themes/__tests__/createSpacing.ts
+++ b/src/themes/__tests__/createSpacing.ts
@@ -1,66 +1,110 @@
-import { createSpacing } from '../createSpacing'
-import { createSize } from '../createSize'
+import { createSpacing, createSpacingByChar, defaultBaseSize } from '../createSpacing'
+
+const toPx = (size: number) => `${size}px`
+
+describe('createSpacingByChar', () => {
+  it('returns default spacing size when no arguments given', () => {
+    const actual = createSpacingByChar()
+
+    expect(actual(0.25)).toBe(toPx(defaultBaseSize / 2))
+    expect(actual(0.5)).toBe(toPx(defaultBaseSize))
+    expect(actual(0.75)).toBe(toPx(defaultBaseSize * 1.5))
+    expect(actual(1)).toBe(toPx(defaultBaseSize * 2))
+    expect(actual(1.25)).toBe(toPx(defaultBaseSize * 2.5))
+    expect(actual(1.5)).toBe(toPx(defaultBaseSize * 3))
+    expect(actual(2)).toBe(toPx(defaultBaseSize * 4))
+    expect(actual(2.5)).toBe(toPx(defaultBaseSize * 5))
+    expect(actual(3)).toBe(toPx(defaultBaseSize * 6))
+    expect(actual(3.5)).toBe(toPx(defaultBaseSize * 7))
+    expect(actual(4)).toBe(toPx(defaultBaseSize * 8))
+    expect(actual(8)).toBe(toPx(defaultBaseSize * 16))
+    expect(actual(-0.25)).toBe(toPx(defaultBaseSize / -2))
+    expect(actual(-0.5)).toBe(toPx(defaultBaseSize * -1))
+    expect(actual(-0.75)).toBe(toPx(defaultBaseSize * -1.5))
+    expect(actual(-1)).toBe(toPx(defaultBaseSize * -2))
+    expect(actual(-1.25)).toBe(toPx(defaultBaseSize * -2.5))
+    expect(actual(-1.5)).toBe(toPx(defaultBaseSize * -3))
+    expect(actual(-2)).toBe(toPx(defaultBaseSize * -4))
+    expect(actual(-2.5)).toBe(toPx(defaultBaseSize * -5))
+    expect(actual(-3)).toBe(toPx(defaultBaseSize * -6))
+    expect(actual(-3.5)).toBe(toPx(defaultBaseSize * -7))
+    expect(actual(-4)).toBe(toPx(defaultBaseSize * -8))
+    expect(actual(-8)).toBe(toPx(defaultBaseSize * -16))
+  })
+
+  it('returns customized size theme when gives baseSize', () => {
+    const baseSize = 13
+    const actual = createSpacingByChar(baseSize)
+
+    expect(actual(0.25)).toBe(toPx(baseSize / 2))
+    expect(actual(0.5)).toBe(toPx(baseSize))
+    expect(actual(0.75)).toBe(toPx(baseSize * 1.5))
+    expect(actual(1)).toBe(toPx(baseSize * 2))
+    expect(actual(1.25)).toBe(toPx(baseSize * 2.5))
+    expect(actual(1.5)).toBe(toPx(baseSize * 3))
+    expect(actual(2)).toBe(toPx(baseSize * 4))
+    expect(actual(2.5)).toBe(toPx(baseSize * 5))
+    expect(actual(3)).toBe(toPx(baseSize * 6))
+    expect(actual(3.5)).toBe(toPx(baseSize * 7))
+    expect(actual(4)).toBe(toPx(baseSize * 8))
+    expect(actual(8)).toBe(toPx(baseSize * 16))
+    expect(actual(-0.25)).toBe(toPx(baseSize / -2))
+    expect(actual(-0.5)).toBe(toPx(baseSize * -1))
+    expect(actual(-0.75)).toBe(toPx(baseSize * -1.5))
+    expect(actual(-1)).toBe(toPx(baseSize * -2))
+    expect(actual(-1.25)).toBe(toPx(baseSize * -2.5))
+    expect(actual(-1.5)).toBe(toPx(baseSize * -3))
+    expect(actual(-2)).toBe(toPx(baseSize * -4))
+    expect(actual(-2.5)).toBe(toPx(baseSize * -5))
+    expect(actual(-3)).toBe(toPx(baseSize * -6))
+    expect(actual(-3.5)).toBe(toPx(baseSize * -7))
+    expect(actual(-4)).toBe(toPx(baseSize * -8))
+    expect(actual(-8)).toBe(toPx(baseSize * -16))
+  })
+})
 
 describe('createSpacing', () => {
-  it('returns same spacing theme with createSize', () => {
+  it('returns default spacing theme when no arguments given', () => {
     const actual = createSpacing()
-    const expected = createSize()
 
-    expect(actual.XXS).toBe(expected.space.XXS)
-    expect(actual.XS).toBe(expected.space.XS)
-    expect(actual.S).toBe(expected.space.S)
-    expect(actual.M).toBe(expected.space.M)
-    expect(actual.L).toBe(expected.space.L)
-    expect(actual.XL).toBe(expected.space.XL)
-    expect(actual.XXL).toBe(expected.space.XXL)
+    expect(actual.X3S).toBe(toPx(8 / 2))
+    expect(actual.XXS).toBe(toPx(8))
+    expect(actual.XS).toBe(toPx(8 * 2))
+    expect(actual.S).toBe(toPx(8 * 3))
+    expect(actual.M).toBe(toPx(8 * 4))
+    expect(actual.L).toBe(toPx(8 * 5))
+    expect(actual.XL).toBe(toPx(8 * 6))
+    expect(actual.XXL).toBe(toPx(8 * 7))
+    expect(actual.X3L).toBe(toPx(8 * 8))
   })
 
-  it('returns same spacing theme with createSize when give base size', () => {
-    const actual = createSpacing({
-      baseSize: 17,
-    })
-    const expected = createSize({
-      space: {
-        defaultRem: 17,
-      },
-    })
+  it('returns customized spacing theme when gives base size', () => {
+    const actual = createSpacing(13)
 
-    expect(actual.XXS).toBe(expected.space.XXS)
-    expect(actual.XS).toBe(expected.space.XS)
-    expect(actual.S).toBe(expected.space.S)
-    expect(actual.M).toBe(expected.space.M)
-    expect(actual.L).toBe(expected.space.L)
-    expect(actual.XL).toBe(expected.space.XL)
-    expect(actual.XXL).toBe(expected.space.XXL)
+    expect(actual.X3S).toBe(toPx(13 / 2))
+    expect(actual.XXS).toBe(toPx(13))
+    expect(actual.XS).toBe(toPx(13 * 2))
+    expect(actual.S).toBe(toPx(13 * 3))
+    expect(actual.M).toBe(toPx(13 * 4))
+    expect(actual.L).toBe(toPx(13 * 5))
+    expect(actual.XL).toBe(toPx(13 * 6))
+    expect(actual.XXL).toBe(toPx(13 * 7))
+    expect(actual.X3L).toBe(toPx(13 * 8))
   })
 
-  it('returns customized spacing theme when give base size', () => {
-    const actual = createSpacing({
-      baseSize: 13,
-    })
+  it('returns the same value as createSpacingByChar', () => {
+    const baseSize = 20
+    const actual = createSpacing(baseSize)
+    const expected = createSpacingByChar(baseSize)
 
-    expect(actual.XXS).toBe(13)
-    expect(actual.XS).toBe(13 * 2)
-    expect(actual.S).toBe(13 * 3)
-    expect(actual.M).toBe(13 * 4)
-    expect(actual.L).toBe(13 * 5)
-    expect(actual.XL).toBe(13 * 6)
-    expect(actual.XXL).toBe(13 * 7)
-  })
-
-  it('returns customized spacing theme when give base size and some tokens', () => {
-    const actual = createSpacing({
-      baseSize: 13,
-      M: 120,
-      XL: 122,
-    })
-
-    expect(actual.XXS).toBe(13)
-    expect(actual.XS).toBe(13 * 2)
-    expect(actual.S).toBe(13 * 3)
-    expect(actual.M).toBe(120)
-    expect(actual.L).toBe(13 * 5)
-    expect(actual.XL).toBe(122)
-    expect(actual.XXL).toBe(13 * 7)
+    expect(actual.X3S).toEqual(expected(0.25))
+    expect(actual.XXS).toEqual(expected(0.5))
+    expect(actual.XS).toEqual(expected(1))
+    expect(actual.S).toEqual(expected(1.5))
+    expect(actual.M).toEqual(expected(2))
+    expect(actual.L).toEqual(expected(2.5))
+    expect(actual.XL).toEqual(expected(3))
+    expect(actual.XXL).toEqual(expected(3.5))
+    expect(actual.X3L).toEqual(expected(4))
   })
 })

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -154,38 +154,31 @@ describe('createTheme', () => {
 
   it('returns theme reflecting "spacing" settings', () => {
     const actual1 = createTheme({
-      spacing: {
-        XXS: 21,
-        XS: 22,
-        S: 23,
-        M: 24,
-        L: 25,
-        XL: 26,
-        XXL: 27,
-      },
+      spacing: { baseSize: 20 },
     })
 
-    expect(actual1.spacing.XXS).toBe(21)
-    expect(actual1.spacing.XS).toBe(22)
-    expect(actual1.spacing.S).toBe(23)
-    expect(actual1.spacing.M).toBe(24)
-    expect(actual1.spacing.L).toBe(25)
-    expect(actual1.spacing.XL).toBe(26)
-    expect(actual1.spacing.XXL).toBe(27)
+    expect(actual1.spacing.X3S).toBe('10px')
+    expect(actual1.spacing.XXS).toBe('20px')
+    expect(actual1.spacing.XS).toBe('40px')
+    expect(actual1.spacing.S).toBe('60px')
+    expect(actual1.spacing.M).toBe('80px')
+    expect(actual1.spacing.L).toBe('100px')
+    expect(actual1.spacing.XL).toBe('120px')
+    expect(actual1.spacing.XXL).toBe('140px')
+    expect(actual1.spacing.X3L).toBe('160px')
+  })
 
-    const actual2 = createTheme({
-      spacing: {
-        baseSize: 17,
-      },
-    })
+  it('default settings, createSpace and createSpacing are set the same', () => {
+    const actual = createTheme()
+    const toPx = (size: number) => `${size}px`
 
-    expect(actual2.spacing.XXS).toBe(17)
-    expect(actual2.spacing.XS).toBe(17 * 2)
-    expect(actual2.spacing.S).toBe(17 * 3)
-    expect(actual2.spacing.M).toBe(17 * 4)
-    expect(actual2.spacing.L).toBe(17 * 5)
-    expect(actual2.spacing.XL).toBe(17 * 6)
-    expect(actual2.spacing.XXL).toBe(17 * 7)
+    expect(actual.spacing.XXS).toBe(toPx(actual.size.space.XXS))
+    expect(actual.spacing.XS).toBe(toPx(actual.size.space.XS))
+    expect(actual.spacing.S).toBe(toPx(actual.size.space.S))
+    expect(actual.spacing.M).toBe(toPx(actual.size.space.M))
+    expect(actual.spacing.L).toBe(toPx(actual.size.space.L))
+    expect(actual.spacing.XL).toBe(toPx(actual.size.space.XL))
+    expect(actual.spacing.XXL).toBe(toPx(actual.size.space.XXL))
   })
 
   it('returns theme reflecting "fontSize" settings', () => {
@@ -362,9 +355,11 @@ describe('createTheme', () => {
     expect(actual.size.space.XXS).toBe(11)
     expect(actual.size.space.XS).toBe(10 * 2)
     expect(actual.size.space.S).toBe(10 * 3)
-    expect(actual.spacing.XXS).toBe(11)
-    expect(actual.spacing.XS).toBe(10 * 2)
-    expect(actual.spacing.S).toBe(10 * 3)
+
+    // size does not affect spacing
+    expect(actual.spacing.XXS).not.toBe(11)
+    expect(actual.spacing.XS).not.toBe(10 * 2)
+    expect(actual.spacing.S).not.toBe(10 * 3)
 
     expect(actual.size.font.SHORT).toBe(100)
     expect(actual.size.font.TALL).toBe(defaultFontSize.TALL)
@@ -375,22 +370,6 @@ describe('createTheme', () => {
     expect(actual.size.mediaQuery.TABLET).toBe(defaultBreakpoint.TABLET)
     expect(actual.breakpoint.SP).toBe(1000)
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
-  })
-
-  it('returns theme reflecting "spacing" settings to "size.space"', () => {
-    const actual = createTheme({
-      spacing: {
-        baseSize: 20,
-        XXS: 21,
-      },
-    })
-
-    expect(actual.size.space.XXS).toBe(21)
-    expect(actual.size.space.XS).toBe(20 * 2)
-    expect(actual.size.space.S).toBe(20 * 3)
-    expect(actual.spacing.XXS).toBe(21)
-    expect(actual.spacing.XS).toBe(20 * 2)
-    expect(actual.spacing.S).toBe(20 * 3)
   })
 
   it('returns theme reflecting "fontSize" settings to "size.fontSize"', () => {
@@ -419,15 +398,10 @@ describe('createTheme', () => {
     expect(actual.breakpoint.TABLET).toBe(defaultBreakpoint.TABLET)
   })
 
-  it('returns theme prioritizing "spacing", "fontSize" and "breakpoint" settings over "size" when given size, spacing, fontSize and breakpoint settings', () => {
+  it('returns theme prioritizing "fontSize" and "breakpoint" settings over "size" when given size, fontSize and breakpoint settings', () => {
     const actual = createTheme({
       size: {
         htmlFontSize: 2,
-        space: {
-          defaultRem: 10,
-          XXS: 11,
-          XS: 12,
-        },
         font: {
           SHORT: 100,
           TALL: 101,
@@ -436,10 +410,6 @@ describe('createTheme', () => {
           SP: 1000,
           TABLET: 1001,
         },
-      },
-      spacing: {
-        baseSize: 13,
-        XS: 14,
       },
       fontSize: {
         htmlFontSize: 8,
@@ -452,13 +422,6 @@ describe('createTheme', () => {
 
     expect(actual.size.pxToRem(400)).toBe(`${400 / 8}rem`)
     expect(actual.fontSize.pxToRem(400)).toBe(`${400 / 8}rem`)
-
-    expect(actual.size.space.XXS).toBe(11)
-    expect(actual.size.space.XS).toBe(14)
-    expect(actual.size.space.S).toBe(13 * 3)
-    expect(actual.spacing.XXS).toBe(11)
-    expect(actual.spacing.XS).toBe(14)
-    expect(actual.spacing.S).toBe(13 * 3)
 
     expect(actual.size.font.SHORT).toBe(100)
     expect(actual.size.font.TALL).toBe(200)

--- a/src/themes/createFontSize.ts
+++ b/src/themes/createFontSize.ts
@@ -1,6 +1,6 @@
 import { merge } from '../libs/lodash'
 
-const defaultHtmlFontSize = 16
+export const defaultHtmlFontSize = 16
 
 export interface FontSizeProperty {
   htmlFontSize?: number

--- a/src/themes/createSpacing.ts
+++ b/src/themes/createSpacing.ts
@@ -1,45 +1,78 @@
-import { merge } from '../libs/lodash'
-
-const defaultBaseSize = 8
+import { defaultHtmlFontSize } from './createFontSize'
+export const defaultBaseSize = defaultHtmlFontSize / 2
 
 export interface SpacingProperty {
   baseSize?: number
-  XXS?: number
-  XS?: number
-  S?: number
-  M?: number
-  L?: number
-  XL?: number
-  XXL?: number
 }
 
 export interface CreatedSpacingTheme {
-  XXS: number
-  XS: number
-  S: number
-  M: number
-  L: number
-  XL: number
-  XXL: number
+  X3S: string
+  XXS: string
+  XS: string
+  S: string
+  M: string
+  L: string
+  XL: string
+  XXL: string
+  X3L: string
 }
 
+export type CreatedSpacingByCharTheme = (size: CharRelativeSize) => string
+
+const primitiveTokens = [
+  0.25,
+  0.5,
+  0.75,
+  1,
+  1.25,
+  1.5,
+  2,
+  2.5,
+  3,
+  3.5,
+  4,
+  8,
+  -0.25,
+  -0.5,
+  -0.75,
+  -1,
+  -1.25,
+  -1.5,
+  -2,
+  -2.5,
+  -3,
+  -3.5,
+  -4,
+  -8,
+] as const
+
+export type CharRelativeSize = typeof primitiveTokens[number]
+
 const getSpacing = (baseSize: number) => {
+  const spacingByChar = createSpacingByChar(baseSize)
   return {
-    XXS: baseSize,
-    XS: baseSize * 2,
-    S: baseSize * 3,
-    M: baseSize * 4,
-    L: baseSize * 5,
-    XL: baseSize * 6,
-    XXL: baseSize * 7,
+    X3S: spacingByChar(0.25),
+    XXS: spacingByChar(0.5),
+    XS: spacingByChar(1),
+    S: spacingByChar(1.5),
+    M: spacingByChar(2),
+    L: spacingByChar(2.5),
+    XL: spacingByChar(3),
+    XXL: spacingByChar(3.5),
+    X3L: spacingByChar(4),
   }
 }
 
-export const defaultSpacing = getSpacing(defaultBaseSize)
-
-export const createSpacing = (userSpacing: SpacingProperty = {}) => {
-  const { baseSize, ...userTokens } = userSpacing
-  const created: CreatedSpacingTheme = merge(getSpacing(baseSize || defaultBaseSize), userTokens)
-
-  return created
+const getSpacingByChar = (baseSize: number) => {
+  const charSize = baseSize * 2
+  return primitiveTokens
+    .map((size) => {
+      return { [size]: `${charSize * size}px` }
+    })
+    .reduce((a, c) => Object.assign(a, c), {})
 }
+
+export const createSpacing = (userBaseSize: number = defaultBaseSize) => getSpacing(userBaseSize)
+export const createSpacingByChar = (userBaseSize: number = defaultBaseSize) => (
+  size: CharRelativeSize,
+) => getSpacingByChar(userBaseSize)[size]

--- a/src/themes/createSpacing.ts
+++ b/src/themes/createSpacing.ts
@@ -76,3 +76,5 @@ export const createSpacing = (userBaseSize: number = defaultBaseSize) => getSpac
 export const createSpacingByChar = (userBaseSize: number = defaultBaseSize) => (
   size: CharRelativeSize,
 ) => getSpacingByChar(userBaseSize)[size]
+
+export const defaultSpacing = createSpacing()

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -10,7 +10,13 @@ import { CreatedPaletteTheme, PaletteProperty, createPalette } from './createPal
 import { ColorProperty, CreatedColorTheme, createColor } from './createColor'
 import { CreatedSizeTheme, SizeProperty, createSize } from './createSize'
 import { CreatedFontSizeTheme, FontSizeProperty, createFontSize } from './createFontSize'
-import { CreatedSpacingTheme, SpacingProperty, createSpacing } from './createSpacing'
+import {
+  CreatedSpacingByCharTheme,
+  CreatedSpacingTheme,
+  SpacingProperty,
+  createSpacing,
+  createSpacingByChar,
+} from './createSpacing'
 import { BreakpointProperty, CreatedBreakpointTheme, createBreakpoint } from './createBreakpoint'
 import { CreatedShadowTheme, ShadowProperty, createShadow } from './createShadow'
 import { CreatedZindexTheme, ZIndexProperty, createZIndex } from './createZIndex'
@@ -51,6 +57,7 @@ export interface CreatedTheme {
   size: CreatedSizeTheme
   fontSize: CreatedFontSizeTheme
   spacing: CreatedSpacingTheme
+  spacingByChar: CreatedSpacingByCharTheme
   breakpoint: CreatedBreakpointTheme
   /**
    * @deprecated The frame property will be deprecated, please use border or radius property instead
@@ -66,12 +73,14 @@ export interface CreatedTheme {
 export const createTheme = (theme: ThemeProperty = {}) => {
   const paletteProperty = getPaletteProperty(theme)
   const colorProperty = getColorProperty(theme)
+  const baseSize = getSpacingProperty(theme).baseSize
   const created: CreatedTheme = {
     palette: createPalette(paletteProperty),
     color: createColor(colorProperty),
     size: createSize(getSizeProperty(theme)),
     fontSize: createFontSize(getFontSizeProperty(theme)),
-    spacing: createSpacing(getSpacingProperty(theme)),
+    spacing: createSpacing(baseSize),
+    spacingByChar: createSpacingByChar(baseSize),
     breakpoint: createBreakpoint(getBreakpointProperty(theme)),
     frame: createFrame(getFrameProperty(theme), paletteProperty),
     border: createBorder(getBorderProperty(theme), colorProperty),
@@ -99,14 +108,14 @@ function getSizeProperty(theme: ThemeProperty): SizeProperty {
   return {
     htmlFontSize: theme.fontSize?.htmlFontSize || theme.size?.htmlFontSize,
     space: {
-      defaultRem: theme.spacing?.baseSize || theme.size?.space?.defaultRem,
-      XXS: theme.spacing?.XXS || theme.size?.space?.XXS,
-      XS: theme.spacing?.XS || theme.size?.space?.XS,
-      S: theme.spacing?.S || theme.size?.space?.S,
-      M: theme.spacing?.M || theme.size?.space?.M,
-      L: theme.spacing?.L || theme.size?.space?.L,
-      XL: theme.spacing?.XL || theme.size?.space?.XL,
-      XXL: theme.spacing?.XXL || theme.size?.space?.XXL,
+      defaultRem: theme.size?.space?.defaultRem,
+      XXS: theme.size?.space?.XXS,
+      XS: theme.size?.space?.XS,
+      S: theme.size?.space?.S,
+      M: theme.size?.space?.M,
+      L: theme.size?.space?.L,
+      XL: theme.size?.space?.XL,
+      XXL: theme.size?.space?.XXL,
     },
     font: {
       SHORT: theme.fontSize?.SHORT || theme.size?.font?.SHORT,
@@ -129,15 +138,7 @@ function getFontSizeProperty(theme: ThemeProperty): FontSizeProperty {
 }
 function getSpacingProperty(theme: ThemeProperty): SpacingProperty {
   return {
-    baseSize: theme.size?.space?.defaultRem,
-    XXS: theme.size?.space?.XXS,
-    XS: theme.size?.space?.XS,
-    S: theme.size?.space?.S,
-    M: theme.size?.space?.M,
-    L: theme.size?.space?.L,
-    XL: theme.size?.space?.XL,
-    XXL: theme.size?.space?.XXL,
-    ...theme.spacing,
+    baseSize: theme.spacing?.baseSize,
   }
 }
 function getBreakpointProperty(theme: ThemeProperty): BreakpointProperty {


### PR DESCRIPTION
余白を pxToRem を使用しないでも使えるように px 値で提供します。

## 概要

- spacing の baseSize を defaultHtmlFontSize から算出します
- spacing の各値を theme から渡すことはできません。baseSize に乗数を掛けたもの各値として設定します
- theme.spacing の各値を数値から px を含む文字列に変更しました
- 既存の `size.space` を使っている箇所を spacingByChar に置き換えました

## 値の置き換え

外から theme を渡さない、デフォルトの状態においては既存の `size.space` と `spacing` には互換性があります。

`size.space` | `spacing` | `spacingByChar` | 実値
--- | --- | --- | ---
\- | X3S | 0.25 | 4px
XXS | XXS | 0.5 | 8px
\- | - | 0.75 | 12px
XS | XS | 1 | 16px
\- | - | 1.25 | 20px
S | S | 1.5 | 24px
M | M | 2 | 32px
L | L | 2.5 | 40px
XL | XL | 3 | 48px
XXL | XXL | 3.5 | 56px
\- | X3L | 4 | 64px
\- | - | 8 | 128px
\- | - | -0.25 | -4px
\- | - | -0.5 | -8px
\- | - | -0.75 | -12px
\- | - | -1 | -16px
\- | - | -1.25 | -20px
\- | - | -1.5 | -24px
\- | - | -2 | -32px
\- | - | -2.5 | -40px
\- | - | -3 | -48px
\- | - | -3.5 | -56px
\- | - | -4 | -64px
\- | - | -8 | -128px

## ほか

FlashMessage の見た目に差分が出ていますが、`200px 相当の rem` に理由がなく、元デザインとも整合性がなかったため、より実態を表した実装にしています。
https://smarthr.invisionapp.com/console/SmartHR-UI-ckhqzotxfh8zt0131gak0mpkm/ckhqzpm20h7em012ahdq62y4m/play