### PR TITLE
perf: avoid bundling the entire lodash package

### DIFF
--- a/src/themes/createLeading.ts
+++ b/src/themes/createLeading.ts
@@ -1,4 +1,4 @@
-import { merge } from 'lodash'
+import { merge } from '../libs/lodash'
 
 interface Leading {
   NONE: number


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

This PR removes importing the lodash package to avoid bundling it in applications.

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

I've changed to use the merge function from `libs/lodash` instead of `lodash` to avoid bundling the entire `lodash` package in applications.

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
