### PR TITLE
chore: e2e にタイムアウトを追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   e2e-win-matrix:
     runs-on: windows-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         browser: [ie, chrome]


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Github Actions で設定している e2e は storybook が正しく起動できなかった場合などに最大6時間回ってしまうので、30分でタイムアウトするように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `timeout-minutes` を設定
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
