### PR TITLE
feat: deprecate FieldSet component

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -21,6 +21,9 @@ type Props = Omit<InputProps, 'error'> & {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
+/**
+ * @deprecated The FieldSet component is deprecated, so use FormGroup component instead.
+ */
 export const FieldSet: VFC<Props & ElementProps> = ({
   label,
   labelType = 'subBlockTitle',


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-396

## Overview

Now use FormGroup component instead of FieldSet component.
So deprecate FieldSet component.

## What I did

deprecate FieldSet component.

## Capture

🍐 
