### PR TITLE
fix (hotfix): modify SingleComboBox to be expected width when set percentage width

### DIFF
--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -167,6 +167,7 @@ export const SingleComboBox: VFC<Props> = ({
     <Container
       ref={outerRef}
       className={`${disabled ? 'disabled' : ''} ${className}`}
+      $width={width}
       role="combobox"
       aria-haspopup="listbox"
       aria-controls={aria.listBoxId}
@@ -177,7 +178,6 @@ export const SingleComboBox: VFC<Props> = ({
         name={name}
         value={inputValue}
         disabled={disabled}
-        width={width}
         error={error}
         placeholder={placeholder}
         suffix={
@@ -259,13 +259,15 @@ export const SingleComboBox: VFC<Props> = ({
   )
 }
 
-const Container = styled.div`
+const Container = styled.div<{ $width: number | string }>`
   display: inline-block;
+  width: ${({ $width = 'auto' }) => (typeof $width === 'number' ? `${$width}px` : $width)};
   &.disabled {
     cursor: not-allowed;
   }
 `
 const StyledInput = styled(Input)`
+  width: 100%;
   input::-ms-clear {
     display: none;
   }


### PR DESCRIPTION
## Related URL
master への反映: #1585 
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
プレリリース v12.4.0-1 に対する hotfix です。

`SingleComboBox` の `width` prop に `100%` を指定するとその値は内部の input 要素の`width` にセットされますが、 wrapper が `inline-block` かつ `width: auto` であることに起因して幅が正しく広がらない問題を解消します。

修正によって `width` prop の値は wrapper の `width` に作用するようになり、内部の input 要素のサイズは常に wrapper に合わせることで正しく幅が制御できるようになります。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
