### PR TITLE
Baloon に span を渡せるように修正 | SHRUI-433

### DIFF
--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -11,6 +11,7 @@ export type Props = {
   vertical: 'top' | 'middle' | 'bottom'
   className?: string
   children?: ReactNode
+  as?: 'div' | 'span'
 }
 
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>


### PR DESCRIPTION
Ballon の Wrapper に対して `as` で `span` を渡せるように修正。