### PR TITLE
TextLink に prefix/suffix を含まない場合はレイアウトコンポーネントを使わない

### DIFF
--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -58,11 +58,15 @@ export const TextLink: VFC<Props & ElementProps> = ({
       onClick={actualOnClick}
       themes={theme}
     >
-      <LineUp gap={0.25} inline vAlign="center" as="span">
-        {prefix}
-        {children}
-        {actualSuffix}
-      </LineUp>
+      {prefix || actualSuffix ? (
+        <LineUp gap={0.25} inline vAlign="center" as="span">
+          {prefix}
+          {children}
+          {actualSuffix}
+        </LineUp>
+      ) : (
+        children
+      )}
     </StyledAncher>
   )
 }


### PR DESCRIPTION
別プロジェクトでアイコンにも下線を引くため `box-shadow` に依る装飾を試している。
折返しの発生する文字列がきた場合に、LineUp が `inline-flex` なため下線が一部にしか適用されないため、prefix / suffix を含まない場合は LineUp で囲むのをやめたい。

参考： https://codepen.io/uknmr/pen/yLboRwV