### PR TITLE
feat!: Button の width / height の固定値をやめる｜SHRUI-427 

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -3,7 +3,6 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { hoverable } from '../../hocs/hoverable'
-import { isTouchDevice } from '../../libs/ua'
 
 type Tag = 'button' | 'a'
 
@@ -77,7 +76,7 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { border, fontSize, interaction, leading, radius, shadow, spacingByChar } = themes
+    const { border, fontSize, leading, radius, shadow, spacingByChar } = themes
 
     return css`
       box-sizing: border-box;
@@ -97,8 +96,6 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       font-weight: bold;
       line-height: ${leading.NONE};
       ${wide && 'width: 100%;'}
-
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &.square {
         padding: ${spacingByChar(0.75)};

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -77,14 +77,13 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { radius, fontSize, spacingByChar, interaction, shadow } = themes
+    const { radius, fontSize, leading, spacingByChar, interaction, shadow } = themes
 
     return css`
       display: inline-flex;
       justify-content: center;
       align-items: center;
       width: ${wide ? '100%;' : 'auto'};
-      min-width: 2rem;
       vertical-align: middle;
       border-radius: ${radius.m};
       font-family: inherit;
@@ -96,30 +95,29 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       white-space: nowrap;
 
+      /* ボタンの高さを合わせるために指定 */
+      border: 1px solid transparent;
+      line-height: ${leading.NONE};
+
       &.default {
         font-size: ${fontSize.M};
-        height: 40px;
-        padding: 0 ${spacingByChar(1)};
+        padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
+      }
+
+      &.square {
+        padding: ${spacingByChar(0.75)};
       }
 
       &.s {
         font-size: ${fontSize.S};
-        height: 27px;
-        padding: 0 ${spacingByChar(0.5)};
-      }
-
-      &.square {
-        width: 40px;
-        padding: 0;
-
-        &.s {
-          width: 27px;
-          min-width: 27px;
-        }
+        padding: ${spacingByChar(0.5)};
       }
 
       &[disabled] {
         cursor: not-allowed;
+
+        /* alpha color を使用しているので、背景色と干渉させない */
+        background-clip: padding-box;
       }
 
       &.suffix {

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -114,8 +114,7 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
       }
 
       &:focus {
-        outline: 0;
-        box-shadow: ${shadow.OUTLINE};
+        ${shadow.focusIndicatorStyles}
       }
     `
   }}

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -77,40 +77,36 @@ export const buttonFactory = <Props extends BaseProps>(tag: Tag) => {
 
 const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
   ${({ themes, wide }) => {
-    const { radius, fontSize, leading, spacingByChar, interaction, shadow } = themes
+    const { border, fontSize, interaction, leading, radius, shadow, spacingByChar } = themes
 
     return css`
+      box-sizing: border-box;
+      cursor: pointer;
       display: inline-flex;
       justify-content: center;
       align-items: center;
-      width: ${wide ? '100%;' : 'auto'};
-      vertical-align: middle;
-      border-radius: ${radius.m};
-      font-family: inherit;
-      font-weight: bold;
       text-align: center;
-      text-decoration: none;
-      box-sizing: border-box;
-      cursor: pointer;
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
       white-space: nowrap;
+      border-radius: ${radius.m};
 
       /* ボタンの高さを合わせるために指定 */
-      border: 1px solid transparent;
+      border: ${border.lineWidth} ${border.lineStyle} transparent;
+      padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
+      font-family: inherit;
+      font-size: ${fontSize.M};
+      font-weight: bold;
       line-height: ${leading.NONE};
+      ${wide && 'width: 100%;'}
 
