### PR TITLE
fix: `Calendar` がブラウザのフォントサイズによってスタイル崩れを起こさないように修正 (SHRUI-466)

### DIFF
--- a/src/components/Calendar/CalendarTable.tsx
+++ b/src/components/Calendar/CalendarTable.tsx
@@ -123,6 +123,7 @@ const DateCell = styled.span<{ themes: Theme; isToday?: boolean; isSelected?: bo
   justify-content: center;
   width: 1.75rem;
   height: 1.75rem;
+  box-sizing: border-box;
   border-radius: 50%;
   line-height: 0;
   ${({ themes: { border, color }, isToday, isSelected }) => css`

--- a/src/components/Calendar/CalendarTable.tsx
+++ b/src/components/Calendar/CalendarTable.tsx
@@ -97,24 +97,21 @@ export const CalendarTable: VFC<Props & ElementProps> = ({
 }
 
 const Table = styled.table<{ themes: Theme }>(({ themes }) => {
-  const { color, fontSize } = themes
+  const { color, fontSize, spacingByChar } = themes
   return css`
     color: ${color.TEXT_BLACK};
     font-size: ${fontSize.M};
     border-spacing: 0;
-    margin: 4px 8px 13px;
+    padding: ${spacingByChar(0.25)} ${spacingByChar(0.75)} ${spacingByChar(1)};
 
     th {
-      height: 37px;
-      padding: 0;
+      padding: ${spacingByChar(0.5)} 0;
       vertical-align: middle;
       text-align: center;
       font-weight: normal;
       color: ${color.TEXT_GREY};
     }
     td {
-      width: 43px;
-      height: 35px;
       padding: 0;
       vertical-align: middle;
     }
@@ -124,14 +121,14 @@ const DateCell = styled.span<{ themes: Theme; isToday?: boolean; isSelected?: bo
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 27px;
-  height: 27px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   line-height: 0;
-  ${({ themes: { color }, isToday, isSelected }) => css`
+  ${({ themes: { border, color }, isToday, isSelected }) => css`
     ${isToday &&
     css`
-      border: solid 1px ${color.BORDER};
+      border: ${border.shorthand};
     `}
 
     ${isSelected &&
@@ -142,23 +139,22 @@ const DateCell = styled.span<{ themes: Theme; isToday?: boolean; isSelected?: bo
   `}
 `
 const CellButton = styled(UnstyledButton)<{ themes: Theme }>(
-  ({ themes }) => css`
+  ({ themes: { color, spacingByChar } }) => css`
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%;
-    height: 100%;
+    padding: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
     cursor: pointer;
 
     :disabled {
-      color: ${themes.color.TEXT_DISABLED};
+      color: ${color.TEXT_DISABLED};
       cursor: not-allowed;
     }
     :not(:disabled) {
       &:hover {
         ${DateCell} {
-          background-color: ${themes.color.BASE_GREY};
-          color: ${themes.color.TEXT_BLACK};
+          background-color: ${color.BASE_GREY};
+          color: ${color.TEXT_BLACK};
         }
       }
     }

--- a/src/components/Calendar/YearPicker.tsx
+++ b/src/components/Calendar/YearPicker.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, VFC, useEffect, useRef } from 'react'
+import React, { HTMLAttributes, VFC, useLayoutEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -40,7 +40,7 @@ export const YearPicker: VFC<Props & ElementProps> = ({
     .fill(null)
     .map((_, i) => fromYear + i)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (focusingRef.current && isDisplayed) {
       focusingRef.current.focus()
       focusingRef.current.blur()

--- a/src/components/Calendar/YearPicker.tsx
+++ b/src/components/Calendar/YearPicker.tsx
@@ -55,7 +55,7 @@ export const YearPicker: VFC<Props & ElementProps> = ({
       id={id}
       className={`${props.className} ${classNames.yearPicker.wrapper}`}
     >
-      <Container>
+      <Container themes={themes}>
         {yearArray.map((year) => {
           const isThisYear = thisYear === year
           const isSelectedYear = selectedYear === year
@@ -93,31 +93,31 @@ const Overlay = styled.div<{ themes: Theme; isDisplayed: boolean }>`
   background-color: ${({ themes }) => themes.color.WHITE};
 `
 
-const Container = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
-  height: 100%;
-  padding: 8px 3px;
-  box-sizing: border-box;
-  overflow-y: scroll;
+const Container = styled.div<{ themes: Theme }>`
+  ${({ themes: { spacingByChar } }) => css`
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    width: 100%;
+    height: 100%;
+    padding: ${spacingByChar(0.5)} ${spacingByChar(0.25)};
+    box-sizing: border-box;
+    overflow-y: auto;
+  `}
 `
 const YearWrapper = styled.span<{ themes: Theme; isThisYear?: boolean; isSelected?: boolean }>(
   ({ themes, isThisYear, isSelected }) => {
-    const { color, fontSize } = themes
+    const { border, color, fontSize, leading, spacingByChar } = themes
     return css`
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 51px;
-      height: 27px;
-      border-radius: 14px;
+      display: inline-block;
+      padding: ${spacingByChar(0.5)} ${spacingByChar(0.75)};
+      border-radius: 2rem;
       font-size: ${fontSize.M};
       box-sizing: border-box;
-      line-height: 0;
+      line-height: ${leading.NONE};
       ${isThisYear &&
       css`
-        border: solid 1px ${color.BORDER};
+        border: ${border.shorthand};
       `};
       ${isSelected &&
       css`
@@ -128,18 +128,19 @@ const YearWrapper = styled.span<{ themes: Theme; isThisYear?: boolean; isSelecte
   },
 )
 const YearButton = styled(UnstyledButton)<{ themes: Theme }>`
-  width: 25%;
-  height: 43px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  &:hover {
-    ${YearWrapper} {
-      ${({ themes }) => css`
-        color: ${themes.color.TEXT_BLACK};
-        background-color: ${themes.color.BASE_GREY};
-      `}
+  ${({ themes: { color, leading, spacingByChar } }) => css`
+    width: 25%;
+    padding: ${spacingByChar(0.5)} 0;
+    line-height: ${leading.NONE};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    &:hover {
+      ${YearWrapper} {
+        color: ${color.TEXT_BLACK};
+        background-color: ${color.BASE_GREY};
+      }
     }
-  }
+  `}
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-466
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Calendar` コンポーネントにおいて、特にブラウザのフォントサイズを大きくした時にスタイル崩れが発生しているため、ブラウザのフォントサイズ指定にも追従できるように修正を行います。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 各スタイル指定で px 値を固定で指定しているところなどを全体的にテーマ値を使うように変更
- 年選択のスクロール処理を同期に変更してチラつきを防止
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
※ chrome にてフォントサイズ「極大」指定時

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/140891241-c7b0edd1-d18d-4f8c-b4b5-8db2130f3511.png) | ![image](https://user-images.githubusercontent.com/270422/140890933-d24fea54-90ca-4f87-a5ee-9c40633c6370.png) |
| ![image](https://user-images.githubusercontent.com/270422/140891281-d63ede93-6925-4ae5-9ab0-fecb3f0805a5.png) | ![image](https://user-images.githubusercontent.com/270422/140891134-a0e07bbf-30d8-4274-a4b5-c3b50cafd2a0.png) |

<!--
Please attach a capture if it looks different.
-->
