### PR TITLE
fix: OVERLAP の重なり順序の改善 (SHRUI-445)

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -158,7 +158,7 @@ const Wrapper = styled.div<{ themes: Theme }>(({ themes }) => {
   const { zIndex } = themes
 
   return css`
-    z-index: ${zIndex.OVERLAP};
+    z-index: ${zIndex.OVERLAP_BASE};
     position: fixed;
     top: 0;
     left: 0;
@@ -190,7 +190,7 @@ const Wrapper = styled.div<{ themes: Theme }>(({ themes }) => {
 
 const Inner = styled.div<StyleProps & { themes: Theme }>`
   ${({ themes, top, right, bottom, left }) => {
-    const { zIndex, radius, shadow } = themes
+    const { radius, shadow } = themes
     const positionRight = exist(right) ? `${right}px` : 'auto'
     const positionBottom = exist(bottom) ? `${bottom}px` : 'auto'
     let positionTop = exist(top) ? `${top}px` : 'auto'
@@ -210,7 +210,6 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
 
     return css`
       position: absolute;
-      z-index: ${zIndex.OVERLAP};
       top: ${positionTop};
       right: ${positionRight};
       bottom: ${positionBottom};

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -118,7 +118,7 @@ const Wrapper = styled.div<{
     return css`
       display: flex;
       visibility: hidden;
-      z-index: ${zIndex.OVERLAP};
+      z-index: ${zIndex.OVERLAP_BASE};
       position: absolute;
       top: ${contentBox.top};
       left: ${contentBox.left};

--- a/src/themes/createZIndex.ts
+++ b/src/themes/createZIndex.ts
@@ -4,6 +4,7 @@ export interface ZIndexProperty {
   AUTO?: 'auto'
   DEFAULT?: number
   FIXED_MENU?: number
+  OVERLAP_BASE?: number
   OVERLAP?: number
   FLASH_MESSAGE?: number
 }
@@ -12,6 +13,7 @@ export interface CreatedZindexTheme {
   AUTO: 'auto'
   DEFAULT: number
   FIXED_MENU: number
+  OVERLAP_BASE: number
   OVERLAP: number
   FLASH_MESSAGE: number
 }
@@ -20,6 +22,7 @@ export const defaultZIndex = {
   AUTO: 'auto',
   DEFAULT: 0,
   FIXED_MENU: 100,
+  OVERLAP_BASE: 9000,
   OVERLAP: 10000,
   FLASH_MESSAGE: 11000,
 }


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-445
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
ダイアログ内にコンボボックス等を置いた時、コンボボックスのドロップダウンがダイアログの裏に表示されてしまう問題があるため、対応します。

![image](https://user-images.githubusercontent.com/270422/131459381-ce9abf96-6996-4fda-a3e8-a5e23c3cc472.png)

### 対応方針
コンボボックスを使用する時にドロップダウンを表示するポータルのコンテナを使用者が自由に指定できるようにすることで問題の解消を試みましたが、これだと組み込み側の対応がかなり大変になってしまいそうでした。具体的には

- `useRef` を用いてコンテナを参照する場合は、ref は最初のループでは null なので `useEffect` + 何かをする必要がある
- `createElement` でコンテナを作る場合はどこかに `appendChild` する必要があり react 的に見通しが悪くなる

といった感じです。

なので、対応が単純かつ現時点で具体的な弊害がなさそうな「OVERLAP の z-index を２つに分割する」方法で対応したほうが良いと判断しました。

### テーマの z-index の変更

`OVERLAP` より小さい `OVERLAP_BASE` を追加します。

| key | z-index |
| --- | --- |
| AUTO | 'auto' |  
| DEFFAULT | 0 |  
| FIXED_MENU | 100 |  
| **OVERLAP_BASE** | **9000** |  
| OVERLAP | 10000 |  
| FLASH_MESSAGE | 11000 |  

元々 `OVERLAP` に属していたコンポーネントの内、インタラクティブな子コンポーネントを持ちうる `Dialog` と `Dropdown` を `OVERLAP_BASE` に変更しましす。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- テーマの z-index に `OVERLAP_BASE` を追加
- `Dialog` と `Dropdown` の z-index を `OVERLAP_BASE` に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
