### PR TITLE
feat: Text コンポーネントに whiteSpace を追加 | SHRUI-429

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -24,7 +24,8 @@ export const Default: Story = () => (
       styled-components と同じく <code>as</code> で要素を差し替えられます。
     </Text>
     <Text as="p">
-      <Text color="TEXT_GREY">色</Text>や<Text weight="bold">ウェイト</Text>を変えられます。
+      <Text color="TEXT_GREY">色</Text>や<Text weight="bold">ウェイト</Text>、
+      <Text whiteSpace="nowrap">ホワイトスペース</Text>を変えられます。
     </Text>
     <Text as="p">
       <code>emphasis</code> を渡すとそのテキストは<Text emphasis>強調</Text>を示し、<code>em</code>{' '}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react'
+import React, { CSSProperties, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { useTheme } from '../../hooks/useTheme'
 import { FontSizes } from '../../themes/createFontSize'
@@ -7,10 +7,11 @@ import { Leadings } from '../../themes/createLeading'
 
 export type TextProps = {
   size?: FontSizes
-  weight?: 'normal' | 'bold'
+  weight?: 'normal' | 'bold' | 'inherit'
   italic?: boolean
   color?: TextColors | 'inherit'
   leading?: Leadings
+  whiteSpace?: CSSProperties['whiteSpace']
   emphasis?: boolean
 }
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof TextProps>
@@ -21,6 +22,7 @@ type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof TextProps>
  * @param [italic] 斜体にするかどうかの真偽値（font-style: italic）
  * @param [color] 色。初期値は inherit（color、）
  * @param [leading] 行送りの抽象値（line-height）
+ * @param [whiteSpace] ホワイトスペース（white-space）
  * @param [emphasis] 強調するかどうかの真偽値。指定すると em 要素になる
  * @param [as] テキストコンポーネントの HTML タグ名。初期値は span
  * @param [children]
@@ -36,9 +38,18 @@ export const Text: React.VFC<
 }
 
 const Wrapper = styled.span<TextProps>(
-  ({ size = 'M', weight = 'normal', italic, color = 'inherit', leading = 'NORMAL', emphasis }) => {
+  ({
+    size = 'M',
+    weight = 'normal',
+    italic,
+    color = 'inherit',
+    leading = 'NORMAL',
+    whiteSpace,
+    emphasis,
+  }) => {
     const { color: shrColor, fontSize, leading: shrLeading } = useTheme()
     return css`
+      ${whiteSpace && `white-space: ${whiteSpace};`}
       font-size: ${fontSize[size]};
       line-height: ${shrLeading[leading]};
       font-weight: ${emphasis ? 'bold' : weight};


### PR DESCRIPTION
Text コンポーネントで `white-space` を扱えるようにしました。