### PR TITLE
chore: replace from FC to VFC in `Table`

### DIFF
--- a/src/components/Table/Body.tsx
+++ b/src/components/Table/Body.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
+import React, { HTMLAttributes, VFC } from 'react'
 import styled from 'styled-components'
 import { TableGroupContext } from './Table'
 
-export const Body: React.VFC<Record<string, unknown>> = (props) => (
+type ElementType = HTMLAttributes<HTMLTableSectionElement>
+
+export const Body: VFC<ElementType> = ({ children, ...props }) => (
   <Wrapper {...props}>
-    <TableGroupContext.Provider value={{ group: 'body' }}>
-      {props.children}
-    </TableGroupContext.Provider>
+    <TableGroupContext.Provider value={{ group: 'body' }}>{children}</TableGroupContext.Provider>
   </Wrapper>
 )
 

--- a/src/components/Table/Body.tsx
+++ b/src/components/Table/Body.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import { TableGroupContext } from './Table'
 
-export const Body: React.FC<Record<string, unknown>> = (props) => (
+export const Body: React.VFC<Record<string, unknown>> = (props) => (
   <Wrapper {...props}>
     <TableGroupContext.Provider value={{ group: 'body' }}>
       {props.children}

--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes, ReactNode, useContext } from 'react'
+import React, { HTMLAttributes, ReactNode, VFC, useContext } from 'react'
 import styled, { css } from 'styled-components'
 
 import { isTouchDevice } from '../../libs/ua'
@@ -17,7 +17,7 @@ export type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLTableDataCellElement>, keyof Props>
 
-export const Cell: FC<Props & ElementProps> = ({
+export const Cell: VFC<Props & ElementProps> = ({
   className = '',
   children,
   onClick,

--- a/src/components/Table/Head.tsx
+++ b/src/components/Table/Head.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -10,7 +10,7 @@ export type Props = {
   className?: string
 }
 
-export const Head: FC<Props> = ({ bulkActionArea, className = '', children }) => {
+export const Head: VFC<Props> = ({ bulkActionArea, className = '', children }) => {
   const themes = useTheme()
   return (
     <thead className={className}>

--- a/src/components/Table/Row.tsx
+++ b/src/components/Table/Row.tsx
@@ -6,7 +6,7 @@ export type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLTableRowElement>, keyof Props>
 
-export const Row: React.FC<Props & ElementProps> = ({ className = '', children, ...props }) => (
+export const Row: React.VFC<Props & ElementProps> = ({ className = '', children, ...props }) => (
   <tr className={className} {...props}>
     {children}
   </tr>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, createContext } from 'react'
+import React, { ReactNode, VFC, createContext } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -14,7 +14,7 @@ type Props = {
   className?: string
 }
 
-export const Table: FC<Props> = ({ children, className = '' }) => {
+export const Table: VFC<Props> = ({ children, className = '' }) => {
   const theme = useTheme()
 
   return (


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in `Table`
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace to `VFC`.
- Modify `Body` props to `HTMLTableSectionElement`.
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
