### PR TITLE
feat: add CheckBoxLabelNew component

### DIFF
--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.stories.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.stories.tsx
@@ -20,16 +20,14 @@ storiesOf('CheckBoxLabelNew', module)
         <Text>checked</Text>
         <List>
           <li>
-            <CheckBoxLabelNew label="enabled" name="name1" checked={true} onChange={onChange} />
+            <CheckBoxLabelNew name="name1" checked={true} onChange={onChange}>
+              enabled
+            </CheckBoxLabelNew>
           </li>
           <li>
-            <CheckBoxLabelNew
-              label="disabled"
-              name="name2"
-              checked={true}
-              disabled={true}
-              onChange={onChange}
-            />
+            <CheckBoxLabelNew name="name2" checked={true} disabled={true} onChange={onChange}>
+              disabled
+            </CheckBoxLabelNew>
           </li>
         </List>
       </li>
@@ -38,16 +36,14 @@ storiesOf('CheckBoxLabelNew', module)
         <Text>unchecked</Text>
         <List>
           <li>
-            <CheckBoxLabelNew label="enabled" name="name4" checked={false} onChange={onChange} />
+            <CheckBoxLabelNew name="name4" checked={false} onChange={onChange}>
+              enabled
+            </CheckBoxLabelNew>
           </li>
           <li>
-            <CheckBoxLabelNew
-              label="disabled"
-              name="name5"
-              checked={false}
-              disabled={true}
-              onChange={onChange}
-            />
+            <CheckBoxLabelNew name="name5" checked={false} disabled={true} onChange={onChange}>
+              disabled
+            </CheckBoxLabelNew>
           </li>
         </List>
       </li>
@@ -56,23 +52,20 @@ storiesOf('CheckBoxLabelNew', module)
         <Text>mixed</Text>
         <List>
           <li>
-            <CheckBoxLabelNew
-              label="enabled"
-              name="name7"
-              checked={true}
-              mixed={true}
-              onChange={onChange}
-            />
+            <CheckBoxLabelNew name="name7" checked={true} mixed={true} onChange={onChange}>
+              enabled
+            </CheckBoxLabelNew>
           </li>
           <li>
             <CheckBoxLabelNew
-              label="disabled"
               name="name8"
               checked={true}
               mixed={true}
               disabled={true}
               onChange={onChange}
-            />
+            >
+              disabled
+            </CheckBoxLabelNew>
           </li>
         </List>
       </li>
@@ -81,13 +74,15 @@ storiesOf('CheckBoxLabelNew', module)
         <Text>multiline text</Text>
         <List>
           <li>
-            <CheckBoxLabelNew
-              label="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
-              name="name9"
-              checked={true}
-              mixed={true}
-              onChange={onChange}
-            />
+            <CheckBoxLabelNew name="name9" checked={true} mixed={true} onChange={onChange}>
+              Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+              has been the industry's standard dummy text ever since the 1500s, when an unknown
+              printer took a galley of type and scrambled it to make a type specimen book. It has
+              survived not only five centuries, but also the leap into electronic typesetting,
+              remaining essentially unchanged. It was popularised in the 1960s with the release of
+              Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
+              publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+            </CheckBoxLabelNew>
           </li>
         </List>
       </li>

