### PR TITLE
`LineClamp` Component SHRUI-413

### DIFF
--- a/src/components/LineClamp/LineClamp.stories.tsx
+++ b/src/components/LineClamp/LineClamp.stories.tsx
@@ -31,10 +31,25 @@ storiesOf('LineClamp', module)
                 </LineClamp>
               </Text>
             </dd>
-            <dt>Max Lines 2 / with Tooltip</dt>
+            <dt>Max Lines 2 / with Light Tooltip</dt>
             <dd>
               <Text>
                 <LineClamp maxLines={2} withTooltip>
+                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                  Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                  unknown printer took a galley of type and scrambled it to make a type specimen
+                  book. It has survived not only five centuries, but also the leap into electronic
+                  typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                  the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                  with desktop publishing software like Aldus PageMaker including versions of Lorem
+                  Ipsum.
+                </LineClamp>
+              </Text>
+            </dd>
+            <dt>Max Lines 4 / with Dark Tooltip</dt>
+            <dd>
+              <Text>
+                <LineClamp maxLines={4} toolTipType="dark" withTooltip>
                   Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
                   Ipsum has been the industry's standard dummy text ever since the 1500s, when an
                   unknown printer took a galley of type and scrambled it to make a type specimen

--- a/src/components/LineClamp/LineClamp.stories.tsx
+++ b/src/components/LineClamp/LineClamp.stories.tsx
@@ -1,0 +1,68 @@
+import { storiesOf } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { LineClamp } from './LineClamp'
+import readme from './README.md'
+
+storiesOf('LineClamp', module)
+  .addParameters({
+    readme: {
+      sidebar: readme,
+    },
+  })
+  .add('all', () => {
+    return (
+      <>
+        <Wrapper>
+          <List>
+            <dt>Default</dt>
+            <dd>
+              <Text>
+                <LineClamp>
+                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                  Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                  unknown printer took a galley of type and scrambled it to make a type specimen
+                  book. It has survived not only five centuries, but also the leap into electronic
+                  typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                  the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                  with desktop publishing software like Aldus PageMaker including versions of Lorem
+                  Ipsum.
+                </LineClamp>
+              </Text>
+            </dd>
+            <dt>Max Lines 2 / with Tooltip</dt>
+            <dd>
+              <Text>
+                <LineClamp maxLines={2} withTooltip>
+                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                  Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                  unknown printer took a galley of type and scrambled it to make a type specimen
+                  book. It has survived not only five centuries, but also the leap into electronic
+                  typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                  the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                  with desktop publishing software like Aldus PageMaker including versions of Lorem
+                  Ipsum.
+                </LineClamp>
+              </Text>
+            </dd>
+          </List>
+        </Wrapper>
+      </>
+    )
+  })
+
+const Wrapper = styled.div`
+  padding: 24px;
+`
+const Text = styled.p`
+  width: 400px;
+  margin: 0 0 16px 0;
+  font-size: 16px;
+`
+const List = styled.dl`
+  margin: 1rem;
+  & > dd {
+    margin: 16px 0 40px;
+  }
+`

--- a/src/components/LineClamp/LineClamp.stories.tsx
+++ b/src/components/LineClamp/LineClamp.stories.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
+import { PrimaryButton } from '../Button'
 
 import { LineClamp } from './LineClamp'
 import readme from './README.md'
@@ -20,6 +21,21 @@ storiesOf('LineClamp', module)
             <dd>
               <Text>
                 <LineClamp>
+                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                  Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+                  unknown printer took a galley of type and scrambled it to make a type specimen
+                  book. It has survived not only five centuries, but also the leap into electronic
+                  typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+                  the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+                  with desktop publishing software like Aldus PageMaker including versions of Lorem
+                  Ipsum.
+                </LineClamp>
+              </Text>
+            </dd>
+            <dt>Max Lines 1 / with Light Tooltip</dt>
+            <dd>
+              <Text>
+                <LineClamp maxLines={1} withTooltip>
                   Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
                   Ipsum has been the industry's standard dummy text ever since the 1500s, when an
                   unknown printer took a galley of type and scrambled it to make a type specimen
@@ -61,6 +77,15 @@ storiesOf('LineClamp', module)
                 </LineClamp>
               </Text>
             </dd>
