### PR TITLE
feat: `Tooltip` に自動位置決め機能を追加し、`LineClamp` のツールチップが見切れないようにする (SHRUI-483)

### DIFF
--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -51,11 +51,11 @@ export const LineClamp: VFC<Props & ElementProps> = ({
 
   const Tooltip = () =>
     toolTipType === 'light' ? (
-      <LightTooltip message={children} multiLine>
+      <LightTooltip message={children} multiLine vertical="auto">
         <LineClampPart />
       </LightTooltip>
     ) : (
-      <DarkTooltip message={children} multiLine>
+      <DarkTooltip message={children} multiLine vertical="auto">
         <LineClampPart />
       </DarkTooltip>
     )

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -20,12 +20,12 @@ import { LightTooltip, DarkTooltip } from 'smarthr-ui'
 
 ## props
 
-| Name         | Required | Type                                      | DefaultValue | Description                                                                                         |
-| ------------ | -------- | ----------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------- |
-| message      | ✓        | **ReactNode**                             | -            | message in the tooltip                                                                              |
-| children     | ✓        | **ReactNode**                             | -            | target element for tooltip                                                                          |
-| triggerType  | -        | **'icon' &#124; 'text'**                  | 'text'       | set 'icon' when the trigger is an icon                                                              |
-| multiLine    | -        | **boolean**                               | false        | set true when text in the tooltip is multi line                                                     |
-| ellipsisOnly | -        | **boolean**                               | false        | set true when you want the tooltip enabled only when the text is too long and ellipsis is displayed |
-| horizontal   | -        | **'right' &#124; 'center' &#124; 'left'** | 'left'       | horizontal position                                                                                 |
-| vertical     | -        | **'top' &#124; 'middle' &#124; 'bottom'** | 'bottom'     | vertical position                                                                                   |
+| Name         | Required | Type                                                    | DefaultValue | Description                                                                                         |
+| ------------ | -------- | ------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------- |
+| message      | ✓        | **ReactNode**                                           | -            | message in the tooltip                                                                              |
+| children     | ✓        | **ReactNode**                                           | -            | target element for tooltip                                                                          |
+| triggerType  | -        | **'icon' &#124; 'text'**                                | 'text'       | set 'icon' when the trigger is an icon                                                              |
+| multiLine    | -        | **boolean**                                             | false        | set true when text in the tooltip is multi line                                                     |
+| ellipsisOnly | -        | **boolean**                                             | false        | set true when you want the tooltip enabled only when the text is too long and ellipsis is displayed |
+| horizontal   | -        | **'right' &#124; 'center' &#124; 'left' &#124; 'auto'** | 'left'       | horizontal position                                                                                 |
+| vertical     | -        | **'top' &#124; 'middle' &#124; 'bottom' &#124; 'auto'** | 'bottom'     | vertical position                                                                                   |

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -8,7 +8,7 @@ import {
   FaArrowAltCircleRightIcon,
   FaArrowAltCircleUpIcon,
 } from '../Icon'
-import { DarkTooltip, LightTooltip } from './Tooltip'
+import { DarkTooltip, LightTooltip, Tooltip } from './Tooltip'
 
 import readme from './README.md'
 
@@ -198,6 +198,28 @@ storiesOf('Tooltip', module)
         >
           <FaArrowAltCircleDownIcon visuallyHiddenText="フォーカスすると情報が表示されます" />
         </LightTooltip>
+      </dd>
+      <dt>自動位置決め</dt>
+      {[undefined, 'center', 'right'].map((className) => (
+        <dd className={className} key={className}>
+          <Tooltip
+            message="メッセージメッセージメッセージメッセージメッセージメッセージメッセージ"
+            horizontal="auto"
+            vertical="auto"
+          >
+            horizontal=auto & vertical=auto
+          </Tooltip>
+        </dd>
+      ))}
+      <dd style={{ marginBottom: '100vh' }}>
+        <Tooltip
+          message="メッセージメッセージメッセージメッセージメッセージメッセージメッセージ"
+          horizontal="auto"
+          vertical="auto"
+          multiLine
+        >
+          multiLine 指定時
+        </Tooltip>
       </dd>
     </List>
   ))

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,8 +13,8 @@ type Props = {
   triggerType?: 'icon' | 'text'
   multiLine?: boolean
   ellipsisOnly?: boolean
-  horizontal?: BalloonProps['horizontal']
-  vertical?: BalloonProps['vertical']
+  horizontal?: BalloonProps['horizontal'] | 'auto'
+  vertical?: BalloonProps['vertical'] | 'auto'
   tabIndex?: number
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-describedby'>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -45,45 +45,28 @@ const tooltipFactory = (balloonTheme: BalloonTheme) => {
     const ref = React.createRef<HTMLDivElement>()
     const tooltipId = useId()
 
-    const getBalloonWrapperWidth = (): number => {
-      if (!ref.current) {
-        return 0
-      }
-
-      return ref.current.clientWidth
-    }
-    const getParentWidth = (): number => {
-      if (!ref.current) {
-        return 0
-      }
-
-      return parseInt(
-        window
-          .getComputedStyle(ref.current.parentNode! as HTMLElement, null)
-          .width.match(/\d+/)![0],
-        10,
-      )
-    }
-
     const getHandlerToShow = <T extends unknown>(handler?: (e: T) => void) => {
       return (e: T) => {
         handler && handler(e)
-
-        if (ref.current) {
-          setRect(ref.current.getBoundingClientRect())
-        }
-
-        if (!ellipsisOnly) {
-          setIsVisible(true)
+        if (!ref.current) {
           return
         }
 
-        const parentWidth = getParentWidth()
-
-        if (parentWidth < 0 || parentWidth > getBalloonWrapperWidth()) {
-          return
+        if (ellipsisOnly) {
+          const outerWidth = parseInt(
+            window
+              .getComputedStyle(ref.current.parentNode! as HTMLElement, null)
+              .width.match(/\d+/)![0],
+            10,
+          )
+          const wrapperWidth = ref.current.clientWidth
+          const existsEllipsis = outerWidth >= 0 && outerWidth <= wrapperWidth
+          if (!existsEllipsis) {
+            return
+          }
         }
 
+        setRect(ref.current.getBoundingClientRect())
         setIsVisible(true)
       }
     }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -2,9 +2,8 @@ import React, { HTMLAttributes, ReactNode, VFC, useEffect, useRef, useState } fr
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 
-import { Props as BalloonProps, BalloonTheme, DarkBalloon, LightBalloon } from '../Balloon'
+import { Props as BalloonProps, BalloonTheme } from '../Balloon'
 import { TooltipPortal } from './TooltipPortal'
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { useId } from '../../hooks/useId'
 import { useClassNames } from './useClassNames'
 
@@ -39,7 +38,6 @@ const tooltipFactory = (balloonTheme: BalloonTheme) => {
     onBlur,
     ...props
   }) => {
-    const themes = useTheme()
     const [isVisible, setIsVisible] = useState(false)
     const [rect, setRect] = useState<DOMRect | null>(null)
     const ref = React.createRef<HTMLDivElement>()
@@ -78,7 +76,6 @@ const tooltipFactory = (balloonTheme: BalloonTheme) => {
       }
     }
 
-    const StyledBalloon = balloonTheme === 'light' ? StyledLightBalloon : StyledDarkBalloon
     const isIcon = triggerType === 'icon'
 
     const portalRoot = useRef(document.createElement('div')).current
@@ -111,17 +108,15 @@ const tooltipFactory = (balloonTheme: BalloonTheme) => {
           rect &&
           createPortal(
             <TooltipPortal
+              message={message}
+              balloonTheme={balloonTheme}
               id={tooltipId}
               parentRect={rect}
               isIcon={isIcon}
               isMultiLine={multiLine}
               horizontal={horizontal}
               vertical={vertical}
-            >
-              <StyledBalloon horizontal={horizontal} vertical={vertical} isMultiLine={multiLine}>
-                <StyledBalloonText themes={themes}>{message}</StyledBalloonText>
-              </StyledBalloon>
-            </TooltipPortal>,
+            />,
             portalRoot,
           )}
         {children}
@@ -145,23 +140,4 @@ const Wrapper = styled.div<{ isIcon?: boolean }>`
     css`
       line-height: 0;
     `}
-`
-
-const StyledLightBalloon = styled(LightBalloon)<{ isMultiLine?: boolean }>(
-  ({ isMultiLine }) =>
-    isMultiLine &&
-    css`
-      max-width: 100%;
-      white-space: normal;
-    `,
-)
-const StyledDarkBalloon = StyledLightBalloon.withComponent(DarkBalloon)
-
-const StyledBalloonText = styled.p<{ themes: Theme }>`
-  margin: 0;
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
-    `
-  }}
 `

--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -13,8 +13,8 @@ type Props = {
   parentRect: DOMRect
   isIcon?: boolean
   isMultiLine?: boolean
-  horizontal: 'left' | 'center' | 'right'
-  vertical: 'top' | 'middle' | 'bottom'
+  horizontal: 'left' | 'center' | 'right' | 'auto'
+  vertical: 'top' | 'middle' | 'bottom' | 'auto'
 }
 
 export const TooltipPortal: VFC<Props> = ({
@@ -35,8 +35,56 @@ export const TooltipPortal: VFC<Props> = ({
     $width: isMultiLine ? parentRect.width : 0,
     $height: 0,
   })
+  const [actualHorizontal, setActualHorizontal] = useState<'left' | 'center' | 'right' | null>(
+    horizontal === 'auto' ? null : horizontal,
+  )
+  const [actualVertical, setActualVertical] = useState<'top' | 'middle' | 'bottom' | null>(
+    vertical === 'auto' ? null : vertical,
+  )
+
+  const outerMargin = 10
   useLayoutEffect(() => {
     if (!portalRef.current) {
+      return
+    }
+    const { offsetWidth, offsetHeight } = portalRef.current
+
+    if (vertical === 'auto') {
+      const requiredHeight = offsetHeight + outerMargin
+      const topSpace = parentRect.top
+      const bottomSpace = window.innerHeight - parentRect.bottom
+      setActualVertical(() => {
+        if (topSpace > requiredHeight) {
+          return 'bottom'
+        } else if (bottomSpace > requiredHeight || bottomSpace > topSpace) {
+          return 'top'
+        } else {
+          return 'bottom'
+        }
+      })
+    }
+
+    if (horizontal === 'auto') {
+      const requiredWidth = offsetWidth + outerMargin
+      const leftSpace = vertical === 'middle' ? parentRect.left : parentRect.right
+      const rightSpace =
+        vertical === 'middle'
+          ? window.innerWidth - parentRect.right
+          : window.innerWidth - parentRect.left
+      setActualHorizontal(() => {
+        if (rightSpace > requiredWidth) {
+          return 'left'
+        } else if (leftSpace > requiredWidth || leftSpace > rightSpace) {
+          return 'right'
+        } else {
+          return 'left'
+        }
+      })
+    }
+  }, [horizontal, parentRect, vertical])
+
+  useLayoutEffect(() => {
+    if (!portalRef.current || !actualHorizontal || !actualVertical) {
       return
     }
     const { offsetWidth, offsetHeight } = portalRef.current
@@ -47,14 +95,14 @@ export const TooltipPortal: VFC<Props> = ({
           width: offsetWidth,
           height: offsetHeight,
         },
-        vertical,
-        horizontal,
+        vertical: actualVertical,
+        horizontal: actualHorizontal,
         isMultiLine,
         isIcon,
-        outerMargin: 10,
+        outerMargin,
       }),
     )
-  }, [horizontal, isIcon, isMultiLine, parentRect, vertical])
+  }, [actualHorizontal, actualVertical, isIcon, isMultiLine, parentRect])
 
   const StyledBalloon = balloonTheme === 'light' ? StyledLightBalloon : StyledDarkBalloon
   const classNames = useClassNames()
@@ -68,7 +116,11 @@ export const TooltipPortal: VFC<Props> = ({
       className={classNames.popup}
       {...rect}
     >
-      <StyledBalloon horizontal={horizontal} vertical={vertical} isMultiLine={isMultiLine}>
+      <StyledBalloon
+        horizontal={actualHorizontal || 'left'}
+        vertical={actualVertical || 'bottom'}
+        isMultiLine={isMultiLine}
+      >
         <StyledBalloonText themes={theme}>{message}</StyledBalloonText>
       </StyledBalloon>
     </Container>

--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -1,14 +1,16 @@
 import React, { ReactNode, VFC, useLayoutEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
+import { BalloonTheme, DarkBalloon, LightBalloon } from '../Balloon'
 import { getTooltipRect } from './tooltipHelper'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
 type Props = {
+  message: ReactNode
+  balloonTheme: BalloonTheme
   id: string
   parentRect: DOMRect
-  children: ReactNode
   isIcon?: boolean
   isMultiLine?: boolean
   horizontal: 'left' | 'center' | 'right'
@@ -16,9 +18,10 @@ type Props = {
 }
 
 export const TooltipPortal: VFC<Props> = ({
+  message,
+  balloonTheme,
   id,
   parentRect,
-  children,
   isIcon = false,
   isMultiLine = false,
   horizontal,
@@ -53,6 +56,7 @@ export const TooltipPortal: VFC<Props> = ({
     )
   }, [horizontal, isIcon, isMultiLine, parentRect, vertical])
 
+  const StyledBalloon = balloonTheme === 'light' ? StyledLightBalloon : StyledDarkBalloon
   const classNames = useClassNames()
 
   return (
@@ -64,7 +68,9 @@ export const TooltipPortal: VFC<Props> = ({
       className={classNames.popup}
       {...rect}
     >
-      {children}
+      <StyledBalloon horizontal={horizontal} vertical={vertical} isMultiLine={isMultiLine}>
+        <StyledBalloonText themes={theme}>{message}</StyledBalloonText>
+      </StyledBalloon>
     </Container>
   )
 }
@@ -90,6 +96,24 @@ const Container = styled.div<{
         height: ${$height}px;
       `}
         z-index: ${themes.zIndex.OVERLAP};
