### PR TITLE
fix: change icon storybook from div to dl

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -637,10 +637,10 @@ export const All: Story = () => {
         return (
           <>
             <CatalogItem key={`${Component.displayName}`}>
+              <IconName>{Component.displayName?.replace(/Icon$/, '')}</IconName>
               <dd>
                 <Component />
               </dd>
-              <IconName>{Component.displayName?.replace(/Icon$/, '')}</IconName>
             </CatalogItem>
           </>
         )
@@ -750,7 +750,7 @@ const CatalogItem = styled.dl`
   }
 `
 const IconName = styled.dt`
-  margin-top: 10px;
+  margin-bottom: 10px;
   font-size: 14px;
   color: #222;
 `

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -637,7 +637,9 @@ export const All: Story = () => {
         return (
           <>
             <CatalogItem key={`${Component.displayName}`}>
-              <Component />
+              <dd>
+                <Component />
+              </dd>
               <IconName>{Component.displayName?.replace(/Icon$/, '')}</IconName>
             </CatalogItem>
           </>
@@ -737,13 +739,17 @@ const Container = styled.div`
   align-items: center;
   flex-wrap: wrap;
 `
-const CatalogItem = styled.div`
+const CatalogItem = styled.dl`
   margin: 10px;
   padding: 10px;
   background-color: #eee;
   text-align: center;
+
+  & > dd {
+    margin: 0;
+  }
 `
-const IconName = styled.p`
+const IconName = styled.dt`
   margin-top: 10px;
   font-size: 14px;
   color: #222;


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-397

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

I want to change Icon's storybook from `div> div` to `dl > dt + dd`

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Change Icon's storybook from `div> div` to `dl > dt + dd`

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

| BEFORE  | AFTER  |
| ---- | ---- |
|  ![image](https://user-images.githubusercontent.com/23610884/118248634-81018800-b4df-11eb-8951-a1e695e82118.png) |![image](https://user-images.githubusercontent.com/23610884/118252920-464e1e80-b4e4-11eb-8184-067bb8e003cb.png)|

<!--
Please attach a capture if it looks different.
-->
