### PR TITLE
chore: `AccordionPanel` のアウトラインを角丸にしないように変更

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -9,7 +9,6 @@ import { AccordionPanelItemContext } from './AccordionPanelItem'
 import { useClassNames } from './useClassNames'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { FaCaretRightIcon, FaCaretUpIcon } from '../Icon'
-import { radiusMap } from '../Base'
 
 type Props = {
   children: React.ReactNode
@@ -99,14 +98,6 @@ const Button = styled.button<{ themes: Theme }>`
       cursor: pointer;
       font-size: inherit;
       text-align: left;
-
-      .smarthr-ui-AccordionPanel > * > *:first-child & {
-        border-radius: ${radiusMap.m} ${radiusMap.m} 0 0;
-      }
-
-      .smarthr-ui-AccordionPanel > * > *:last-child & {
-        border-radius: 0 0 ${radiusMap.m} ${radiusMap.m};
-      }
 
       &:hover,
       &:focus:not(:focus-visible) {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-443
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`AccordionPanel` はこのコンポーネント自体を角丸にする責務を負っていないので、アウトラインを角丸にする処理を外します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- アウトラインを角丸にするスタイルを削除
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
![image](https://user-images.githubusercontent.com/270422/130580626-d0a9eb25-ce55-4f76-abe3-195ed81ff291.png)

<!--
Please attach a capture if it looks different.
-->