+    `
+  }}
+`
+const StyledLightBalloon = styled(LightBalloon)<{ isMultiLine?: boolean }>(
+  ({ isMultiLine }) =>
+    isMultiLine &&
+    css`
+      max-width: 100%;
+      white-space: normal;
+    `,
+)
+const StyledDarkBalloon = StyledLightBalloon.withComponent(DarkBalloon)
+
+const StyledBalloonText = styled.p<{ themes: Theme }>`
+  margin: 0;
+  ${({ themes: { spacingByChar } }) => {
+    return css`
+      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
     `
   }}
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-483
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、 `LineClamp` コンポーネントのツールチップは常に上側に表示されるため、画面上上側のスペースが小さいと見切れてしまいます。

![image](https://user-images.githubusercontent.com/270422/140694801-a1f09275-2581-40a5-8128-80ec6fb9556f.png)

これを解消するにはツールチップを表示する方向を上下のスペースに応じて出し分けるロジックが必要になりますが、そもそもこの機能は `Tooltip` コンポーネントが持っていたほうが良いので、`Tooltip` に自動位置決め機能を実装し、 `LineClamp` でそれを使うことでツールチップが見切れないように対応します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Tooltip` コンポーネントの `vertical`, `horizontal` に `auto` オプションを追加
  - `auto` を指定した時自動で表示位置が決まる
- `LineClamp` コンポーネント内の `Tooltip` に上記 `auto` オプションを適用

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture


| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/140694479-49651c51-780d-4b96-927b-a66126551856.png) | ![image](https://user-images.githubusercontent.com/270422/140694353-df2cbac1-c9b8-4a2e-a056-ba983e074f78.png) |
<!--
Please attach a capture if it looks different.
-->
