### PR TITLE
chore: e2e ワークフローのキャッシュ対象を変更

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,13 +17,16 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: 12
-      - name: use node_modules cache
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Use yarn cache
         uses: actions/cache@v2
         with:
-          path: node_modules
-          key: e2e-yarn-${{ hashFiles('**\yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            e2e-yarn-
+            ${{ runner.os }}-yarn-
       - name: run
         run: |
           yarn install --frozen-lockfile


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`node_modules` をキャッシュするのは推奨されないようなので、 yarn のキャッシュをキャッシュするように変更します。
参考: https://github.com/actions/cache/blob/main/examples.md#node---npm
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- e2e ワークフローのキャッシュ対象を変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
