### PR TITLE
fix: `SegmentedControl` のフォーカスインジケータが兄弟要素に隠れないように修正 (SHRUI-426)

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -149,7 +149,7 @@ const Container = styled.div`
   display: inline-flex;
 `
 const Button = styled(SecondaryButton)<{ themes: Theme }>(({ themes }) => {
-  const { color, border, frame } = themes
+  const { color, border, frame, shadow } = themes
   return css`
     border: ${border.shorthand};
     border-radius: 0;
@@ -163,6 +163,10 @@ const Button = styled(SecondaryButton)<{ themes: Theme }>(({ themes }) => {
         background-color: ${color.hoverColor(color.MAIN)};
         border-color: ${color.hoverColor(color.MAIN)};
       }
+    }
+
+    &:focus {
+      ${shadow.focusIndicatorStyles}
     }
 
     /* active時、buttonの両端にborder.defaultが表示されることを防ぐための処置 */


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-426
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`SegmentedControl` のフォーカスインジケータが兄弟要素によって隠れないように修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `theme.shadow.focusIndicatorStyles` を適用
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/124545844-ae760c80-de64-11eb-8e00-b487f416ba1f.png) | ![image](https://user-images.githubusercontent.com/270422/124545805-9ef6c380-de64-11eb-875f-f9916a03b09b.png) |
<!--
Please attach a capture if it looks different.
-->
