### PR TITLE
新フォントサイズを定義

### DIFF
--- a/src/themes/__tests__/createFontSize.ts
+++ b/src/themes/__tests__/createFontSize.ts
@@ -13,6 +13,18 @@ describe('createFontSize', () => {
     expect(actual.pxToRem(29)).toBe(expected.pxToRem(29))
   })
 
+  it('returns default font size when no arguments given', () => {
+    const actual = createFontSize()
+
+    expect(actual.XXS).toBe(`${6 / 9}rem`)
+    expect(actual.XS).toBe(`${6 / 8}rem`)
+    expect(actual.S).toBe(`${6 / 7}rem`)
+    expect(actual.M).toBe(`${6 / 6}rem`)
+    expect(actual.L).toBe(`${6 / 5}rem`)
+    expect(actual.XL).toBe(`${6 / 4}rem`)
+    expect(actual.XXL).toBe(`${6 / 3}rem`)
+  })
+
   it('returns customized font size theme when give user font size', () => {
     const actual = createFontSize({
       htmlFontSize: 15,
@@ -27,5 +39,17 @@ describe('createFontSize', () => {
     expect(actual.GRANDE).toBe(31)
     expect(actual.VENTI).toBe(37)
     expect(actual.pxToRem(41)).toBe(`${41 / 15}rem`)
+  })
+
+  it('returns customized size theme when gives baseSize', () => {
+    const actual = createFontSize({ scaleFactor: 8 })
+
+    expect(actual.XXS).toBe(`${8 / 11}rem`)
+    expect(actual.XS).toBe(`${8 / 10}rem`)
+    expect(actual.S).toBe(`${8 / 9}rem`)
+    expect(actual.M).toBe(`${8 / 8}rem`)
+    expect(actual.L).toBe(`${8 / 7}rem`)
+    expect(actual.XL).toBe(`${8 / 6}rem`)
+    expect(actual.XXL).toBe(`${8 / 5}rem`)
   })
 })

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -189,6 +189,7 @@ describe('createTheme', () => {
         TALL: 13,
         GRANDE: 14,
         VENTI: 15,
+        scaleFactor: 8,
       },
     })
 
@@ -197,6 +198,13 @@ describe('createTheme', () => {
     expect(actual.fontSize.TALL).toBe(13)
     expect(actual.fontSize.GRANDE).toBe(14)
     expect(actual.fontSize.VENTI).toBe(15)
+    expect(actual.fontSize.XXS).toBe(`${8 / 11}rem`)
+    expect(actual.fontSize.XS).toBe(`${8 / 10}rem`)
+    expect(actual.fontSize.S).toBe(`${8 / 9}rem`)
+    expect(actual.fontSize.M).toBe(`${8 / 8}rem`)
+    expect(actual.fontSize.L).toBe(`${8 / 7}rem`)
+    expect(actual.fontSize.XL).toBe(`${8 / 6}rem`)
+    expect(actual.fontSize.XXL).toBe(`${8 / 5}rem`)
   })
 
   it('returns theme reflecting "breakpoint" settings', () => {

--- a/src/themes/createFontSize.ts
+++ b/src/themes/createFontSize.ts
@@ -1,26 +1,60 @@
 import { merge } from '../libs/lodash'
 
 export const defaultHtmlFontSize = 16
+const defaultScaleFactor = 6
 
 export interface FontSizeProperty {
+  /** @deprecated */
   htmlFontSize?: number
   // respect for Starbucks...
+  /** @deprecated */
   SHORT?: number
+  /** @deprecated */
   TALL?: number
+  /** @deprecated */
   GRANDE?: number
+  /** @deprecated */
   VENTI?: number
+
+  scaleFactor?: number
 }
 
 export interface CreatedFontSizeTheme {
+  /** @deprecated You shouldn't use rem except for font size. use calc. */
   pxToRem: (px: number) => string
+  /** @deprecated */
   SHORT: number
+  /** @deprecated */
   TALL: number
+  /** @deprecated */
   GRANDE: number
+  /** @deprecated */
   VENTI: number
+  XXS: string
+  XS: string
+  S: string
+  M: string
+  L: string
+  XL: string
+  XXL: string
 }
 
 const pxToRem = (htmlFontSize: number) => (px: number) => {
   return `${px / htmlFontSize}rem`
+}
+const getFontSize = (scaleFactor: number, diff: number = 0) =>
+  // calc(1rem * scaleFactor / (scaleFactor + diff))
+  `${scaleFactor / (scaleFactor + diff)}rem`
+const getSizes = (scaleFactor: number) => {
+  return {
+    XXS: getFontSize(scaleFactor, 3),
+    XS: getFontSize(scaleFactor, 2),
+    S: getFontSize(scaleFactor, 1),
+    M: getFontSize(scaleFactor),
+    L: getFontSize(scaleFactor, -1),
+    XL: getFontSize(scaleFactor, -2),
+    XXL: getFontSize(scaleFactor, -3),
+  }
 }
 
 export const defaultFontSize: CreatedFontSizeTheme = {
@@ -29,16 +63,18 @@ export const defaultFontSize: CreatedFontSizeTheme = {
   TALL: 14,
   GRANDE: 18,
   VENTI: 24,
+  ...getSizes(defaultScaleFactor),
 }
 
 export const createFontSize = (userFontSize: FontSizeProperty = {}) => {
-  const { htmlFontSize, ...userTokens } = userFontSize
+  const { htmlFontSize, scaleFactor, ...userTokens } = userFontSize
   const created: CreatedFontSizeTheme = merge(
     {
       ...defaultFontSize,
       pxToRem: pxToRem(htmlFontSize || defaultHtmlFontSize),
     },
     userTokens,
+    scaleFactor ? getSizes(scaleFactor) : {},
   )
 
   return created


### PR DESCRIPTION
調和数列を元にした新フォントサイズを追加しました。
SHORT / TALL / GRANDE / VENTI を `@deprecated` にしました。

このプルリクでは既存コンポーネントの修正は行なっていないため、影響はありません。
#1545 のマージ後に作業予定です。