### PR TITLE
fix: display all items when refocus SingleCombobox 

### DIFF
--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -117,7 +117,13 @@ export function SingleComboBox<T>({
   const [isExpanded, setIsExpanded] = useState(false)
   const [inputValue, setInputValue] = useState('')
   const [isComposing, setIsComposing] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+
   const filteredItems = useMemo(() => {
+    if (!isEditing) {
+      return items
+    }
+
     return items
       .filter(({ label }) => {
         if (!inputValue) return true
@@ -127,7 +133,7 @@ export function SingleComboBox<T>({
         ...item,
         isSelected: selectedItem === null ? false : item.label === selectedItem.label,
       }))
-  }, [inputValue, items, selectedItem])
+  }, [inputValue, isEditing, items, selectedItem])
   const isDuplicate = items.some((item) => item.label === inputValue)
   const hasSelectableExactMatch = filteredItems.some((item) => item.label === inputValue)
   const {
@@ -145,6 +151,7 @@ export function SingleComboBox<T>({
       onSelect && onSelect(selected)
       onChangeSelected && onChangeSelected(selected)
       setIsExpanded(false)
+      setIsEditing(false)
     },
     isExpanded,
     isAddable: creatable && !!inputValue && !isDuplicate,
@@ -255,12 +262,16 @@ export function SingleComboBox<T>({
         onChange={(e) => {
           if (onChange) onChange(e)
           if (onChangeInput) onChangeInput(e)
+          if (!isEditing) setIsEditing(true)
           const { value } = e.currentTarget
           setInputValue(value)
           if (value === '') {
             onClear && onClear()
             onChangeSelected && onChangeSelected(null)
           }
+        }}
+        onBlur={() => {
+          setIsEditing(false)
         }}
         onFocus={() => {
           if (!isFocused) {


### PR DESCRIPTION
## Related URL
- https://smarthr.atlassian.net/browse/SHRUI-477

## Overview

SingleComboboxの値を変更しようとするとき、オプションが現在の値でフィルタリングされ、他のオプションが表示されない問題があった。編集中の状態を追加し、編集している時のみオプションのフィルタリングをするようにした。

When trying to change the value of a SingleCombobox, the options would be filtered by the current value and other options would not be displayed. Added editing state, so that options are filtered only when editing.

## What I did

- add `isEditing` state
- return all items when is not editing
- start isEditing when fire `onChange`
- end isEditing, when fire `onSelect` and `onBlur`

## Capture

https://deploy-preview-1922--smarthr-ui.netlify.app/?path=/story/combobox--single

<details open>
<summary>Demo animation gif</summary>
<img src="https://user-images.githubusercontent.com/6724665/134853413-05974fb9-da79-4f4d-844d-99c57cd30a40.gif" alt="選択肢を選択した後に、フォーカスを外してからもう一度フォーカスするとすべての選択肢が表示される。また文字列を編集すると文字列によりフィルタリングされるデモ" />
</details>