### PR TITLE
Fix Icon components aria

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -676,6 +676,45 @@ Size.parameters = {
   },
 }
 
+export const AltText: Story = () => (
+  <div>
+    <p>
+      <span id="text">連絡帳</span>
+    </p>
+    <dl>
+      <dt>visually hidden text</dt>
+      <dd>
+        <FaAddressBookIcon visuallyHiddenText="連絡帳" />
+      </dd>
+      <dt>
+        <code>aria-labelledby</code>
+      </dt>
+      <dd>
+        <FaAddressBookIcon aria-labelledby="text" />
+      </dd>
+      <dt>
+        <code>aria-label</code>
+      </dt>
+      <dd>
+        <FaAddressBookIcon aria-label="連絡帳" />
+      </dd>
+      <dt>
+        none ( <code>aria-hidden</code> )
+      </dt>
+      <dd>
+        <FaAddressBookIcon />
+      </dd>
+    </dl>
+  </div>
+)
+Size.parameters = {
+  docs: {
+    description: {
+      story: 'An icon can be any size.',
+    },
+  },
+}
+
 export const Color: Story = () => (
   <List>
     <FaAddressBookIcon size={40} color="#D4F4F5" />

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,0 +1,21 @@
+import { create } from 'react-test-renderer'
+import React from 'react'
+
+import { FaAddressBookIcon } from './Icon'
+
+const Icon = () => (
+  <>
+    <span id="text">連絡帳</span>
+    <FaAddressBookIcon />
+    <FaAddressBookIcon visuallyHiddenText="連絡帳" />
+    <FaAddressBookIcon aria-label="連絡帳" />
+    <FaAddressBookIcon aria-labelledby="text" />
+  </>
+)
+
+describe('Icon', () => {
+  it('should be match snapshot', () => {
+    const testRenderer = create(<Icon />)
+    expect(testRenderer.toJSON()).toMatchSnapshot()
+  })
+})

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -342,18 +342,15 @@ const IconComponent: React.VFC<IconComponentProps> = ({
   focusable = false,
   ...props
 }) => {
-  const hasAltText =
-    visuallyHiddenText !== undefined ||
-    props['aria-label'] !== undefined ||
-    props['aria-labelledby'] !== undefined
-  const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasAltText
+  const hasLabelByAria = props['aria-label'] !== undefined || props['aria-labelledby'] !== undefined
+  const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasLabelByAria
   return (
     <>
       {visuallyHiddenText && <VisuallyHiddenText>{visuallyHiddenText}</VisuallyHiddenText>}
       <Component
         className={className}
         role={role}
-        aria-hidden={isAriaHidden || undefined}
+        aria-hidden={isAriaHidden || visuallyHiddenText !== undefined || undefined}
         focusable={focusable}
         {...props}
       />

--- a/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Icon should be match snapshot 1`] = `
+Array [
+  <span
+    id="text"
+  >
+    連絡帳
+  </span>,
+  <svg
+    aria-hidden={true}
+    fill="currentColor"
+    focusable={false}
+    height="1em"
+    role="img"
+    stroke="currentColor"
+    strokeWidth="0"
+    style={
+      Object {
+        "color": undefined,
+      }
+    }
+    viewBox="0 0 448 512"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-228-32c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H118.4C106 384 96 375.4 96 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2z"
+    />
+  </svg>,
+  .c0 {
+  position: absolute;
+  top: -1px;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  padding: 0;
+  white-space: nowrap;
+  -webkit-clip-path: inset(100%);
+  clip-path: inset(100%);
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+}
+
+<span
+    className="c0"
+  >
+    連絡帳
+  </span>,
+  <svg
+    aria-hidden={true}
+    fill="currentColor"
+    focusable={false}
+    height="1em"
+    role="img"
+    stroke="currentColor"
+    strokeWidth="0"
+    style={
+      Object {
+        "color": undefined,
+      }
+    }
+    viewBox="0 0 448 512"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-228-32c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H118.4C106 384 96 375.4 96 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2z"
+    />
+  </svg>,
+  <svg
+    aria-label="連絡帳"
+    fill="currentColor"
+    focusable={false}
+    height="1em"
+    role="img"
+    stroke="currentColor"
+    strokeWidth="0"
+    style={
+      Object {
+        "color": undefined,
+      }
+    }
+    viewBox="0 0 448 512"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-228-32c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H118.4C106 384 96 375.4 96 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2z"
+    />
+  </svg>,
+  <svg
+    aria-labelledby="text"
+    fill="currentColor"
+    focusable={false}
+    height="1em"
+    role="img"
+    stroke="currentColor"
+    strokeWidth="0"
+    style={
+      Object {
+        "color": undefined,
+      }
+    }
+    viewBox="0 0 448 512"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-228-32c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H118.4C106 384 96 375.4 96 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2z"
+    />
+  </svg>,
+]
+`;


### PR DESCRIPTION
## Overview

- `<svg>` should have `aria-hidden` when has alternative text by `visuallyHiddenText` props.

## What I did

- Add snapshot testing for Icon component
- If the icon has visuallyHiddenText, set true to aria-hidden.