### PR TITLE
Stack をインライン要素のように振る舞えるように inline を追加｜SHRUI-448

### DIFF
--- a/src/components/Layout/Stack/Stack.tsx
+++ b/src/components/Layout/Stack/Stack.tsx
@@ -3,18 +3,20 @@ import { AbstractSize, CharRelativeSize } from '../../../themes/createSpacing'
 import { useSpacing } from '../../../hooks/useSpacing'
 
 /**
+ * @param inline true の場合は inline-flex
  * @param gap 間隔の指定（基準フォントサイズの相対値または抽象値）
  * @param recursive 直下の要素だけでなく再帰的に適用するかどうかの指定
  * @param splitAfter 分割する位置の指定（nth-child に渡す値）
  */
 export const Stack = styled.div<{
+  inline?: boolean
   gap?: CharRelativeSize | AbstractSize
   recursive?: boolean
   splitAfter?: number | string
 }>(
-  ({ gap = 1, recursive = false, splitAfter }) =>
+  ({ inline = false, gap = 1, recursive = false, splitAfter }) =>
     css`
-      display: flex;
+      display: ${inline ? 'inline-flex' : 'flex'};
       flex-direction: column;
       justify-content: flex-start;
 


### PR DESCRIPTION
インライン要素として振る舞いたい時もあるため、inline を渡せば inline-flex になるようにしました。
as に依って切り替えることも考えましたが、要素の種類とブロック / インライン要素の振る舞いは別なため inline を明示的に渡す形になっています。

LineUp と同じ I/F です。