### PR TITLE
chore: replace from FC to VFC in `TabBar`

### DIFF
--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -9,7 +9,7 @@ type Props = {
   className?: string
 }
 
-export const TabBar: FC<Props> = ({ className = '', bordered = true, children }) => {
+export const TabBar: VFC<Props> = ({ className = '', bordered = true, children }) => {
   const theme = useTheme()
   const classNames = `${className} ${bordered ? 'bordered' : ''}`
 

--- a/src/components/TabBar/TabItem.tsx
+++ b/src/components/TabBar/TabItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -13,7 +13,7 @@ type Props = {
   onClick: (tabId: string) => void
 }
 
-export const TabItem: FC<Props> = ({
+export const TabItem: VFC<Props> = ({
   id,
   children,
   onClick,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in `TabBar`
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace to `VFC`.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
