### PR TITLE
feat!: Button のスタイリングを見直す｜SHRUI-427

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -3,7 +3,6 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { hoverable } from '../../hocs/hoverable'
-import { isTouchDevice } from '../../libs/ua'
 
 type Tag = 'button' | 'a'
 
@@ -77,62 +76,46 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { radius, fontSize, spacingByChar, interaction, shadow } = themes
+    const { radius, fontSize, leading, spacingByChar, shadow } = themes
 
     return css`
+      box-sizing: border-box;
+      cursor: pointer;
       display: inline-flex;
       justify-content: center;
       align-items: center;
-      width: ${wide ? '100%;' : 'auto'};
-      min-width: 2rem;
-      vertical-align: middle;
-      border-radius: ${radius.m};
-      font-family: inherit;
-      font-weight: bold;
       text-align: center;
-      text-decoration: none;
-      box-sizing: border-box;
-      cursor: pointer;
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       white-space: nowrap;
+      border-radius: ${radius.m};
 
-      &.default {
-        font-size: ${fontSize.M};
-        height: 40px;
-        padding: 0 ${spacingByChar(1)};
-      }
+      /* ボタンの高さを合わせるために指定 */
+      border: 1px solid transparent;
+
+      /* disabled で alpha color を使用しているので、背景色が影響しないように指定 */
+      background-clip: padding-box;
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
+      font-family: inherit;
+      font-size: ${fontSize.M};
+      font-weight: bold;
+      line-height: ${leading.NORMAL};
+      ${wide && 'width: 100%;'}
 
       &.s {
+        padding: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
         font-size: ${fontSize.S};
-        height: 27px;
-        padding: 0 ${spacingByChar(0.5)};
       }
 
       &.square {
-        width: 40px;
-        padding: 0;
+        padding: ${spacingByChar(0.75)};
 
         &.s {
-          width: 27px;
-          min-width: 27px;
+          /* fontSize.S（1rem * (6 / 7)) の調和数列分だけ調整する */
+          padding: calc(${spacingByChar(0.5)} * (6 / 7));
         }
       }
 
       &[disabled] {
         cursor: not-allowed;
-      }
-
-      &.suffix {
-        justify-content: space-between;
-      }
-
-      &.prefix {
-        justify-content: left;
-      }
-
-      &:hover,
-      &:focus {
-        text-decoration: none;
       }
 
       &:focus {
@@ -167,6 +150,8 @@ export const BaseButton: VFC<ButtonProps> = buttonFactory<ButtonProps>('button')
 
 const AnchorButton: VFC<AnchorProps> = buttonFactory<AnchorProps>('a')
 export const BaseButtonAnchor = styled(AnchorButton)`
+  text-decoration: none;
+
   &:not([href]) {
     cursor: not-allowed;
   }

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -107,6 +107,7 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
 
       &.square {
         padding: ${spacingByChar(0.75)};
+        line-height: ${leading.NONE};
 
         &.s {
           /* fontSize.S（1rem * (6 / 7)) の調和数列分だけ調整する */

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -87,33 +87,33 @@ function renderButtons(
       <dt>Default</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button onClick={action('clicked')}>ボタン</Button>
-            <Button prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button disabled onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button disabled prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button disabled suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button disabled square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
@@ -123,45 +123,35 @@ function renderButtons(
       <dt>Small</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" prefix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Button size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" suffix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Button size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button disabled size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button
-              disabled
-              size="s"
-              prefix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Button disabled size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button
-              disabled
-              size="s"
-              suffix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Button disabled size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button disabled size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
@@ -204,33 +194,33 @@ function renderAnchors(
       <dt>Default</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor href="#" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor href="#" prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor href="#" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor href="#" suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor href="#" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor href="#" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor onClick={action('clicked')}>ボタン</Anchor>
-            <Anchor prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>
@@ -240,45 +230,35 @@ function renderAnchors(
       <dt>Small</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor size="s" href="#" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor
-              size="s"
-              href="#"
-              prefix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Anchor size="s" href="#" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor
-              size="s"
-              href="#"
-              suffix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Anchor size="s" href="#" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor size="s" href="#" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor size="s" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" prefix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Anchor size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" suffix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Anchor size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -36,15 +35,15 @@ export const DangerButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props 
 
 const dangerStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
-      color: ${color.TEXT_WHITE};
-      border: none;
+      border-color: ${color.DANGER};
       background-color: ${color.DANGER};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      color: ${color.TEXT_WHITE};
 
       &.hover {
+        border-color: ${color.hoverColor(color.DANGER)};
         background-color: ${color.hoverColor(color.DANGER)};
       }
     `
@@ -52,6 +51,7 @@ const dangerStyle = css`
 `
 const disabledStyle = css`
   ${({ themes: { color } }: { themes: Theme }) => css`
+    border-color: ${color.disableColor(color.DANGER)};
     background-color: ${color.disableColor(color.DANGER)};
     color: ${color.disableColor(color.TEXT_WHITE)};
   `}

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -44,24 +43,24 @@ PrimaryButtonAnchor.displayName = 'PrimaryButtonAnchor'
 
 const primaryStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
-      color: ${color.TEXT_WHITE};
-      border: none;
+      border-color: ${color.MAIN};
       background-color: ${color.MAIN};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
+      color: ${color.TEXT_WHITE};
 
       &.hover,
       &:focus {
+        border-color: ${color.hoverColor(color.MAIN)};
         background-color: ${color.hoverColor(color.MAIN)};
-        color: ${color.TEXT_WHITE};
       }
     `
   }}
 `
 const disabledStyle = css`
   ${({ themes: { color } }: { themes: Theme }) => css`
+    border-color: ${color.disableColor(color.MAIN)};
     background-color: ${color.disableColor(color.MAIN)};
     color: ${color.disableColor(color.TEXT_WHITE)};
   `}

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -46,12 +45,11 @@ SecondaryButtonAnchor.displayName = 'SecondaryButtonAnchor'
 
 const secondaryStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction, border } = themes
+    const { color, border } = themes
 
     return css`
       background-color: ${color.WHITE};
       color: ${color.TEXT_BLACK};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       border: ${border.shorthand};
 
       &.hover,

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -36,12 +35,11 @@ export const SkeletonButtonAnchor: VFC<AnchorProps> = ({ className = '', ...prop
 
 const skeletonStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction, border } = themes
+    const { color, border } = themes
 
     return css`
       background-color: transparent;
       color: ${color.TEXT_WHITE};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       border: ${border.lineWidth} ${border.lineStyle} ${color.WHITE};
 
       &.hover,

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import {
@@ -44,12 +43,11 @@ export const TextButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props })
 
 const textStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction, border } = themes
+    const { color, border } = themes
 
     return css`
       background-color: transparent;
       color: ${color.TEXT_BLACK};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       border: ${border.lineWidth} ${border.lineStyle} transparent;
 
       &.hover,


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-427

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

ボタンの height が固定指定になっていたので、font-size * line-height + padding + border の積み上げでサイズが定まるようにしました。
ついでに全体的にスタイリングを見直しました。

## 標準フォントサイズを 16px とした時の各ボタンサイズ

以下は Chrome でのサイズです。ブラウザに依って計算値の丸め方が異なるので誤差あります。
また、`Input` のスタイリングを見直す場合に調整する可能性があります。

\- | 既存 | 修正後
--- | --- | ---
`.default` | 40px | 42px
`.s` | 27px | 30px
`.square` | 40px | 42px
`.square.s` | 27px | 29.39px