### PR TITLE
feat: コンボボックスに `onChangeSelected` を追加 (SHRUI-436)

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -66,13 +66,11 @@ export const Default: Story = () => {
           selectedItem={selectedItem}
           width={400}
           placeholder="Enter the text for filtering"
-          onSelect={(option) => {
-            action('onSelect')(option)
-            setSelectedItem(option)
-          }}
-          onClear={() => {
-            action('onClear')()
-            setSelectedItem(null)
+          onSelect={action('onSelect')}
+          onClear={action('onClear')}
+          onChangeSelected={(item) => {
+            action('onChangeSelected')(item)
+            setSelectedItem(item)
           }}
         />
       </dd>
@@ -83,13 +81,11 @@ export const Default: Story = () => {
           selectedItems={selectedItems}
           width={400}
           placeholder="Enter the text for filtering"
-          onDelete={(option) => {
-            action('onDelete')(option)
-            setSelectedItems(selectedItems.filter((item) => item.value !== option.value))
-          }}
-          onSelect={(option) => {
-            action('onSelect')(option)
-            setSelectedItems([...selectedItems, option])
+          onDelete={action('onDelete')}
+          onSelect={action('onSelect')}
+          onChangeSelected={(items) => {
+            action('onChangeSelected')(items)
+            setSelectedItems(items)
           }}
         />
       </dd>

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -80,6 +80,10 @@ type Props<T> = {
    * Fire when clicking an element of `items`.
    */
   onSelect: (item: Item<T>) => void
+  /**
+   * Fire when the item selections are changed.
+   */
+  onChangeSelected?: (selectedItems: Array<Item<T>>) => void
 }
 
 type ElementProps<T> = Omit<HTMLAttributes<HTMLDivElement>, keyof Props<T>>
@@ -100,6 +104,7 @@ export function MultiComboBox<T>({
   onAdd,
   onDelete,
   onSelect,
+  onChangeSelected,
   ...props
 }: Props<T> & ElementProps<T>) {
   const theme = useTheme()
@@ -128,7 +133,10 @@ export function MultiComboBox<T>({
     items: filteredItems,
     inputValue,
     onAdd,
-    onSelect,
+    onSelect: (selected) => {
+      onSelect(selected)
+      onChangeSelected && onChangeSelected(selectedItems.concat(selected))
+    },
     isExpanded: isFocused,
     isAddable: creatable && !!inputValue && !isDuplicate,
     isDuplicate: creatable && !!inputValue && isDuplicate && !hasSelectableExactMatch,
@@ -223,7 +231,16 @@ export function MultiComboBox<T>({
                       themes={theme}
                       className={classNames.deleteButton}
                       disabled={disabled}
-                      onClick={() => onDelete(item)}
+                      onClick={() => {
+                        onDelete(item)
+                        onChangeSelected &&
+                          onChangeSelected(
+                            selectedItems.filter(
+                              (selected) =>
+                                selected.label !== item.label || selected.value !== item.value,
+                            ),
+                          )
+                      }}
                     >
                       <FaTimesCircleIcon
                         size={11}

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -75,11 +75,11 @@ type Props<T> = {
   /**
    *  Fire when clicking the delete element of `selectedItems` button.
    */
-  onDelete: (item: Item<T>) => void
+  onDelete?: (item: Item<T>) => void
   /**
    * Fire when clicking an element of `items`.
    */
-  onSelect: (item: Item<T>) => void
+  onSelect?: (item: Item<T>) => void
   /**
    * Fire when the item selections are changed.
    */
@@ -134,7 +134,7 @@ export function MultiComboBox<T>({
     inputValue,
     onAdd,
     onSelect: (selected) => {
-      onSelect(selected)
+      onSelect && onSelect(selected)
       onChangeSelected && onChangeSelected(selectedItems.concat(selected))
     },
     isExpanded: isFocused,
@@ -232,7 +232,7 @@ export function MultiComboBox<T>({
                       className={classNames.deleteButton}
                       disabled={disabled}
                       onClick={() => {
-                        onDelete(item)
+                        onDelete && onDelete(item)
                         onChangeSelected &&
                           onChangeSelected(
                             selectedItems.filter(

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -74,9 +74,9 @@ type Props<T> = {
    */
   onAdd?: (label: string) => void
   /**
-   * Fire when the selected item is changed.
+   * Fire when an item is selected.
    */
-  onSelect: (item: Item<T>) => void
+  onSelect?: (item: Item<T>) => void
   /**
    * Fire when the selected item is cleared.
    */
@@ -142,7 +142,7 @@ export function SingleComboBox<T>({
     inputValue,
     onAdd,
     onSelect: (selected) => {
-      onSelect(selected)
+      onSelect && onSelect(selected)
       onChangeSelected && onChangeSelected(selected)
       setIsExpanded(false)
     },

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -81,6 +81,10 @@ type Props<T> = {
    * Fire when the selected item is cleared.
    */
   onClear?: () => void
+  /**
+   * Fire when the item selection is changed.
+   */
+  onChangeSelected?: (selectedItem: Item<T> | null) => void
 }
 
 type ElementProps<T> = Omit<HTMLAttributes<HTMLDivElement>, keyof Props<T>>
@@ -101,6 +105,7 @@ export function SingleComboBox<T>({
   onAdd,
   onSelect,
   onClear,
+  onChangeSelected,
   ...props
 }: Props<T> & ElementProps<T>) {
   const theme = useTheme()
@@ -138,6 +143,7 @@ export function SingleComboBox<T>({
     onAdd,
     onSelect: (selected) => {
       onSelect(selected)
+      onChangeSelected && onChangeSelected(selected)
       setIsExpanded(false)
     },
     isExpanded,
@@ -214,6 +220,7 @@ export function SingleComboBox<T>({
               onClick={(e) => {
                 e.stopPropagation()
                 onClear && onClear()
+                onChangeSelected && onChangeSelected(null)
                 if (isFocused) {
                   setIsExpanded(true)
                 }
@@ -251,6 +258,7 @@ export function SingleComboBox<T>({
           setInputValue(value)
           if (value === '') {
             onClear && onClear()
+            onChangeSelected && onChangeSelected(null)
           }
         }}
         onFocus={() => {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-436
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`SingleComboBox`, `MultiComboBox` に対して、選択値の変更を監視するハンドラとして `onChangeSelected` を追加します。また同時に、組み込み側でハンドリング方法を選べるようにするために、既存の `onSelect`, `onDelete` ハンドラを optional に変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `SingleComboBox`
  - `onChangeSelected` を追加
  - `onSelect` を optional に変更
- `MultiComboBox`
  - `onChangeSelected` を追加
  - `onSelect`, `onDelete` を optional に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
