### PR TITLE
新 fontSize に依る置換

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -212,7 +212,6 @@ const Content = styled.div<{ themes: Theme }>(
   ({ themes: { color } }) => css`
     background-color: ${color.BACKGROUND};
     padding: 16px;
-    font-size: 14px;
   `,
 )
 const Stack = styled.div`

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -175,7 +175,6 @@ const ListWrapper = styled.ul<{ themes: Theme }>`
         padding: 0 20px;
         border: none;
         background-color: #fff;
-        font-size: 14px;
         color: ${palette.TEXT_BLACK};
 
         &:hover {

--- a/src/components/AppNavi/appNaviHelper.tsx
+++ b/src/components/AppNavi/appNaviHelper.tsx
@@ -47,8 +47,9 @@ export type ItemStyleProps = {
   isUnclickable?: boolean
 }
 export function getItemStyle({ themes, isActive, isUnclickable }: ItemStyleProps) {
-  const { pxToRem, font } = themes.size
-  const { hoverColor, MAIN, TEXT_BLACK, TEXT_GREY } = themes.palette
+  const { fontSize, palette, size } = themes
+  const { pxToRem } = size
+  const { hoverColor, MAIN, TEXT_BLACK, TEXT_GREY } = palette
 
   return css`
     display: flex;
@@ -60,7 +61,7 @@ export function getItemStyle({ themes, isActive, isUnclickable }: ItemStyleProps
     background: none;
     border: none;
     color: ${TEXT_GREY};
-    font-size: ${pxToRem(font.TALL)};
+    font-size: ${fontSize.M};
     font-weight: bold;
     text-decoration: none;
     transition: background-color 0.3s;

--- a/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
+++ b/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
@@ -129,10 +129,9 @@ const Header = styled.div`
   display: flex;
   align-items: center;
 `
-const Title = styled.div<{ themes: Theme }>(({ themes: { size, spacingByChar } }) => {
-  const { font, pxToRem } = size
+const Title = styled.div<{ themes: Theme }>(({ themes: { fontSize, spacingByChar } }) => {
   return css`
-    font-size: ${pxToRem(font.TALL)};
+    font-size: ${fontSize.M};
     padding: ${spacingByChar(1)};
   `
 })
@@ -181,30 +180,27 @@ const JobIconWrapper = styled.div`
   line-height: 0;
 `
 const JobName = styled(OmittableJobText)<{ themes: Theme }>(
-  ({ themes: { size, spacingByChar } }) => {
-    const { font, pxToRem } = size
+  ({ themes: { fontSize, spacingByChar } }) => {
     return css`
       margin-left: ${spacingByChar(0.5)};
-      font-size: ${pxToRem(font.TALL)};
+      font-size: ${fontSize.M};
     `
   },
 )
 const JobDesc = styled(OmittableJobText)<{ themes: Theme }>(
-  ({ themes: { size, spacingByChar } }) => {
-    const { font, pxToRem } = size
+  ({ themes: { fontSize, spacingByChar } }) => {
     return css`
       margin-left: ${spacingByChar(0.5)};
-      font-size: ${pxToRem(font.SHORT)};
+      font-size: ${fontSize.S};
     `
   },
 )
 const CancelButton = styled(ResetButton)<{ themes: Theme }>(
-  ({ themes: { color, size, spacingByChar } }) => {
-    const { font, pxToRem } = size
+  ({ themes: { color, fontSize, spacingByChar } }) => {
     return css`
       flex-shrink: 0;
       margin-left: ${spacingByChar(0.5)};
-      font-size: ${pxToRem(font.SHORT)};
+      font-size: ${fontSize.S};
       color: ${color.TEXT_LINK};
       cursor: pointer;
       :hover {

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -40,12 +40,12 @@ export const DarkBalloon = balloonFactory('dark')
 
 const Base = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette, frame, size } = themes
+    const { palette, frame, fontSize } = themes
 
     return css`
       position: relative;
       display: inline-block;
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       border-radius: 4px;
       box-shadow: 0 2px 8px 0 rgba(51, 51, 51, 0.35);
       white-space: nowrap;

--- a/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
@@ -18,6 +18,6 @@ storiesOf('BottomFixedArea', module)
       description="This is description."
       primaryButton={<PrimaryButton>Primary Button</PrimaryButton>}
       secondaryButton={<SecondaryButton>Secondary Button</SecondaryButton>}
-      tertiaryLinks={[{ text: 'tertiary_1', icon: FaTrashIcon, onClick: action('click_1') }]}
+      tertiaryLinks={[{ text: 'Tertiary_1', icon: FaTrashIcon, onClick: action('click_1') }]}
     />
   ))

--- a/src/components/BottomFixedArea/TertiaryLink.tsx
+++ b/src/components/BottomFixedArea/TertiaryLink.tsx
@@ -66,11 +66,10 @@ const Button = styled.button<{ themes: Theme }>`
   }}
 `
 const Text = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, font } = themes.size
+  ${({ themes: { fontSize } }) => {
     return css`
       margin: 0;
-      font-size: ${pxToRem(font.GRANDE)};
+      font-size: ${fontSize.L};
     `
   }}
 `

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -78,7 +78,7 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { frame, size, spacingByChar, interaction, shadow } = themes
+    const { frame, fontSize, spacingByChar, interaction, shadow } = themes
 
     return css`
       display: inline-flex;
@@ -98,13 +98,13 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       white-space: nowrap;
 
       &.default {
-        font-size: ${size.pxToRem(size.font.TALL)};
+        font-size: ${fontSize.M};
         height: 40px;
         padding: 0 ${spacingByChar(1)};
       }
 
       &.s {
-        font-size: ${size.pxToRem(size.font.SHORT)};
+        font-size: ${fontSize.S};
         height: 27px;
         padding: 0 ${spacingByChar(0.5)};
       }

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -126,14 +126,14 @@ const YearMonth = styled.div`
   font-weight: bold;
 `
 const Header = styled.header<{ themes: Theme }>(({ themes }) => {
-  const { palette, size } = themes
+  const { palette, fontSize } = themes
   return css`
     display: flex;
     align-items: center;
     padding: 16px;
     border-bottom: solid 1px ${palette.BORDER};
     ${YearMonth} {
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
     }
   `
 })

--- a/src/components/Calendar/CalendarTable.tsx
+++ b/src/components/Calendar/CalendarTable.tsx
@@ -92,10 +92,10 @@ export const CalendarTable: VFC<Props & ElementProps> = ({
 }
 
 const Table = styled.table<{ themes: Theme }>(({ themes }) => {
-  const { palette, size } = themes
+  const { palette, fontSize } = themes
   return css`
     color: ${palette.TEXT_BLACK};
