### PR TITLE
fix: set DIALOG shadow to CompactInformationPanel (SHRUI-400)

### DIFF
--- a/src/components/CompactInformationPanel/CompactInformationPanel.tsx
+++ b/src/components/CompactInformationPanel/CompactInformationPanel.tsx
@@ -73,8 +73,8 @@ const Wrapper = styled(Base)<{ themes: Theme }>`
   }) => {
     return css`
       display: flex;
-      padding: ${pxToRem(spacing.XS)};
       box-shadow: ${shadow.DIALOG};
+      padding: ${pxToRem(spacing.XS)};
     `
   }}
 `

--- a/src/components/CompactInformationPanel/CompactInformationPanel.tsx
+++ b/src/components/CompactInformationPanel/CompactInformationPanel.tsx
@@ -68,11 +68,13 @@ const Wrapper = styled(Base)<{ themes: Theme }>`
     themes: {
       fontSize: { pxToRem },
       spacing,
+      shadow,
     },
   }) => {
     return css`
       display: flex;
       padding: ${pxToRem(spacing.XS)};
+      box-shadow: ${shadow.DIALOG};
     `
   }}
 `


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-400

## Overview

- CompactInformationPanelのbox-shadowをDIALOG（`rgba(51, 51, 51, 0.3) 0 4px 10px 0`）に設定します。

## What I did

- CompactInformationPanelのbox-shadowが適切ではなかったため、正しい値を設定した。
  - 修正前：設定なし（デフォルトの`BASE`）
  - 修正後：`DIALOG`

## Capture

### 修正前
<img width="1031" alt="スクリーンショット 2021-04-28 16 46 24" src="https://user-images.githubusercontent.com/64398878/116366579-6a053980-a841-11eb-81d2-bced4a91b614.png">


### 修正後
<img width="1033" alt="スクリーンショット 2021-04-28 16 44 42" src="https://user-images.githubusercontent.com/64398878/116366563-64a7ef00-a841-11eb-929c-0af7dc7fc9c3.png">
