### PR TITLE
fix: コンボボックスの `onChange` ハンドラをリネーム (SHRUI-432)

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -61,8 +61,13 @@ type Props<T> = {
   className?: string
   /**
    * Fire when the value of input changes.
+   * @deprecated The onChange handler is deprecated, so use onChangeInput handler instead.
    */
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  /**
+   * Fire when the value of input changes.
+   */
+  onChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
   /**
    * Fire when adding an item that does not exist in `items` props.
    */
@@ -91,6 +96,7 @@ export function MultiComboBox<T>({
   width = 'auto',
   className = '',
   onChange,
+  onChangeInput,
   onAdd,
   onDelete,
   onSelect,
@@ -244,6 +250,7 @@ export function MultiComboBox<T>({
               themes={theme}
               onChange={(e) => {
                 if (onChange) onChange(e)
+                if (onChangeInput) onChangeInput(e)
                 setInputValue(e.currentTarget.value)
               }}
               onFocus={() => {

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -62,8 +62,13 @@ type Props<T> = {
   className?: string
   /**
    * Fire when the value of input changes.
+   * @deprecated The onChange handler is deprecated, so use onChangeInput handler instead.
    */
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void
+  /**
+   * Fire when the value of input changes.
+   */
+  onChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
   /**
    * Fire when adding an item that does not exist in `items` props.
    */
@@ -88,6 +93,7 @@ export function SingleComboBox<T>({
   width = 'auto',
   className = '',
   onChange,
+  onChangeInput,
   onAdd,
   onSelect,
   ...props
@@ -234,6 +240,7 @@ export function SingleComboBox<T>({
         }}
         onChange={(e) => {
           if (onChange) onChange(e)
+          if (onChangeInput) onChangeInput(e)
           const { value } = e.currentTarget
           setInputValue(value)
           if (value === '') {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-432
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
コンボボックスが持っている `onChange` ハンドラは、意味としては「テキストボックスの変更のハンドラ」であり誤解を招きやすいので、 `onChangeInput` にリネームして `onChange` は deprecated にする
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `onChangeInput` を追加
- `onChange` を deprecated に
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