--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.stories.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.stories.tsx
@@ -1,0 +1,115 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { CheckBoxLabelNew } from './CheckBoxLabelNew'
+import readme from './README.md'
+
+const onChange = action('onChange')
+
+storiesOf('CheckBoxLabelNew', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
+  .add('all', () => (
+    <Group>
+      <li>
+        <Text>checked</Text>
+        <List>
+          <li>
+            <CheckBoxLabelNew label="enabled" name="name1" checked={true} onChange={onChange} />
+          </li>
+          <li>
+            <CheckBoxLabelNew
+              label="disabled"
+              name="name2"
+              checked={true}
+              disabled={true}
+              onChange={onChange}
+            />
+          </li>
+        </List>
+      </li>
+
+      <li>
+        <Text>unchecked</Text>
+        <List>
+          <li>
+            <CheckBoxLabelNew label="enabled" name="name4" checked={false} onChange={onChange} />
+          </li>
+          <li>
+            <CheckBoxLabelNew
+              label="disabled"
+              name="name5"
+              checked={false}
+              disabled={true}
+              onChange={onChange}
+            />
+          </li>
+        </List>
+      </li>
+
+      <li>
+        <Text>mixed</Text>
+        <List>
+          <li>
+            <CheckBoxLabelNew
+              label="enabled"
+              name="name7"
+              checked={true}
+              mixed={true}
+              onChange={onChange}
+            />
+          </li>
+          <li>
+            <CheckBoxLabelNew
+              label="disabled"
+              name="name8"
+              checked={true}
+              mixed={true}
+              disabled={true}
+              onChange={onChange}
+            />
+          </li>
+        </List>
+      </li>
+
+      <li>
+        <Text>multiline text</Text>
+        <List>
+          <li>
+            <CheckBoxLabelNew
+              label="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+              name="name9"
+              checked={true}
+              mixed={true}
+              onChange={onChange}
+            />
+          </li>
+        </List>
+      </li>
+    </Group>
+  ))
+
+const List = styled.ul`
+  padding: 0;
+
+  & > li {
+    display: inline-block;
+    padding: 16px;
+  }
+`
+const Group = styled.ul`
+  list-style: none;
+
+  & > li:not(:first-child) {
+    margin-top: 24px;
+  }
+`
+const Text = styled.p`
+  margin: 0 0 16px 0;
+  font-size: 16px;
+`

--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.stories.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.stories.tsx
@@ -1,12 +1,10 @@
-import { action } from '@storybook/addon-actions'
-import { storiesOf } from '@storybook/react'
-import * as React from 'react'
+import React, { ChangeEvent, useState } from 'react'
 import styled from 'styled-components'
+import { storiesOf } from '@storybook/react'
 
-import { CheckBoxLabelNew } from './CheckBoxLabelNew'
 import readme from './README.md'
 
-const onChange = action('onChange')
+import { CheckBoxLabelNew } from './CheckBoxLabelNew'
 
 storiesOf('CheckBoxLabelNew', module)
   .addParameters({
@@ -14,97 +12,145 @@ storiesOf('CheckBoxLabelNew', module)
       sidebar: readme,
     },
   })
