### PR TITLE
test: CI のタスク最適化 (SHRUI-418)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,26 @@
 version: 2.1
 
 commands:
-  run-npm-test:
+  setup-for-test:
     steps:
       - checkout
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - dependencies-test-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - modules-cache-
+            - dependencies-test-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - modules-cache-
       - run: yarn install
       - save_cache:
           paths:
             - node_modules
           key: dependencies-test-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-      # run tests!
+  check-source:
+    steps:
       - run: yarn audit --groups dependencies
       - run: yarn lint
+  run-npm-test:
+    steps:
       - run: yarn test -w 1
       - run: yarn test:build-assets
   # visual regression testing
@@ -63,6 +66,7 @@ jobs:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
     steps:
+      - setup-for-test
       - run-npm-test
   node-v14:
     docker:
@@ -71,6 +75,8 @@ jobs:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
     steps:
+      - setup-for-test
+      - check-source
       - run-npm-test
   reg-suit:
     docker:


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-418
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
CI で node のバージョンごとに行っている処理の内、 lint と yarn audit はバージョンごとに実行する必要がないため、一度だけ実行されるように変更します。実行する node バージョンは `.node-version` 似合わせて v14 としました。

この変更で CI 内の  node v10 の処理時間が約20秒短縮されますが、並列で実行されるジョブの中で最も時間のかかる reg-suit の処理時間は変わらないため、 CI 全体が完了するまでの時間に変化はほぼ無いと思われます。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- lint と yarn audit が node v14 でだけ実行されるように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
