### PR TITLE
chore: e2e で storybook のビルドに失敗した時にプロセスが終了するように変更

### DIFF
--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -3,10 +3,13 @@ import waitForLocalhost from 'wait-for-localhost'
 ;(async () => {
   const PORT = 6006
 
-  spawnSync('yarn', ['run', 'build-storybook', '--quiet'], {
+  const buildSpawn = spawnSync('yarn', ['run', 'build-storybook', '--quiet'], {
     stdio: 'inherit',
     shell: true,
   })
+  if (buildSpawn.status !== 0) {
+    process.exit(1)
+  }
   const httpServer = spawn(
     'yarn',
     ['http-server', 'storybook-static', '--port', `${PORT}`, '--silent'],


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、e2e テスト実行時に storybook のビルドに失敗してもプロセスが終了せず残り続けるため、プロセスがエラー終了するように修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- ビルド失敗時に `exit(1)` するように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
