### PR TITLE
chore: replace from VFC to FC in MessageScreen

### DIFF
--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -19,7 +19,7 @@ type Props = {
 
 const LOGO_HEIGHT = 20
 
-export const MessageScreen: FC<Props> = ({ title, links, children, className = '' }) => {
+export const MessageScreen: VFC<Props> = ({ title, links, children, className = '' }) => {
   const theme = useTheme()
 
   return (

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -14,6 +14,7 @@ type Props = {
     url: string
     target?: string
   }>
+  children?: ReactNode
   className?: string
 }
 


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in `MessageScreen`
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace `FC`
- Add necessary `children` props
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
