### PR TITLE
fix: DialogContentInner の className が Wrraper にあたっていたのを Inner に戻す

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -126,7 +126,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
       >
-        <Wrapper ref={domRef} themes={theme} className={`${className} ${classNames.wrapper}`}>
+        <Wrapper ref={domRef} themes={theme} className={classNames.wrapper}>
           <Background
             onClick={handleClickOverlay}
             themes={theme}
@@ -138,7 +138,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
               themes={theme}
               role="dialog"
               aria-modal="true"
-              className={classNames.dialog}
+              className={`${className} ${classNames.dialog}`}
               {...props}
             >
               {/* dummy element for focus management. */}


### PR DESCRIPTION
#1514 で Inner にあたっていた `className` が Wrapper に移動し、既存アプリケーションに影響を与えていたので修正。
コンポーネントとして Dialog の実態は Wrapper ではなく Inner なので想像する使用感とも合致しそう。
https://github.com/kufu/smarthr-ui/commit/93a345d5dcb2a00e0b65cd5281cfff47147031f2#diff-23541497bd86a5f30d84af5daeff6522a804e0dab196d2ce0d3742002742011aR128-R142

Story で ```const MessageDiaglo = styled(shrMessageDialog)`` ``` として確認済み。