### PR TITLE
feat: `MessageScreen` の属性の改善 (SHRUI-276)

### DIFF
--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, VFC } from 'react'
+import React, { HTMLAttributes, ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -20,13 +20,20 @@ type Props = {
 }
 
 const LOGO_HEIGHT = 20
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const MessageScreen: VFC<Props> = ({ title, links, children, className = '' }) => {
+export const MessageScreen: VFC<Props & ElementProps> = ({
+  title,
+  links,
+  children,
+  className = '',
+  ...props
+}) => {
   const theme = useTheme()
   const classNames = useClassNames()
 
   return (
-    <Wrapper themes={theme} className={`${className} ${classNames.wrapper}`}>
+    <Wrapper {...props} themes={theme} className={`${className} ${classNames.wrapper}`}>
       <Box>
         <Logo className={classNames.logo}>
           <SmartHRLogo width={111} height={LOGO_HEIGHT} fill={theme.palette.BRAND} />

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { useClassNames } from './useClassNames'
 
 import { SmartHRLogo } from '../SmartHRLogo'
 import { Footer } from '../Footer'
@@ -22,26 +23,36 @@ const LOGO_HEIGHT = 20
 
 export const MessageScreen: VFC<Props> = ({ title, links, children, className = '' }) => {
   const theme = useTheme()
+  const classNames = useClassNames()
 
   return (
-    <Wrapper themes={theme} className={className}>
+    <Wrapper themes={theme} className={`${className} ${classNames.wrapper}`}>
       <Box>
-        <Logo>
+        <Logo className={classNames.logo}>
           <SmartHRLogo width={111} height={LOGO_HEIGHT} fill={theme.palette.BRAND} />
         </Logo>
 
-        {title && <Title themes={theme}>{title}</Title>}
+        {title && (
+          <Title themes={theme} className={classNames.title}>
+            {title}
+          </Title>
+        )}
 
-        {children && <Content themes={theme}>{children}</Content>}
+        {children && (
+          <Content themes={theme} className={classNames.content}>
+            {children}
+          </Content>
+        )}
 
         {links && links.length && (
-          <Links themes={theme}>
+          <Links themes={theme} className={classNames.linkList}>
             {links.map((link) => (
               <li key={link.label}>
                 <Link
                   href={link.url}
                   {...(link.target ? { target: link.target } : {})}
                   themes={theme}
+                  className={classNames.link}
                 >
                   {link.label}
                   {link.target === '_blank' && (
@@ -54,7 +65,7 @@ export const MessageScreen: VFC<Props> = ({ title, links, children, className = 
         )}
       </Box>
 
-      <FooterArea themes={theme}>
+      <FooterArea themes={theme} className={classNames.footer}>
         <Footer />
       </FooterArea>
     </Wrapper>

--- a/src/components/MessageScreen/useClassNames.ts
+++ b/src/components/MessageScreen/useClassNames.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+import { MessageScreen } from './MessageScreen'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator(MessageScreen.displayName || 'MessageScreen')
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+      logo: generate('logo'),
+      title: generate('title'),
+      content: generate('content'),
+      linkList: generate('linkList'),
+      link: generate('link'),
+      footer: generate('footer'),
+    }),
+    [generate],
+  )
+}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-276
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`MessageScreen` の属性に関する改善を行います。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- escape hatch 用のクラスを追加
  - 各パーツ
    - logo
    - title
    - content
    - linkList
    - footer
- このコンポーネントの最外の要素である div のデフォルト属性を渡せるように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
