### PR TITLE
feat: 各種 Dialog を body 直下以外からも生成できるようにする｜SHRUI-474

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -6,10 +6,11 @@ import { ActionDialogContentInner, ActionDialogContentInnerProps } from './Actio
 
 type Props = ActionDialogContentInnerProps & {
   onClickClose: () => void
+  portalParent?: HTMLElement
 } & Pick<
     DialogContentInnerProps,
     'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
-  > & { portalParent?: HTMLElement }
+  >
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const ActionDialog: React.VFC<Props & ElementProps> = ({
@@ -25,16 +26,17 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   actionDisabled = false,
   closeDisabled,
   className = '',
-  portalParent = document.body,
+  portalParent,
   ...props
 }) => {
   const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    portalParent.appendChild(portalContainer)
-
+    // SSR を考慮し、useEffect 内で初期値 document.body を指定
+    const pp = portalParent || document.body
+    pp.appendChild(portalContainer)
     return () => {
-      portalParent.removeChild(portalContainer)
+      pp.removeChild(portalContainer)
     }
   }, [portalContainer, portalParent])
 

--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -8,16 +8,8 @@ type Props = ActionDialogContentInnerProps & {
   onClickClose: () => void
 } & Pick<
     DialogContentInnerProps,
-    | 'isOpen'
-    | 'onClickOverlay'
-    | 'onPressEscape'
-    | 'top'
-    | 'right'
-    | 'bottom'
-    | 'left'
-    | 'id'
-    | 'portalParent'
-  >
+    'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
+  > & { portalParent?: HTMLElement }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const ActionDialog: React.VFC<Props & ElementProps> = ({
@@ -39,10 +31,6 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    if (!portalParent) {
-      return
-    }
-
     portalParent.appendChild(portalContainer)
 
     return () => {

--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -8,7 +8,15 @@ type Props = ActionDialogContentInnerProps & {
   onClickClose: () => void
 } & Pick<
     DialogContentInnerProps,
-    'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
+    | 'isOpen'
+    | 'onClickOverlay'
+    | 'onPressEscape'
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'left'
+    | 'id'
+    | 'portalParent'
   >
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
@@ -25,17 +33,22 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   actionDisabled = false,
   closeDisabled,
   className = '',
+  portalParent = document.body,
   ...props
 }) => {
-  const element = useRef(document.createElement('div')).current
+  const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    document.body.appendChild(element)
+    if (!portalParent) {
+      return
+    }
+
+    portalParent.appendChild(portalContainer)
 
     return () => {
-      document.body.removeChild(element)
+      portalParent.removeChild(portalContainer)
     }
-  }, [element])
+  }, [portalContainer, portalParent])
 
   const handleClickClose = useCallback(() => {
     if (!props.isOpen) {
@@ -68,6 +81,6 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
         {children}
       </ActionDialogContentInner>
     </DialogContentInner>,
-    element,
+    portalContainer,
   )
 }

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -664,7 +664,7 @@ export const Body以外のPortalParent: Story = () => {
         id="portal-default"
         ariaLabel="Dialog"
         data-test="dialog-content"
-        portalParent={portalParentRef.current as HTMLElement}
+        portalParent={portalParentRef.current || undefined}
       >
         <Title themes={themes}>Dialog</Title>
         <Content>
@@ -691,7 +691,7 @@ export const Body以外のPortalParent: Story = () => {
         onPressEscape={onClickClose}
         id="portal-action"
         data-test="dialog-content"
-        portalParent={portalParentRef.current as HTMLElement}
+        portalParent={portalParentRef.current || undefined}
       >
         <Content>
           <p>ActionDialog を近接要素に生成しています</p>
@@ -707,7 +707,7 @@ export const Body以外のPortalParent: Story = () => {
         onPressEscape={onClickClose}
         id="portal-message"
         data-test="dialog-content"
-        portalParent={portalParentRef.current as HTMLElement}
+        portalParent={portalParentRef.current || undefined}
       />
       <ModelessDialog
         isOpen={isOpen === 'modeless'}
@@ -715,7 +715,7 @@ export const Body以外のPortalParent: Story = () => {
         onClickClose={onClickClose}
         onPressEscape={onClickClose}
         id="portal-modeless"
-        portalParent={portalParentRef.current as HTMLElement}
+        portalParent={portalParentRef.current || undefined}
       >
         <Content>
           <p>ModelessDialog を近接要素に生成しています。</p>

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from '@storybook/react'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
 
@@ -611,6 +611,117 @@ export const RegOpenedModeless: Story = () => {
         {dummyText}
       </div>
     </ModelessDialog>
+  )
+}
+
+export const Body以外のPortalParent: Story = () => {
+  const [isOpen, setIsOpen] = useState<'deault' | 'actiion' | 'message' | 'modeless'>()
+  const onClickOpen = (type: 'deault' | 'actiion' | 'message' | 'modeless') => setIsOpen(type)
+  const onClickClose = () => setIsOpen(undefined)
+  const portalParentRef = useRef<HTMLDivElement>(null)
+  const themes = useTheme()
+
+  return (
+    <div ref={portalParentRef}>
+      <Stack align="flex-start">
+        <SecondaryButton
+          onClick={() => onClickOpen('deault')}
+          aria-haspopup="dialog"
+          aria-controls="portal-default"
+          data-test="dialog-trigger"
+        >
+          Dialog を開く
+        </SecondaryButton>
+        <SecondaryButton
+          onClick={() => onClickOpen('actiion')}
+          aria-haspopup="dialog"
+          aria-controls="portal-action"
+          data-test="dialog-trigger"
+        >
+          ActionDialog を開く
+        </SecondaryButton>
+        <SecondaryButton
+          onClick={() => onClickOpen('message')}
+          aria-haspopup="dialog"
+          aria-controls="portal-message"
+          data-test="dialog-trigger"
+        >
+          MessageDialog を開く
+        </SecondaryButton>
+        <SecondaryButton
+          onClick={() => onClickOpen('modeless')}
+          aria-haspopup="dialog"
+          aria-controls="portal-modeless"
+        >
+          ModelessDialog を開く
+        </SecondaryButton>
+      </Stack>
+
+      <Dialog
+        isOpen={isOpen === 'deault'}
+        onClickOverlay={onClickClose}
+        onPressEscape={onClickClose}
+        id="portal-default"
+        ariaLabel="Dialog"
+        data-test="dialog-content"
+        portalParent={portalParentRef.current as HTMLElement}
+      >
+        <Title themes={themes}>Dialog</Title>
+        <Content>
+          <p>Dialog を近接要素に生成しています。</p>
+        </Content>
+        <Footer themes={themes}>
+          <SecondaryButton onClick={onClickClose} data-test="dialog-closer">
+            閉じる
+          </SecondaryButton>
+        </Footer>
+      </Dialog>
+      <ActionDialog
+        isOpen={isOpen === 'actiion'}
+        title="ActionDialog"
+        closeText="閉じる"
+        actionText="実行"
+        actionTheme="primary"
+        onClickAction={(closeDialog) => {
+          action('executed')()
+          closeDialog()
+        }}
+        onClickClose={onClickClose}
+        onClickOverlay={onClickClose}
+        onPressEscape={onClickClose}
+        id="portal-action"
+        data-test="dialog-content"
+        portalParent={portalParentRef.current as HTMLElement}
+      >
+        <Content>
+          <p>ActionDialog を近接要素に生成しています</p>
+        </Content>
+      </ActionDialog>
+      <MessageDialog
+        isOpen={isOpen === 'message'}
+        title="MessageDialog"
+        description={<p>MessageDialog を近接要素に生成しています</p>}
+        closeText="閉じる"
+        onClickClose={onClickClose}
+        onClickOverlay={onClickClose}
+        onPressEscape={onClickClose}
+        id="portal-message"
+        data-test="dialog-content"
+        portalParent={portalParentRef.current as HTMLElement}
+      />
+      <ModelessDialog
+        isOpen={isOpen === 'modeless'}
+        header={<ModelessHeading>ModelessDialog</ModelessHeading>}
+        onClickClose={onClickClose}
+        onPressEscape={onClickClose}
+        id="portal-modeless"
+        portalParent={portalParentRef.current as HTMLElement}
+      >
+        <Content>
+          <p>ModelessDialog を近接要素に生成しています。</p>
+        </Content>
+      </ModelessDialog>
+    </div>
   )
 }
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -5,21 +5,30 @@ import { DialogContentInner, DialogContentInnerProps } from './DialogContentInne
 type Props = DialogContentInnerProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const Dialog: React.VFC<Props & ElementProps> = ({ children, className = '', ...props }) => {
-  const element = useRef(document.createElement('div')).current
+export const Dialog: React.VFC<Props & ElementProps> = ({
+  children,
+  className = '',
+  portalParent = document.body,
+  ...props
+}) => {
+  const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    document.body.appendChild(element)
+    if (!portalParent) {
+      return
+    }
+
+    portalParent.appendChild(portalContainer)
 
     return () => {
-      document.body.removeChild(element)
+      portalParent.removeChild(portalContainer)
     }
-  }, [element])
+  }, [portalContainer, portalParent])
 
   return createPortal(
     <DialogContentInner className={className} {...props}>
       {children}
     </DialogContentInner>,
-    element,
+    portalContainer,
   )
 }

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -8,16 +8,17 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 export const Dialog: React.VFC<Props & ElementProps> = ({
   children,
   className = '',
-  portalParent = document.body,
+  portalParent,
   ...props
 }) => {
   const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    portalParent.appendChild(portalContainer)
-
+    // SSR を考慮し、useEffect 内で初期値 document.body を指定
+    const pp = portalParent || document.body
+    pp.appendChild(portalContainer)
     return () => {
-      portalParent.removeChild(portalContainer)
+      pp.removeChild(portalContainer)
     }
   }, [portalContainer, portalParent])
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
 
