### PR TITLE
Stack に align を追加

### DIFF
--- a/src/components/Layout/Stack/Stack.tsx
+++ b/src/components/Layout/Stack/Stack.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from 'react'
 import styled, { css } from 'styled-components'
 import { AbstractSize, CharRelativeSize } from '../../../themes/createSpacing'
 import { useSpacing } from '../../../hooks/useSpacing'
@@ -5,19 +6,22 @@ import { useSpacing } from '../../../hooks/useSpacing'
 /**
  * @param inline true の場合は inline-flex
  * @param gap 間隔の指定（基準フォントサイズの相対値または抽象値）
+ * @param align 並べ方の指定（align-items）
  * @param recursive 直下の要素だけでなく再帰的に適用するかどうかの指定
  * @param splitAfter 分割する位置の指定（nth-child に渡す値）
  */
 export const Stack = styled.div<{
   inline?: boolean
   gap?: CharRelativeSize | AbstractSize
+  align?: CSSProperties['alignItems']
   recursive?: boolean
   splitAfter?: number | string
 }>(
-  ({ inline = false, gap = 1, recursive = false, splitAfter }) =>
+  ({ inline = false, gap = 1, align, recursive = false, splitAfter }) =>
     css`
       display: ${inline ? 'inline-flex' : 'flex'};
       flex-direction: column;
+      ${align && `align-items: ${align};`}
       justify-content: flex-start;
 
       /* For greater specificity than element type selectors */


### PR DESCRIPTION
Stack したいけど flex アイテムを `stretch` にはしたくない場合があるので、align-items を align として渡せるようにしました。
（display: flex 時の align-items のデフォルトは normal で、これは内部的に stretch 扱いになります）

align の名前は LineUp と I/F を合わせています。