### PR TITLE
chore: PR タイトルチェックで先頭の角括弧表記を許容するように変更

### DIFF
--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: check title
         run: |
-          regex="^(feat|fix|docs|chore|style|refactor|perf|test)!?(\([^\)]+\))?:[[:space:]].+"
+          regex="^(\[[^]]+\][[:space:]]?)?(feat|fix|docs|chore|style|refactor|perf|test)!?(\([^\)]+\))?:[[:space:]].+"
           if [[ "${{ github.event.pull_request.title }}" =~ $regex ]]; then
               echo OK
           else


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状のチェックでは先頭に [WIP] などを付けるとエラーになってしまっていたため、許容するように変更。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 正規表現を修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
