### PR TITLE
TextLink の縦位置を中央合わせに修正

### DIFF
--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -2,6 +2,7 @@ import React, { AnchorHTMLAttributes, ReactNode, VFC, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaExternalLinkAltIcon } from '../Icon'
+import { LineUp } from '../Layout/LineUp'
 
 type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof Props>
 type Props = {
@@ -57,9 +58,11 @@ export const TextLink: VFC<Props & ElementProps> = ({
       onClick={actualOnClick}
       themes={theme}
     >
-      {prefix && <PrefixWrapper themes={theme}>{prefix}</PrefixWrapper>}
-      {children}
-      {actualSuffix && <SuffixWrapper themes={theme}>{actualSuffix}</SuffixWrapper>}
+      <LineUp gap={0.5} inline vAlign="center" as="span">
+        {prefix}
+        {children}
+        {actualSuffix}
+      </LineUp>
     </StyledAncher>
   )
 }
@@ -74,23 +77,6 @@ const StyledAncher = styled.a<{ themes: Theme }>`
       &:hover {
         color: ${color.hoverColor(color.TEXT_LINK)};
       }
-    `
-  }}
-`
-
-const PrefixWrapper = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { spacingByChar } = themes
-    return css`
-      margin-right: ${spacingByChar(0.5)};
-    `
-  }}
-`
-const SuffixWrapper = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { spacingByChar } = themes
-    return css`
-      margin-left: ${spacingByChar(0.5)};
     `
   }}
 `

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -58,7 +58,7 @@ export const TextLink: VFC<Props & ElementProps> = ({
       onClick={actualOnClick}
       themes={theme}
     >
-      <LineUp gap={0.5} inline vAlign="center" as="span">
+      <LineUp gap={0.25} inline vAlign="center" as="span">
         {prefix}
         {children}
         {actualSuffix}


### PR DESCRIPTION
LineUp を使って
- inline で inline-flex に
- vAlign で align-items: center
- as で span

にしている。

また、SmartHR Design System を参考に余白を変更した。
https://smarthr.design/products/design-guide/spacing-layout-pattern/#%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%EF%BC%88Icon%EF%BC%89%E3%82%84%E3%83%A9%E3%83%99%E3%83%AB%EF%BC%88Label%EF%BC%89%E3%81%AA%E3%81%A9%E3%81%AE%E5%B0%8F%E3%81%95%E3%81%84%E8%A6%81%E7%B4%A0%E9%96%93