### PR TITLE
fix: ダイアログがアニメーション中に低いスタッキングコンテキストにならないように修正

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -146,9 +146,9 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
 const Layout = styled.div`
   position: fixed;
   top: 0;
+  right: 0;
+  bottom: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
 `
 const Inner = styled.div<StyleProps & { themes: Theme }>`
   ${({ themes, top, right, bottom, left }) => {
@@ -188,9 +188,9 @@ const Background = styled.div<{ themes: Theme }>`
     return css`
       position: fixed;
       top: 0;
+      right: 0;
+      bottom: 0;
       left: 0;
-      width: 100%;
-      height: 100%;
       background-color: ${themes.color.SCRIM};
     `
   }}

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -7,7 +7,7 @@ import { DialogPositionProvider } from './DialogPositionProvider'
 import { FocusTrap } from './FocusTrap'
 import { useClassNames } from './useClassNames'
 import { BodyScrollSuppressor } from './BodyScrollSuppressor'
-import { DialogTransition } from './DialogTransition'
+import { DialogOverlap } from './DialogOverlap'
 
 export type DialogContentInnerProps = {
   /**
@@ -107,9 +107,8 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
 
   return (
     <DialogPositionProvider top={props.top} bottom={props.bottom}>
-      <DialogTransition isOpen={isOpen}>
-        <Wrapper
-          themes={theme}
+      <DialogOverlap isOpen={isOpen}>
+        <Layout
           className={classNames.wrapper}
           id={id}
           role="dialog"
@@ -138,25 +137,19 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
           </FocusTrap>
           {/* Suppresses scrolling of body while modal is displayed */}
           <BodyScrollSuppressor />
-        </Wrapper>
-      </DialogTransition>
+        </Layout>
+      </DialogOverlap>
     </DialogPositionProvider>
   )
 }
 
-const Wrapper = styled.div<{ themes: Theme }>(({ themes }) => {
-  const { zIndex } = themes
-
-  return css`
-    z-index: ${zIndex.OVERLAP_BASE};
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  `
-})
-
+const Layout = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
 const Inner = styled.div<StyleProps & { themes: Theme }>`
   ${({ themes, top, right, bottom, left }) => {
     const { color, radius, shadow } = themes

--- a/src/components/Dialog/DialogOverlap.tsx
+++ b/src/components/Dialog/DialogOverlap.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const transitionClassName = 'shr-dialog-transition'
 
-export const DialogTransition: VFC<Props> = ({ isOpen, children }) => {
+export const DialogOverlap: VFC<Props> = ({ isOpen, children }) => {
   const theme = useTheme()
   return (
     <CSSTransition

--- a/src/components/Dialog/DialogTransition.tsx
+++ b/src/components/Dialog/DialogTransition.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode, VFC } from 'react'
 import styled from 'styled-components'
 import { CSSTransition } from 'react-transition-group'
 
+import { Theme, useTheme } from '../../hooks/useTheme'
+
 type Props = {
   isOpen: boolean
   children: ReactNode
@@ -10,6 +12,7 @@ type Props = {
 const transitionClassName = 'shr-dialog-transition'
 
 export const DialogTransition: VFC<Props> = ({ isOpen, children }) => {
+  const theme = useTheme()
   return (
     <CSSTransition
       classNames={transitionClassName}
@@ -22,12 +25,15 @@ export const DialogTransition: VFC<Props> = ({ isOpen, children }) => {
       appear
       unmountOnExit
     >
-      <Wrapper>{children}</Wrapper>
+      <Wrapper themes={theme}>{children}</Wrapper>
     </CSSTransition>
   )
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ themes: Theme }>`
+  position: absolute;
+  z-index: ${({ themes }) => themes.zIndex.OVERLAP_BASE};
+
   &.${transitionClassName}-appear {
     opacity: 0;
   }

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -17,7 +17,7 @@ import { useHandleEscape } from '../../hooks/useHandleEscape'
 import { BaseElementProps, DialogBase } from '../Base'
 import { SecondaryButton } from '../Button'
 import { FaTimesIcon } from '../Icon'
