### PR TITLE
chore: reg と e2e の CI 改善

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,12 @@ commands:
           fi
       - restore_cache:
           keys:
-            - dependencies-reg-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
-            - modules-cache-
+            - yarn-packages-reg-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
       - save_cache:
           paths:
-            - node_modules
-          key: dependencies-reg-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+            - ~/.cache/yarn
+          key: yarn-packages-reg-{{ checksum "yarn.lock" }}
       - run: yarn test-visual
   install-noto-sans-cjk-jp:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,12 +80,20 @@ jobs:
       - run-npm-test
   reg-suit:
     docker:
-      - image: regviz/node-xcb
+      - image: circleci/node:14
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
     working_directory: ~/repo
     steps:
+      - run:
+          name: Install System Dependencies
+          command: |
+            sudo apt-get update -y && sudo apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
+            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
+            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
       - install-noto-sans-cjk-jp
       - run-reg-suit
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "ts-loader": "^9.2.5",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.3",
-    "wait-for-localhost": "^3.3.0",
     "webpack": "^5.53.0"
   },
   "peerDependencies": {

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -1,34 +1,30 @@
 import { spawn, spawnSync } from 'child_process'
-import waitForLocalhost from 'wait-for-localhost'
-;(async () => {
-  const PORT = 6006
 
-  const buildSpawn = spawnSync('yarn', ['run', 'build-storybook', '--quiet'], {
+const PORT = 6006
+
+const buildSpawn = spawnSync('yarn', ['run', 'build-storybook', '--quiet'], {
+  stdio: 'inherit',
+  shell: true,
+})
+if (buildSpawn.status !== 0) {
+  process.exit(1)
+}
+const httpServer = spawn(
+  'yarn',
+  ['http-server', 'storybook-static', '--port', `${PORT}`, '--silent'],
+  {
     stdio: 'inherit',
     shell: true,
-  })
-  if (buildSpawn.status !== 0) {
-    process.exit(1)
-  }
-  const httpServer = spawn(
-    'yarn',
-    ['http-server', 'storybook-static', '--port', `${PORT}`, '--silent'],
-    {
-      stdio: 'inherit',
-      shell: true,
-    },
-  )
+  },
+)
 
-  await waitForLocalhost({ port: PORT, path: '/iframe.html' })
-
-  const browser = process.env.TESTCAFE_BROWSER || 'chrome'
-  const testcafeArgs = `"e2e/**/*.test.ts" --host localhost --skip-js-errors`
-  const testcafe = spawn('yarn', ['run', 'testcafe', browser, ...testcafeArgs.split(' ')], {
-    stdio: 'inherit',
-    shell: true,
-  })
-  testcafe.on('close', (code) => {
-    httpServer.kill()
-    process.exit(code || undefined)
-  })
-})()
+const browser = process.env.TESTCAFE_BROWSER || 'chrome'
+const testcafeArgs = `"e2e/**/*.test.ts" --host localhost --skip-js-errors`
+const testcafe = spawn('yarn', ['run', 'testcafe', browser, ...testcafeArgs.split(' ')], {
+  stdio: 'inherit',
+  shell: true,
+})
+testcafe.on('close', (code) => {
+  httpServer.kill()
+  process.exit(code || undefined)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -16609,11 +16609,6 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
-wait-for-localhost@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/wait-for-localhost/-/wait-for-localhost-3.3.0.tgz#aa3df1aeb7067a29630683a42e06515d18006061"
-  integrity sha512-/9FDq1qaRXfFwVpRSDiybxHSt6TakGscBqyhO3tsPB1ToRVyjOXVSI2IvW1T04MqM2Mq3a+6J8PdzAlscrCQzg==
-
 wait-on@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"


### PR DESCRIPTION
## Related URL
#1808 
#1853 
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`reg-suit` を CI で実行するための docker image `regviz/node-xcb` の node のバージョンが古い問題に対処します。

### Docker Image について

docker image を新しく作って docker hub に上げることは出来ますが、そうするとその image を保守する必要が出てきてしまいます。そこで、 image は Circle CI 公式の `circleci/node:14` ものを使いつつ、ジョブ内で必要な依存を追加する方法を試しました。
インストール分だけ実行時間が増えてしまうと予想していましたが、結果として image を準備する時間が `circleci/node:14` の方が早いため、掛かる時間は差し引きゼロという感じで、問題なさそうです。

### `wait-for-localhost` が `ERR_REQUIRE_ESM` で動かない問題

`wait-for-localhost` のバージョンが上がると ESM になるため発生しますが、そもそも `wait-for-localhost` が無くても e2e は動くようなので削除しました。おそらく、 `testcafe` がいい感じに待ってくれているものと思われます。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- e2e の CI の image を `circleci/node:14` に変更して、必要な依存をインストールするように変更
- e2e の CI のキャッシュ対象を変更
- e2e のスクリプトから `wait-for-localhost` を削除
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
