### PR TITLE
fix: コンボボックスのドロップダウンが画面からはみ出さないようにする (SHRUI-478)

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -129,7 +129,7 @@ export function MultiComboBox<T>({
   const hasSelectableExactMatch = filteredItems.some((item) => item.label === inputValue)
   const {
     renderListBox,
-    setDropdownStyle,
+    calculateDropdownRect,
     resetActiveOptionIndex,
     handleInputKeyDown,
     listBoxRef,
@@ -175,15 +175,9 @@ export function MultiComboBox<T>({
     }
 
     if (outerRef.current) {
-      const rect = outerRef.current.getBoundingClientRect()
-
-      setDropdownStyle({
-        top: rect.top + rect.height - 2 + window.pageYOffset,
-        left: rect.left + window.pageXOffset,
-        width: outerRef.current.clientWidth,
-      })
+      calculateDropdownRect(outerRef.current)
     }
-  }, [isFocused, selectedItems, setDropdownStyle])
+  }, [calculateDropdownRect, isFocused, selectedItems])
 
   return (
     <Container

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -138,7 +138,7 @@ export function SingleComboBox<T>({
   const hasSelectableExactMatch = filteredItems.some((item) => item.label === inputValue)
   const {
     renderListBox,
-    setDropdownStyle,
+    calculateDropdownRect,
     resetActiveOptionIndex,
     handleInputKeyDown,
     listBoxRef,
@@ -190,15 +190,9 @@ export function SingleComboBox<T>({
     }
 
     if (outerRef.current) {
-      const rect = outerRef.current.getBoundingClientRect()
-
-      setDropdownStyle({
-        top: rect.top + rect.height - 2 + window.pageYOffset,
-        left: rect.left + window.pageXOffset,
-        width: outerRef.current.clientWidth,
-      })
+      calculateDropdownRect(outerRef.current)
     }
-  }, [isFocused, selectedItem, setDropdownStyle])
+  }, [calculateDropdownRect, isFocused, selectedItem])
 
   const needsClearButton = selectedItem !== null && !disabled
 

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -57,6 +57,15 @@ export function useListBox<T>({
   })
   const [activeOptionIndex, setActiveOptionIndex] = useState<number | null>(null)
 
+  const calculateDropdownRect = useCallback((triggerElement: Element) => {
+    const rect = triggerElement.getBoundingClientRect()
+    setDropdownStyle({
+      top: rect.top + rect.height - 2 + window.pageYOffset,
+      left: rect.left + window.pageXOffset,
+      width: rect.width,
+    })
+  }, [])
+
   const options: Array<Option<T>> = useMemo(() => {
     if (isAddable) {
       const addingOption = { label: inputValue, value: inputValue, isAdding: true }
@@ -262,7 +271,7 @@ export function useListBox<T>({
   }
   return {
     renderListBox,
-    setDropdownStyle,
+    calculateDropdownRect,
     resetActiveOptionIndex: () => setActiveOptionIndex(null),
     handleInputKeyDown,
     listBoxRef,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-478
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、コンボボックスのドロップダウンを表示する際は特に条件無く下側に表示しており、それ自体は body をスクロールできればアクセスは可能な状態でしたが、例えばダイアログ表示時などで body のスクロールを抑止している場合にはドロップダウンの画面からはみ出た部分にアクセスできない不具合があります。

これを解消するため、表示可能領域に合わせてドロップダウンの位置・サイズを調整する変更を行います。
ドロップダウンの表示パターンとして、以下を想定しています。

- 下側に十分なスペースがある場合は下に表示
- 下側に十分なスペースがなく、上側に十分なスペースガある場合は上に表示
- 上下に十分なスペースがなく、上側のスペース > 下側のスペースの場合は、上に縮めて表示
- 上下に十分なスペースがなく、上側のスペース <= 下側のスペースの場合は、下に縮めて表示

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- ドロップダウンの rect 計算ロジックを `useListBox` に移動
- 表示領域を考慮した rect 計算に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
### Before
- 下側がはみ出す
![image](https://user-images.githubusercontent.com/270422/135441163-70010bc0-a50d-4702-a7d4-04dc1e955546.png) 

### After
- 上側にスペースがあれば上に表示
![image](https://user-images.githubusercontent.com/270422/135441898-c600bb5d-edd4-428b-8b5e-1db45f5cc428.png)
- 上下に十分なスペースがなければリストボックス自体を小さくしてはみ出さないようにする
![image](https://user-images.githubusercontent.com/270422/135441556-27be5fac-e40b-4021-8ffc-3daf455be33a.png)

<!--
Please attach a capture if it looks different.
-->
