### PR TITLE
テキストコンポーネントを追加

### DIFF
--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,0 +1,12 @@
+A Text component.
+
+あらゆる文字のためのコンポーネントです。
+
+<details>
+<summary>how to import</summary>
+
+```tsx
+import { Text } from 'smarthr-ui'
+```
+
+</details>

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Story } from '@storybook/react'
+
+// import { useTheme } from '../../hooks/useTheme'
+
+import { Text } from './Text'
+
+import readme from './README.md'
+
+export default {
+  title: 'Text',
+  component: Text,
+  parameters: {
+    docs: {
+      description: { component: readme },
+    },
+  },
+}
+
+export const Default: Story = () => (
+  <>
+    <Text>
+      デフォルトの出力要素は <code>span</code> で、文字サイズは <code>M</code>、行間は{' '}
+      <code>NORMAL</code>、色は <code>inherit</code> です。
+    </Text>
+    <Text as="p">
+      styled-components と同じく <code>as</code> で要素を差し替えられます。
+    </Text>
+    <Text as="p">
+      <Text color="TEXT_GREY">色</Text>や<Text weight="bold">ウェイト</Text>を変えられます。
+    </Text>
+    <Text as="p">
+      <code>emphasis</code> を渡すとそのテキストは<Text emphasis>強調</Text>を示し、<code>em</code>{' '}
+      要素の太字装飾で出力します。
+    </Text>
+    <Text as="p">
+      <Text emphasis>入れ子</Text>もできますが、
+      <Text color="TEXT_LINK" weight="bold">
+        Valid
+      </Text>{' '}
+      な HTML になるよう注意してください。
+    </Text>
+  </>
+)

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -21,12 +21,12 @@ export interface TextProps {
  * @param [color] 色。初期値は inherit（color、）
  * @param [leading] 行送りの抽象値（line-height）
  * @param [emphasis] 強調するかどうかの真偽値。指定すると em 要素になる
- * @param [as] テキストコンポーネントの HTML タグ名。初期値は span。リンクは Link コンポーネントを使うこと
+ * @param [as] テキストコンポーネントの HTML タグ名。初期値は span
  * @param [children]
  */
 export const Text: React.VFC<
   TextProps & {
-    as?: Exclude<React.ElementType, 'a'>
+    as?: 'address' | 'b' | 'em' | 'i' | 'mark' | 'p' | 'q' | 'small' | 'span' | 'strong' | 'time'
     children: React.ReactNode
   }
 > = ({ as = 'span', ...props }) => {

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -14,24 +14,27 @@ export interface TextProps {
   emphasis?: boolean
 }
 
+/**
+ * @param [size] フォントサイズの抽象値（font-size）
+ * @param [weight] フォントウェイト（font-weight）
+ * @param [italic] 斜体にするかどうかの真偽値（font-style: italic）
+ * @param [color] 色。初期値は inherit（color、）
+ * @param [leading] 行送りの抽象値（line-height）
+ * @param [emphasis] 強調するかどうかの真偽値。指定すると em 要素になる
+ * @param [as] テキストコンポーネントの HTML タグ名。初期値は span。リンクは Link コンポーネントを使うこと
+ * @param [children]
+ */
 export const Text: React.VFC<
   TextProps & {
+    as?: Exclude<React.ElementType, 'a'>
     children: React.ReactNode
-    as?: React.ElementType
   }
 > = ({ as = 'span', ...props }) => {
   return <Wrapper as={props.emphasis ? 'em' : as} {...props} />
 }
 
 const Wrapper = styled.span<TextProps>(
-  ({
-    size = 'M',
-    weight = 'normal',
-    italic = false,
-    color = 'inherit',
-    leading = 'NORMAL',
-    emphasis,
-  }) => {
+  ({ size = 'M', weight = 'normal', italic, color = 'inherit', leading = 'NORMAL', emphasis }) => {
     const { color: shrColor, fontSize, leading: shrLeading } = useTheme()
     return css`
       font-size: ${fontSize[size]};

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+import { useTheme } from '../../hooks/useTheme'
+import { FontSizes } from '../../themes/createFontSize'
+import { TextColors } from '../../themes/createColor'
+import { Leadings } from '../../themes/createLeading'
+
+export interface TextProps {
+  size?: FontSizes
+  weight?: 'normal' | 'bold'
+  italic?: boolean
+  color?: TextColors | 'inherit'
+  leading?: Leadings
+  emphasis?: boolean
+}
+
+export const Text: React.VFC<
+  TextProps & {
+    children: React.ReactNode
+    as?: React.ElementType
+  }
+> = ({ as = 'span', ...props }) => {
+  return <Wrapper as={props.emphasis ? 'em' : as} {...props} />
+}
+
+const Wrapper = styled.span<TextProps>(
+  ({
+    size = 'M',
+    weight = 'normal',
+    italic = false,
+    color = 'inherit',
+    leading = 'NORMAL',
+    emphasis,
+  }) => {
+    const { color: shrColor, fontSize, leading: shrLeading } = useTheme()
+    return css`
+      font-size: ${fontSize[size]};
+      line-height: ${shrLeading[leading]};
+      font-weight: ${emphasis ? 'bold' : weight};
+      ${italic && `font-style: italic;`}
+      color: ${color === 'inherit' ? color : shrColor[color]};
+    `
+  },
+)

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,0 +1,1 @@
+export { Text } from './Text'

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export {
 export { MultiComboBox, SingleComboBox } from './components/ComboBox'
 export { SideNav } from './components/SideNav'
 export { CompactInformationPanel } from './components/CompactInformationPanel'
+export { Text } from './components/Text'
 
 // themes
 export { createTheme } from './themes/createTheme'

--- a/src/themes/__tests__/createLeading.ts
+++ b/src/themes/__tests__/createLeading.ts
@@ -1,0 +1,24 @@
+import { createLeading } from '../createLeading'
+
+describe('createLeading', () => {
+  it('returns default leading when no arguments given', () => {
+    const actual = createLeading()
+
+    expect(actual.NONE).toBe(1)
+    expect(actual.NORMAL).toBe(1.5)
+    expect(actual.TIGHT).toBe(1.25)
+    expect(actual.RELAXED).toBe(1.75)
+  })
+
+  it('returns customed leading when give user leading', () => {
+    const actual = createLeading({
+      NORMAL: 3,
+      TIGHT: 2,
+      RELAXED: 7,
+    })
+
+    expect(actual.NORMAL).toBe(3)
+    expect(actual.TIGHT).toBe(2)
+    expect(actual.RELAXED).toBe(7)
+  })
+})

--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -1,6 +1,7 @@
 import { createTheme } from '../createTheme'
 import { defaultColor } from '../createColor'
 import { defaultFontSize } from '../createFontSize'
+import { defaultLeading } from '../createLeading'
 import { defaultBreakpoint } from '../createBreakpoint'
 import { defaultBorder } from '../createBorder'
 import { defaultRadius } from '../createRadius'
@@ -205,6 +206,19 @@ describe('createTheme', () => {
     expect(actual.fontSize.L).toBe(`${8 / 7}rem`)
     expect(actual.fontSize.XL).toBe(`${8 / 6}rem`)
     expect(actual.fontSize.XXL).toBe(`${8 / 5}rem`)
+  })
+
+  it('returns theme reflecting "leading" settings', () => {
+    const actual = createTheme({
+      leading: {
+        NORMAL: 1.6,
+        TIGHT: 1.125,
+      },
+    })
+
+    expect(actual.leading.NORMAL).toBe(1.6)
+    expect(actual.leading.TIGHT).toBe(1.125)
+    expect(actual.leading.RELAXED).toBe(defaultLeading.RELAXED)
   })
 
   it('returns theme reflecting "breakpoint" settings', () => {

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -30,6 +30,8 @@ export type CreatedColorTheme = Palette & {
   disableColor: (value: string) => string
 }
 
+export type TextColors = 'TEXT_BLACK' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
+
 const baseColor = {
   TEXT_BLACK: '#23221f',
   TEXT_GREY: '#706d65',

--- a/src/themes/createFontSize.ts
+++ b/src/themes/createFontSize.ts
@@ -39,6 +39,8 @@ export interface CreatedFontSizeTheme {
   XXL: string
 }
 
+export type FontSizes = 'XXS' | 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL'
+
 const pxToRem = (htmlFontSize: number) => (px: number) => {
   return `${px / htmlFontSize}rem`
 }

--- a/src/themes/createLeading.ts
+++ b/src/themes/createLeading.ts
@@ -1,0 +1,26 @@
+import { merge } from 'lodash'
+
+interface Leading {
+  NONE: number
+  TIGHT: number
+  NORMAL: number
+  RELAXED: number
+}
+
+export type LeadingProperty = Partial<Omit<Leading, 'NONE'>>
+export type CreatedLeading = Leading
+
+export type Leadings = 'NORMAL' | 'TIGHT' | 'RELAXED' | 'NONE'
+
+export const defaultLeading: CreatedLeading = {
+  NONE: 1,
+  TIGHT: 1.25,
+  NORMAL: 1.5,
+  RELAXED: 1.75,
+}
+
+export const createLeading = (userLeading: LeadingProperty = {}) => {
+  const { ...userTokens } = userLeading
+  const created: CreatedLeading = merge(defaultLeading, userTokens)
+  return created
+}

--- a/src/themes/createLeading.ts
+++ b/src/themes/createLeading.ts
@@ -10,7 +10,7 @@ interface Leading {
 export type LeadingProperty = Partial<Omit<Leading, 'NONE'>>
 export type CreatedLeading = Leading
 
-export type Leadings = 'NORMAL' | 'TIGHT' | 'RELAXED' | 'NONE'
+export type Leadings = keyof Leading
 
 export const defaultLeading: CreatedLeading = {
   NONE: 1,

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -10,6 +10,7 @@ import { CreatedPaletteTheme, PaletteProperty, createPalette } from './createPal
 import { ColorProperty, CreatedColorTheme, createColor } from './createColor'
 import { CreatedSizeTheme, SizeProperty, createSize } from './createSize'
 import { CreatedFontSizeTheme, FontSizeProperty, createFontSize } from './createFontSize'
+import { CreatedLeading, LeadingProperty, createLeading } from './createLeading'
 import {
   CreatedSpacingByCharTheme,
   CreatedSpacingTheme,
@@ -32,6 +33,7 @@ interface ThemeProperty {
    */
   size?: SizeProperty
   fontSize?: FontSizeProperty
+  leading?: LeadingProperty
   spacing?: SpacingProperty
   breakpoint?: BreakpointProperty
   /**
@@ -56,6 +58,7 @@ export interface CreatedTheme {
    */
   size: CreatedSizeTheme
   fontSize: CreatedFontSizeTheme
+  leading: CreatedLeading
   spacing: CreatedSpacingTheme
   spacingByChar: CreatedSpacingByCharTheme
   breakpoint: CreatedBreakpointTheme
@@ -81,6 +84,7 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     fontSize: createFontSize(getFontSizeProperty(theme)),
     spacing: createSpacing(baseSize),
     spacingByChar: createSpacingByChar(baseSize),
+    leading: createLeading(getLeadingProperty(theme)),
     breakpoint: createBreakpoint(getBreakpointProperty(theme)),
     frame: createFrame(getFrameProperty(theme), paletteProperty),
     border: createBorder(getBorderProperty(theme), colorProperty),
@@ -135,6 +139,9 @@ function getFontSizeProperty(theme: ThemeProperty): FontSizeProperty {
     ...theme.size?.font,
     ...theme.fontSize,
   }
+}
+const getLeadingProperty = (theme: ThemeProperty): LeadingProperty => {
+  return { ...theme.leading }
 }
 function getSpacingProperty(theme: ThemeProperty): SpacingProperty {
   return {


### PR DESCRIPTION
文字にまつわるスタイリングを管理するテキストコンポーネントを作成。
渡せるプロパティは下記の通り。

プロパティ | 対象 CSS プロパティ | 備考
--- | --- | ---
size | font-size | XXS / XS / S / M / L / XL / XXL
weight | font-weight | normal / bold
italic | font-style: italic | -
color | color | TEXT_BLACK / TEXT_GREY / TEXT_LINK / TEXT_DISABLED / inherit
leading | line-height | NORMAL / TIGHT / RELAXED / NONE
emphasis | - | em 要素として出力
as | - | 渡した要素として出力

as に渡せる要素
---

Text コンポーネントとして使う可能性があるものをフローコンテンツと記述コンテンツから選択肢、ホワイトリストとしました。

- `<address>`
- `<b>`
- `<em>`
- `<i>`
- `<mark>`
- `<p>`
- `<q>`
- `<small>`
- `<span>`
- `<strong>`
- `<time>`

as に渡せてもよさそうだけど除外した要素
---

局所的なマークアップであってり、代替コンポーネントが存在するため以下の要素は除外しました。

- `<abbr>`
- `<bdi>`
- `<blockquote>`
- `<button>`
- `<cite>`
- `<code>`
- `<data>`
- `<del>`
- `<dfn>`
- `<h1>`
- `<h2>`
- `<h3>`
- `<h4>`
- `<h5>`
- `<h6>`
- `<ins>`
- `<kbd>`
- `<label>`
- `<pre>`
- `<ruby>`
- `<s>`
- `<samp>`
- `<sub>`
- `<sup>`
- `<var>`