-    font-size: ${size.pxToRem(size.font.TALL)};
+    font-size: ${fontSize.M};
     border-spacing: 0;
     margin: 4px 8px 13px;
 

--- a/src/components/Calendar/YearPicker.tsx
+++ b/src/components/Calendar/YearPicker.tsx
@@ -97,7 +97,7 @@ const Container = styled.div`
 `
 const YearWrapper = styled.span<{ themes: Theme; isThisYear?: boolean; isSelected?: boolean }>(
   ({ themes, isThisYear, isSelected }) => {
-    const { palette, size } = themes
+    const { palette, fontSize } = themes
     return css`
       display: flex;
       align-items: center;
@@ -105,7 +105,7 @@ const YearWrapper = styled.span<{ themes: Theme; isThisYear?: boolean; isSelecte
       width: 51px;
       height: 27px;
       border-radius: 14px;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       box-sizing: border-box;
       line-height: 0;
       ${isThisYear &&

--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -81,5 +81,4 @@ const Group = styled.ul`
 `
 const Text = styled.p`
   margin: 0 0 16px 0;
-  font-size: 16px;
 `

--- a/src/components/CheckBoxLabel/CheckBoxLabel.stories.tsx
+++ b/src/components/CheckBoxLabel/CheckBoxLabel.stories.tsx
@@ -111,5 +111,4 @@ const Group = styled.ul`
 `
 const Text = styled.p`
   margin: 0 0 16px 0;
-  font-size: 16px;
 `

--- a/src/components/CheckBoxLabel/CheckBoxLabel.tsx
+++ b/src/components/CheckBoxLabel/CheckBoxLabel.tsx
@@ -65,7 +65,7 @@ const Txt = styled.span<{ themes: Theme; lineHeight: number }>`
     // checkbox と text の位置がずれるため、line-height 分を調整する疑似要素を作る
     return css`
       margin: 0 0 0 ${spacingByChar(0.5)};
-      font-size: ${fontSize.pxToRem(fontSize.TALL)};
+      font-size: ${fontSize.M};
       line-height: ${lineHeight};
       &::before {
         content: '';

--- a/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
+++ b/src/components/CheckBoxLabel/__snapshots__/CheckBoxLabel.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`CheckBoxLabel should be match snapshot 1`] = `
 
 .c6 {
   margin: 0 0 0 8px;
-  font-size: 0.875rem;
+  font-size: 1rem;
   line-height: 1.5;
 }
 

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -329,11 +329,11 @@ const SelectedItem = styled.div<{ themes: Theme; disabled: boolean }>`
 
     return css`
       display: flex;
-      border-radius: calc(${fontSize.SHORT}px + (${spacingByChar(0.5)} - ${borderWidth}px) * 2);
+      border-radius: calc(${fontSize.S} + (${spacingByChar(0.5)} - ${borderWidth}px) * 2);
       border: ${border.shorthand};
       background-color: ${disabled ? color.disableColor('#fff') : '#fff'};
       color: ${disabled ? color.TEXT_DISABLED : color.TEXT_BLACK};
-      font-size: ${fontSize.SHORT}px;
+      font-size: ${fontSize.S};
       line-height: 1;
     `
   }}
@@ -383,7 +383,7 @@ const Input = styled.input<{ themes: Theme }>`
       min-width: 80px;
       width: 100%;
       border: none;
-      font-size: ${fontSize.TALL}px;
+      font-size: ${fontSize.M};
       box-sizing: border-box;
       outline: none;
       &[disabled] {
@@ -399,7 +399,7 @@ const Placeholder = styled.p<{ themes: Theme }>`
     return css`
       margin: 0;
       color: ${color.TEXT_GREY};
-      font-size: ${fontSize.TALL}px;
+      font-size: ${fontSize.M};
       line-height: 25px;
     `
   }}

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -267,19 +267,19 @@ const Container = styled.div<{ top: number; left: number; width: number; themes:
 )
 const NoItems = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar } = themes
+    const { fontSize, spacingByChar } = themes
 
     return css`
       margin: 0;
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       background-color: #fff;
-      font-size: ${size.font.TALL}px;
+      font-size: ${fontSize.M};
     `
   }}
 `
 const SelectButton = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar, palette } = themes
+    const { fontSize, spacingByChar, palette } = themes
 
     return css`
       display: block;
@@ -287,7 +287,7 @@ const SelectButton = styled.button<{ themes: Theme }>`
       border: none;
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       background-color: #fff;
-      font-size: ${size.font.TALL}px;
+      font-size: ${fontSize.M};
       text-align: left;
       cursor: pointer;
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -273,7 +273,7 @@ const CalendarIconLayout = styled.span<{ themes: Theme }>(({ themes: { spacingBy
   `
 })
 const CalendarIconWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { palette, size, spacingByChar } = themes
+  const { fontSize, palette, spacingByChar } = themes
   return css`
     display: flex;
     align-items: center;
@@ -282,6 +282,6 @@ const CalendarIconWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
     height: 100%;
     padding-left: ${spacingByChar(0.5)};
     border-left: 1px solid ${palette.BORDER};
-    font-size: ${size.pxToRem(size.font.TALL)};
+    font-size: ${fontSize.M};
   `
 })

--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -98,5 +98,5 @@ const Alert = styled.span`
 const AlertText = styled.span<{ themes: Theme }>`
   margin-left: 4px;
   color: ${({ themes }) => themes.palette.TEXT_BLACK};
-  font-size: 11px;
+  font-size: ${({ themes }) => themes.fontSize.S};
 `

--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -49,13 +49,13 @@ const Wrapper = styled.div<{ themes: Theme }>`
 `
 const Content = styled.dd<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette } = themes
+    const { size, fontSize, palette } = themes
 
     return css`
       margin: ${size.pxToRem(5)} 0 0;
       padding: 0;
       color: ${palette.TEXT_BLACK};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
     `
   }}

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -124,12 +124,11 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
 
 const Title = styled.p<{ themes: Theme }>`
   ${({ themes: { fontSize, border, spacing } }) => {
-    const { pxToRem } = fontSize
     return css`
       margin: 0;
       padding: ${spacing.XS} ${spacing.S};
       border-bottom: ${border.shorthand};
-      font-size: ${pxToRem(fontSize.GRANDE)};
+      font-size: ${fontSize.L};
       line-height: 1;
     `
   }}
@@ -162,10 +161,7 @@ const ResponseMessage: React.VFC<{
     return null
   }
 
-  const {
-    color,
-    fontSize: { pxToRem, TALL },
-  } = themes
+  const { color, fontSize } = themes
   const { status, text } = responseMessage
   const Wrapper = styled.p`
     display: flex;
@@ -173,7 +169,7 @@ const ResponseMessage: React.VFC<{
     justify-content: flex-end;
     margin-top: 0;
     margin-bottom: 0;
-    font-size: ${pxToRem(TALL)};
+    font-size: ${fontSize.M};
   `
   const Spinner = styled(Loader)`
     &&& {

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -160,10 +160,11 @@ Message_Dialog.parameters = {
 export const Action_Dialog: Story = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = React.useState('Apple')
-  const [responseMessage, setResponseMessage] = useState<{
-    status: 'success' | 'error' | 'processing'
-    text: string
-  }>()
+  const [responseMessage, setResponseMessage] =
+    useState<{
+      status: 'success' | 'error' | 'processing'
+      text: string
+    }>()
   const onClickOpen = () => setIsOpen(true)
   const onClickClose = () => {
     setIsOpen(false)

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -160,11 +160,10 @@ Message_Dialog.parameters = {
 export const Action_Dialog: Story = () => {
   const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = React.useState('Apple')
-  const [responseMessage, setResponseMessage] =
-    useState<{
-      status: 'success' | 'error' | 'processing'
-      text: string
-    }>()
+  const [responseMessage, setResponseMessage] = useState<{
+    status: 'success' | 'error' | 'processing'
+    text: string
+  }>()
   const onClickOpen = () => setIsOpen(true)
   const onClickClose = () => {
     setIsOpen(false)

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -483,18 +483,16 @@ RegOpendAction.parameters = { docs: { disable: true } }
 const Title = styled.p<{ themes: Theme }>`
   padding: 16px 24px;
   margin: 0;
-  font-size: 18px;
+  font-size: ${({ themes }) => themes.fontSize.L};
   line-height: 1;
   border-bottom: ${({ themes }) => themes.frame.border.default};
 `
 const Description = styled.p`
   margin: 16px 24px;
-  font-size: 14px;
   line-height: 1.5;
 `
 const Content = styled.div`
   margin: 16px 24px;
-  font-size: 14px;
   line-height: 1.5;
 `
 const RadioList = styled.ul`

--- a/src/components/Dialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialogContentInner.tsx
@@ -58,24 +58,23 @@ export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
 
 const Title = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar, frame } = themes
+    const { fontSize, spacingByChar, frame } = themes
     return css`
       margin: 0;
       padding: ${spacingByChar(1)} ${spacingByChar(1.5)};
       border-bottom: ${frame.border.default};
-      font-size: ${size.pxToRem(size.font.GRANDE)};
+      font-size: ${fontSize.L};
       line-height: 1;
     `
   }}
 `
 const Description = styled.div<{ themes: Theme; offsetHeight: number }>`
-  ${({ themes: { size, spacingByChar }, offsetHeight }) => {
-    const { pxToRem, font } = size
+  ${({ themes: { fontSize, spacingByChar }, offsetHeight }) => {
     return css`
       max-height: calc(100vh - ${offsetHeight}px);
       overflow: auto;
       padding: 0 ${spacingByChar(1.5)};
-      font-size: ${pxToRem(font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
     `
   }}

--- a/src/components/Downloader/Downloader.stories.tsx
+++ b/src/components/Downloader/Downloader.stories.tsx
@@ -28,7 +28,7 @@ const Wrapper = styled.div<{ themes: Theme }>`
   border-radius: 6px;
   box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
   color: ${({ themes }) => themes.palette.TEXT_BLACK};
-  font-size: ${({ themes }) => themes.size.font.TALL};
+  font-size: ${({ themes }) => themes.fontSize.M};
   text-align: center;
   line-height: 1;
   position: absolute;

--- a/src/components/DropZone/DropZone.stories.tsx
+++ b/src/components/DropZone/DropZone.stories.tsx
@@ -58,7 +58,6 @@ const Group = styled.ul`
 
 const Text = styled.p`
   margin: 0 0 16px 0;
-  font-size: 16px;
 `
 
 const DropZoneText = styled.p<{ theme: Theme }>`
@@ -70,7 +69,6 @@ const DropZoneText = styled.p<{ theme: Theme }>`
         display: block;
         margin: 0 0 16px;
         text-align: center;
-        font-size: 14px;
         line-height: 1;
         color: ${palette.TEXT_GREY};
       }

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -249,7 +249,6 @@ const List = styled.ul<{ themes: Theme }>`
         padding: 0 20px;
         border: none;
         background-color: #fff;
-        font-size: 14px;
         color: ${palette.TEXT_BLACK};
 
         &:hover {
@@ -280,7 +279,6 @@ const ControllableBoxMain = styled.div`
 `
 const Text = styled.p<{ themes: Theme }>`
   margin: 0;
-  font-size: 14px;
   color: ${({ themes }) => themes.palette.TEXT_BLACK};
 `
 const ControllableBoxBottom = styled.div<{ themes: Theme }>`
@@ -297,7 +295,6 @@ const ControllableBoxBottom = styled.div<{ themes: Theme }>`
 const Description = styled.p`
   margin: 0;
   padding: 100px 0;
-  font-size: 20px;
 `
 const RightAlign = styled.div`
   display: flex;
@@ -314,7 +311,6 @@ const Fixed = styled.div<{ themes: Theme }>`
   width: 100%;
   padding: 0 20px;
   border: none;
-  font-size: 14px;
   font-weight: bold;
   line-height: 40px;
   color: ${({ themes }) => themes.palette.TEXT_BLACK};

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -135,13 +135,11 @@ const List = styled.dl`
 `
 const Text = styled.p<{ themes: Theme }>`
   margin: 0;
-  font-size: 14px;
   color: ${({ themes }) => themes.color.TEXT_BLACK};
 `
 const Description = styled.p`
   margin: 0;
   padding: 100px 0;
-  font-size: 20px;
 `
 const RadioButtonList = styled.ul`
   list-style: none;

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -89,7 +89,7 @@ const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean; themes: Theme }
 `
 const StatusText = styled.span<{ themes: Theme }>`
   margin-left: ${({ themes }) => themes.spacing.XXS};
-  font-size: ${({ themes }) => themes.size.pxToRem(themes.fontSize.SHORT)};
+  font-size: ${({ themes }) => themes.fontSize.S};
 `
 const ContentLayout = styled.div`
   padding: 24px;

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -65,7 +65,7 @@ storiesOf('FieldSet', module)
             labelSuffix={
               <Suffix>
                 <FaExclamationCircleIcon size={12} color={themes.palette.TEXT_GREY} />
-                <SuffixText>suffix text</SuffixText>
+                <SuffixText themes={themes}>suffix text</SuffixText>
               </Suffix>
             }
           />
@@ -83,7 +83,7 @@ storiesOf('FieldSet', module)
             labelSuffix={
               <Suffix>
                 <FaExclamationCircleIcon size={12} color={themes.palette.TEXT_GREY} />
-                <SuffixText>suffix text</SuffixText>
+                <SuffixText themes={themes}>suffix text</SuffixText>
               </Suffix>
             }
             required
@@ -111,9 +111,9 @@ const Suffix = styled.div`
     margin-right: 4px;
   }
 `
-const SuffixText = styled.p`
+const SuffixText = styled.p<{ themes: Theme }>`
   margin: 0;
-  font-size: 11px;
+  font-size: ${({ themes }) => themes.fontSize.S};
 `
 const CustomTag = styled.div<{ themes: Theme }>`
   ${({ themes }) => {

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -103,17 +103,17 @@ const TitleText = styled(Heading)`
   display: inline-block;
 `
 const Help = styled.div<{ themes: Theme }>`
-  ${({ themes: { color, size, spacingByChar } }) => css`
+  ${({ themes: { color, fontSize, spacingByChar } }) => css`
     margin: ${spacingByChar(0.5)} 0 0 0;
-    font-size: ${size.pxToRem(size.font.SHORT)};
+    font-size: ${fontSize.S};
     line-height: 1;
     color: ${color.TEXT_GREY};
   `}
 `
 const Error = styled.div<{ themes: Theme }>`
-  ${({ themes: { size, spacingByChar } }) => css`
+  ${({ themes: { fontSize, spacingByChar } }) => css`
     margin: ${spacingByChar(0.5)} 0 0 0;
-    font-size: ${size.pxToRem(size.font.SHORT)};
+    font-size: ${fontSize.S};
     line-height: 1;
   `}
 `

--- a/src/components/FlashMessage/FlashMessage.tsx
+++ b/src/components/FlashMessage/FlashMessage.tsx
@@ -182,16 +182,14 @@ const IconWrapper = styled.span`
 `
 
 const Txt = styled.p<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { pxToRem, font } = themes.size
-
+  ${({ themes: { fontSize } }) => {
     return css`
       flex-grow: 1;
       flex-shrink: 1;
       margin-top: 0;
       margin-bottom: 0;
       padding: 0;
-      font-size: ${pxToRem(font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
     `
   }}

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -99,7 +99,7 @@ const ErrorIcon = styled.div<{ themes: Theme }>`
 const ErrorText = styled.div<{ themes: Theme }>`
   ${({ themes: { fontSize } }) => {
     return css`
-      font-size: ${fontSize.pxToRem(fontSize.SHORT)};
+      font-size: ${fontSize.S};
     `
   }}
 `

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -22,18 +22,12 @@ export const Footer: VFC = () => {
 }
 
 const Wrapper = styled.footer<{ themes: Theme }>`
-  ${({
-    themes: {
-      color,
-      size: { font, pxToRem },
-      spacingByChar,
-    },
-  }) => css`
+  ${({ themes: { color, fontSize, spacingByChar } }) => css`
     overflow: hidden;
     padding: ${spacingByChar(1)} ${spacingByChar(1.5)};
     background-color: ${color.BRAND};
     color: #fff;
-    font-size: ${pxToRem(font.TALL)};
+    font-size: ${fontSize.M};
     white-space: nowrap;
   `}
 `
@@ -78,6 +72,6 @@ const ItemPart = styled.a`
 const Copy = styled.small<{ themes: Theme }>`
   ${({ themes }) => css`
     float: right;
-    font-size: ${themes.size.pxToRem(themes.size.font.TALL)};
+    font-size: ${themes.fontSize.M};
   `}
 `

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -122,7 +122,7 @@ const HelpMessage = styled.span<{ themes: Theme }>`
     css`
       display: block;
       margin-top: ${spacingByChar(0.5)};
-      font-size: ${fontSize.pxToRem(fontSize.TALL)};
+      font-size: ${fontSize.M};
     `}
 `
 
@@ -132,7 +132,7 @@ const ErrorMessage = styled.span<{ themes: Theme }>`
       display: flex;
       align-items: center;
       margin-top: ${spacingByChar(0.5)};
-      font-size: ${fontSize.pxToRem(fontSize.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1;
     `}
 `

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -146,11 +146,11 @@ const HeaderLogo = styled.button<{ themes: Theme }>`
 `
 const TenantName = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar } = themes
+    const { fontSize, spacingByChar } = themes
 
     return css`
       margin: 0 0 0 ${spacingByChar(1)};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       color: #fff;
     `
   }}

--- a/src/components/Header/HeaderButton.tsx
+++ b/src/components/Header/HeaderButton.tsx
@@ -26,7 +26,7 @@ export const HeaderButton: VFC<Props> = ({ icon: Icon, children, onClick }) => {
 
 const Wrapper = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, interaction } = themes
+    const { size, fontSize, interaction } = themes
 
     return css`
       display: inline-block;
@@ -35,7 +35,7 @@ const Wrapper = styled.button<{ themes: Theme }>`
       border: none;
       background: none;
       color: #fff;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 50px;
       transition: background-color ${interaction.hover.animation};
       cursor: pointer;

--- a/src/components/Header/HeaderCrewDropdown.tsx
+++ b/src/components/Header/HeaderCrewDropdown.tsx
@@ -91,7 +91,7 @@ export const HeaderCrewDropdown: VFC<Props> = ({
 
 const TriggerButton = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, interaction } = themes
+    const { size, fontSize, interaction } = themes
 
     return css`
       display: flex;
@@ -102,7 +102,7 @@ const TriggerButton = styled.button<{ themes: Theme }>`
       border: none;
       background: none;
       color: #fff;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       transition: background-color ${interaction.hover.animation};
       cursor: pointer;
 
@@ -162,7 +162,7 @@ const MenuListItemIcon = styled.figure<{ themes: Theme }>`
 `
 const MenuListItemButton = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette, interaction } = themes
+    const { size, fontSize, palette, interaction } = themes
 
     return css`
       display: flex;
@@ -172,7 +172,7 @@ const MenuListItemButton = styled.button<{ themes: Theme }>`
       border: none;
       background: none;
       color: ${palette.TEXT_BLACK};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
       white-space: nowrap;
       box-sizing: border-box;

--- a/src/components/Header/HeaderNotification.tsx
+++ b/src/components/Header/HeaderNotification.tsx
@@ -39,7 +39,7 @@ const Wrapper = styled.div<{ themes: Theme }>`
 `
 const Button = styled.button<{ themes: Theme; isZero: boolean }>`
   ${({ themes, isZero }) => {
-    const { size, interaction } = themes
+    const { fontSize, interaction } = themes
 
     return css`
       display: inline-block;
@@ -50,7 +50,7 @@ const Button = styled.button<{ themes: Theme; isZero: boolean }>`
       border-radius: 4px;
       background-color: ${isZero ? '#aaa' : '#fcb156'};
       color: #fff;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       transition: background-color ${interaction.hover.animation};
       cursor: pointer;
 

--- a/src/components/Header/HeaderUserDropdown.tsx
+++ b/src/components/Header/HeaderUserDropdown.tsx
@@ -137,7 +137,7 @@ export const HeaderUserDropdown: VFC<Props> = ({
 
 const TriggerButton = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, interaction } = themes
+    const { fontSize, size, interaction } = themes
 
     return css`
       display: flex;
@@ -148,7 +148,7 @@ const TriggerButton = styled.button<{ themes: Theme }>`
       border: none;
       background: none;
       color: #fff;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       transition: background-color ${interaction.hover.animation};
       cursor: pointer;
 
@@ -205,7 +205,7 @@ const MenuListItemIcon = styled.figure<{ themes: Theme }>`
 `
 const MenuListItemButton = styled.button<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette, interaction } = themes
+    const { fontSize, size, palette, interaction } = themes
 
     return css`
       display: flex;
@@ -215,7 +215,7 @@ const MenuListItemButton = styled.button<{ themes: Theme }>`
       border: none;
       background: none;
       color: ${palette.TEXT_BLACK};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
       white-space: nowrap;
       box-sizing: border-box;
@@ -230,12 +230,12 @@ const MenuListItemButton = styled.button<{ themes: Theme }>`
 `
 const MenuListItemHeader = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, palette } = themes
+    const { fontSize, size, palette } = themes
 
     return css`
       padding: ${size.pxToRem(3)} ${size.pxToRem(20)};
       color: ${palette.TEXT_GREY};
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       line-height: 1.6;
       white-space: nowrap;
     `

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -36,7 +36,7 @@ export const Heading: VFC<Props> = ({
 
 const Wrapper = styled.h1<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette, size } = themes
+    const { palette, fontSize } = themes
 
     return css`
       display: block;
@@ -46,31 +46,31 @@ const Wrapper = styled.h1<{ themes: Theme }>`
 
       &.screenTitle {
         color: ${palette.TEXT_BLACK};
-        font-size: ${size.pxToRem(size.font.VENTI)};
+        font-size: ${fontSize.XL};
         font-weight: normal;
       }
 
       &.sectionTitle {
         color: ${palette.TEXT_BLACK};
-        font-size: ${size.pxToRem(size.font.GRANDE)};
+        font-size: ${fontSize.L};
         font-weight: normal;
       }
 
       &.blockTitle {
         color: ${palette.TEXT_BLACK};
-        font-size: ${size.pxToRem(size.font.TALL)};
+        font-size: ${fontSize.M};
         font-weight: bold;
       }
 
       &.subBlockTitle {
         color: ${palette.TEXT_GREY};
-        font-size: ${size.pxToRem(size.font.TALL)};
+        font-size: ${fontSize.M};
         font-weight: bold;
       }
 
       &.subSubBlockTitle {
         color: ${palette.TEXT_GREY};
-        font-size: ${size.pxToRem(size.font.SHORT)};
+        font-size: ${fontSize.S};
         font-weight: bold;
       }
     `

--- a/src/components/HeadlineArea/HeadlineArea.tsx
+++ b/src/components/HeadlineArea/HeadlineArea.tsx
@@ -34,12 +34,12 @@ const Wrapper = styled.div`
 `
 const Description = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar, palette } = themes
+    const { fontSize, spacingByChar, palette } = themes
 
     return css`
       margin-top: ${spacingByChar(1)};
       color: ${palette.TEXT_BLACK};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
     `
   }}

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -751,7 +751,6 @@ const CatalogItem = styled.dl`
 `
 const IconName = styled.dt`
   margin-bottom: 10px;
-  font-size: 14px;
   color: #222;
 `
 const List = styled.div`

--- a/src/components/IndexNav/IndexNav.tsx
+++ b/src/components/IndexNav/IndexNav.tsx
@@ -37,18 +37,16 @@ export const IndexNav: VFC<Props> = ({ items }) => {
   )
 }
 
-const List = styled.ol<{ themes: Theme }>(({ themes }) => {
-  const { size } = themes
-
+const List = styled.ol<{ themes: Theme }>(({ themes: { fontSize } }) => {
   return css`
     list-style: none;
     margin: 0;
     padding: 0;
-    font-size: ${size.pxToRem(size.font.TALL)};
+    font-size: ${fontSize.M};
   `
 })
 const Item = styled.li<{ themes: Theme }>(({ themes }) => {
-  const { size, spacingByChar } = themes
+  const { fontSize, spacingByChar } = themes
 
   return css`
     line-height: 1em;
@@ -60,7 +58,7 @@ const Item = styled.li<{ themes: Theme }>(({ themes }) => {
     & > ${List} {
       margin-top: ${spacingByChar(1)};
       margin-left: ${spacingByChar(1.5)};
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
     }
   `
 })

--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -168,12 +168,10 @@ const ErrorTitleIcon = createTitleIcon(FaExclamationCircleIcon)
 const SyncIcon = createTitleIcon(FaSyncAltIcon)
 
 const Content = styled.div<{ themes: Theme }>`
-  ${({ themes: { size, spacingByChar } }) => {
-    const { pxToRem, font } = size
-
+  ${({ themes: { fontSize, spacingByChar } }) => {
     return css`
       margin-top: ${spacingByChar(1.5)};
-      font-size: ${pxToRem(font.TALL)};
+      font-size: ${fontSize.M};
       &[aria-hidden='true'] {
         display: none;
       }

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -88,8 +88,6 @@ const StyledInput = styled(Input)`
 const Note = styled.div<{ themes: Theme }>`
   ${({ themes }) => css`
     margin-top: 8px;
-    font-size: 12px;
-    font-size: 14px;
     color: ${themes.color.TEXT_GREY};
   `}
 `

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -143,7 +143,7 @@ const StyledInput = styled.input<
 >`
   ${(props) => {
     const { prefixWidth, suffixWidth, themes } = props
-    const { size, spacingByChar, palette, frame } = themes
+    const { fontSize, spacingByChar, palette, frame } = themes
 
     return css`
       flex-grow: 1;
@@ -155,7 +155,7 @@ const StyledInput = styled.input<
       padding-right: calc(${spacingByChar(0.5)} + ${suffixWidth}px);
       border: none;
       border-radius: ${frame.border.radius.m};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       color: ${palette.TEXT_BLACK};
       line-height: 1.6;
       box-sizing: border-box;

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -102,9 +102,9 @@ const Wrapper = styled.div`
 `
 
 const FileList = styled.ul<{ themes: Theme }>(({ themes }) => {
-  const { palette, size, spacingByChar } = themes
+  const { fontSize, palette, spacingByChar } = themes
   return css`
-    font-size: ${size.pxToRem(size.font.TALL)};
+    font-size: ${fontSize.M};
     padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
     margin-bottom: ${spacingByChar(1)};
     background-color: ${palette.COLUMN};
@@ -170,7 +170,7 @@ const FileButtonWrapper = styled.div<{ themes: Theme }>(({ themes }) => {
 })
 
 const FileButton = styled.button<{ themes: Theme }>(({ themes }) => {
-  const { frame, palette, size, spacingByChar } = themes
+  const { fontSize, frame, palette, spacingByChar } = themes
   return css`
     font-family: inherit;
     font-weight: bold;
@@ -185,13 +185,13 @@ const FileButton = styled.button<{ themes: Theme }>(({ themes }) => {
     }
 
     &.default {
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       height: 40px;
       padding: 0 ${spacingByChar(1)};
     }
 
     &.s {
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       height: 27px;
       padding: 0 ${spacingByChar(0.5)};
     }

--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -66,7 +66,6 @@ const GrayWrapper = styled(Wrapper)`
 `
 const Text = styled.p`
   margin: 0 0 16px 0;
-  font-size: 18px;
 `
 const List = styled.dl`
   margin: 1rem;

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -183,11 +183,11 @@ const Ticker = styled.div`
 
 const Text = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette, size, spacingByChar } = themes
+    const { fontSize, palette, spacingByChar } = themes
 
     return css`
       margin-top: ${spacingByChar(1)};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       text-align: center;
 
       &.primary {

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -122,7 +122,7 @@ storiesOf('MessageScreen', module)
 const Description = styled.div<{ themes: Theme }>`
   ${({ themes }) => css`
     color: ${themes.palette.TEXT_BLACK};
-    font-size: ${themes.size.pxToRem(themes.size.font.TALL)};
+    font-size: ${themes.fontSize.M};
     line-height: 21px;
     text-align: center;
   `}
@@ -156,7 +156,7 @@ const Bottom = styled.div`
 const Link = styled.a<{ themes: Theme }>`
   ${({ themes }) => css`
     color: ${themes.palette.TEXT_LINK};
-    font-size: ${themes.size.pxToRem(themes.size.font.TALL)};
+    font-size: ${themes.fontSize.M};
     text-decoration: none;
 
     &:hover {
@@ -170,7 +170,7 @@ const Headline = styled.span<{ themes: Theme }>`
     width: 100%;
     margin-top: 16px;
     color: ${themes.palette.TEXT_BLACK};
-    font-size: ${themes.size.pxToRem(themes.size.font.GRANDE)};
+    font-size: ${themes.fontSize.L};
     text-align: center;
   `}
 `

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -86,15 +86,14 @@ const Logo = styled.div`
 `
 const Title = styled.h1<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar, palette } = themes
-    const { font } = size
+    const { fontSize, spacingByChar, palette } = themes
 
     return css`
       margin: ${spacingByChar(1.5)} 0 0;
       background-color: ${palette.BACKGROUND};
       color: ${palette.TEXT_BLACK};
       font-weight: normal;
-      font-size: ${font.VENTI}px;
+      font-size: ${fontSize.XL};
       line-height: 1;
     `
   }}
@@ -123,11 +122,11 @@ const Links = styled.ul<{ themes: Theme }>`
 `
 const Link = styled.a<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette, size } = themes
+    const { fontSize, palette } = themes
 
     return css`
       color: ${palette.TEXT_LINK};
-      font-size: ${size.font.TALL}px;
+      font-size: ${fontSize.M};
       line-height: 1.4;
       text-decoration: none;
 

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -59,5 +59,4 @@ const List = styled.ul`
 `
 const Txt = styled.p`
   margin: 0 0 10px 0;
-  font-size: 16px;
 `

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -28,7 +28,6 @@ const Wrapper = styled.div<{ themes: Theme }>`
   border-radius: 6px;
   box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
   color: ${({ themes }) => themes.palette.TEXT_BLACK};
-  font-size: 14px;
   text-align: center;
   line-height: 1;
   position: absolute;

--- a/src/components/RadioButtonLabel/RadioButtonLabel.tsx
+++ b/src/components/RadioButtonLabel/RadioButtonLabel.tsx
@@ -46,10 +46,10 @@ const Label = styled.label<{ themes: Theme }>`
 `
 const Txt = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar } = themes
+    const { fontSize, spacingByChar } = themes
     return css`
       margin: 0 0 0 ${spacingByChar(0.5)};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
     `
   }}
 `

--- a/src/components/RightFixedNote/RightFixedNoteItem.tsx
+++ b/src/components/RightFixedNote/RightFixedNoteItem.tsx
@@ -64,14 +64,12 @@ const TextBase = styled(Base)<{ themes: Theme }>`
 `
 
 const Text = styled.p<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { font, pxToRem } = themes.size
-
+  ${({ themes: { fontSize } }) => {
     return css`
       display: block;
       padding: 0;
       margin: 0;
-      font-size: ${pxToRem(font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
     `
   }}
@@ -82,12 +80,10 @@ const EditButton = styled(SecondaryButton)`
 `
 
 const Info = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { size, palette } = themes
-
+  ${({ themes: { fontSize, palette } }) => {
     return css`
       color: ${palette.TEXT_GREY};
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       text-align: right;
     `
   }}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -130,7 +130,7 @@ const Wrapper = styled.div<{
 })
 const SelectBox = styled.select<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar, frame, palette } = themes
+    const { fontSize, spacingByChar, frame, palette } = themes
 
     return css`
       display: inline-block;
@@ -140,7 +140,7 @@ const SelectBox = styled.select<{ themes: Theme }>`
       border-radius: ${frame.border.radius.m};
       border: none;
       background-color: transparent;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       color: ${palette.TEXT_BLACK};
       line-height: 1.6;
       outline: none;

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -79,7 +79,7 @@ const Wrapper = styled.li<{ themes: Theme }>`
 
 const Button = styled(ResetButton)<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar } = themes
+    const { fontSize, spacingByChar } = themes
 
     return css`
       width: 100%;
@@ -89,12 +89,12 @@ const Button = styled(ResetButton)<{ themes: Theme }>`
 
       &.default {
         padding: ${spacingByChar(1)};
-        font-size: ${size.pxToRem(size.font.TALL)};
+        font-size: ${fontSize.M};
       }
 
       &.s {
         padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
-        font-size: ${size.pxToRem(size.font.SHORT)};
+        font-size: ${fontSize.S};
       }
     `
   }}

--- a/src/components/SmartHRLogo/SmartHRLogo.stories.tsx
+++ b/src/components/SmartHRLogo/SmartHRLogo.stories.tsx
@@ -41,5 +41,4 @@ const List = styled.ul`
 `
 const Text = styled.p`
   margin: 0 0 8px 0;
-  font-size: 16px;
 `

--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -21,7 +21,7 @@ export const StatusLabel: VFC<Props> = ({ type = 'done', className = '', childre
 
 const Wrapper = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
-    const { size, spacingByChar, palette } = themes
+    const { fontSize, size, spacingByChar, palette } = themes
 
     return css`
       box-sizing: border-box;
@@ -33,7 +33,7 @@ const Wrapper = styled.span<{ themes: Theme }>`
       text-align: center;
       white-space: nowrap;
       min-width: ${size.pxToRem(60)};
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       font-weight: bold;
       line-height: 1;
 

--- a/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`StatusLabel should be match snapshot 1`] = `
   text-align: center;
   white-space: nowrap;
   min-width: 3.75rem;
-  font-size: 0.6875rem;
+  font-size: 0.8571428571428571rem;
   font-weight: bold;
   line-height: 1;
 }

--- a/src/components/TabBar/TabItem.tsx
+++ b/src/components/TabBar/TabItem.tsx
@@ -49,10 +49,10 @@ const resetButtonStyle = css`
 const Wrapper = styled.button<{ themes: Theme }>`
   ${resetButtonStyle}
   ${({ themes }) => {
-    const { size, spacingByChar, palette, interaction } = themes
+    const { fontSize, spacingByChar, palette, interaction } = themes
     return css`
       font-weight: bold;
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       color: ${palette.TEXT_GREY};
       height: 40px;
       border-bottom: solid 3px transparent;

--- a/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`TabBar should be match snapshot 1`] = `
   -moz-appearance: none;
   appearance: none;
   font-weight: bold;
-  font-size: 0.875rem;
+  font-size: 1rem;
   color: #706d65;
   height: 40px;
   border-bottom: solid 3px transparent;

--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -53,11 +53,11 @@ export const Cell: VFC<Props & ElementProps> = ({
 
 const Th = styled.th<{ themes: Theme; onClick?: () => void }>`
   ${({ themes, onClick }) => {
-    const { size, spacingByChar, palette, interaction } = themes
+    const { fontSize, size, spacingByChar, palette, interaction } = themes
 
     return css`
       height: ${size.pxToRem(40)};
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       font-weight: bold;
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       color: ${palette.TEXT_BLACK};
@@ -91,14 +91,14 @@ const Td = styled.td<{ themes: Theme }>`
   }
 
   ${({ themes }) => {
-    const { size, spacingByChar, palette, frame } = themes
+    const { fontSize, size, spacingByChar, palette, frame } = themes
 
     return css`
       color: ${palette.TEXT_BLACK};
       height: ${size.pxToRem(44)};
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       border-top: ${frame.border.default};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       line-height: 1.5;
       vertical-align: middle;
       box-sizing: border-box;

--- a/src/components/Table/Head.tsx
+++ b/src/components/Table/Head.tsx
@@ -27,12 +27,11 @@ export const Head: VFC<Props> = ({ bulkActionArea, className = '', children }) =
 }
 
 const BulkActionTD = styled.td<{ themes: Theme }>(({ themes }) => {
-  const { frame, color, spacingByChar } = themes
-  const { font, pxToRem } = themes.size
+  const { fontSize, frame, color, spacingByChar } = themes
   return css`
     border-top: ${frame.border.default};
     background-color: ${color.ACTION_BACKGROUND};
     padding: ${spacingByChar(1)};
-    font-size: ${pxToRem(font.TALL)};
+    font-size: ${fontSize.M};
   `
 })

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -65,11 +65,11 @@ export const Textarea: VFC<Props> = ({ autoFocus, maxLength, width, ...props }) 
 const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: string | number }>`
   ${(props) => {
     const { themes, textAreaWidth = 'auto', error } = props
-    const { size, spacingByChar, frame, palette } = themes
+    const { fontSize, spacingByChar, frame, palette } = themes
 
     return css`
       padding: ${spacingByChar(0.5)};
-      font-size: ${size.pxToRem(size.font.TALL)};
+      font-size: ${fontSize.M};
       color: ${palette.TEXT_BLACK};
       border-radius: ${frame.border.radius.m};
       width: ${textAreaWidth};
@@ -96,9 +96,9 @@ const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: 
 
 const Counter = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { palette, size } = themes
+    const { fontSize, palette } = themes
     return css`
-      font-size: ${size.pxToRem(size.font.SHORT)};
+      font-size: ${fontSize.S};
       > span {
         font-weight: bold;
         color: ${palette.TEXT_GREY};

--- a/src/themes/__tests__/createFontSize.ts
+++ b/src/themes/__tests__/createFontSize.ts
@@ -52,4 +52,22 @@ describe('createFontSize', () => {
     expect(actual.XL).toBe(`${8 / 6}rem`)
     expect(actual.XXL).toBe(`${8 / 5}rem`)
   })
+
+  it('the value from scaleFactor wil be overridden if a deprecated abstract value is specified', () => {
+    const actual = createFontSize({
+      scaleFactor: 8,
+      S: '1.1rem',
+      M: '1.4rem',
+      L: '1.8rem',
+      XL: '2.4rem',
+    })
+
+    expect(actual.XXS).toBe(`${8 / 11}rem`)
+    expect(actual.XS).toBe(`${8 / 10}rem`)
+    expect(actual.S).toBe('1.1rem')
+    expect(actual.M).toBe('1.4rem')
+    expect(actual.L).toBe('1.8rem')
+    expect(actual.XL).toBe('2.4rem')
+    expect(actual.XXL).toBe(`${8 / 5}rem`)
+  })
 })

--- a/src/themes/createFontSize.ts
+++ b/src/themes/createFontSize.ts
@@ -17,6 +17,13 @@ export interface FontSizeProperty {
   VENTI?: number
 
   scaleFactor?: number
+  XXS?: string
+  XS?: string
+  S?: string
+  M?: string
+  L?: string
+  XL?: string
+  XXL?: string
 }
 
 export interface CreatedFontSizeTheme {
@@ -75,8 +82,8 @@ export const createFontSize = (userFontSize: FontSizeProperty = {}) => {
       ...defaultFontSize,
       pxToRem: pxToRem(htmlFontSize || defaultHtmlFontSize),
     },
-    userTokens,
     scaleFactor ? getSizes(scaleFactor) : {},
+    userTokens,
   )
 
   return created


### PR DESCRIPTION
#1552 で行なった fontSize の再定義を各コンポーネントに反映しました。

置換ルールは以下の通り。

before | after
--- | ---
\- | XXS(10.67px)
\- | XS(12px)
SHORT(11px) | S(13.71px)
TALL(14px) | M(16px)
GRANDE(18px) | L(19.2px)
VENTI(24px) | XL(24px)
\- | XXL(32px)

また各 Story におけるマジックナンバーは以下の方針で置換しました。
- 14px / 16px： 標準フォントサイズとみなして記述を削除
- 18px： 必要そうなところは L で置換
- 11px： S で置換

## 既存アプリの移行方法

既存のデフォルト値を再現したい場合は `fontSize` の `S / M / L / XL` を下記のように上書く想定です。
例は htmlFontSize が 10 の場合を想定しています。htmlFontSize の指定に依って `{実際に表示したい大きさ} / {htmlFontSize}` を計算する必要があります。

※ SmartHR UI では、scaleFactor による一貫したジャンプ率を提供したいため、この抽象値の上書きを非推奨とします。

key | value
--- | ---
S | 1.1rem
M | 1.4rem
L | 1.8rem
XL | 2.4rem