### PR TITLE
fix: `FormGroup` がグループであることを示せるように変更 (SHRUI-482)

### DIFF
--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -64,19 +64,29 @@ storiesOf('FormGroup', module)
       <Wrapper>
         <Title themes={theme}>default</Title>
         <Body>
-          <FormGroup title="Title" titleType="blockTitle">
+          <FormGroup title="Title" titleType="blockTitle" role="group">
             <SampleChildren id1="id_1-1" id2="id_1-2" />
           </FormGroup>
         </Body>
         <Title themes={theme}>with status label</Title>
         <Body>
-          <FormGroup title="Title" titleType="blockTitle" statusLabelProps={SampleStatusLabelProps}>
+          <FormGroup
+            title="Title"
+            titleType="blockTitle"
+            statusLabelProps={SampleStatusLabelProps}
+            role="group"
+          >
             <SampleChildren id1="id_2-1" id2="id_2-2" />
           </FormGroup>
         </Body>
         <Title themes={theme}>with help message</Title>
         <Body>
-          <FormGroup title="Title" titleType="blockTitle" helpMessage="help message text">
+          <FormGroup
+            title="Title"
+            titleType="blockTitle"
+            helpMessage="help message text"
+            role="group"
+          >
             <SampleChildren id1="id_3-1" id2="id_3-2" />
           </FormGroup>
         </Body>
@@ -87,6 +97,7 @@ storiesOf('FormGroup', module)
             titleType="blockTitle"
             statusLabelProps={SampleStatusLabelProps}
             errorMessages={['error message 1', 'error message 2']}
+            role="group"
           >
             <SampleChildren id1="id_4-1" id2="id_4-2" />
           </FormGroup>
@@ -99,6 +110,7 @@ storiesOf('FormGroup', module)
             statusLabelProps={SampleStatusLabelProps}
             helpMessage="help message text"
             errorMessages={['error message 1', 'error message 2']}
+            role="group"
           >
             <SampleChildren id1="id_5-1" id2="id_5-2" />
           </FormGroup>
@@ -112,6 +124,7 @@ storiesOf('FormGroup', module)
             helpMessage="help message text"
             errorMessages="error message"
             disabled
+            role="group"
           >
             <SampleChildren id1="id_6-1" id2="id_6-2" disabled />
           </FormGroup>

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -1,6 +1,7 @@
-import React, { ComponentProps, ReactNode, VFC } from 'react'
+import React, { ComponentProps, HTMLAttributes, ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { useId } from '../../hooks/useId'
 import { StatusLabel } from '../StatusLabel'
 import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
@@ -19,8 +20,9 @@ type Props = {
   className?: string
   children: ReactNode
 }
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-labelledby'>
 
-export const FormGroup: VFC<Props> = ({
+export const FormGroup: VFC<Props & ElementProps> = ({
   title,
   titleType,
   htmlFor,
@@ -32,14 +34,22 @@ export const FormGroup: VFC<Props> = ({
   disabled,
   className = '',
   children,
+  ...props
 }) => {
   const theme = useTheme()
   const disabledClass = disabled ? 'disabled' : ''
+  const managedLabelId = useId(labelId)
+  const isRoleGroup = props.role === 'group'
 
   return (
-    <Wrapper className={`${className} ${disabledClass}`} themes={theme}>
+    <Wrapper
+      {...props}
+      className={`${className} ${disabledClass}`}
+      themes={theme}
+      aria-labelledby={isRoleGroup ? managedLabelId : undefined}
+    >
       <TitleWrapper>
-        <label htmlFor={htmlFor} id={labelId}>
+        <label htmlFor={htmlFor} id={managedLabelId}>
           <Title tag="span" type={titleType} themes={theme} className={disabledClass}>
             {title}
           </Title>


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-482
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`FormGroup` コンポーネントは子の状態によってはグループとして表現したい場合があるため、グループとして表現できる手段を提供します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `FormGroup` に対して、要素のデフォルトの属性を渡せるように変更
  - `role` を渡せるようになるので、 `role=group` でグループとして表現できるようになる
  - デフォルト属性の内 `aria-labelledby` だけは下記との兼ね合いで対象外とした
- `role=group` が設定された時、タイトル部分の要素を `aria-labelledby` で参照するように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
