### PR TITLE
[WIP] fix: `Cell` の box-sizing 見直し (SHRUI-442)

### DIFF
--- a/src/components/Table/Cell.tsx
+++ b/src/components/Table/Cell.tsx
@@ -60,10 +60,10 @@ export const Cell: VFC<Props & ElementProps> = ({
 
 const Th = styled.th<{ themes: Theme; onClick?: () => void }>`
   ${({ themes, onClick }) => {
-    const { fontSize, size, spacingByChar, color, interaction } = themes
+    const { fontSize, spacingByChar, color, interaction } = themes
 
     return css`
-      height: ${size.pxToRem(40)};
+      height: 1.5rem;
       font-size: ${fontSize.S};
       font-weight: bold;
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
@@ -72,7 +72,6 @@ const Th = styled.th<{ themes: Theme; onClick?: () => void }>`
       text-align: left;
       line-height: 1.5;
       vertical-align: middle;
-      box-sizing: border-box;
 
       &.highlighted {
         background-color: ${color.hoverColor(color.HEAD)};
@@ -98,17 +97,16 @@ const Td = styled.td<{ themes: Theme }>`
   }
 
   ${({ themes }) => {
-    const { fontSize, size, spacingByChar, color, border } = themes
+    const { fontSize, spacingByChar, color, border } = themes
 
     return css`
       color: ${color.TEXT_BLACK};
-      height: ${size.pxToRem(44)};
+      height: 1.75rem;
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       border-top: ${border.shorthand};
       font-size: ${fontSize.M};
       line-height: 1.5;
       vertical-align: middle;
-      box-sizing: border-box;
     `
   }};
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-442
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Cell` コンポーネントは `box-sizing: border-box` を指定しているが、これだとサイズ指定に余白やボーダーの幅を含めて指定する必要があり拡張がやや難しくなる。そこで、 `box-sizing` の指定をデフォルトに戻し、 余白やボーダーの幅を校了すこと無くサイズ指定ができるように変更する。

#### 既存実装の意図

* 前提: td, th 要素に対する `height` 指定は、実際には `min-height` のように作用する
* 既存の `height: pxToRem(44)` および `pxToRem(40)` 指定は、 `Cell` の最小の高さを規定している
  * 44px の内訳
    * 8px*2(padding) + 27px(小ボタンの高さ) + 1px(ボーダー)
    * つまり、`Cell` の高さが小ボタンを含む場合より小さくならないことを規定している
  * 40px の内訳
    * 8px*2(padding) + 24px(1.5rem) + 1px(ボーダー)
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `box-sizing: border-box` の指定を削除
- 高さの指定方法を `pxToRem` から単純な rem の割合指定に変更
  - `pxToRem(44)` → `1.75rem`
    - 1.75 は近似値
    - この変更により td の高さが 1px 増加します
  - `pxToRem(40)` → `1.5rem`
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
