### PR TITLE
refactor: IconComponent の処理をインライン化

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -358,51 +358,45 @@ export interface ComponentProps extends IconProps, ElementProps {
    */
   className?: string
 }
-type IconComponentProps = ComponentProps & { Component: IconType }
-
-// This should be inlined in the createIcon function after the Icon component had been removed
-const IconComponent: React.VFC<IconComponentProps> = ({
-  Component,
-  color,
-  className = '',
-  role = 'img',
-  visuallyHiddenText,
-  'aria-hidden': ariaHidden,
-  focusable = false,
-  ...props
-}) => {
-  const hasLabelByAria = props['aria-label'] !== undefined || props['aria-labelledby'] !== undefined
-  const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasLabelByAria
-
-  const theme = useTheme()
-  const replacedColor = React.useMemo(() => {
-    const asserted = color as string | undefined
-    if (asserted && isDefinedColor(asserted)) {
-      return theme.color[asserted]
-    }
-    return color
-  }, [color, theme.color])
-
-  const classNames = useClassNames()
-
-  return (
-    <>
-      {visuallyHiddenText && <VisuallyHiddenText>{visuallyHiddenText}</VisuallyHiddenText>}
-      <Component
-        color={replacedColor}
-        className={`${className} ${classNames.wrapper}`}
-        role={role}
-        aria-hidden={isAriaHidden || visuallyHiddenText !== undefined || undefined}
-        focusable={focusable}
-        {...props}
-      />
-    </>
-  )
-}
 
 const createIcon = (SvgIcon: IconType) => {
-  const Icon: React.VFC<ComponentProps> = (props: ComponentProps) => {
-    return <IconComponent {...props} Component={SvgIcon} />
+  const Icon: React.VFC<ComponentProps> = ({
+    color,
+    className = '',
+    role = 'img',
+    visuallyHiddenText,
+    'aria-hidden': ariaHidden,
+    focusable = false,
+    ...props
+  }) => {
+    const hasLabelByAria =
+      props['aria-label'] !== undefined || props['aria-labelledby'] !== undefined
+    const isAriaHidden = ariaHidden !== undefined ? ariaHidden : !hasLabelByAria
+
+    const theme = useTheme()
+    const replacedColor = React.useMemo(() => {
+      const asserted = color as string | undefined
+      if (asserted && isDefinedColor(asserted)) {
+        return theme.color[asserted]
+      }
+      return color
+    }, [color, theme.color])
+
+    const classNames = useClassNames()
+
+    return (
+      <>
+        {visuallyHiddenText && <VisuallyHiddenText>{visuallyHiddenText}</VisuallyHiddenText>}
+        <SvgIcon
+          color={replacedColor}
+          className={`${className} ${classNames.wrapper}`}
+          role={role}
+          aria-hidden={isAriaHidden || visuallyHiddenText !== undefined || undefined}
+          focusable={focusable}
+          {...props}
+        />
+      </>
+    )
   }
   return Icon
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
非推奨だった `Icon` コンポーネントは既に削除されているため、 `Icon` コンポーネントのために処理を分割していた `IconComponent` を `createIcon` 内にインライン化します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `IconComponent` の処理を `createIcon` 内にインライン化
  - diff が分かりにくいですが、`IconComponent` の VFC を `createIcon` 内で定義している `Icon` に移動させ、 VFC 内で `Component` を参照している部分を `SvgIcon` に置き換えただけです。
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
