### PR TITLE
chore: レビュワーにアサインされる対象をグループから人指定に変更

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,12 @@
 # https://help.github.com/en/articles/about-code-owners
 
-* @kufu/group-dev-frontend
+* @nabeliwo
+* @wmoai
+* @Tokky0425
+* @AtsushiM
+* @zoshigayan
+* @diescake
+* @yt-ymmt
+* @yamakeeeeeeeeen
+* @im36-123
+* @uknmr


### PR DESCRIPTION
## Related URL

なし

## Overview

- レビューが滞る問題があった
- 現状のレビュワーはフロントエンドエンジニアの中からランダムでアサインされる状態
- 特にメンバーに確認なく、フロントエンドとして入社するとレビュワーになっちゃっている
- 実装と同じでレビュワーも有志の方が良いよね

## What I did

レビュワーにアサインされる対象をグループから人に変更。
この記述で動くか若干の不安があるのですがまあ一度入れてみてからで…。

## Capture

なし
