### PR TITLE
`<Cluster>` に水平方向と垂直方向で別々の余白を定義できるようにする

### DIFF
--- a/src/components/Layout/Cluster/Cluster.stories.tsx
+++ b/src/components/Layout/Cluster/Cluster.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Story } from '@storybook/react'
 
-import { useTheme } from '../../../hooks/useTheme'
+import { Theme, useTheme } from '../../../hooks/useTheme'
 import { Cluster } from '.'
 import { Stack } from '../Stack'
 import { Heading as shrHeading } from '../../Heading'
@@ -9,6 +9,8 @@ import { StatusLabel } from '../../StatusLabel'
 
 import readme from './README.md'
 import styled, { css } from 'styled-components'
+import { Base } from '../../Base'
+import { RadioButton } from '../../RadioButton'
 
 export default {
   title: 'Cluster',
@@ -20,53 +22,91 @@ export default {
   },
 }
 
-export const Default: Story = () => (
-  <Stack>
-    <figure>
-      <figcaption>幅を狭めて収まり切らなくなると折返します。</figcaption>
-      <Cluster>
-        <StatusLabel type="done">アコーディオン</StatusLabel>
-        <StatusLabel type="success">コンボボックス</StatusLabel>
-        <StatusLabel type="process">ディスクロージャ</StatusLabel>
-        <StatusLabel type="required">タブ・コントロール</StatusLabel>
-        <StatusLabel type="disabled">ツリー・ビュー</StatusLabel>
-        <StatusLabel type="must">ツリー・グリッド</StatusLabel>
-        <StatusLabel type="warning">ウィンドウ・スプリッター</StatusLabel>
-        <StatusLabel type="error">ランドマーク・リージョン</StatusLabel>
-      </Cluster>
-    </figure>
-    <figure>
-      <figcaption>
-        間隔を <code>gap</code> で変えられます。
-      </figcaption>
-      <Cluster gap="XS">
-        {[...Array(10)].map((_, i) => (
-          <ColorBox key={i} />
-        ))}
-      </Cluster>
-    </figure>
-    <figure>
-      <figcaption>
-        入れ子にして <code>align</code> や <code>justify</code>{' '}
-        を組み合わせるとメディアクエリを使用せずに柔軟なレイアウトを作れます。
-      </figcaption>
-      <Cluster align="center" justify="space-between">
-        <Heading>これは Cluster の構成例です</Heading>
+export const Default: Story = () => {
+  const themes = useTheme()
+  const { spacing } = themes
 
+  return (
+    <Stack gap="L" style={{ padding: spacing.L }}>
+      <Stack as="figure" gap="X3S">
+        <figcaption>幅を狭めて収まり切らなくなると折返します。</figcaption>
         <Cluster>
           <StatusLabel type="done">アコーディオン</StatusLabel>
           <StatusLabel type="success">コンボボックス</StatusLabel>
           <StatusLabel type="process">ディスクロージャ</StatusLabel>
+          <StatusLabel type="required">タブ・コントロール</StatusLabel>
+          <StatusLabel type="disabled">ツリー・ビュー</StatusLabel>
+          <StatusLabel type="must">ツリー・グリッド</StatusLabel>
+          <StatusLabel type="warning">ウィンドウ・スプリッター</StatusLabel>
+          <StatusLabel type="error">ランドマーク・リージョン</StatusLabel>
         </Cluster>
-      </Cluster>
-    </figure>
-  </Stack>
-)
+      </Stack>
+      <Stack as="figure" gap="X3S">
+        <figcaption>
+          間隔を <code>gap</code> で変えられます。
+        </figcaption>
+        <Cluster gap="XS">
+          {[...Array(10)].map((_, i) => (
+            <ColorBox key={i} />
+          ))}
+        </Cluster>
+      </Stack>
+      <Stack as="figure" gap="X3S">
+        <figcaption>垂直方向と水平方向で異なった余白を設定できます。</figcaption>
+        <StyledBase themes={themes}>
+          <Cluster gap={{ row: 'X3S', column: 'XS' }}>
+            <RadioButton name="部署" defaultChecked={true}>
+              申請者に戻す
+            </RadioButton>
+            <RadioButton name="部署" defaultChecked={false}>
+              ステップ1に戻す
+            </RadioButton>
+            <RadioButton name="部署" defaultChecked={false}>
+              ステップ2に戻す
+            </RadioButton>
+            <RadioButton name="部署" defaultChecked={false}>
+              ステップ3に戻す
+            </RadioButton>
+            <RadioButton name="部署" defaultChecked={false}>
+              ステップ4に戻す
+            </RadioButton>
+          </Cluster>
+        </StyledBase>
+      </Stack>
+      <Stack as="figure" gap="X3S">
+        <figcaption>
+          入れ子にして <code>align</code> や <code>justify</code>{' '}
+          を組み合わせるとメディアクエリを使用せずに柔軟なレイアウトを作れます。
+        </figcaption>
+        <Cluster align="center" justify="space-between">
+          <Heading>これは Cluster の構成例です</Heading>
+
+          <Cluster>
+            <StatusLabel type="done">アコーディオン</StatusLabel>
+            <StatusLabel type="success">コンボボックス</StatusLabel>
+            <StatusLabel type="process">ディスクロージャ</StatusLabel>
+          </Cluster>
+        </Cluster>
+      </Stack>
+    </Stack>
+  )
+}
 
 const Heading = styled(shrHeading)`
   margin-top: 0;
   margin-bottom: 0;
 `
