### PR TITLE
Add quiet option for build storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "build": "run-p build:*",
     "build:lib": "tsc -p tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.esm.build.json",
-    "build-storybook": "build-storybook",
+    "build-storybook": "build-storybook --quiet",
     "clean": "rimraf ./lib",
     "format": "eslint --fix './**/*.ts{,x}'",
     "lint": "run-p lint:*",


### PR DESCRIPTION
## Related URL

https://storybook.js.org/docs/react/api/cli-options#build-storybook

## Overview

SmartHR Team の Netlify の Build budget を使い切りそう。一番 build しているのが smarthr-ui だった。

This month, we will be almost using up the SmartHR Team's Netlify build budget.
smarthr-ui was the project that took the most time to build.

## What I did

build 時間の短縮化のために `--quiet` オプションを追加

Add `--quiet` option to speed up build time.

## Capture

### local

```
build-storybook
yarn build-storybook  87.00s user 11.16s system 151% cpu 1:04.99 total
```

```
build-storybook --quiet
yarn build-storybook  44.67s user 7.73s system 151% cpu 34.573 total
```

### on Netlify

```
Production: master@fd76aee
4m18s
```

```
Deploy Preview #1548: chore/build-storybook-quiet@98bfd89
1m45s
```
