### PR TITLE
test: use circleci contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
 workflows:
   multiple_builds:
     jobs:
-      - node-v12
-      - node-v14
-      - reg-suit
+      - node-v12:
+          context: smarthr-dockerhub
+      - node-v14:
+          context: smarthr-dockerhub
+      - reg-suit:
+          context: smarthr-dockerhub


### PR DESCRIPTION
## Related URL

org レベルで環境変数を管理できるようになったらしいので、そちらに移行します。
![テック定例のキャプチャ](https://user-images.githubusercontent.com/11153463/125227964-d22ace00-e30e-11eb-87a2-0f03bf9060cb.png)
[この記事のリンク](https://smarthr-inc.docbase.io/posts/1986993#circleci-%E3%81%AE-contexts-%E3%81%AE%E3%82%B9%E3%82%B9%E3%83%A1-tknzk) (社内のみ)

## Overview

現在、リポジトリの範囲で CIrcleCI の環境変数を設定しているが、 org の値を使うようにする。

## What I did

Context を追加。
この PR をマージ後、 CircleCI 上の smarthr-ui リポジトリの環境変数を削除します。
