### PR TITLE
fix: MessageScreen のリンクに下線を引く｜SHRUI-368

### DIFF
--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -7,6 +7,7 @@ import { Base } from '../Base'
 import { FieldSet } from '../FieldSet'
 import { MessageScreen } from './MessageScreen'
 import { PrimaryButton } from '../Button'
+import { TextLink } from '../TextLink'
 
 import readme from './README.md'
 
@@ -40,7 +41,6 @@ storiesOf('MessageScreen', module)
     )
   })
   .add('without title', () => {
-    const themes = useTheme()
     return (
       <MessageScreen
         links={[
@@ -66,9 +66,7 @@ storiesOf('MessageScreen', module)
             </List>
             <Bottom>
               <PrimaryButton wide>ログイン</PrimaryButton>
-              <Link href="http://example.com" themes={themes}>
-                パスワードをお忘れの方
-              </Link>
+              <TextLink href="http://example.com">パスワードをお忘れの方</TextLink>
             </Bottom>
           </Box>
         </BoxWrapper>
@@ -98,9 +96,7 @@ storiesOf('MessageScreen', module)
           </List>
           <Bottom>
             <PrimaryButton wide>ログイン</PrimaryButton>
-            <Link href="http://example.com" themes={themes}>
-              パスワードをお忘れの方
-            </Link>
+            <TextLink href="http://example.com">パスワードをお忘れの方</TextLink>
           </Bottom>
         </Box>
       </MessageScreen>
@@ -152,17 +148,6 @@ const Bottom = styled.div`
   > *:first-child {
     margin-bottom: 24px;
   }
-`
-const Link = styled.a<{ themes: Theme }>`
-  ${({ themes }) => css`
-    color: ${themes.color.TEXT_LINK};
-    font-size: ${themes.fontSize.M};
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  `}
 `
 const Headline = styled.span<{ themes: Theme }>`
   ${({ themes }) => css`

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -5,8 +5,8 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
 import { SmartHRLogo } from '../SmartHRLogo'
+import { TextLink } from '../TextLink'
 import { Footer } from '../Footer'
-import { FaExternalLinkAltIcon } from '../Icon'
 
 type Props = {
   title?: ReactNode
@@ -55,17 +55,13 @@ export const MessageScreen: VFC<Props & ElementProps> = ({
           <Links themes={theme} className={classNames.linkList}>
             {links.map((link) => (
               <li key={link.label}>
-                <Link
+                <TextLink
                   href={link.url}
                   {...(link.target ? { target: link.target } : {})}
-                  themes={theme}
                   className={classNames.link}
                 >
                   {link.label}
-                  {link.target === '_blank' && (
-                    <ExternalIcon color={theme.color.TEXT_LINK} aria-label="別タブで開く" />
-                  )}
-                </Link>
+                </TextLink>
               </li>
             ))}
           </Links>
@@ -137,28 +133,6 @@ const Links = styled.ul<{ themes: Theme }>`
       }
     `
   }}
-`
-const Link = styled.a<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, color } = themes
-
-    return css`
-      color: ${color.TEXT_LINK};
-      font-size: ${fontSize.M};
-      line-height: 1.4;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    `
-  }}
-`
-const ExternalIcon = styled(FaExternalLinkAltIcon).attrs(() => ({
-  size: 14,
-}))`
-  margin-left: 0.4rem;
-  vertical-align: -1px;
 `
 const FooterArea = styled.div<{ themes: Theme }>`
   ${({ themes: { spacingByChar } }) => {


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-368

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

MessageScreen のリンクがリンクであることが文字色でしか判別できないため、下線を引きます。
背景色（BACKGROUND）の上にある青文字はコントラスト比 4.5:1 を担保できないが周囲の文字とのコントラスト比や下線に依る資格示唆で判別できるため、色はそのままとした。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

SmartHR UI の TextLink で置き換えました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

これが | こう
--- | ---
![image](https://user-images.githubusercontent.com/19403400/140239202-175f7b6a-cb2e-4037-a229-21b1c6c269d8.png) | ![image](https://user-images.githubusercontent.com/19403400/140239152-15d83c42-ef09-4bd3-9e30-440362b2e4a3.png)


<!--
Please attach a capture if it looks different.
-->
