### PR TITLE
chore: replace from FC to VFC in `Select`

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -14,7 +14,7 @@ type Optgroup = {
   options: Option[]
 } & React.OptgroupHTMLAttributes<HTMLOptGroupElement>
 
-type Props = SelectHTMLAttributes<HTMLSelectElement> & {
+type Props = {
   options: Array<Option | Optgroup>
   error?: boolean
   width?: number | string
@@ -22,7 +22,9 @@ type Props = SelectHTMLAttributes<HTMLSelectElement> & {
   blankLabel?: string
 }
 
-export const Select: VFC<Props> = ({
+type ElementProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'children'>
+
+export const Select: VFC<Props & ElementProps> = ({
   options,
   onChange,
   error = false,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, SelectHTMLAttributes, useCallback } from 'react'
+import React, { ChangeEvent, SelectHTMLAttributes, VFC, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { isMobileSafari, isTouchDevice } from '../../libs/ua'
@@ -22,7 +22,7 @@ type Props = SelectHTMLAttributes<HTMLSelectElement> & {
   blankLabel?: string
 }
 
-export const Select: FC<Props> = ({
+export const Select: VFC<Props> = ({
   options,
   onChange,
   error = false,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in `Select`
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace to `VFC`
- Remove `children` from `Select` props because this component should not be passed children and `SelectHTMLAttributes<HTMLSelectElement>` type contains `children`.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