-type Props = DialogContentInnerProps
+type Props = DialogContentInnerProps & { portalParent?: HTMLElement }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const Dialog: React.VFC<Props & ElementProps> = ({
@@ -14,10 +14,6 @@ export const Dialog: React.VFC<Props & ElementProps> = ({
   const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    if (!portalParent) {
-      return
-    }
-
     portalParent.appendChild(portalContainer)
 
     return () => {

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -51,6 +51,10 @@ export type DialogContentInnerProps = {
    */
   ariaLabelledby?: string
   /**
+   * ポータルの container となる DOM 要素を追加する親要素
+   */
+  portalParent?: HTMLElement
+  /**
    * `className` of the component.
    */
   className?: string

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -51,10 +51,6 @@ export type DialogContentInnerProps = {
    */
   ariaLabelledby?: string
   /**
-   * ポータルの container となる DOM 要素を追加する親要素
-   */
-  portalParent?: HTMLElement
-  /**
    * `className` of the component.
    */
   className?: string

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -21,16 +21,17 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
   closeText,
   onClickClose,
   className = '',
-  portalParent = document.body,
+  portalParent,
   ...props
 }) => {
   const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    portalParent.appendChild(portalContainer)
-
+    // SSR を考慮し、useEffect 内で初期値 document.body を指定
+    const pp = portalParent || document.body
+    pp.appendChild(portalContainer)
     return () => {
-      portalParent.removeChild(portalContainer)
+      pp.removeChild(portalContainer)
     }
   }, [portalContainer, portalParent])
 

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -10,7 +10,15 @@ import {
 type Props = MessageDialogContentInnerProps &
   Pick<
     DialogContentInnerProps,
-    'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
+    | 'isOpen'
+    | 'onClickOverlay'
+    | 'onPressEscape'
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'left'
+    | 'id'
+    | 'portalParent'
   >
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
@@ -21,17 +29,22 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
   closeText,
   onClickClose,
   className = '',
+  portalParent = document.body,
   ...props
 }) => {
-  const element = useRef(document.createElement('div')).current
+  const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    document.body.appendChild(element)
+    if (!portalParent) {
+      return
+    }
+
+    portalParent.appendChild(portalContainer)
 
     return () => {
-      document.body.removeChild(element)
+      portalParent.removeChild(portalContainer)
     }
-  }, [element])
+  }, [portalContainer, portalParent])
 
   const handleClickClose = useCallback(() => {
     if (!props.isOpen) {
@@ -50,6 +63,6 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
         onClickClose={handleClickClose}
       />
     </DialogContentInner>,
-    element,
+    portalContainer,
   )
 }

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -10,16 +10,8 @@ import {
 type Props = MessageDialogContentInnerProps &
   Pick<
     DialogContentInnerProps,
-    | 'isOpen'
-    | 'onClickOverlay'
-    | 'onPressEscape'
-    | 'top'
-    | 'right'
-    | 'bottom'
-    | 'left'
-    | 'id'
-    | 'portalParent'
-  >
+    'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
+  > & { portalParent?: HTMLElement }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const MessageDialog: React.VFC<Props & ElementProps> = ({
@@ -35,10 +27,6 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
   const portalContainer = useRef(document.createElement('div')).current
 
   useEffect(() => {
-    if (!portalParent) {
-      return
-    }
-
     portalParent.appendChild(portalContainer)
 
     return () => {

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -89,7 +89,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
   left,
   right,
   bottom,
-  portalParent = document.body,
+  portalParent,
   className = '',
   ...props
 }) => {
@@ -106,9 +106,11 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
   const theme = useTheme()
 
   useEffect(() => {
-    portalParent.appendChild(portalContainer)
+    // SSR を考慮し、useEffect 内で初期値 document.body を指定
+    const pp = portalParent || document.body
+    pp.appendChild(portalContainer)
     return () => {
-      portalParent.removeChild(portalContainer)
+      pp.removeChild(portalContainer)
     }
   }, [portalContainer, portalParent])
 

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -70,6 +70,10 @@ type Props = {
    * ダイアログを開いたときの初期 bottom 位置
    */
   bottom?: string | number
+  /**
+   * ポータルの container となる DOM 要素を追加する親要素
+   */
+  portalParent?: HTMLElement
 }
 
 export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
@@ -85,10 +89,11 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
   left,
   right,
   bottom,
+  portalParent = document.body,
   className = '',
   ...props
 }) => {
-  const portalParent = useRef(document.createElement('div')).current
+  const portalContainer = useRef(document.createElement('div')).current
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [centering, setCentering] = useState<{
     top?: number
@@ -101,11 +106,15 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
   const theme = useTheme()
 
   useEffect(() => {
-    document.body.appendChild(portalParent)
-    return () => {
-      document.body.removeChild(portalParent)
+    if (!portalParent) {
+      return
     }
-  }, [portalParent])
+
+    portalParent.appendChild(portalContainer)
+    return () => {
+      portalParent.removeChild(portalContainer)
+    }
+  }, [portalContainer, portalParent])
 
   useHandleEscape(
     useCallback(() => {
@@ -248,7 +257,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
         </Layout>
       </Draggable>
     </DialogOverlap>,
-    portalParent,
+    portalContainer,
   )
 }
 

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -106,10 +106,6 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
   const theme = useTheme()
 
   useEffect(() => {
-    if (!portalParent) {
-      return
-    }
-
     portalParent.appendChild(portalContainer)
     return () => {
       portalParent.removeChild(portalContainer)


### PR DESCRIPTION
決め打ちで `document.body` に生える各種ダイアログにポータルの親要素として `portalParent: HTMLElement` を渡せるようにしました。
デフォルトは `document.body` なので、今までと挙動は変わりません。

ちなみに [Fullscreen API](https://developer.mozilla.org/ja/docs/Web/API/Fullscreen_API) を使うにあたって、特定の要素をフルスクリーンにし、かつフルスクリーン内でダイアログを出したい場合に、`body` 直下では実現が面倒なのが発端です。