-  .add('all', () => (
-    <Group>
-      <li>
-        <Text>checked</Text>
-        <List>
-          <li>
-            <CheckBoxLabelNew name="name1" checked={true} onChange={onChange}>
-              enabled
-            </CheckBoxLabelNew>
-          </li>
-          <li>
-            <CheckBoxLabelNew name="name2" checked={true} disabled={true} onChange={onChange}>
-              disabled
-            </CheckBoxLabelNew>
-          </li>
-        </List>
-      </li>
+  .add('all', () => {
+    const [checkedName, setCheckedName] = useState<string[]>([])
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const currentName = e.currentTarget.name
 
-      <li>
-        <Text>unchecked</Text>
-        <List>
-          <li>
-            <CheckBoxLabelNew name="name4" checked={false} onChange={onChange}>
-              enabled
-            </CheckBoxLabelNew>
-          </li>
-          <li>
-            <CheckBoxLabelNew name="name5" checked={false} disabled={true} onChange={onChange}>
-              disabled
-            </CheckBoxLabelNew>
-          </li>
-        </List>
-      </li>
+      if (checkedName.includes(currentName)) {
+        setCheckedName(checkedName.filter((name) => name !== currentName))
+      } else {
+        setCheckedName([...checkedName, currentName])
+      }
+    }
 
-      <li>
-        <Text>mixed</Text>
-        <List>
-          <li>
-            <CheckBoxLabelNew name="name7" checked={true} mixed={true} onChange={onChange}>
-              enabled
-            </CheckBoxLabelNew>
-          </li>
-          <li>
-            <CheckBoxLabelNew
-              name="name8"
-              checked={true}
-              mixed={true}
-              disabled={true}
-              onChange={onChange}
-            >
-              disabled
-            </CheckBoxLabelNew>
-          </li>
-        </List>
-      </li>
+    return (
+      <WrapperList>
+        <li>
+          <Title>With children prop</Title>
 
-      <li>
-        <Text>multiline text</Text>
-        <List>
-          <li>
-            <CheckBoxLabelNew name="name9" checked={true} mixed={true} onChange={onChange}>
-              Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-              has been the industry's standard dummy text ever since the 1500s, when an unknown
-              printer took a galley of type and scrambled it to make a type specimen book. It has
-              survived not only five centuries, but also the leap into electronic typesetting,
-              remaining essentially unchanged. It was popularised in the 1960s with the release of
-              Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
-              publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-            </CheckBoxLabelNew>
-          </li>
-        </List>
-      </li>
-    </Group>
-  ))
+          <InnerList>
+            <li>
+              <CheckBoxLabelNew
+                name="1"
+                checked={checkedName.includes('1')}
+                onChange={handleChange}
+              >
+                CheckBoxLabelNew
+              </CheckBoxLabelNew>
+            </li>
 
-const List = styled.ul`
+            <li>
+              <CheckBoxLabelNew disabled onChange={handleChange}>
+                CheckBoxLabelNew / disabled
+              </CheckBoxLabelNew>
+            </li>
+
+            <li>
+              <CheckBoxLabelNew checked disabled onChange={handleChange}>
+                CheckBoxLabelNew / disabled /checked
+              </CheckBoxLabelNew>
+            </li>
+          </InnerList>
+        </li>
+
+        <li>
+          <Title>Without children prop</Title>
+
+          <InnerList>
+            <li>
+              <CheckBoxLabelNew
+                name="2"
+                checked={checkedName.includes('2')}
+                onChange={handleChange}
+              />
+            </li>
+
+            <li>
+              <CheckBoxLabelNew disabled onChange={handleChange} />
+            </li>
+
+            <li>
+              <CheckBoxLabelNew checked disabled onChange={handleChange} />
+            </li>
+          </InnerList>
+        </li>
+
+        <li>
+          <Title>With mixed prop</Title>
+
+          <InnerList>
+            <li>
+              <CheckBoxLabelNew
+                name="3"
+                checked={checkedName.includes('3')}
+                mixed
+                onChange={handleChange}
+              >
+                CheckBoxLabelNew / mixed
+              </CheckBoxLabelNew>
+            </li>
+
+            <li>
+              <CheckBoxLabelNew mixed disabled onChange={handleChange}>
+                CheckBoxLabelNew / mixed / disabled
+              </CheckBoxLabelNew>
+            </li>
+
+            <li>
+              <CheckBoxLabelNew checked mixed disabled onChange={handleChange}>
+                CheckBoxLabelNew / mixed / disabled / checked
+              </CheckBoxLabelNew>
+            </li>
+          </InnerList>
+        </li>
+
+        <li>
+          <Title>With multiline text</Title>
+
+          <InnerList>
+            <li>
+              <CheckBoxLabelNew
+                name="4"
+                checked={checkedName.includes('4')}
+                onChange={handleChange}
+              >
+                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                unknown printer took a galley of type and scrambled it to make a type specimen book.
+                It has survived not only five centuries, but also the leap into electronic
+                typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                with desktop publishing software like Aldus PageMaker including versions of Lorem
+                Ipsum.
+              </CheckBoxLabelNew>
+            </li>
+          </InnerList>
+        </li>
+      </WrapperList>
+    )
+  })
+
+const WrapperList = styled.ul`
+  padding: 0 24px;
+  list-style: none;
+  & > li {
+    padding: 16px;
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+  }
+`
+const InnerList = styled.ul`
   padding: 0;
-
+  list-style: none;
   & > li {
     display: inline-block;
-    padding: 16px;
+    &:not(:first-child) {
+      margin-left: 16px;
+    }
   }
 `
-const Group = styled.ul`
-  list-style: none;
-
-  & > li:not(:first-child) {
-    margin-top: 24px;
-  }
-`
-const Text = styled.p`
+const Title = styled.p`
   margin: 0 0 16px 0;
-  font-size: 16px;
 `

--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
@@ -1,0 +1,76 @@
+import React, { HTMLAttributes, VFC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
+import { Theme, useTheme } from '../../hooks/useTheme'
+import { useClassNames } from './useClassNames'
+
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+
+type Props = CheckBoxProps & {
+  label: string
+  lineHeight?: number
+}
+
+export const CheckBoxLabelNew: VFC<Props & ElementProps> = ({
+  label,
+  lineHeight = 1.5,
+  className = '',
+  ...props
+}) => {
+  const theme = useTheme()
+  const classNames = useClassNames()
+
+  return (
+    <Wrapper className={`${className} ${classNames.wrapper}`}>
+      <Label className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`} themes={theme}>
+        <CheckBox {...props} />
+        <Txt className={classNames.text} lineHeight={lineHeight} themes={theme}>
+          {label}
+        </Txt>
+      </Label>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.div`
+  display: inline-block;
+`
+const Label = styled.label<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { color } = themes
+
+    // 複数行テキストに対応させるため flex-start にする
+    return css`
+      display: flex;
+      align-items: flex-start;
+      color: ${color.TEXT_BLACK};
+      cursor: pointer;
+
+      &.disabled {
+        color: ${color.TEXT_DISABLED};
+        cursor: default;
+        pointer-events: none;
+      }
+    `
+  }}
+`
+const Txt = styled.span<{ themes: Theme; lineHeight: number }>`
+  ${({ themes, lineHeight }) => {
+    const { fontSize, spacingByChar } = themes
+
+    // checkbox と text の位置がずれるため、line-height 分を調整する疑似要素を作る
+    return css`
+      margin: 0 0 0 ${spacingByChar(0.5)};
+      font-size: ${fontSize.pxToRem(fontSize.TALL)};
+      line-height: ${lineHeight};
+      &::before {
+        content: '';
+        display: block;
+        height: 0;
+        width: 0;
+        margin-top: calc((1 - ${lineHeight}) * 0.3em);
+      }
+    `
+  }}
+`

--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
@@ -1,21 +1,19 @@
-import React, { HTMLAttributes, VFC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
-import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
 import { useClassNames } from './useClassNames'
 
-type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
-
 type Props = CheckBoxProps & {
-  label: string
   lineHeight?: number
+  children?: ReactNode
 }
 
-export const CheckBoxLabelNew: VFC<Props & ElementProps> = ({
-  label,
+export const CheckBoxLabelNew: FC<Props> = ({
   lineHeight = 1.5,
   className = '',
+  children,
   ...props
 }) => {
   const theme = useTheme()
@@ -25,8 +23,8 @@ export const CheckBoxLabelNew: VFC<Props & ElementProps> = ({
     <Wrapper className={`${className} ${classNames.wrapper}`}>
       <Label className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`} themes={theme}>
         <CheckBox {...props} />
-        <Txt className={classNames.text} lineHeight={lineHeight} themes={theme}>
-          {label}
+        <Txt className={classNames.text} $lineHeight={lineHeight} themes={theme}>
+          {children}
         </Txt>
       </Label>
     </Wrapper>
@@ -36,7 +34,7 @@ export const CheckBoxLabelNew: VFC<Props & ElementProps> = ({
 const Wrapper = styled.div`
   display: inline-block;
 `
-const Label = styled.label<{ themes: Theme }>`
+const Label = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
     const { color } = themes
 
@@ -55,21 +53,21 @@ const Label = styled.label<{ themes: Theme }>`
     `
   }}
 `
-const Txt = styled.span<{ themes: Theme; lineHeight: number }>`
-  ${({ themes, lineHeight }) => {
+const Txt = styled.label<{ themes: Theme; $lineHeight: number }>`
+  ${({ themes, $lineHeight }) => {
     const { fontSize, spacingByChar } = themes
 
     // checkbox と text の位置がずれるため、line-height 分を調整する疑似要素を作る
     return css`
       margin: 0 0 0 ${spacingByChar(0.5)};
       font-size: ${fontSize.pxToRem(fontSize.TALL)};
-      line-height: ${lineHeight};
+      line-height: ${$lineHeight};
       &::before {
         content: '';
         display: block;
         height: 0;
         width: 0;
-        margin-top: calc((1 - ${lineHeight}) * 0.3em);
+        margin-top: calc((1 - ${$lineHeight}) * 0.3em);
       }
     `
   }}

--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
@@ -2,8 +2,10 @@ import React, { FC, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
+import { useId } from '../../hooks/useId'
 import { useClassNames } from './useClassNames'
+
+import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
 
 type Props = CheckBoxProps & {
   lineHeight?: number
@@ -18,15 +20,24 @@ export const CheckBoxLabelNew: FC<Props> = ({
 }) => {
   const theme = useTheme()
   const classNames = useClassNames()
+  const checkBoxId = useId()
+
+  if (!children) return <CheckBox className={`${className} ${classNames.checkBox}`} {...props} />
 
   return (
     <Wrapper className={`${className} ${classNames.wrapper}`}>
-      <Label className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`} themes={theme}>
-        <CheckBox {...props} />
-        <Txt className={classNames.text} $lineHeight={lineHeight} themes={theme}>
+      <Inner>
+        <CheckBox id={checkBoxId} className={classNames.checkBox} {...props} />
+
+        <Label
+          className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
+          htmlFor={checkBoxId}
+          $lineHeight={lineHeight}
+          themes={theme}
+        >
           {children}
-        </Txt>
-      </Label>
+        </Label>
+      </Inner>
     </Wrapper>
   )
 }
@@ -34,40 +45,34 @@ export const CheckBoxLabelNew: FC<Props> = ({
 const Wrapper = styled.div`
   display: inline-block;
 `
-const Label = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color } = themes
+// Use flex-start to support multi-line text.
+const Inner = styled.div`
+  display: flex;
+  align-items: flex-start;
+`
+const Label = styled.label<{ themes: Theme; $lineHeight: number }>`
+  ${({ themes, $lineHeight }) => {
+    const { spacingByChar, color, fontSize } = themes
 
-    // 複数行テキストに対応させるため flex-start にする
     return css`
-      display: flex;
-      align-items: flex-start;
+      margin-left: ${spacingByChar(0.5)};
       color: ${color.TEXT_BLACK};
-      cursor: pointer;
+      font-size: ${fontSize.S};
+      line-height: ${$lineHeight};
 
       &.disabled {
         color: ${color.TEXT_DISABLED};
-        cursor: default;
+        cursor: not-allowed;
         pointer-events: none;
       }
-    `
-  }}
-`
-const Txt = styled.label<{ themes: Theme; $lineHeight: number }>`
-  ${({ themes, $lineHeight }) => {
-    const { fontSize, spacingByChar } = themes
 
-    // checkbox と text の位置がずれるため、line-height 分を調整する疑似要素を作る
-    return css`
-      margin: 0 0 0 ${spacingByChar(0.5)};
-      font-size: ${fontSize.pxToRem(fontSize.TALL)};
-      line-height: ${$lineHeight};
+      /* Since the positions of checkbox and text are misaligned, create a pseudo element that adjusts the line-height. */
       &::before {
-        content: '';
         display: block;
-        height: 0;
         width: 0;
+        height: 0;
         margin-top: calc((1 - ${$lineHeight}) * 0.3em);
+        content: '';
       }
     `
   }}

--- a/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
+++ b/src/components/CheckBoxLabelNew/CheckBoxLabelNew.tsx
@@ -59,6 +59,7 @@ const Label = styled.label<{ themes: Theme; $lineHeight: number }>`
       color: ${color.TEXT_BLACK};
       font-size: ${fontSize.S};
       line-height: ${$lineHeight};
+      cursor: pointer;
 
       &.disabled {
         color: ${color.TEXT_DISABLED};

--- a/src/components/CheckBoxLabelNew/README.md
+++ b/src/components/CheckBoxLabelNew/README.md
@@ -1,0 +1,17 @@
+# CheckBoxLabel
+
+```tsx
+import { CheckBoxLabelNew } from 'smarthr-ui'
+
+<CheckBoxLabelNew label="checkbox label" name="sample" checked={true} mixed={true} onChange={() => {}} themeColor="light" />
+```
+
+## props
+
+CheckBoxLabelNew props extends Checkbox props.
+
+In addition to it...
+
+| Name  | Required | Type       | DefaultValue | Description                        |
+| ----- | -------- | ---------- | ------------ | ---------------------------------- |
+| label | ✓        | **string** | -            | Text to the right of the checkbox. |

--- a/src/components/CheckBoxLabelNew/README.md
+++ b/src/components/CheckBoxLabelNew/README.md
@@ -1,9 +1,11 @@
-# CheckBoxLabel
+# CheckBoxLabelNew
 
 ```tsx
 import { CheckBoxLabelNew } from 'smarthr-ui'
 
-<CheckBoxLabelNew label="checkbox label" name="sample" checked={true} mixed={true} onChange={() => {}} themeColor="light" />
+<CheckBoxLabelNew name="sample" checked mixed onChange={(e) => console.log(e)}>
+  checkbox label
+</CheckBoxLabelNew>
 ```
 
 ## props
@@ -12,6 +14,6 @@ CheckBoxLabelNew props extends Checkbox props.
 
 In addition to it...
 
-| Name  | Required | Type       | DefaultValue | Description                        |
-| ----- | -------- | ---------- | ------------ | ---------------------------------- |
-| label | ✓        | **string** | -            | Text to the right of the checkbox. |
+| Name     | Required | Type                | DefaultValue | Description                                                       |
+| -------- | -------- | ------------------- | ------------ | ----------------------------------------------------------------- |
+| children | -        | **React.ReactNode** | -            | If children prop is passed, the checkbox label will be displayed. |

--- a/src/components/CheckBoxLabelNew/index.ts
+++ b/src/components/CheckBoxLabelNew/index.ts
@@ -1,0 +1,1 @@
+export { CheckBoxLabelNew } from './CheckBoxLabelNew'

--- a/src/components/CheckBoxLabelNew/useClassNames.ts
+++ b/src/components/CheckBoxLabelNew/useClassNames.ts
@@ -5,6 +5,7 @@ import { CheckBoxLabelNew } from './CheckBoxLabelNew'
 
 export function useClassNames() {
   const generate = useClassNameGenerator(CheckBoxLabelNew.displayName || 'CheckBoxLabelNew')
+
   return useMemo(
     () => ({
       wrapper: generate(),

--- a/src/components/CheckBoxLabelNew/useClassNames.ts
+++ b/src/components/CheckBoxLabelNew/useClassNames.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+import { CheckBoxLabelNew } from './CheckBoxLabelNew'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator(CheckBoxLabelNew.displayName || 'CheckBoxLabelNew')
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+      label: generate('label'),
+      text: generate('text'),
+    }),
+    [generate],
+  )
+}

--- a/src/components/CheckBoxLabelNew/useClassNames.ts
+++ b/src/components/CheckBoxLabelNew/useClassNames.ts
@@ -9,8 +9,8 @@ export function useClassNames() {
   return useMemo(
     () => ({
       wrapper: generate(),
+      checkBox: generate('checkBox'),
       label: generate('label'),
-      text: generate('text'),
     }),
     [generate],
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 export { LightBalloon, DarkBalloon } from './components/Balloon'
 export { CheckBox } from './components/CheckBox'
 export { CheckBoxLabel } from './components/CheckBoxLabel'
+export { CheckBoxLabelNew } from './components/CheckBoxLabelNew'
 export {
   Dropdown,
   DropdownTrigger,


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-378

## Overview

- CheckBoxLabel というコンポーネントが、「チェックボックス +  ラベル」なのか「チェックボックスにつけるラベル単体」なのかが命名でわかりづらい
- 現状は CheckBox と CheckBoxLabel というものがあり、 CheckBox はチェックボックス単体、 CheckBoxLabel はチェックボックス + ラベルになっている
- ごちゃごちゃしてきたので CheckBox 単体にする
  - このコンポーネントに children を渡すとラジオボタンにラベルがつくようにする
- この変更を一気にやってしまうと BREAKING CHANGE になってしまうので、移行期間を挟めるような変更にする

## What I did

- CheckBoxLabelNew コンポーネントを追加
  - 従来の CheckBoxLabel のような、テキストとチェックボックスとを label タグでラップする運用はやめて、 useId hooks を使用してチェックボックスと label タグとを並列に置く
  - children prop を追加して、それが渡されればラベルが表示されるようにする

## ここではやってないが別やる必要があること

- まず CheckBox と CheckBoxLabel を deprecated にする
- 一度リリースして移行期間を作る
- その後、 CheckBox と CheckBoxLabel コンポーネントを削除する
  - CheckBox は削除というより CheckBoxLabelNew のディレクトリ内に内包させる
- CheckBoxLabelNew を CheckBox に改名する

## Capture

![image](https://user-images.githubusercontent.com/11153463/119423425-33d2b100-bd3e-11eb-8b3f-d467226a3688.png)
