### PR TITLE
fix: SingleComboboxで絞り込んだアイテムが選択できないのを修正

### DIFF
--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -173,6 +173,7 @@ export function SingleComboBox<T>({
   const blur = useCallback(() => {
     setIsFocused(false)
     setIsExpanded(false)
+    setIsEditing(false)
   }, [])
 
   const caretIconColor = useMemo(() => {
@@ -272,9 +273,6 @@ export function SingleComboBox<T>({
             onClear && onClear()
             onChangeSelected && onChangeSelected(null)
           }
-        }}
-        onBlur={() => {
-          setIsEditing(false)
         }}
         onFocus={() => {
           if (!isFocused) {


### PR DESCRIPTION
## 原因

- `onBlur` で `isEditing` を `false` にしていた
- Listboxをクリックしたタイミングで、`<StyledInput>` の `onBlur` が走り、`state` が変わり再レンダリングされるため意図しない挙動を起こしていた

## 対策

- `useOuterClick` 時の `blur()` で `state` をセット

## Capture

<details open>
<summary>before</summary>
<img src="https://user-images.githubusercontent.com/6724665/139433277-12989876-639d-4558-b268-17f84b9c3433.gif" alt="SingleComboboxの検索フィールドに文言入れて部分一致したアイテムをクリックで選択している様子。選択できずに絞り込みが解除される。"  />
</details>

<details open>
<summary>after</summary>
<img src="https://user-images.githubusercontent.com/6724665/139433756-39ec84f7-93fd-4ae9-aa46-9b6065eaf843.gif" alt="SingleComboboxの検索フィールドに文言入れて部分一致したアイテムをクリックで選択している様子。選択できる。"  />
</details>