### PR TITLE
Baseのbox-shadowをオーバーライド可能にする SHRUI-431

### DIFF
--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -1,28 +1,49 @@
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
+import { useTheme } from '../../hooks/useTheme'
 
-import { Base } from './Base'
+import { Base, LayerKeys, RadiusKeys, layerMap, radiusMap } from './Base'
 import { DialogBase } from './DialogBase'
 
-storiesOf('Base', module).add('Base', () => (
-  <List>
-    <li>
-      <Base radius="s">
-        <Txt>
-          If radius props is specified as <Bold>s</Bold>, border-radius becomes <Bold>6px</Bold>.
-        </Txt>
-      </Base>
-    </li>
-    <li>
-      <Base radius="m">
-        <Txt>
-          If radius props is specified as <Bold>m</Bold>, border-radius becomes <Bold>8px</Bold>.
-        </Txt>
-      </Base>
-    </li>
-  </List>
-))
+storiesOf('Base', module).add('Base', () => {
+  const themes = useTheme()
+
+  return (
+    <List>
+      <dt>radius</dt>
+      <dd>
+        <List>
+          {Object.keys(radiusMap).map((radius, index) => (
+            <li key={`${radius}-${index}`}>
+              <Base radius={radius as RadiusKeys}>
+                <Txt>
+                  If radius props is specified as <Bold>{radius}</Bold>, border-radius becomes
+                  <Bold> {radiusMap[radius as RadiusKeys]}</Bold>.
+                </Txt>
+              </Base>
+            </li>
+          ))}
+        </List>
+      </dd>
+      <dt>box-shadow</dt>
+      <dd>
+        <List>
+          {Object.keys(layerMap).map((layer, index) => (
+            <li key={`${layer}-${index}`}>
+              <Base layer={Number(layer) as LayerKeys}>
+                <Txt>
+                  If layer props is specified as <Bold>{layer}</Bold>, box-shadow becomes
+                  <Bold> {themes.shadow[layerMap[Number(layer) as LayerKeys]]}</Bold>.
+                </Txt>
+              </Base>
+            </li>
+          ))}
+        </List>
+      </dd>
+    </List>
+  )
+})
 
 storiesOf('Base', module).add('DialogBase', () => (
   <List>

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -5,17 +5,30 @@ import { useClassNames } from './useClassNames'
 
 type Props = {
   children: ReactNode
-  radius?: 's' | 'm'
+  radius?: RadiusKeys
+  layer: LayerKeys
 }
-export type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+type RadiusKeys = keyof typeof radiusMap
+
+type LayerKeys = keyof typeof shadowMap
 
 export const radiusMap = {
   s: '6px',
   m: '8px',
-}
+} as const
+
+const shadowMap = {
+  0: 'LAYER0',
+  1: 'LAYER1',
+  2: 'LAYER2',
+  3: 'LAYER3',
+  4: 'LAYER4',
+} as const
+
+export type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
-  ({ radius = 'm', className = '', ...props }, ref) => {
+  ({ radius = 'm', layer = 1, className = '', ...props }, ref) => {
     const themes = useTheme()
     const classNames = useClassNames()
 
@@ -24,6 +37,7 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
         className={`${className} ${classNames.base.wrapper}`}
         themes={themes}
         $radius={radiusMap[radius]}
+        $layer={shadowMap[layer]}
         ref={ref}
         {...props}
       />
@@ -31,10 +45,14 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
   },
 )
 
-const Wrapper = styled.div<{ themes: Theme; $radius: string }>`
-  ${({ themes, $radius }) => {
+const Wrapper = styled.div<{
+  themes: Theme
+  $radius: typeof radiusMap[RadiusKeys]
+  $layer: typeof shadowMap[LayerKeys]
+}>`
+  ${({ themes, $radius, $layer }) => {
     return css`
-      box-shadow: ${themes.shadow.LAYER1};
+      box-shadow: ${themes.shadow[$layer]};
       border-radius: ${$radius};
       background-color: #fff;
     `

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -6,7 +6,7 @@ import { useClassNames } from './useClassNames'
 type Props = {
   children: ReactNode
   radius?: RadiusKeys
-  layer: LayerKeys
+  layer?: LayerKeys
 }
 type RadiusKeys = keyof typeof radiusMap
 

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -8,16 +8,16 @@ type Props = {
   radius?: RadiusKeys
   layer?: LayerKeys
 }
-type RadiusKeys = keyof typeof radiusMap
 
-type LayerKeys = keyof typeof shadowMap
+export type RadiusKeys = keyof typeof radiusMap
+export type LayerKeys = keyof typeof layerMap
 
 export const radiusMap = {
   s: '6px',
   m: '8px',
 } as const
 
-const shadowMap = {
+export const layerMap = {
   0: 'LAYER0',
   1: 'LAYER1',
   2: 'LAYER2',
@@ -37,7 +37,7 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
         className={`${className} ${classNames.base.wrapper}`}
         themes={themes}
         $radius={radiusMap[radius]}
-        $layer={shadowMap[layer]}
+        $layer={layerMap[layer]}
         ref={ref}
         {...props}
       />
@@ -48,7 +48,7 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
 const Wrapper = styled.div<{
   themes: Theme
   $radius: typeof radiusMap[RadiusKeys]
-  $layer: typeof shadowMap[LayerKeys]
+  $layer: typeof layerMap[LayerKeys]
 }>`
   ${({ themes, $radius, $layer }) => {
     return css`

--- a/src/components/Base/DialogBase.tsx
+++ b/src/components/Base/DialogBase.tsx
@@ -14,6 +14,9 @@ const radiusMap = {
   m: '8px',
 }
 
+/**
+ * @deprecated The DialogBase component is deprecated, so use Base component instead.
+ */
 export const DialogBase = forwardRef<HTMLDivElement, Props & ElementProps>(
   ({ radius = 'm', className = '', ...props }, ref) => {
     const themes = useTheme()


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-431

## Overview

- Baseコンポーネントのbox-shadowをオーバーライド可能にする
- DialogBaseをdeprecated化する

## What I did

- [x] propsにlayerを追加
- [x] 型定義の厳格化
- [x] DialogBaseのdeprecated化
- [x] storybookの追加 

## Capture

![image](https://user-images.githubusercontent.com/5885283/130327245-e91a38fc-d1fa-4812-a16a-cc65d50872f5.png)