### PR TITLE
fix: SingleCombobox の削除ボタンが Input の suffix を使っていたため、縦位置がずれていたので修正

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -150,6 +150,7 @@ const Affix = styled.span<{ themes: Theme }>(
     flex-shrink: 0;
 
     display: flex;
+    align-items: center;
     color: ${color.TEXT_GREY};
   `,
 )


### PR DESCRIPTION
申し訳ない!
Input の改修に依ってずれていました。

before | after
--- | ---
![image](https://user-images.githubusercontent.com/19403400/134848533-4f9c4300-3f0a-4b6a-9468-2affe964ca3c.png) | ![image](https://user-images.githubusercontent.com/19403400/134848188-718cd9db-065e-44f3-a7d9-20aa8160432b.png)