### PR TITLE
fix: `Input` の affix にデフォルトカラーを設定 (SHRUI-425)

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -57,11 +57,11 @@ storiesOf('Input', module).add('all', () => {
       </li>
       <li>
         <Txt>prefix</Txt>
-        <Input prefix={<FaSearchIcon color={theme.color.TEXT_GREY} />} />
+        <Input prefix={<FaSearchIcon />} />
       </li>
       <li>
         <Txt>suffix</Txt>
-        <Input suffix={<FaSearchIcon color={theme.color.TEXT_GREY} />} />
+        <Input suffix={<FaSearchIcon />} />
       </li>
       <li>
         <Txt>extending style (width 50%)</Txt>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -178,7 +178,7 @@ const StyledInput = styled.input<
   }}
 `
 const Prefix = styled.span<{ themes: Theme }>(
-  ({ themes: { spacingByChar } }) =>
+  ({ themes: { color, spacingByChar } }) =>
     css`
       position: absolute;
       top: 0;
@@ -187,10 +187,11 @@ const Prefix = styled.span<{ themes: Theme }>(
       display: flex;
       align-items: center;
       padding-left: ${spacingByChar(0.5)};
+      color: ${color.TEXT_GREY};
     `,
 )
 const Suffix = styled.span<{ themes: Theme }>(
-  ({ themes: { spacingByChar } }) =>
+  ({ themes: { color, spacingByChar } }) =>
     css`
       position: absolute;
       top: 0;
@@ -199,5 +200,6 @@ const Suffix = styled.span<{ themes: Theme }>(
       display: flex;
       align-items: center;
       padding-right: ${spacingByChar(0.5)};
+      color: ${color.TEXT_GREY};
     `,
 )


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-425
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Input` の prefix / suffix にアイコンを配置する場合のデフォルトカラーを規定します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- prefix / suffix の wrapper に `color` スタイルに `TEXT_GREY` を設定
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
