### PR TITLE
chore: PR タイトル形式をチェックするワークフローを追加

### DIFF
--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -1,0 +1,19 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  conventional_commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check title
+        run: |
+          regex="^(feat|fix|docs|chore|style|refactor|perf|test)!?(\([^\)]+\))?:[[:space:]].+"
+          if [[ "${{ github.event.pull_request.title }}" =~ $regex ]]; then
+              echo OK
+          else
+              echo "::error::Pull Request のタイトルが Conventional Commits 形式にマッチしません"
+              exit 1
+          fi


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
PR タイトルが Conventional Commits 形式になっているかをチェックする GitHub Actions ワークフローを追加しました。

チェックする内容は
- 規定された接頭辞
- BREAKING CHANGE を表す `!` の有無を許容
- `(deps)` のような括弧書きの許容
- コロン + スペース + タイトル本文
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `titleCheck` ワークフローを追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
