### PR TITLE
chore: replace from FC to VFC in hooks

### DIFF
--- a/src/hooks/useId.tsx
+++ b/src/hooks/useId.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, createContext, useContext, useMemo } from 'react'
+import React, { ReactNode, VFC, createContext, useContext, useMemo } from 'react'
 
 interface IdContextValue {
   prefix: number
@@ -20,7 +20,7 @@ export function useId(defaultId?: string) {
   ])
 }
 
-export const SequencePrefixIdProvider: FC<{ children: ReactNode }> = ({ children }) => {
+export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {
   const context = useContext(IdContext)
   // increment `prefix` and reset `current` to 0 on every Provider
   const value: IdContextValue = {

--- a/src/hooks/usePortal.tsx
+++ b/src/hooks/usePortal.tsx
@@ -1,6 +1,6 @@
 import React, {
-  FC,
   ReactNode,
+  VFC,
   createContext,
   useCallback,
   useContext,
@@ -47,7 +47,7 @@ export function usePortal() {
     [currentSeq],
   )
 
-  const PortalParentProvider: FC<{ children: ReactNode }> = useCallback(
+  const PortalParentProvider: VFC<{ children: ReactNode }> = useCallback(
     ({ children }) => {
       const value: ParentContextValue = {
         seqs: parentSeqs,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-321
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Replace from `FC` to `VFC` in hooks.
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Replace to `VFC` in:
  - `useId` hook
  - `usePortal` hook
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