+            <dt>with button</dt>
+            <dd>
+              <Button>
+                <LineClamp maxLines={1} toolTipType="dark" withTooltip>
+                  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+                  Ipsum has been the industry's standard dummy text ever since the 1500s.
+                </LineClamp>
+              </Button>
+            </dd>
           </List>
         </Wrapper>
       </>
@@ -80,4 +105,7 @@ const List = styled.dl`
   & > dd {
     margin: 16px 0 40px;
   }
+`
+const Button = styled(PrimaryButton)`
+  width: 200px;
 `

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -1,0 +1,69 @@
+import React, { HTMLAttributes, ReactNode, VFC, useRef, useState } from 'react'
+import styled from 'styled-components'
+import { LightTooltip } from '../Tooltip'
+import { useClassNames } from './useClassNames'
+
+type Props = {
+  maxLines?: number
+  withTooltip?: boolean
+  children: ReactNode
+}
+type ElementProps = Omit<HTMLAttributes<HTMLSpanElement>, keyof Props>
+
+export const LineClamp: VFC<Props & ElementProps> = ({
+  maxLines = 3,
+  withTooltip = false,
+  children,
+  className = '',
+  ...props
+}) => {
+  const classNames = useClassNames()
+  const [isTooltipVisible, setTooltipVisible] = useState(false)
+  const wrapper = useRef<HTMLSpanElement>(null)
+
+  const isMultiLineOverflow = () => {
+    const el = wrapper.current
+    return el ? el.scrollHeight > el.clientHeight : false
+  }
+
+  const overAction = () => {
+    setTooltipVisible(isMultiLineOverflow())
+  }
+
+  return withTooltip && isTooltipVisible ? (
+    <LightTooltip message={children} multiLine>
+      <Wrapper
+        ref={wrapper}
+        maxLines={maxLines}
+        className={`${className} ${classNames.wrapper}`}
+        onMouseEnter={overAction}
+        {...props}
+      >
+        {children}
+      </Wrapper>
+    </LightTooltip>
+  ) : (
+    <Wrapper
+      ref={wrapper}
+      maxLines={maxLines}
+      onMouseEnter={overAction}
+      className={`${className} ${classNames.wrapper}`}
+      {...props}
+    >
+      {children}
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.span<{ maxLines: number }>`
+  display: box;
+  display: -webkit-box;
+  display: -moz-box;
+  box-orient: vertical;
+  -webkit-box-orient: vertical;
+  -moz-box-orient: vertical;
+  line-clamp: ${({ maxLines }) => maxLines};
+  -webkit-line-clamp: ${({ maxLines }) => maxLines};
+  overflow-y: hidden;
+  word-break: break-word;
+`

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -1,5 +1,5 @@
-import React, { HTMLAttributes, ReactNode, VFC, useRef, useState } from 'react'
-import styled from 'styled-components'
+import React, { HTMLAttributes, ReactNode, VFC, useEffect, useRef, useState } from 'react'
+import styled, { css } from 'styled-components'
 import { BalloonTheme } from '../Balloon'
 import { DarkTooltip, LightTooltip } from '../Tooltip'
 import { useClassNames } from './useClassNames'
@@ -26,12 +26,12 @@ export const LineClamp: VFC<Props & ElementProps> = ({
 
   const isMultiLineOverflow = () => {
     const el = ref.current
-    return el ? el.scrollHeight > el.clientHeight : false
+    return el ? el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight : false
   }
 
-  const overAction = () => {
-    setTooltipVisible(isMultiLineOverflow())
-  }
+  useEffect(() => {
+    setTooltipVisible(withTooltip && isMultiLineOverflow())
+  }, [maxLines, withTooltip, children])
 
   const LineClampPart = () => (
     <Wrapper
@@ -39,7 +39,6 @@ export const LineClamp: VFC<Props & ElementProps> = ({
       ref={ref}
       maxLines={maxLines}
       className={`${className} ${classNames.wrapper}`}
-      onMouseEnter={overAction}
     >
       {children}
     </Wrapper>
@@ -56,20 +55,32 @@ export const LineClamp: VFC<Props & ElementProps> = ({
       </DarkTooltip>
     )
 
-  return withTooltip && isTooltipVisible ? <Tooltip /> : <LineClampPart />
+  return isTooltipVisible ? <Tooltip /> : <LineClampPart />
 }
 
 const Wrapper = styled.span<{ maxLines: number }>`
-  /* stylelint-disable */
-  display: box;
-  display: -webkit-box;
-  display: -moz-box;
-  box-orient: vertical;
-  -webkit-box-orient: vertical;
-  -moz-box-orient: vertical;
-  line-clamp: ${({ maxLines }) => maxLines};
-  -webkit-line-clamp: ${({ maxLines }) => maxLines};
-  /* stylelint-enable */
-  overflow-y: hidden;
   word-break: break-word;
+  ${({ maxLines }) =>
+    maxLines === 1
+      ? css`
+          display: inline-block;
+          width: 100%;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          vertical-align: middle;
+        `
+      : css`
+          /* stylelint-disable */
+          display: box;
+          display: -webkit-box;
+          display: -moz-box;
+          box-orient: vertical;
+          -webkit-box-orient: vertical;
+          -moz-box-orient: vertical;
+          line-clamp: ${maxLines};
+          -webkit-line-clamp: ${maxLines};
+          /* stylelint-enable */
+          overflow-y: hidden;
+        `}
 `

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -1,11 +1,13 @@
 import React, { HTMLAttributes, ReactNode, VFC, useRef, useState } from 'react'
 import styled from 'styled-components'
-import { LightTooltip } from '../Tooltip'
+import { BalloonTheme } from '../Balloon'
+import { DarkTooltip, LightTooltip } from '../Tooltip'
 import { useClassNames } from './useClassNames'
 
 type Props = {
   maxLines?: number
   withTooltip?: boolean
+  toolTipType?: BalloonTheme
   children: ReactNode
 }
 type ElementProps = Omit<HTMLAttributes<HTMLSpanElement>, keyof Props>
@@ -13,6 +15,7 @@ type ElementProps = Omit<HTMLAttributes<HTMLSpanElement>, keyof Props>
 export const LineClamp: VFC<Props & ElementProps> = ({
   maxLines = 3,
   withTooltip = false,
+  toolTipType = 'light',
   children,
   className = '',
   ...props
@@ -42,13 +45,18 @@ export const LineClamp: VFC<Props & ElementProps> = ({
     </Wrapper>
   )
 
-  return withTooltip && isTooltipVisible ? (
-    <LightTooltip message={children} multiLine>
-      <LineClampPart />
-    </LightTooltip>
-  ) : (
-    <LineClampPart />
-  )
+  const Tooltip = () =>
+    toolTipType === 'light' ? (
+      <LightTooltip message={children} multiLine>
+        <LineClampPart />
+      </LightTooltip>
+    ) : (
+      <DarkTooltip message={children} multiLine>
+        <LineClampPart />
+      </DarkTooltip>
+    )
+
+  return withTooltip && isTooltipVisible ? <Tooltip /> : <LineClampPart />
 }
 
 const Wrapper = styled.span<{ maxLines: number }>`

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -33,6 +33,10 @@ export const LineClamp: VFC<Props & ElementProps> = ({
     setTooltipVisible(withTooltip && isMultiLineOverflow())
   }, [maxLines, withTooltip, children])
 
+  if (maxLines < 1) {
+    throw new Error('"maxLines" cannot be less than 0.')
+  }
+
   const LineClampPart = () => (
     <Wrapper
       {...props}

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -19,10 +19,10 @@ export const LineClamp: VFC<Props & ElementProps> = ({
 }) => {
   const classNames = useClassNames()
   const [isTooltipVisible, setTooltipVisible] = useState(false)
-  const wrapper = useRef<HTMLSpanElement>(null)
+  const ref = useRef<HTMLSpanElement>(null)
 
   const isMultiLineOverflow = () => {
-    const el = wrapper.current
+    const el = ref.current
     return el ? el.scrollHeight > el.clientHeight : false
   }
 
@@ -30,28 +30,24 @@ export const LineClamp: VFC<Props & ElementProps> = ({
     setTooltipVisible(isMultiLineOverflow())
   }
 
-  return withTooltip && isTooltipVisible ? (
-    <LightTooltip message={children} multiLine>
-      <Wrapper
-        ref={wrapper}
-        maxLines={maxLines}
-        className={`${className} ${classNames.wrapper}`}
-        onMouseEnter={overAction}
-        {...props}
-      >
-        {children}
-      </Wrapper>
-    </LightTooltip>
-  ) : (
+  const LineClampPart = () => (
     <Wrapper
-      ref={wrapper}
-      maxLines={maxLines}
-      onMouseEnter={overAction}
-      className={`${className} ${classNames.wrapper}`}
       {...props}
+      ref={ref}
+      maxLines={maxLines}
+      className={`${className} ${classNames.wrapper}`}
+      onMouseEnter={overAction}
     >
       {children}
     </Wrapper>
+  )
+
+  return withTooltip && isTooltipVisible ? (
+    <LightTooltip message={children} multiLine>
+      <LineClampPart />
+    </LightTooltip>
+  ) : (
+    <LineClampPart />
   )
 }
 

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -56,6 +56,7 @@ export const LineClamp: VFC<Props & ElementProps> = ({
 }
 
 const Wrapper = styled.span<{ maxLines: number }>`
+  /* stylelint-disable */
   display: box;
   display: -webkit-box;
   display: -moz-box;
@@ -64,6 +65,7 @@ const Wrapper = styled.span<{ maxLines: number }>`
   -moz-box-orient: vertical;
   line-clamp: ${({ maxLines }) => maxLines};
   -webkit-line-clamp: ${({ maxLines }) => maxLines};
+  /* stylelint-enable */
   overflow-y: hidden;
   word-break: break-word;
 `

--- a/src/components/LineClamp/README.md
+++ b/src/components/LineClamp/README.md
@@ -2,7 +2,8 @@
 
 ```tsx
 import { LineClamp } from 'smarthr-ui'
-;<LineClamp maxLines={3} withTooltip>
+
+<LineClamp maxLines={3} withTooltip>
   Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
   the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
   type and scrambled it to make a type specimen book. It has survived not only five centuries, but

--- a/src/components/LineClamp/README.md
+++ b/src/components/LineClamp/README.md
@@ -18,6 +18,7 @@ import { LineClamp } from 'smarthr-ui'
 | Name        | Required | Type          | DefaultValue | Description                                    |
 | ----------- | -------- | ------------- | ------------ | ---------------------------------------------- |
 | maxLines    | -        | **number**    | 3          | Number of lines to be ellipsis.                |
+| withTooltip | -        | **boolean**   | false      | ToolTip is enabled when ellipsis is displayed. |
+| tooltipType | -        | **'light' &#124; 'dark'**   | 'light'      | Theme type of ToolTip. |
 | className   | -        | **string**    | -           | Overwrite style.                               |
 | children    | ✓        | **ReactNode** | -           | The Description of this area.                  |
-| withTooltip | -        | **boolean**   | false      | ToolTip is enabled when ellipsis is displayed. |

--- a/src/components/LineClamp/README.md
+++ b/src/components/LineClamp/README.md
@@ -17,7 +17,7 @@ import { LineClamp } from 'smarthr-ui'
 
 | Name        | Required | Type          | DefaultValue | Description                                    |
 | ----------- | -------- | ------------- | ------------ | ---------------------------------------------- |
-| maxLines    | -        | **number**    | '3'          | Number of lines to be ellipsis.                |
-| className   | -        | **string**    | ''           | Overwrite style.                               |
-| children    | ✓        | **ReactNode** | ''           | The Description of this area.                  |
-| withTooltip | -        | **boolean**   | 'false'      | ToolTip is enabled when ellipsis is displayed. |
+| maxLines    | -        | **number**    | 3          | Number of lines to be ellipsis.                |
+| className   | -        | **string**    | -           | Overwrite style.                               |
+| children    | ✓        | **ReactNode** | -           | The Description of this area.                  |
+| withTooltip | -        | **boolean**   | false      | ToolTip is enabled when ellipsis is displayed. |

--- a/src/components/LineClamp/README.md
+++ b/src/components/LineClamp/README.md
@@ -1,0 +1,22 @@
+# LineClamp
+
+```tsx
+import { LineClamp } from 'smarthr-ui'
+;<LineClamp maxLines={3} withTooltip>
+  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been
+  the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
+  type and scrambled it to make a type specimen book. It has survived not only five centuries, but
+  also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in
+  the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+  with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+</LineClamp>
+```
+
+## props
+
+| Name        | Required | Type          | DefaultValue | Description                                    |
+| ----------- | -------- | ------------- | ------------ | ---------------------------------------------- |
+| maxLines    | -        | **number**    | '3'          | Number of lines to be ellipsis.                |
+| className   | -        | **string**    | ''           | Overwrite style.                               |
+| children    | ✓        | **ReactNode** | ''           | The Description of this area.                  |
+| withTooltip | -        | **boolean**   | 'false'      | ToolTip is enabled when ellipsis is displayed. |

--- a/src/components/LineClamp/index.ts
+++ b/src/components/LineClamp/index.ts
@@ -1,0 +1,1 @@
+export * from './LineClamp'

--- a/src/components/LineClamp/useClassNames.ts
+++ b/src/components/LineClamp/useClassNames.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+import { LineClamp } from './LineClamp'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator(LineClamp.displayName || 'LineClamp')
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+    }),
+    [generate],
+  )
+}

--- a/src/components/MessageScreen/README.md
+++ b/src/components/MessageScreen/README.md
@@ -3,7 +3,7 @@
 ```tsx
 import { MessageScreen } from 'smarthr-ui'
 
-;<MessageScreen
+<MessageScreen
   title="お探しのページはみつかりませんでした"
   links={[
     {
@@ -31,8 +31,8 @@ import { MessageScreen } from 'smarthr-ui'
 
 ### type of Link
 
-| Name   | Required | Type       | DefaultValue | Description                                                        |
-| ------ | -------- | ---------- | ------------ | ------------------------------------------------------------------ |
-| label  | ✓        | **string** | -            | inner text of anchor element                                       |
-| url    | ✓        | **string** | -            | href of anchor element                                             |
+| Name   | Required | Type       | DefaultValue | Description                                                         |
+| ------ | -------- | ---------- | ------------ | ------------------------------------------------------------------- |
+| label  | ✓        | **string** | -            | inner text of anchor element                                        |
+| url    | ✓        | **string** | -            | href of anchor element                                              |
 | target | -        | **string** | -            | target of anchor element. For "\_blank", ExternalIcon is displayed |

--- a/src/components/MessageScreen/README.md
+++ b/src/components/MessageScreen/README.md
@@ -3,7 +3,7 @@
 ```tsx
 import { MessageScreen } from 'smarthr-ui'
 
-<MessageScreen
+;<MessageScreen
   title="お探しのページはみつかりませんでした"
   links={[
     {
@@ -31,8 +31,8 @@ import { MessageScreen } from 'smarthr-ui'
 
 ### type of Link
 
-| Name   | Required | Type       | DefaultValue | Description                                                         |
-| ------ | -------- | ---------- | ------------ | ------------------------------------------------------------------- |
-| label  | ✓        | **string** | -            | inner text of anchor element                                        |
-| url    | ✓        | **string** | -            | href of anchor element                                              |
+| Name   | Required | Type       | DefaultValue | Description                                                        |
+| ------ | -------- | ---------- | ------------ | ------------------------------------------------------------------ |
+| label  | ✓        | **string** | -            | inner text of anchor element                                       |
+| url    | ✓        | **string** | -            | href of anchor element                                             |
 | target | -        | **string** | -            | target of anchor element. For "\_blank", ExternalIcon is displayed |

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ export { MultiComboBox, SingleComboBox } from './components/ComboBox'
 export { SideNav } from './components/SideNav'
 export { CompactInformationPanel } from './components/CompactInformationPanel'
 export { Text } from './components/Text'
+export { LineClamp } from './components/LineClamp'
 
 // layout components
 export { Cluster, LineUp, Stack } from './components/Layout'


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-413

## Overview

- 複数行を省略表示しつつ、省略されたテキストをToolTipで表示できるコンポーネント
- Tooltipがdivタグで生成されるため、テキストが h*タグ及びpタグの場合、p > div の構造となり、warning が出力されますが、別チケットでの対応とします

## What I did

- LineClamp コンポーネントの追加

## Capture