-      &.default {
-        font-size: ${fontSize.M};
-        padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
-      }
+      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &.square {
         padding: ${spacingByChar(0.75)};
       }
 
       &.s {
-        font-size: ${fontSize.S};
         padding: ${spacingByChar(0.5)};
+        font-size: ${fontSize.S};
       }
 
       &[disabled] {
@@ -118,19 +114,6 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
 
         /* alpha color を使用しているので、背景色と干渉させない */
         background-clip: padding-box;
-      }
-
-      &.suffix {
-        justify-content: space-between;
-      }
-
-      &.prefix {
-        justify-content: left;
-      }
-
-      &:hover,
-      &:focus {
-        text-decoration: none;
       }
 
       &:focus {
@@ -165,7 +148,12 @@ export const BaseButton: VFC<ButtonProps> = buttonFactory<ButtonProps>('button')
 
 const AnchorButton: VFC<AnchorProps> = buttonFactory<AnchorProps>('a')
 export const BaseButtonAnchor = styled(AnchorButton)`
+  text-decoration: none;
+
   &:not([href]) {
     cursor: not-allowed;
+
+    /* alpha color を使用しているので、背景色と干渉させない */
+    background-clip: padding-box;
   }
 `

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -15,7 +15,7 @@ import {
   TextButton,
   TextButtonAnchor,
 } from '.'
-import { FaPlusCircleIcon } from '../Icon'
+import { FaPlusCircleIcon, FaPlusIcon, FaPlusSquareIcon } from '../Icon'
 import { AnchorProps, ButtonProps } from './BaseButton'
 import { LineUp, Stack } from '../Layout'
 
@@ -89,10 +89,10 @@ function renderButtons(
         <Stack>
           <WrapLineUp vAlign="center">
             <Button onClick={action('clicked')}>ボタン</Button>
-            <Button prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
@@ -105,10 +105,10 @@ function renderButtons(
             <Button disabled onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button disabled prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button disabled suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
@@ -127,10 +127,10 @@ function renderButtons(
             <Button size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button size="s" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
@@ -143,10 +143,10 @@ function renderButtons(
             <Button disabled size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button disabled size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Button disabled size="s" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
@@ -198,10 +198,10 @@ function renderAnchors(
             <Anchor href="#" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor href="#" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor href="#" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor href="#" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor href="#" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
@@ -212,10 +212,10 @@ function renderAnchors(
           </WrapLineUp>
           <WrapLineUp vAlign="center">
             <Anchor onClick={action('clicked')}>ボタン</Anchor>
-            <Anchor prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
@@ -234,10 +234,10 @@ function renderAnchors(
             <Anchor size="s" href="#" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" href="#" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor size="s" href="#" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" href="#" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor size="s" href="#" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
@@ -250,10 +250,10 @@ function renderAnchors(
             <Anchor size="s" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
+            <Anchor size="s" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -87,33 +87,33 @@ function renderButtons(
       <dt>Default</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button onClick={action('clicked')}>ボタン</Button>
-            <Button prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button disabled onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button disabled prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Button disabled suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button disabled square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
@@ -123,45 +123,35 @@ function renderButtons(
       <dt>Small</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" prefix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Button size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" suffix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Button size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Button disabled size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button
-              disabled
-              size="s"
-              prefix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Button disabled size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button
-              disabled
-              size="s"
-              suffix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Button disabled size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
               <Button disabled size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
@@ -204,33 +194,33 @@ function renderAnchors(
       <dt>Default</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor href="#" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor href="#" prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor href="#" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor href="#" suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor href="#" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor href="#" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor onClick={action('clicked')}>ボタン</Anchor>
-            <Anchor prefix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor suffix={<FaPlusCircleIcon size={14} />} onClick={action('clicked')}>
+            <Anchor suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={16} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>
@@ -240,45 +230,35 @@ function renderAnchors(
       <dt>Small</dt>
       <dd>
         <Stack>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor size="s" href="#" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor
-              size="s"
-              href="#"
-              prefix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Anchor size="s" href="#" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor
-              size="s"
-              href="#"
-              suffix={<FaPlusCircleIcon size={11} />}
-              onClick={action('clicked')}
-            >
+            <Anchor size="s" href="#" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor size="s" href="#" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>
-          <WrapLineUp>
+          <WrapLineUp vAlign="center">
             <Anchor size="s" onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" prefix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Anchor size="s" prefix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
-            <Anchor size="s" suffix={<FaPlusCircleIcon size={11} />} onClick={action('clicked')}>
+            <Anchor size="s" suffix={<FaPlusCircleIcon />} onClick={action('clicked')}>
               ボタン
             </Anchor>
             {!noSquare && (
               <Anchor size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon size={13} visuallyHiddenText="プラスボタン" />
+                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Anchor>
             )}
           </WrapLineUp>

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -36,13 +35,12 @@ export const DangerButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props 
 
 const dangerStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
       border-color: ${color.DANGER};
       background-color: ${color.DANGER};
       color: ${color.TEXT_WHITE};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &:focus,
       &:hover {

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -39,12 +39,13 @@ const dangerStyle = css`
     const { color, interaction } = themes
 
     return css`
-      color: ${color.TEXT_WHITE};
       border-color: ${color.DANGER};
       background-color: ${color.DANGER};
+      color: ${color.TEXT_WHITE};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
-      &.hover {
+      &:focus,
+      &:hover {
         border-color: ${color.hoverColor(color.DANGER)};
         background-color: ${color.hoverColor(color.DANGER)};
       }

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -40,11 +40,12 @@ const dangerStyle = css`
 
     return css`
       color: ${color.TEXT_WHITE};
-      border: none;
+      border-color: ${color.DANGER};
       background-color: ${color.DANGER};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &.hover {
+        border-color: ${color.hoverColor(color.DANGER)};
         background-color: ${color.hoverColor(color.DANGER)};
       }
     `
@@ -52,6 +53,7 @@ const dangerStyle = css`
 `
 const disabledStyle = css`
   ${({ themes: { color } }: { themes: Theme }) => css`
+    border-color: ${color.disableColor(color.DANGER)};
     background-color: ${color.disableColor(color.DANGER)};
     color: ${color.disableColor(color.TEXT_WHITE)};
   `}

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -44,13 +43,12 @@ PrimaryButtonAnchor.displayName = 'PrimaryButtonAnchor'
 
 const primaryStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
       border-color: ${color.MAIN};
       background-color: ${color.MAIN};
       color: ${color.TEXT_WHITE};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &:focus,
       &:hover {

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -47,13 +47,13 @@ const primaryStyle = css`
     const { color, interaction } = themes
 
     return css`
-      color: ${color.TEXT_WHITE};
       border-color: ${color.MAIN};
       background-color: ${color.MAIN};
+      color: ${color.TEXT_WHITE};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
-      &.hover,
-      &:focus {
+      &:focus,
+      &:hover {
         border-color: ${color.hoverColor(color.MAIN)};
         background-color: ${color.hoverColor(color.MAIN)};
         color: ${color.TEXT_WHITE};

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -48,12 +48,13 @@ const primaryStyle = css`
 
     return css`
       color: ${color.TEXT_WHITE};
-      border: none;
+      border-color: ${color.MAIN};
       background-color: ${color.MAIN};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &.hover,
       &:focus {
+        border-color: ${color.hoverColor(color.MAIN)};
         background-color: ${color.hoverColor(color.MAIN)};
         color: ${color.TEXT_WHITE};
       }
@@ -62,6 +63,7 @@ const primaryStyle = css`
 `
 const disabledStyle = css`
   ${({ themes: { color } }: { themes: Theme }) => css`
+    border-color: ${color.disableColor(color.MAIN)};
     background-color: ${color.disableColor(color.MAIN)};
     color: ${color.disableColor(color.TEXT_WHITE)};
   `}

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -46,13 +45,12 @@ SecondaryButtonAnchor.displayName = 'SecondaryButtonAnchor'
 
 const secondaryStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
       border-color: ${color.BORDER};
       background-color: ${color.WHITE};
       color: ${color.TEXT_BLACK};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &:focus,
       &:hover {

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -46,16 +46,17 @@ SecondaryButtonAnchor.displayName = 'SecondaryButtonAnchor'
 
 const secondaryStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction, border } = themes
+    const { color, interaction } = themes
 
     return css`
+      border-color: ${color.BORDER};
       background-color: ${color.WHITE};
       color: ${color.TEXT_BLACK};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
-      border: ${border.shorthand};
 
-      &.hover,
-      &:focus {
+      &:focus,
+      &:hover {
+        border-color: ${color.hoverColor(color.BORDER)};
         background-color: ${color.hoverColor(color.WHITE)};
         color: ${color.TEXT_BLACK};
       }
@@ -64,7 +65,8 @@ const secondaryStyle = css`
 `
 const disabledStyle = css`
   ${({ themes: { color } }: { themes: Theme }) => css`
-    background-color: ${color.COLUMN};
+    border-color: ${color.disableColor(color.BORDER)};
+    background-color: ${color.disableColor(color.WHITE)};
     color: ${color.TEXT_DISABLED};
   `}
 `

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
@@ -36,13 +35,12 @@ export const SkeletonButtonAnchor: VFC<AnchorProps> = ({ className = '', ...prop
 
 const skeletonStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
       border-color: ${color.WHITE};
       background-color: transparent;
       color: ${color.TEXT_WHITE};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &:focus,
       &:hover {

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -36,24 +36,26 @@ export const SkeletonButtonAnchor: VFC<AnchorProps> = ({ className = '', ...prop
 
 const skeletonStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction, border } = themes
+    const { color, interaction } = themes
 
     return css`
+      border-color: ${color.WHITE};
       background-color: transparent;
       color: ${color.TEXT_WHITE};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
-      border: ${border.lineWidth} ${border.lineStyle} ${color.WHITE};
 
-      &.hover,
-      &:focus {
+      &:focus,
+      &:hover {
+        border-color: ${color.hoverColor(color.WHITE)};
         background-color: ${color.OVERLAY};
-        color: ${color.TEXT_WHITE};
+        color: ${color.hoverColor(color.TEXT_WHITE)};
       }
     `
   }}
 `
 const disabledStyle = css`
   ${({ themes: { color } }: { themes: Theme }) => css`
+    border-color: ${color.disableColor(color.WHITE)};
     background-color: transparent;
     color: ${color.disableColor(color.TEXT_WHITE)};
   `}

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -44,16 +44,15 @@ export const TextButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props })
 
 const textStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction, border } = themes
+    const { color, interaction } = themes
 
     return css`
       background-color: transparent;
       color: ${color.TEXT_BLACK};
       transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
-      border: ${border.lineWidth} ${border.lineStyle} transparent;
 
-      &.hover,
-      &:focus {
+      &:focus,
+      &:hover {
         background-color: ${color.hoverColor(color.WHITE)};
         color: ${color.TEXT_BLACK};
       }

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -1,7 +1,6 @@
 import React, { VFC } from 'react'
 import styled, { css } from 'styled-components'
 
-import { isTouchDevice } from '../../libs/ua'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import {
@@ -44,12 +43,11 @@ export const TextButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props })
 
 const textStyle = css`
   ${({ themes }: { themes: Theme }) => {
-    const { color, interaction } = themes
+    const { color } = themes
 
     return css`
       background-color: transparent;
       color: ${color.TEXT_BLACK};
-      transition: ${isTouchDevice ? 'none' : `all ${interaction.hover.animation}`};
 
       &:focus,
       &:hover {

--- a/src/components/Pagination/PaginationItem.tsx
+++ b/src/components/Pagination/PaginationItem.tsx
@@ -39,16 +39,15 @@ export const ItemButton = styled(SecondaryButton).attrs({
   square: true,
   size: 's',
 })<{ themes: Theme }>`
-  ${({ themes: { color } }) =>
+  ${({ themes: { color, radius } }) =>
     css`
-      line-height: 25px;
-      border-radius: 4px;
+      border-radius: ${radius.s};
       &.active {
-        color: ${color.TEXT_WHITE};
-        background-color: ${color.MAIN};
-        border: solid 1px ${color.MAIN};
         cursor: default;
         outline: none;
+        border: 1px solid ${color.MAIN};
+        background-color: ${color.MAIN};
+        color: ${color.TEXT_WHITE};
       }
     `}
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-427

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

ボタンの height が固定指定になっていたので、font-size * line-height + padding + border の積み上げでサイズが定まるようにしました。

### transition を意図的に消しました

[SmartHR のデザイン基本原則](https://smarthr.design/foundations/) と照らし合わせたときに、無駄なアニメーションはない方が SmartHR らしいと判断しました。

参考： https://kufuinc.slack.com/archives/CGC58MW01/p1632449933127300

### その他

- Primary / Secondary に border 分の高さがなかったので追加
- Button は複数行を想定しないため `line-height: 1` としました
- 全体的に CSS を見直しました

## 標準フォントサイズを 16px とした時の各ボタンサイズ

以下は Chrome でのサイズです。ブラウザに依って計算値の丸め方が異なるので誤差あります。
（Chrome は 2021-09-25 現在 line-height 計算後の高さにおいて小数点を切り捨てるため、小サイズの Button でアイコンのあるなしで高さが異なります）

\- | 既存 | 修正後
--- | --- | ---
`.default` | 40px or 42px | 42px
`.s` | 27px | 31.7px
`.square` | 40px or 42px | 42px
`.square.s` | 27px | 31.7px