### PR TITLE
fix: ツールチップ、バルーンのダークモードを非推奨にする (SHRUI-444)

### DIFF
--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -36,7 +36,10 @@ const balloonFactory = (theme: BalloonTheme) => {
   return Balloon
 }
 
-export const LightBalloon = balloonFactory('light')
+export const Balloon = balloonFactory('light')
+/** @deprecated このコンポーネントは非推奨です。 Balloon コンポーネントを使用してください。 */
+export const LightBalloon = Balloon
+/** @deprecated このコンポーネントは非推奨です。 Balloon コンポーネントを使用してください。 */
 export const DarkBalloon = balloonFactory('dark')
 
 const Base = styled.div<{ themes: Theme }>`

--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -7,6 +7,7 @@ import { useClassNames } from './useClassNames'
 type Props = {
   maxLines?: number
   withTooltip?: boolean
+  /** @deprecated このプロパティは廃止予定です。 */
   toolTipType?: BalloonTheme
   children: ReactNode
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -148,7 +148,10 @@ const tooltipFactory = (balloonTheme: BalloonTheme) => {
   return Tooltip
 }
 
-export const LightTooltip = tooltipFactory('light')
+export const Tooltip = tooltipFactory('light')
+/** @deprecated このコンポーネントは非推奨です。 Tooltip コンポーネントを使用してください。 */
+export const LightTooltip = Tooltip
+/** @deprecated このコンポーネントは非推奨です。 Tooltip コンポーネントを使用してください。 */
 export const DarkTooltip = tooltipFactory('dark')
 
 const Wrapper = styled.div<{ isIcon?: boolean }>`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // components
-export { LightBalloon, DarkBalloon } from './components/Balloon'
+export { Balloon, LightBalloon, DarkBalloon } from './components/Balloon'
 export { CheckBox } from './components/CheckBox'
 export {
   Dropdown,

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export {
 export { InformationPanel } from './components/InformationPanel'
 export { Footer } from './components/Footer'
 export { RightFixedNote } from './components/RightFixedNote'
-export { LightTooltip, DarkTooltip } from './components/Tooltip'
+export { Tooltip, LightTooltip, DarkTooltip } from './components/Tooltip'
 export { BottomFixedArea } from './components/BottomFixedArea'
 export { MessageScreen } from './components/MessageScreen'
 export { Calendar } from './components/Calendar'


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-444
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
視認性の観点からツールチップ、バルーンのダークモードを廃止することになったので、関連する箇所を非推奨にします。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `LightTooltip`, `DarkTooltip` を非推奨にし、`Tooltip` でライトモードのツールチップを使用できるように追加
- `LightBalloon`, `DarkBalloon` を非推奨にし、 `Balloon` でライトモードのバルーンを使用できるように追加
- `LineClamp` コンポーネントの `toolTipType` プロパティを非推奨に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
