### PR TITLE
fix: `MultiComboBox` のスタイル崩れ修正

### DIFF
--- a/src/components/ComboBox/MultiSelectedItemInner.tsx
+++ b/src/components/ComboBox/MultiSelectedItemInner.tsx
@@ -93,7 +93,7 @@ const Wrapper = styled.div<{ themes: Theme; disabled?: boolean }>`
 const ItemLabel = styled.div<{ enableEllipsis?: boolean; themes: Theme }>`
   ${({ enableEllipsis, themes: { border, spacingByChar } }) => {
     return css`
-      flex: 1;
+      flex: 1 1 0;
       padding: calc(${spacingByChar(0.5)} - ${border.lineWidth});
 
       ${enableEllipsis &&
@@ -108,7 +108,7 @@ const ItemLabel = styled.div<{ enableEllipsis?: boolean; themes: Theme }>`
 const DeleteButton = styled(UnstyledButton)<{ themes: Theme; disabled?: boolean }>`
   ${({ themes: { border, spacingByChar, shadow }, disabled }) => {
     return css`
-      flex: 0;
+      flex: 0 1 0;
       padding: calc(${spacingByChar(0.5)} - ${border.lineWidth});
       border-radius: 50%;
       cursor: ${disabled ? 'not-allowed' : 'pointer'};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
IE において、`MultiComboBox` の選択済みアイテムが flex ショートハンド起因でスタイル崩れを起こしていたので修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- flex ショートハンドを省略せずに記述
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/135587476-c01c3666-6163-49dc-b0f3-9a25a34e9875.png) | ![image](https://user-images.githubusercontent.com/270422/135587369-39c7b892-122d-4351-8309-4ac1b0090ca2.png) |

<!--
Please attach a capture if it looks different.
-->
