### PR TITLE
feat: TextLink の折返しに対応し、Affix にも下線を引く｜SHRUI-481

### DIFF
--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -31,6 +31,11 @@ storiesOf('TextLink', module)
       <li>
         <TextLink>unuse href attribute: can tab focasable.</TextLink>
       </li>
+      <li>
+        <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">
+          健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+        </TextLink>
+      </li>
     </Wrapper>
   ))
 

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -15,21 +15,21 @@ storiesOf('TextLink', module)
     <Wrapper>
       <li>
         <TextLink href="/" prefix={<FaFlagIcon />}>
-          Link to Root.
+          ルートへのリンク
         </TextLink>
       </li>
       <li>
         <TextLink href="/" target="_blank">
-          Link to Root with new Tabs.
+          別タブで開くルートへのリンク
         </TextLink>
       </li>
       <li>
         <TextLink onClick={() => alert('click!')}>
-          Even if only onClick is set, it is focusable.
+          onClick しか設定していなくてもフォーカスできます。
         </TextLink>
       </li>
       <li>
-        <TextLink>unuse href attribute: can tab focasable.</TextLink>
+        <TextLink>onClick も href も指定されていない場合はフォーカスできません</TextLink>
       </li>
       <li>
         <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -75,6 +75,10 @@ const StyledAncher = styled.a<{ themes: Theme }>`
       &:hover {
         color: ${color.hoverColor(color.TEXT_LINK)};
       }
+
+      &:not([href]) {
+        box-shadow: none;
+      }
     `
   }}
 `

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -68,7 +68,8 @@ const StyledAncher = styled.a<{ themes: Theme }>`
   ${({ themes }) => {
     const { color } = themes
     return css`
-      text-underline-position: under;
+      text-decoration: none;
+      box-shadow: 0 1px 0 0;
       color: ${color.TEXT_LINK};
 
       &:hover {

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -2,7 +2,6 @@ import React, { AnchorHTMLAttributes, ReactNode, VFC, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaExternalLinkAltIcon } from '../Icon'
-import { LineUp } from '../Layout/LineUp'
 
 type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof Props>
 type Props = {
@@ -58,15 +57,9 @@ export const TextLink: VFC<Props & ElementProps> = ({
       onClick={actualOnClick}
       themes={theme}
     >
-      {prefix || actualSuffix ? (
-        <LineUp gap={0.25} inline vAlign="center" as="span">
-          {prefix}
-          {children}
-          {actualSuffix}
-        </LineUp>
-      ) : (
-        children
-      )}
+      {prefix && <PrefixWrapper themes={theme}>{prefix}</PrefixWrapper>}
+      {children}
+      {actualSuffix && <SuffixWrapper themes={theme}>{actualSuffix}</SuffixWrapper>}
     </StyledAncher>
   )
 }
@@ -84,3 +77,13 @@ const StyledAncher = styled.a<{ themes: Theme }>`
     `
   }}
 `
+const PrefixWrapper = styled.span<{ themes: Theme }>(
+  ({ themes: { spacingByChar } }) => css`
+    margin-right: ${spacingByChar(0.25)};
+  `,
+)
+const SuffixWrapper = styled.span<{ themes: Theme }>(
+  ({ themes: { spacingByChar } }) => css`
+    margin-left: ${spacingByChar(0.25)};
+  `,
+)


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-481

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

LineUp つかった flexbox にしたため発生した :bug: でした:pray:
ついでに下線を box-shadow に変え、アイコンの下にも引かれるようにしました。
（`text-decoration: none` のリセットしてるプロジェクトは `box-shadow: none` に変える必要があります）