### PR TITLE
feat!: チェックボックスとラベルがずれているので修正

### DIFF
--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -32,19 +32,19 @@ storiesOf('CheckBox', module)
           <InnerList>
             <li>
               <CheckBox name="1" checked={checkedName.includes('1')} onChange={handleChange}>
-                CheckBox
+                チェックボックス
               </CheckBox>
             </li>
 
             <li>
               <CheckBox disabled onChange={handleChange}>
-                CheckBox / disabled
+                チェックボックス / disabled
               </CheckBox>
             </li>
 
             <li>
               <CheckBox checked disabled onChange={handleChange}>
-                CheckBox / disabled /checked
+                チェックボックス / disabled /checked
               </CheckBox>
             </li>
           </InnerList>
@@ -74,19 +74,19 @@ storiesOf('CheckBox', module)
           <InnerList>
             <li>
               <CheckBox name="3" checked={checkedName.includes('3')} mixed onChange={handleChange}>
-                CheckBox / mixed
+                チェックボックス / mixed
               </CheckBox>
             </li>
 
             <li>
               <CheckBox mixed disabled onChange={handleChange}>
-                CheckBox / mixed / disabled
+                チェックボックス / mixed / disabled
               </CheckBox>
             </li>
 
             <li>
               <CheckBox checked mixed disabled onChange={handleChange}>
-                CheckBox / mixed / disabled / checked
+                チェックボックス / mixed / disabled / checked
               </CheckBox>
             </li>
           </InnerList>
@@ -97,15 +97,20 @@ storiesOf('CheckBox', module)
 
           <InnerList>
             <li>
-              <CheckBox name="4" checked={checkedName.includes('4')} onChange={handleChange}>
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
-                Ipsum has been the industry&apos;s standard dummy text ever since the 1500s, when an
-                unknown printer took a galley of type and scrambled it to make a type specimen book.
-                It has survived not only five centuries, but also the leap into electronic
-                typesetting, remaining essentially unchanged. It was popularised in the 1960s with
-                the release of Letraset sheets containing Lorem Ipsum passages, and more recently
-                with desktop publishing software like Aldus PageMaker including versions of Lorem
-                Ipsum.
+              <CheckBox
+                name="4"
+                checked={checkedName.includes('4')}
+                onChange={handleChange}
+                checkBoxPosition="top"
+              >
+                ローレムイプサム is simply dummy text of the printing and typesetting industry.
+                Lorem Ipsum has been the industry&apos;s standard dummy text ever since the 1500s,
+                when an unknown printer took a galley of type and scrambled it to make a type
+                specimen book. It has survived not only five centuries, but also the leap into
+                electronic typesetting, remaining essentially unchanged. It was popularised in the
+                1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more
+                recently with desktop publishing software like Aldus PageMaker including versions of
+                Lorem Ipsum.
               </CheckBox>
             </li>
           </InnerList>

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -4,15 +4,24 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useId } from '../../hooks/useId'
 import { useClassNames } from './useClassNames'
+import { Leadings } from '../../themes/createLeading'
 
 import { CheckBoxInput, Props as CheckBoxInputProps } from './CheckBoxInput'
 
+type CheckBoxPosition = 'center' | 'top'
 type Props = CheckBoxInputProps & {
-  lineHeight?: number
+  checkBoxPosition?: CheckBoxPosition
+  lineHeight?: Leadings
   children?: ReactNode
 }
 
-export const CheckBox: FC<Props> = ({ lineHeight = 1.5, className = '', children, ...props }) => {
+export const CheckBox: FC<Props> = ({
+  checkBoxPosition = 'center',
+  lineHeight = 'TIGHT',
+  className = '',
+  children,
+  ...props
+}) => {
   const theme = useTheme()
   const classNames = useClassNames()
   const checkBoxId = useId(props.id)
@@ -25,13 +34,14 @@ export const CheckBox: FC<Props> = ({ lineHeight = 1.5, className = '', children
     )
 
   return (
-    <Wrapper className={`${className} ${classNames.wrapper}`}>
+    <Wrapper checkBoxPosition={checkBoxPosition} className={`${className} ${classNames.wrapper}`}>
       <CheckBoxInput id={checkBoxId} {...props} />
 
       <Label
         className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
         htmlFor={checkBoxId}
         $lineHeight={lineHeight}
+        checkBoxPosition={checkBoxPosition}
         themes={theme}
       >
         {children}
@@ -41,34 +51,35 @@ export const CheckBox: FC<Props> = ({ lineHeight = 1.5, className = '', children
 }
 
 // Use flex-start to support multi-line text.
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ checkBoxPosition?: CheckBoxPosition }>`
   display: inline-flex;
-  align-items: flex-start;
+  align-items: ${({ checkBoxPosition }) => (checkBoxPosition === 'top' ? 'flex-start' : 'center')};
 `
-const Label = styled.label<{ themes: Theme; $lineHeight: number }>`
-  ${({ themes, $lineHeight }) => {
-    const { spacingByChar, color, fontSize } = themes
+const Label = styled.label<{
+  themes: Theme
+  $lineHeight: Leadings
+  checkBoxPosition?: CheckBoxPosition
+}>`
+  ${({ themes, $lineHeight, checkBoxPosition }) => {
+    const { spacingByChar, color, fontSize, leading } = themes
 
     return css`
+      ${checkBoxPosition === 'top' &&
+      // top 合わせの場合は CheckBoxInput と line-height の分だけずれるので調整する
+      css`
+        /* 行の高さ（文字の高さ * line-height）- 文字の高さ / 2 = 差となるハーフレディング */
+        margin-top: calc(((1em * ${leading[$lineHeight]}) - 1em) / -2);
+      `}
       margin-left: ${spacingByChar(0.5)};
       color: ${color.TEXT_BLACK};
       font-size: ${fontSize.M};
-      line-height: ${$lineHeight};
+      line-height: ${leading[$lineHeight]};
       cursor: pointer;
 
       &.disabled {
         color: ${color.TEXT_DISABLED};
         cursor: not-allowed;
         pointer-events: none;
-      }
-
-      /* Since the positions of checkbox and text are misaligned, create a pseudo element that adjusts the line-height. */
-      &::before {
-        display: block;
-        width: 0;
-        height: 0;
-        margin-top: calc((1 - ${$lineHeight}) * 0.4em);
-        content: '';
       }
     `
   }}


### PR DESCRIPTION
チェックボックスとそのラベルの縦位置がずれていたので修正した。

### やったこと

- `lineHeight` に数値ではなくデザイントークンを渡すようにした
- `checkBoxPosition` でチェックボックスの縦位置を上か中央のどちらかから選べるようにした
- 上合わせで line-height の違いに依るズレの計算を正した
- ストーリーのラベルを日本語にした