### PR TITLE
fix: MultiComboBox の項目削除ボタンのアイコンの visuallyHiddenText に項目名を含める

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -202,6 +202,7 @@ export function MultiComboBox<T>({
         <List themes={theme}>
           {selectedItems.map((selectedItem, i) => {
             const { deletable = true, ...item } = selectedItem
+
             return (
               <li key={i}>
                 <SelectedItem
@@ -221,7 +222,11 @@ export function MultiComboBox<T>({
                       disabled={disabled}
                       onClick={() => onDelete(item)}
                     >
-                      <FaTimesCircleIcon size={11} color={'inherit'} visuallyHiddenText="delete" />
+                      <FaTimesCircleIcon
+                        size={11}
+                        color={'inherit'}
+                        visuallyHiddenText={`${item.label}を削除`}
+                      />
                     </DeleteButton>
                   )}
                 </SelectedItem>


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-410

## Overview

MultiCombobox の項目削除ボタンのラベルが delete のみで、どの項目を削除するかがわかりにくい。（特に入力後に、DOM 順をさかのぼった場合） 
ラベルに項目名を含むことで対象を明確にしたい。

## What I did

項目削除のボタンのラベルを `${項目名}を削除` に変更。

## Capture

なし
