### PR TITLE
Calendar の年選択ボタンのイベント伝播を阻止する

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -54,7 +54,10 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
             {currentMonth.year()}年{currentMonth.month() + 1}月
           </YearMonth>
           <SecondaryButton
-            onClick={() => setIsSelectingYear(!isSelectingYear)}
+            onClick={(e) => {
+              e.stopPropagation()
+              setIsSelectingYear(!isSelectingYear)
+            }}
             size="s"
             square
             aria-expanded={isSelectingYear}


### PR DESCRIPTION
年選択ボタンの位置に依ってイベントが伝播し、予期しない動作を生む。
Event. stopPropagation() でイベントの伝播を阻止する。