### PR TITLE
feat: add FlashMessageList

### DIFF
--- a/src/components/FlashMessage/FlashMessage.stories.tsx
+++ b/src/components/FlashMessage/FlashMessage.stories.tsx
@@ -4,6 +4,9 @@ import readme from './README.md'
 import styled from 'styled-components'
 
 import { FlashMessage, Props, animationTypes, messageTypes } from './FlashMessage'
+import { FlashMessageListProvider, useFlashMessageList } from './'
+
+import { SecondaryButton } from '../Button'
 
 export default {
   title: 'FlashMessage',
@@ -128,6 +131,26 @@ export const Demo: Story = () => {
         }}
       />
     </div>
+  )
+}
+
+let messageCount = 1
+const ListInner = () => {
+  const { enqueueMessage } = useFlashMessageList()
+
+  const handleClick = () => {
+    enqueueMessage({
+      type: 'success',
+      text: `success ${messageCount++}`,
+    })
+  }
+  return <SecondaryButton onClick={handleClick}>Add message</SecondaryButton>
+}
+export const FlashMessageList: Story = () => {
+  return (
+    <FlashMessageListProvider>
+      <ListInner />
+    </FlashMessageListProvider>
   )
 }
 

--- a/src/components/FlashMessage/FlashMessage.tsx
+++ b/src/components/FlashMessage/FlashMessage.tsx
@@ -30,7 +30,6 @@ export type Props = {
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 const REMOVE_DELAY = 8000
-let timerId: any = 0
 
 export const FlashMessage: VFC<Props & ElementProps> = ({
   visible,
@@ -45,11 +44,10 @@ export const FlashMessage: VFC<Props & ElementProps> = ({
   const classNames = useClassNames()
 
   useEffect(() => {
-    if (visible) {
-      timerId = setTimeout(onClose, REMOVE_DELAY)
-    } else {
-      clearTimeout(timerId)
+    if (!visible) {
+      return
     }
+    const timerId = setTimeout(onClose, REMOVE_DELAY)
 
     return () => {
       clearTimeout(timerId)

--- a/src/components/FlashMessage/FlashMessageList/FlashMessageList.tsx
+++ b/src/components/FlashMessage/FlashMessageList/FlashMessageList.tsx
@@ -1,0 +1,33 @@
+import React, { VFC, useContext } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../../hooks/useTheme'
+import { FlashMessageListContext } from './FlashMessageListProvider'
+import { Item } from './Item'
+
+export const FlashMessageList: VFC = () => {
+  const theme = useTheme()
+  const { messages } = useContext(FlashMessageListContext)
+
+  return (
+    <List themes={theme}>
+      {messages.map((message) => (
+        <Item key={message.seq} {...message} />
+      ))}
+    </List>
+  )
+}
+
+const List = styled.ul<{ themes: Theme }>`
+  ${({ themes: { spacingByChar, zIndex } }) => css`
+    z-index: ${zIndex.FLASH_MESSAGE};
+    position: fixed;
+    display: flex;
+    flex-direction: column-reverse;
+    bottom: 0;
+    left: 0;
+    padding: 0;
+    margin: ${spacingByChar(0.5)};
+    list-style: none;
+  `}
+`

--- a/src/components/FlashMessage/FlashMessageList/FlashMessageListProvider.tsx
+++ b/src/components/FlashMessage/FlashMessageList/FlashMessageListProvider.tsx
@@ -10,6 +10,7 @@ export const FlashMessageListContext = createContext<{
   messages: NumberedMessage[]
   enqueueMessage: (message: Message) => void
   dequeueMessage: (seq: number) => void
+  isProvided: boolean
 }>({
   messages: [],
   enqueueMessage: (_) => {
@@ -18,6 +19,7 @@ export const FlashMessageListContext = createContext<{
   dequeueMessage: (_) => {
     // no-op
   },
+  isProvided: false,
 })
 
 export const FlashMessageListProvider: VFC<{ children: ReactNode }> = ({ children }) => {
@@ -37,7 +39,9 @@ export const FlashMessageListProvider: VFC<{ children: ReactNode }> = ({ childre
   }, [])
 
   return (
-    <FlashMessageListContext.Provider value={{ messages, enqueueMessage, dequeueMessage }}>
+    <FlashMessageListContext.Provider
+      value={{ messages, enqueueMessage, dequeueMessage, isProvided: true }}
+    >
       {children}
       <FlashMessageList />
     </FlashMessageListContext.Provider>

--- a/src/components/FlashMessage/FlashMessageList/FlashMessageListProvider.tsx
+++ b/src/components/FlashMessage/FlashMessageList/FlashMessageListProvider.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode, VFC, createContext, useCallback, useState } from 'react'
+
+import { Props as FlashMessageProps } from '../FlashMessage'
+import { FlashMessageList } from './FlashMessageList'
+
+type Message = Omit<FlashMessageProps, 'visible' | 'onClose'>
+export type NumberedMessage = Message & { seq: number }
+
+export const FlashMessageListContext = createContext<{
+  messages: NumberedMessage[]
+  enqueueMessage: (message: Message) => void
+  dequeueMessage: (seq: number) => void
+}>({
+  messages: [],
+  enqueueMessage: (_) => {
+    // no-op
+  },
+  dequeueMessage: (_) => {
+    // no-op
+  },
+})
+
+export const FlashMessageListProvider: VFC<{ children: ReactNode }> = ({ children }) => {
+  const [currentSeq, setCurrentSeq] = useState(0)
+  const [messages, setMessages] = useState<NumberedMessage[]>([])
+
+  const enqueueMessage = useCallback(
+    (message: Message) => {
+      setMessages((_messages) => [..._messages, { ...message, seq: currentSeq }])
+      setCurrentSeq(currentSeq + 1)
+    },
+    [currentSeq],
+  )
+
+  const dequeueMessage = useCallback((seq: number) => {
+    setMessages((_messages) => _messages.filter((_message) => _message.seq !== seq))
+  }, [])
+
+  return (
+    <FlashMessageListContext.Provider value={{ messages, enqueueMessage, dequeueMessage }}>
+      {children}
+      <FlashMessageList />
+    </FlashMessageListContext.Provider>
+  )
+}

--- a/src/components/FlashMessage/FlashMessageList/Item.tsx
+++ b/src/components/FlashMessage/FlashMessageList/Item.tsx
@@ -1,0 +1,33 @@
+import React, { VFC, useCallback, useContext } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../../hooks/useTheme'
+import { FlashMessage } from '../FlashMessage'
+import { FlashMessageListContext, NumberedMessage } from './FlashMessageListProvider'
+
+export const Item: VFC<NumberedMessage> = ({ seq, ...message }) => {
+  const theme = useTheme()
+  const { dequeueMessage } = useContext(FlashMessageListContext)
+
+  const handleClose = useCallback(() => {
+    dequeueMessage(seq)
+  }, [dequeueMessage, seq])
+
+  return (
+    <Li themes={theme}>
+      <StaticFlashMessage {...message} visible onClose={handleClose} />
+    </Li>
+  )
+}
+
+const Li = styled.li<{ themes: Theme }>`
+  ${({ themes: { spacingByChar } }) => css`
+    margin-top: ${spacingByChar(0.5)};
+  `}
+`
+const StaticFlashMessage = styled(FlashMessage)`
+  position: static;
+  display: inline-flex;
+  top: auto;
+  left: auto;
+`

--- a/src/components/FlashMessage/FlashMessageList/README.md
+++ b/src/components/FlashMessage/FlashMessageList/README.md
@@ -1,0 +1,34 @@
+# FlashMessageList
+
+## Usage
+
+1. Wrap the location where you want the messages to show with `FlashMessageListProvider`.
+
+```tsx
+import { FlashMessageListProvider } from 'smarthr-ui'
+```
+
+```tsx
+<FlashMessageListProvider>
+  <MyApp />
+</FlashMessageListProvider>
+```
+
+2. Add message by `useFlashMessageList` hook.
+
+```tsx
+import { useFlashMessageList } from 'smarthr-ui'
+
+const MyComponent = () => {
+  const { enqueueMessage } = useFlashMessageList()
+
+  const handleClick = () => {
+    enqueueMessage({
+      type: 'success',
+      text: `success`,
+    })
+  }
+
+  return <button onClick={handleClick}>Add message</button>
+}
+```

--- a/src/components/FlashMessage/FlashMessageList/README.md
+++ b/src/components/FlashMessage/FlashMessageList/README.md
@@ -25,7 +25,7 @@ const MyComponent = () => {
   const handleClick = () => {
     enqueueMessage({
       type: 'success',
-      text: `success`,
+      text: 'message',
     })
   }
 

--- a/src/components/FlashMessage/FlashMessageList/useFlashMessageList.tsx
+++ b/src/components/FlashMessage/FlashMessageList/useFlashMessageList.tsx
@@ -6,7 +6,7 @@ export function useFlashMessageList() {
   const { enqueueMessage, isProvided } = useContext(FlashMessageListContext)
   if (!isProvided) {
     console.warn(
-      `No context is provided. Please wrap the upper layer that uses "useFlashMessageList" hook with "FlashMessageListProvder".`,
+      'No context is provided. Please wrap the upper layer that uses "useFlashMessageList" hook with "FlashMessageListProvder".',
     )
   }
   return { enqueueMessage }

--- a/src/components/FlashMessage/FlashMessageList/useFlashMessageList.tsx
+++ b/src/components/FlashMessage/FlashMessageList/useFlashMessageList.tsx
@@ -3,6 +3,11 @@ import { useContext } from 'react'
 import { FlashMessageListContext } from './FlashMessageListProvider'
 
 export function useFlashMessageList() {
-  const { enqueueMessage } = useContext(FlashMessageListContext)
+  const { enqueueMessage, isProvided } = useContext(FlashMessageListContext)
+  if (!isProvided) {
+    console.warn(
+      `No context is provided. Please wrap the upper layer that uses "useFlashMessageList" hook with "FlashMessageListProvder".`,
+    )
+  }
   return { enqueueMessage }
 }

--- a/src/components/FlashMessage/FlashMessageList/useFlashMessageList.tsx
+++ b/src/components/FlashMessage/FlashMessageList/useFlashMessageList.tsx
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+
+import { FlashMessageListContext } from './FlashMessageListProvider'
+
+export function useFlashMessageList() {
+  const { enqueueMessage } = useContext(FlashMessageListContext)
+  return { enqueueMessage }
+}

--- a/src/components/FlashMessage/index.ts
+++ b/src/components/FlashMessage/index.ts
@@ -1,1 +1,3 @@
 export { FlashMessage } from './FlashMessage'
+export { FlashMessageListProvider } from './FlashMessageList/FlashMessageListProvider'
+export { useFlashMessageList } from './FlashMessageList/useFlashMessageList'

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ export {
   FilterDropdown,
 } from './components/Dropdown'
 export { FieldSet } from './components/FieldSet'
-export { FlashMessage } from './components/FlashMessage'
+export {
+  FlashMessage,
+  FlashMessageListProvider,
+  useFlashMessageList,
+} from './components/FlashMessage'
 export { FloatArea } from './components/FloatArea'
 export { Input, CurrencyInput } from './components/Input'
 export { InputFile } from './components/InputFile'


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-374
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`FlashMeesage` の複数表示を制御する `FlashMessageList` を追加します。

使い方は、まず複数 `FlashMessage` を表示させたい場所の上層を `FlashMessageListProvider` で wrap します。
```tsx
import { FlashMessageListProvider } from 'smarthr-ui'

<FlashMessageListProvider>
  <MyComponent />
</FlashMessageListProvider>
```

次に、 wrap した配下で `useFlashMessageList` hook を用いてメッセージを追加すると、メッセージが順次スタック表示されます。

```ts
import { useFlashMessageList } from 'smarthr-ui'

const MyComponent = () => {
  const { enqueueMessage } = useFlashMessageList()
  const handleClick = () => {
    enqueueMessage({
      type: 'success',
      text: `success`,
    })
  }
  return <button onClick={handleClick}>Add message</button>
}
```

![image](https://user-images.githubusercontent.com/270422/118745133-89b3de80-b890-11eb-8f27-6b9585c17f0a.png)

表示されたあとのメッセージを消す処理は内部で完結させていて、組み込み時に改めて制御を記述する必要はありません。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `FlashMessageList` の構成要素の追加
- `FlashMessage` が timeoutID をコンポーネント間で共有しないように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
