### PR TITLE
余白トークンに 0 を追加

### DIFF
--- a/src/themes/__tests__/createSpacing.ts
+++ b/src/themes/__tests__/createSpacing.ts
@@ -6,6 +6,7 @@ describe('createSpacingByChar', () => {
   it('returns default spacing size when no arguments given', () => {
     const actual = createSpacingByChar()
 
+    expect(actual(0)).toBe('0')
     expect(actual(0.25)).toBe(toPx(defaultBaseSize / 2))
     expect(actual(0.5)).toBe(toPx(defaultBaseSize))
     expect(actual(0.75)).toBe(toPx(defaultBaseSize * 1.5))
@@ -36,6 +37,7 @@ describe('createSpacingByChar', () => {
     const baseSize = 13
     const actual = createSpacingByChar(baseSize)
 
+    expect(actual(0)).toBe('0')
     expect(actual(0.25)).toBe(toPx(baseSize / 2))
     expect(actual(0.5)).toBe(toPx(baseSize))
     expect(actual(0.75)).toBe(toPx(baseSize * 1.5))
@@ -76,6 +78,7 @@ describe('createSpacing', () => {
     expect(actual.XL).toBe(toPx(8 * 6))
     expect(actual.XXL).toBe(toPx(8 * 7))
     expect(actual.X3L).toBe(toPx(8 * 8))
+    expect(actual.NONE).toBe('0')
   })
 
   it('returns customized spacing theme when gives base size', () => {
@@ -90,6 +93,7 @@ describe('createSpacing', () => {
     expect(actual.XL).toBe(toPx(13 * 6))
     expect(actual.XXL).toBe(toPx(13 * 7))
     expect(actual.X3L).toBe(toPx(13 * 8))
+    expect(actual.NONE).toBe('0')
   })
 
   it('returns the same value as createSpacingByChar', () => {
@@ -106,5 +110,6 @@ describe('createSpacing', () => {
     expect(actual.XL).toEqual(expected(3))
     expect(actual.XXL).toEqual(expected(3.5))
     expect(actual.X3L).toEqual(expected(4))
+    expect(actual.NONE).toBe('0')
   })
 })

--- a/src/themes/createSpacing.ts
+++ b/src/themes/createSpacing.ts
@@ -20,7 +20,7 @@ export interface CreatedSpacingTheme {
 export type CreatedSpacingByCharTheme = (size: CharRelativeSize) => string
 
 const primitiveTokens = [
-  0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 8, -0.25, -0.5, -0.75, -1, -1.25, -1.5, -2,
+  0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 8, -0.25, -0.5, -0.75, -1, -1.25, -1.5, -2,
   -2.5, -3, -3.5, -4, -8,
 ] as const
 
@@ -39,6 +39,7 @@ const getSpacing = (baseSize: number) => {
     XL: spacingByChar(3),
     XXL: spacingByChar(3.5),
     X3L: spacingByChar(4),
+    NONE: spacingByChar(0),
   }
 }
 
@@ -46,7 +47,8 @@ const getSpacingByChar = (baseSize: number) => {
   const charSize = baseSize * 2
   return primitiveTokens
     .map((size) => {
-      return { [size]: `${charSize * size}px` }
+      const value = !size ? '0' : `${charSize * size}px`
+      return { [size]: value }
     })
     .reduce((a, c) => Object.assign(a, c), {})
 }


### PR DESCRIPTION
Layout コンポーネントで 0 を利用したことがあるので、余白トークンに 0 を追加しました。
プリミティブトークンは 0、抽象トークンは `ZERO: 0` にしました。