### PR TITLE
add `<Sidebar>` Component

### DIFF
--- a/src/components/Layout/Cluster/Cluster.tsx
+++ b/src/components/Layout/Cluster/Cluster.tsx
@@ -1,15 +1,10 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
-import { AbstractSize, CharRelativeSize } from '../../../themes/createSpacing'
 import { useSpacing } from '../../../hooks/useSpacing'
+import type { Gap, SeparateGap } from '../type'
 
 type alignMethod = 'normal' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
 type justifyMethod = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around'
-type Gap = CharRelativeSize | AbstractSize
-type SeparateGap = {
-  row: Gap
-  column: Gap
-}
 
 /**
  * @param gap 間隔の指定（基準フォントサイズの相対値または抽象値）

--- a/src/components/Layout/Sidebar/README.md
+++ b/src/components/Layout/Sidebar/README.md
@@ -1,0 +1,14 @@
+A Sidebar component.
+
+メインコンテンツとサイドコンテンツの2つのコンテンツをレイアウトするコンポーネントです。メインコンテンツは親要素の幅に対して可変となり、メインコンテンツが設定した最小幅以上の場合は2カラム、最小幅未満になると段落ちします。
+
+[Every LayoutのSidebar](https://every-layout.dev/layouts/sidebar/) を参考にしています。
+
+<details>
+<summary>how to import</summary>
+
+```tsx
+import { SideBar } from 'smarthr-ui'
+```
+
+</details>

--- a/src/components/Layout/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.stories.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { Story } from '@storybook/react'
+
+import { useTheme } from '../../../hooks/useTheme'
+import { Sidebar } from './Sidebar'
+
+import readme from './README.md'
+import styled, { css } from 'styled-components'
+
+export default {
+  title: 'Sidebar',
+  component: Sidebar,
+  parameters: {
+    docs: {
+      description: { component: readme },
+    },
+  },
+}
+
+export const Default: Story = () => {
+  return (
+    <div style={{ margin: '32px' }}>
+      <h1>Sidebar</h1>
+      <p>
+        メインコンテンツとサイドコンテンツの2つのコンテンツをレイアウトするコンポーネントです。メインコンテンツは親要素の幅に対して可変となり、メインコンテンツが設定した最小幅以上の場合は2カラム、最小幅未満になると段落ちします。
+      </p>
+      <Sidebar>
+        <Side>
+          <h2>サイドコンテンツ</h2>
+        </Side>
+        <Main>
+          <h2>メインコンテンツ</h2>
+          <p>
+            メインコンテンツの幅が可変で、メインコンテンツが<Code>contentsMinWidth</Code>
+            未満になると段落ちします。<Code>contentsMinWidth</Code>の幅はデフォルトで50%です。
+          </p>
+        </Main>
+      </Sidebar>
+
+      <hr style={{ margin: '32px' }} />
+
+      <Sidebar right contentsMinWidth="600px" gap={{ row: 1, column: 0 }}>
+        <Main>
+          <h2>メインコンテンツ</h2>
+          <p>
+            メインコンテンツの<Code>contentsMinWidth</Code>
+            を600pxにしています。600px未満になると段落ちします。
+            <Code>box-sizing</Code>
+            の値に注意してください。
+          </p>
+          <p>
+            メインコンテンツとサイドコンテンツの間の余白は<Code>gap</Code>プロパティで設定できます。
+            <Code>row</Code>と<Code>column</Code>
+            で別々の値を設定できるので、横並びのときは余白なし、段落ちしたら余白をとる、ということが可能です。
+          </p>
+        </Main>
+        <Side>
+          <h2>サイドコンテンツ</h2>
+          <p>
+            サイドコンテンツを右に配置するには<Code>right</Code>プロパティを
+            <Code>true</Code>
+            にします。
+          </p>
+        </Side>
+      </Sidebar>
+    </div>
+  )
+}
+
+const Main = styled.main(() => {
+  const theme = useTheme()
+  const { color, spacing } = theme
+
+  return css`
+    box-sizing: border-box;
+    padding: ${spacing.XXS} ${spacing.S};
+    border: 3px solid ${color.MAIN};
+  `
+})
+
+const Side = styled.aside(() => {
+  const theme = useTheme()
+  const { color, spacing } = theme
+
+  return css`
+    width: 300px;
+    box-sizing: border-box;
+    padding: ${spacing.XXS} ${spacing.S};
+    border: 3px solid ${color.BORDER};
+    background-color: ${color.BACKGROUND};
+  `
+})
+
+const Code = styled.code(() => {
+  const theme = useTheme()
+  const { color, radius, spacing } = theme
+
+  return css`
+    display: inline-block;
+    padding: 0 ${spacing.X3S};
+    border: 1px solid ${color.BORDER};
+    border-radius: ${radius.s};
+    background-color: ${color.BACKGROUND};
+  `
+})

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,0 +1,48 @@
+import type { CSSProperties } from 'react'
+import type { Gap, SeparateGap } from '../type'
+import styled, { css } from 'styled-components'
+import { useSpacing } from '../../../hooks/useSpacing'
+
+type Props = {
+  align?: CSSProperties['alignItems']
+  contentsMinWidth?: CSSProperties['minWidth']
+  gap?: Gap | SeparateGap
+  right?: boolean
+}
+
+export const Sidebar = styled.div<Props>(
+  ({ align = 'stretch', contentsMinWidth = '50%', gap = 1, right }) => {
+    const isGapSeparate = gap instanceof Object
+    const gapValue = isGapSeparate
+      ? css`
+          row-gap: ${useSpacing(gap.row)};
+          column-gap: ${useSpacing(gap.column)};
+        `
+      : css`
+          gap: ${useSpacing(gap)};
+        `
+    const sidebarValue = css`
+      flex-grow: 1;
+    `
+    const mainContentsValue = css`
+      flex-basis: 0;
+      flex-grow: 999;
+      min-width: ${contentsMinWidth};
+    `
+
+    return css`
+      display: flex;
+      flex-wrap: wrap;
+      align-items: ${align};
+      ${gapValue}
+
+      & > *:last-child {
+        ${right ? sidebarValue : mainContentsValue}
+      }
+
+      & > *:first-child {
+        ${right ? mainContentsValue : sidebarValue}
+      }
+    `
+  },
+)

--- a/src/components/Layout/Sidebar/index.ts
+++ b/src/components/Layout/Sidebar/index.ts
@@ -1,0 +1,1 @@
+export { Sidebar } from './Sidebar'

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,3 +1,4 @@
 export { Stack } from './Stack'
 export { LineUp } from './LineUp'
 export { Cluster } from './Cluster'
+export { Sidebar } from './Sidebar'

--- a/src/components/Layout/type.ts
+++ b/src/components/Layout/type.ts
@@ -1,0 +1,7 @@
+import { AbstractSize, CharRelativeSize } from '../../themes/createSpacing'
+
+export type Gap = CharRelativeSize | AbstractSize
+export type SeparateGap = {
+  row: Gap
+  column: Gap
+}


### PR DESCRIPTION
## Related URL

- [The Sidebar: Every Layout](https://every-layout.dev/layouts/sidebar/)

## Overview

add `<Sidebar>` component via Every Layout The Sidebar

## What I did

- add Layout `Gap` type
- add `<Sidebar>` component

## Capture

[📕 Sidebar Story](https://deploy-preview-1888--smarthr-ui.netlify.app/?path=/story/sidebar--default)

<img width="984" alt="画面幅ひろいときのスクショ" src="https://user-images.githubusercontent.com/6724665/133366826-2f941530-ea22-43e5-b9c8-4846a4f478a4.png">

<img width="665" alt="画面幅せまいときのスクショ" src="https://user-images.githubusercontent.com/6724665/133366869-21328150-e29a-4832-a608-e37f2d567a80.png">
