### PR TITLE
fix: `InputFile` が IE でクラッシュしないように修正

### DIFF
--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -40,12 +40,17 @@ export const InputFile: VFC<Props> = ({
 
   useEffect(() => {
     if (inputRef.current) {
-      const buff = new DataTransfer()
-      files.forEach((file) => {
-        buff.items.add(file)
-      })
+      // IE は DataTransfer constructor をサポートしていないので try catch でクラッシュを防ぐ
+      try {
+        const buff = new DataTransfer()
+        files.forEach((file) => {
+          buff.items.add(file)
+        })
 
-      inputRef.current.files = buff.files
+        inputRef.current.files = buff.files
+      } catch {
+        // no-op
+      }
     }
   }, [files])
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
IE は DataTransfer() constructor をサポートしていなかったためクラッシュが発生する。
https://caniuse.com/mdn-api_datatransfer_datatransfer

![image](https://user-images.githubusercontent.com/270422/141755370-22ac3d67-2931-4514-a488-407efb8dacee.png)

IE の場合は input の value の書き換えを行わないようにすることでクラッシュを防ぐように修正する。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 該当の処理を try catch で囲い、 catch した場合は何もしない
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
