### PR TITLE
chore: レビュワーにアサインされる対象を人からグループ指定に変更

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 
-* @nabeliwo
-* @wmoai
-* @Tokky0425
-* @AtsushiM
-* @zoshigayan
-* @diescake
-* @yt-ymmt
-* @yamakeeeeeeeeen
-* @im36-123
-* @uknmr
+* @kufu/group-dev-smarthr-ui-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 
-* @kufu/group-dev-smarthr-ui-reviewers
+* @kufu/group-dev-smarthr-ui-reviewers @wmoai


### PR DESCRIPTION
## Related URL

なし

## Overview

- この PR https://github.com/kufu/smarthr-ui/pull/1862 で人指定に変更したが、このやり方だと 2 assign で round robin という設定ができない
- なので新しいグループを作って運用という形にしたい
  - 2人とか round robin みたいなのはグループに紐づく設定
- グループに @wmoai san を追加するのは権限的にできない
  - ここは一旦置いておいてもう少し考えます
    - 試しに CODEOWNERS に @wmoai san を追加してみました
    - こうなるとレビュワーがどうアサインされるかは試してみないとわからない…

## What I did

設定変更しました。

メンバー

![image](https://user-images.githubusercontent.com/11153463/132814332-a754a54c-2d7d-4eeb-b6e7-1aaa0cdf241f.png)

設定

![image](https://user-images.githubusercontent.com/11153463/132815585-19d1e1c0-b96e-4a80-b380-6e6ff98ee754.png)


## Capture

なし