-import { DialogTransition } from './DialogTransition'
+import { DialogOverlap } from './DialogOverlap'
 import { useTriggerFocusControl } from './FocusTrap'
 import { useClassNames } from './useClassNames'
 
@@ -185,7 +185,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
   const classNames = useClassNames().modelessDialog
 
   return createPortal(
-    <DialogTransition isOpen={isOpen}>
+    <DialogOverlap isOpen={isOpen}>
       <Draggable
         handle={`.${classNames.header}`}
         onStart={(_, data) => setPosition({ x: data.x, y: data.y })}
@@ -210,7 +210,6 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
             height,
           }}
           ref={wrapperRef}
-          themes={theme}
           role="dialog"
           aria-labelledby={labelId}
           {...props}
@@ -248,16 +247,13 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
           </Box>
         </Layout>
       </Draggable>
-    </DialogTransition>,
+    </DialogOverlap>,
     portalParent,
   )
 }
 
-const Layout = styled.div<{ themes: Theme }>`
-  ${({ themes: { zIndex } }) => css`
-    position: fixed;
-    z-index: ${zIndex.OVERLAP};
-  `}
+const Layout = styled.div`
+  position: fixed;
 `
 const Box = styled(DialogBase).attrs({ radius: 'm' })`
   display: flex;

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -14,7 +14,7 @@ import Draggable from 'react-draggable'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useId } from '../../hooks/useId'
 import { useHandleEscape } from '../../hooks/useHandleEscape'
-import { BaseElementProps, DialogBase } from '../Base'
+import { Base, BaseElementProps } from '../Base'
 import { SecondaryButton } from '../Button'
 import { FaTimesIcon } from '../Icon'
 import { DialogOverlap } from './DialogOverlap'
@@ -255,7 +255,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
 const Layout = styled.div`
   position: fixed;
 `
-const Box = styled(DialogBase).attrs({ radius: 'm' })`
+const Box = styled(Base).attrs({ radius: 'm', layer: 3 })`
   display: flex;
   flex-direction: column;
   width: 100%;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
### 現象

`v14.3.0` において、ダイアログの開閉アニメーション時にダイアログの後ろ側に表示されるべき要素が前側に表示されることによりチラつきが発生する問題が生じています。

<details>
<summary>再現</summary>

![output](https://user-images.githubusercontent.com/270422/133199709-7499f36d-4c16-41e7-a07f-272fd27af3c1.gif)

</details>

### 原因

ダイアログのアニメーション部分の DOM 構造を変更したことに起因して、ダイアログの z-index を設定する層より `CSSTransition` を設定する層の方が親に変わっていました。 `CSSTransition` の層では `opacity` の設定によりダイアログ開閉時のアニメーションを表現していますが、アニメーション時に `opacity` が設定されることにより低いスタッキングコンテキストが発生しそちらが優先されてしまうため、結果として他の `z-index: 1` 以上を持つ要素のスタッキングコンテキストに負けてしまうことにより、アニメーションの間だけそれらの要素が前面に表示されるためチラつきが発生するようでした。

### 対策

`CSSTransition` を設定する要素に `z-index` を設定し、 `opacity` 設定により低いスタッキングコンテキストが生成されないように変更します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `DialogTransition` コンポーネントに z-index: OVERLAP_BASE を設定
- `DialogTransition` コンポーネントが重なりの責務を持つのは違和感があるため、命名を `DialogOverlap` に変更し、重なりの責務を主にしつつアニメーションの責務を兼務させる意味合いに変更
- 一部 deprecated なコンポーネントを使用している部分を修正
<!-- 
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
<details>
<summary>修正後</summary>

![output2](https://user-images.githubusercontent.com/270422/133200857-7bd91994-8e08-4121-bd4b-0bc213a6a9db.gif)

</details>

<!--
Please attach a capture if it looks different.
-->
