### PR TITLE
docs: DatePickerのREADMEのtypo修正

### DIFF
--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -32,5 +32,5 @@ import { DatePicker } from 'smarthr-ui'
 | error        | -        | **boolean**                                     | -                      | `error` of input.                          |
 | className    | -        | **string**                                      | -                      | `className` of component.                  |
 | parseInput   | -        | **(input: string) => Date \| null**             | -                      | Custom parsing function for input.         |
-| formatDate   | -        | **(date: Date \| null) => string**              | -                      | Custom formatting function to displa date. |
+| formatDate   | -        | **(date: Date \| null) => string**              | -                      | Custom formatting function to display date. |
 | onChangeDate | -        | **(date: Date \| null, value: string) => void** | -                      | Fired when date is changed.                |


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DatePickerのREADMEを読んでいたらtypoを発見しました。

## What I did

* DatePickerのREADME内、 `formatDate` オプションの `Description` で、 `displa` → `display` に変更。

## Capture

<!--
Please attach a capture if it looks different.
-->
