### PR TITLE
feat: ComboBox・DatePicker・Selectのキャレットの色を変更・統一

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -307,7 +307,15 @@ export function MultiComboBox<T>({
       </InputArea>
 
       <Suffix themes={theme}>
-        <FaCaretDownIcon color={isFocused ? theme.color.TEXT_BLACK : theme.color.BORDER} />
+        <FaCaretDownIcon
+          color={
+            !disabled
+              ? isFocused
+                ? theme.color.TEXT_BLACK
+                : theme.color.TEXT_GREY
+              : theme.color.BORDER
+          }
+        />
       </Suffix>
 
       {renderListBox()}

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -178,6 +178,12 @@ export function MultiComboBox<T>({
     setIsFocused(false)
   }, [isFocused, onBlur])
 
+  const caretIconColor = useMemo(() => {
+    if (isFocused) return theme.color.TEXT_BLACK
+    if (disabled) return theme.color.TEXT_DISABLED
+    return theme.color.TEXT_GREY
+  }, [disabled, isFocused, theme])
+
   useOuterClick(
     [outerRef, listBoxRef],
     useCallback(() => {
@@ -307,15 +313,7 @@ export function MultiComboBox<T>({
       </InputArea>
 
       <Suffix themes={theme}>
-        <FaCaretDownIcon
-          color={
-            !disabled
-              ? isFocused
-                ? theme.color.TEXT_BLACK
-                : theme.color.TEXT_GREY
-              : theme.color.BORDER
-          }
-        />
+        <FaCaretDownIcon color={caretIconColor} />
       </Suffix>
 
       {renderListBox()}

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -238,7 +238,15 @@ export function SingleComboBox<T>({
             </ClearButton>
             <CaretDownLayout themes={theme}>
               <CaretDownWrapper themes={theme}>
-                <FaCaretDownIcon color={isFocused ? theme.color.TEXT_BLACK : theme.color.BORDER} />
+                <FaCaretDownIcon
+                  color={
+                    !disabled
+                      ? isFocused
+                        ? theme.color.TEXT_BLACK
+                        : theme.color.TEXT_GREY
+                      : theme.color.BORDER
+                  }
+                />
               </CaretDownWrapper>
             </CaretDownLayout>
           </>

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -175,6 +175,12 @@ export function SingleComboBox<T>({
     setIsExpanded(false)
   }, [])
 
+  const caretIconColor = useMemo(() => {
+    if (isFocused) return theme.color.TEXT_BLACK
+    if (disabled) return theme.color.TEXT_DISABLED
+    return theme.color.TEXT_GREY
+  }, [disabled, isFocused, theme])
+
   useOuterClick(
     [outerRef, listBoxRef, clearButtonRef],
     useCallback(() => {
@@ -238,15 +244,7 @@ export function SingleComboBox<T>({
             </ClearButton>
             <CaretDownLayout themes={theme}>
               <CaretDownWrapper themes={theme}>
-                <FaCaretDownIcon
-                  color={
-                    !disabled
-                      ? isFocused
-                        ? theme.color.TEXT_BLACK
-                        : theme.color.TEXT_GREY
-                      : theme.color.BORDER
-                  }
-                />
+                <FaCaretDownIcon color={caretIconColor} />
               </CaretDownWrapper>
             </CaretDownLayout>
           </>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { VFC, useCallback, useEffect, useRef, useState } from 'react'
+import React, { VFC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import dayjs from 'dayjs'
 
@@ -174,6 +174,12 @@ export const DatePicker: VFC<Props & InputAttributes> = ({
   )
   useGlobalKeyDown(handleKeyDown)
 
+  const caretIconColor = useMemo(() => {
+    if (isInputFocused || isCalendarShown) return themes.color.TEXT_BLACK
+    if (disabled) return themes.color.TEXT_DISABLED
+    return themes.color.TEXT_GREY
+  }, [isCalendarShown, isInputFocused, disabled, themes])
+
   const classNames = useClassNames()
 
   return (
@@ -227,13 +233,7 @@ export const DatePicker: VFC<Props & InputAttributes> = ({
           suffix={
             <CalendarIconLayout themes={themes}>
               <CalendarIconWrapper themes={themes}>
-                <FaCalendarAltIcon
-                  color={
-                    isInputFocused || isCalendarShown
-                      ? themes.color.TEXT_BLACK
-                      : themes.color.BORDER
-                  }
-                />
+                <FaCalendarAltIcon color={caretIconColor} />
               </CalendarIconWrapper>
             </CalendarIconLayout>
           }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -89,7 +89,7 @@ export const Select: VFC<Props & ElementProps> = ({
         }
       </SelectBox>
       <IconWrap themes={theme} className="caret">
-        <StyledIcon />
+        <FaSortIcon color="inherit" />
       </IconWrap>
     </Wrapper>
   )
@@ -150,10 +150,6 @@ const SelectBox = styled.select<{ themes: Theme }>`
       line-height: ${leading.NONE};
       width: 100%;
 
-      + .caret {
-        color: ${color.TEXT_GREY};
-      }
-
       &::placeholder {
         color: ${color.TEXT_GREY};
       }
@@ -195,17 +191,14 @@ const IconWrap = styled.span<{ themes: Theme }>`
       bottom: 0;
       display: inline-flex;
       align-items: center;
+      color: ${color.TEXT_GREY};
+
       ${SelectBox}:focus + & {
         color: ${color.TEXT_BLACK};
       }
     `
   }}
 `
-
-const StyledIcon = styled(FaSortIcon)`
-  color: inherit;
-`
-
 const BlankOptgroup = styled.optgroup`
   display: none;
 `

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,11 +1,4 @@
-import React, {
-  ChangeEvent,
-  SelectHTMLAttributes,
-  VFC,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react'
+import React, { ChangeEvent, SelectHTMLAttributes, VFC, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { isMobileSafari } from '../../libs/ua'
@@ -52,13 +45,6 @@ export const Select: VFC<Props & ElementProps> = ({
     [onChange],
   )
   const classNames = useClassNames()
-  const [isFocused, setIsFocused] = useState(false)
-
-  const caretIconColor = useMemo(() => {
-    if (isFocused) return theme.color.TEXT_BLACK
-    if (disabled) return theme.color.TEXT_DISABLED
-    return theme.color.TEXT_GREY
-  }, [isFocused, disabled, theme])
 
   return (
     <Wrapper
@@ -72,12 +58,7 @@ export const Select: VFC<Props & ElementProps> = ({
         onChange={handleChange}
         aria-invalid={error || undefined}
         themes={theme}
-        onFocus={() => {
-          setIsFocused(true)
-        }}
-        onBlur={() => {
-          setIsFocused(false)
-        }}
+        disabled={disabled}
         {...props}
       >
         {hasBlank && <option value="">{blankLabel}</option>}
@@ -107,8 +88,8 @@ export const Select: VFC<Props & ElementProps> = ({
           isMobileSafari && <BlankOptgroup />
         }
       </SelectBox>
-      <IconWrap themes={theme}>
-        <FaSortIcon color={caretIconColor} />
+      <IconWrap themes={theme} className="caret">
+        <StyledIcon />
       </IconWrap>
     </Wrapper>
   )
@@ -169,6 +150,10 @@ const SelectBox = styled.select<{ themes: Theme }>`
       line-height: ${leading.NONE};
       width: 100%;
 
+      + .caret {
+        color: ${color.TEXT_GREY};
+      }
+
       &::placeholder {
         color: ${color.TEXT_GREY};
       }
@@ -178,6 +163,10 @@ const SelectBox = styled.select<{ themes: Theme }>`
         cursor: not-allowed;
         opacity: 1;
         color: ${color.TEXT_DISABLED};
+
+        + .caret {
+          color: ${color.TEXT_DISABLED};
+        }
       }
 
       /* for IE11 */
@@ -195,14 +184,28 @@ const SelectBox = styled.select<{ themes: Theme }>`
   }}
 `
 const IconWrap = styled.span<{ themes: Theme }>`
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  right: ${({ themes: { spacingByChar } }) => spacingByChar(0.75)};
-  bottom: 0;
-  display: inline-flex;
-  align-items: center;
+  ${({ themes }) => {
+    const { color, spacingByChar } = themes
+
+    return css`
+      pointer-events: none;
+      position: absolute;
+      top: 0;
+      right: ${spacingByChar(0.75)};
+      bottom: 0;
+      display: inline-flex;
+      align-items: center;
+      ${SelectBox}:focus + & {
+        color: ${color.TEXT_BLACK};
+      }
+    `
+  }}
 `
+
+const StyledIcon = styled(FaSortIcon)`
+  color: inherit;
+`
+
 const BlankOptgroup = styled.optgroup`
   display: none;
 `

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -159,10 +159,6 @@ const SelectBox = styled.select<{ themes: Theme }>`
         cursor: not-allowed;
         opacity: 1;
         color: ${color.TEXT_DISABLED};
-
-        + .caret {
-          color: ${color.TEXT_DISABLED};
-        }
       }
 
       /* for IE11 */
@@ -193,6 +189,9 @@ const IconWrap = styled.span<{ themes: Theme }>`
       align-items: center;
       color: ${color.TEXT_GREY};
 
+      ${SelectBox}:disabled + & {
+        color: ${color.TEXT_DISABLED};
+      }
       ${SelectBox}:focus + & {
         color: ${color.TEXT_BLACK};
       }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -88,7 +88,7 @@ export const Select: VFC<Props & ElementProps> = ({
           isMobileSafari && <BlankOptgroup />
         }
       </SelectBox>
-      <IconWrap themes={theme} className="caret">
+      <IconWrap themes={theme}>
         <FaSortIcon color="inherit" />
       </IconWrap>
     </Wrapper>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,11 @@
-import React, { ChangeEvent, SelectHTMLAttributes, VFC, useCallback } from 'react'
+import React, {
+  ChangeEvent,
+  SelectHTMLAttributes,
+  VFC,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react'
 import styled, { css } from 'styled-components'
 
 import { isMobileSafari } from '../../libs/ua'
@@ -33,6 +40,7 @@ export const Select: VFC<Props & ElementProps> = ({
   hasBlank = false,
   blankLabel = '選択してください',
   className = '',
+  disabled,
   ...props
 }) => {
   const theme = useTheme()
@@ -44,19 +52,32 @@ export const Select: VFC<Props & ElementProps> = ({
     [onChange],
   )
   const classNames = useClassNames()
+  const [isFocused, setIsFocused] = useState(false)
+
+  const caretIconColor = useMemo(() => {
+    if (isFocused) return theme.color.TEXT_BLACK
+    if (disabled) return theme.color.TEXT_DISABLED
+    return theme.color.TEXT_GREY
+  }, [isFocused, disabled, theme])
 
   return (
     <Wrapper
       className={`${className} ${classNames.wrapper}`}
       $width={widthStyle}
       error={error}
-      disabled={props.disabled}
+      disabled={disabled}
       themes={theme}
     >
       <SelectBox
         onChange={handleChange}
         aria-invalid={error || undefined}
         themes={theme}
+        onFocus={() => {
+          setIsFocused(true)
+        }}
+        onBlur={() => {
+          setIsFocused(false)
+        }}
         {...props}
       >
         {hasBlank && <option value="">{blankLabel}</option>}
@@ -87,7 +108,7 @@ export const Select: VFC<Props & ElementProps> = ({
         }
       </SelectBox>
       <IconWrap themes={theme}>
-        <FaSortIcon />
+        <FaSortIcon color={caretIconColor} />
       </IconWrap>
     </Wrapper>
   )


### PR DESCRIPTION
## Related URL

- https://kufuinc.slack.com/archives/CGC58MW01/p1634686160240700
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- プロポーザル的なPR
- Comboboxのキャレットが、デフォルト`BORDER`カラーとなっており、`disabled`とも取れる色になっていた
- 有効であるということを、もっと視覚的にわかるようにしたい
- DatePicker, Selectも同じようなスタイルに合わせたい

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- ComboBoxのキャレットのデフォルトカラーを`TEXT_GRAY`に変更
- active、disabled時のカラーは据え置き

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

### ComboBox

| Before | After |
|:------:|:------:|
| <img width="431" alt="CleanShot 2021-10-20 at 13 47 04@2x" src="https://user-images.githubusercontent.com/4032232/138029909-44bd225a-fc80-4b52-86ea-c9040a45e835.png"> | <img width="425" alt="CleanShot 2021-10-20 at 13 46 10@2x" src="https://user-images.githubusercontent.com/4032232/138029817-96fa0d8e-aee8-41b9-b417-c36636270263.png"> |

### Select

| Before | After |
|:------:|:------:|
| <img width="354" alt="CleanShot 2021-10-20 at 18 36 27@2x" src="https://user-images.githubusercontent.com/4032232/138068570-64c11f25-f1ee-4924-a23f-4cad60711086.png"> | <img width="298" alt="CleanShot 2021-10-20 at 18 33 22@2x" src="https://user-images.githubusercontent.com/4032232/138068084-9d9e022c-05f9-458a-a1a3-82391cb95eed.png">
 |

### DatePicker

| Before | After |
|:------:|:------:|
| <img width="411" alt="CleanShot 2021-10-20 at 18 34 39@2x" src="https://user-images.githubusercontent.com/4032232/138068251-f6e2d585-ee5f-4727-a98a-596baf036f13.png"> | <img width="388" alt="CleanShot 2021-10-20 at 18 35 09@2x" src="https://user-images.githubusercontent.com/4032232/138068350-6782aa38-991e-4755-96dd-066db15a1e2d.png"> |


<!--
Please attach a capture if it looks different.
-->