+
+const StyledBase = styled(Base)<{ themes: Theme }>(({ themes }) => {
+  const { color, spacing } = themes
+
+  return css`
+    width: 50%;
+    padding: ${spacing.M};
+    background-color: ${color.BACKGROUND};
+  `
+})
+
 const ColorBox = styled.div(() => {
   const { color, radius } = useTheme()
 

--- a/src/components/Layout/Cluster/Cluster.tsx
+++ b/src/components/Layout/Cluster/Cluster.tsx
@@ -5,9 +5,16 @@ import { useSpacing } from '../../../hooks/useSpacing'
 
 type alignMethod = 'normal' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
 type justifyMethod = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around'
+type Gap = CharRelativeSize | AbstractSize
+type SeparateGap = {
+  row: Gap
+  column: Gap
+}
 
 /**
  * @param gap 間隔の指定（基準フォントサイズの相対値または抽象値）
+ * @param rowGap 垂直方向の間隔の指定（基準フォントサイズの相対値または抽象値）
+ * @param columnGap 水平方向の間隔の指定（基準フォントサイズの相対値または抽象値）
  * @param align 垂直方向の揃え方（align-items）
  * @param justify 水平方向の揃え方（justify-content）
  * @param as ネガティブマージンを隠す要素の HTML タグ名
@@ -15,7 +22,7 @@ type justifyMethod = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 's
  * @param children 均等に間隔を空けたい要素群
  */
 export const Cluster: React.VFC<{
-  gap?: CharRelativeSize | AbstractSize
+  gap?: Gap | SeparateGap
   align?: alignMethod
   justify?: justifyMethod
   as?: React.ElementType
@@ -40,28 +47,32 @@ const Wrapper = styled.div`
   }
 `
 const Body = styled.div<{
-  gap: CharRelativeSize | AbstractSize
+  gap: Gap | SeparateGap
   align?: alignMethod
   justify?: justifyMethod
-}>(
-  ({ gap, align, justify }) => css`
+}>(({ gap, align, justify }) => {
+  const rowGap = gap instanceof Object ? useSpacing(gap.row) : useSpacing(gap)
+  const columnGap = gap instanceof Object ? useSpacing(gap.column) : useSpacing(gap)
+
+  return css`
     display: flex;
     flex-wrap: wrap;
     ${align && `align-items: ${align};`}
     ${justify && `justify-content: ${justify};`}
-    margin: calc(${useSpacing(gap)} / 2 * -1);
+    margin: calc(${rowGap} / 2 * -1) calc(${columnGap} / 2 * -1);
 
     > * {
-      margin: calc(${useSpacing(gap)} / 2);
+      margin: calc(${rowGap} / 2) calc(${columnGap} / 2);
     }
 
     @supports (gap: 1px) {
       margin: revert;
-      gap: ${useSpacing(gap)};
+      row-gap: ${rowGap};
+      column-gap: ${columnGap};
 
       > * {
         margin: revert;
       }
     }
-  `,
-)
+  `
+})


### PR DESCRIPTION
## Related URL

- [Clusterに水平方向と垂直方向で別々の余白を定義したい - SmartHR JIRA](https://smarthr.atlassian.net/browse/SHRUI-470)

## Overview

Make Cluster component possible to set the vertical and horizontal margins.

## What I did

- add `rowGap`/`columnGap` property to `<Cluster>` component.
- prioritize rowGap or columnGap over gap if available.

## Capture

<img width="560" alt="縦横別の余白を持ったいくつかのラジオボタンのスクリーンショット" src="https://user-images.githubusercontent.com/6724665/131307170-a1ee2b31-7b30-4d12-b5c2-7b3f7dfe963d.png">

