### PR TITLE
feat: fix input prefix/suffix icons color in storybook

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -57,11 +57,11 @@ storiesOf('Input', module).add('all', () => {
       </li>
       <li>
         <Txt>prefix</Txt>
-        <Input prefix={<FaSearchIcon color={theme.palette.BORDER} />} />
+        <Input prefix={<FaSearchIcon color={theme.color.TEXT_GREY} />} />
       </li>
       <li>
         <Txt>suffix</Txt>
-        <Input suffix={<FaSearchIcon color={theme.palette.BORDER} />} />
+        <Input suffix={<FaSearchIcon color={theme.color.TEXT_GREY} />} />
       </li>
       <li>
         <Txt>extending style (width 50%)</Txt>
@@ -90,6 +90,6 @@ const Note = styled.div<{ themes: Theme }>`
     margin-top: 8px;
     font-size: 12px;
     font-size: 14px;
-    color: ${themes.palette.TEXT_GREY};
+    color: ${themes.color.TEXT_GREY};
   `}
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-425

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- Inputで使われているprefix,suffixアイコンの色が実際のプロダクトで使う色と合ってない

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- BORDERからTEXT_GREYに変更する

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
