### PR TITLE
chore: Layout story の export 方法を変更

### DIFF
--- a/src/components/Layout/Cluster/Cluster.stories.tsx
+++ b/src/components/Layout/Cluster/Cluster.stories.tsx
@@ -11,11 +11,7 @@ import styled, { css } from 'styled-components'
 import { Base } from '../../Base'
 import { RadioButton } from '../../RadioButton'
 
-export default {
-  title: 'Layout',
-}
-
-export const _Cluster: Story = () => {
+export const ClusterStory: Story = () => {
   const themes = useTheme()
   const { spacing } = themes
 

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -5,3 +5,8 @@ export default {
   component: Cluster,
   subcomponents: { Cluster, LineUp, Sidebar, Stack },
 }
+
+export { ClusterStory as Cluster } from './Cluster/Cluster.stories'
+export { LineUpStory as LineUp } from './LineUp/LineUp.stories'
+export { SidebarStory as Sidebar } from './Sidebar/Sidebar.stories'
+export { StackStory as Stack } from './Stack/Stack.stories'

--- a/src/components/Layout/LineUp/LineUp.stories.tsx
+++ b/src/components/Layout/LineUp/LineUp.stories.tsx
@@ -10,11 +10,7 @@ import { Heading } from '../../Heading'
 import { StatusLabel } from '../../StatusLabel'
 import { FaExternalLinkAltIcon } from '../../Icon'
 
-export default {
-  title: 'Layout',
-}
-
-export const _LineUp: Story = () => (
+export const LineUpStory: Story = () => (
   <Stack>
     <figure>
       <figcaption>

--- a/src/components/Layout/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.stories.tsx
@@ -6,11 +6,7 @@ import { Sidebar } from './Sidebar'
 
 import styled, { css } from 'styled-components'
 
-export default {
-  title: 'Layout',
-}
-
-export const _Sidebar: Story = () => {
+export const SidebarStory: Story = () => {
   return (
     <div style={{ margin: '32px' }}>
       <h1>Sidebar</h1>

--- a/src/components/Layout/Stack/Stack.stories.tsx
+++ b/src/components/Layout/Stack/Stack.stories.tsx
@@ -8,11 +8,7 @@ import { Base as shrBase } from '../../Base'
 import { Heading } from '../../Heading'
 import { LineUp } from '../LineUp'
 
-export default {
-  title: 'Layout',
-}
-
-export const _Stack: Story = () => (
+export const StackStory: Story = () => (
   <LineUp gap={2}>
     <Content>
       <Stack recursive>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Layout 配下のコンポーネントの story の構成を変更したことに起因して、 story のタイトルが重複しているという警告が発生するようになった。
![image](https://user-images.githubusercontent.com/270422/141758385-02225d8c-8a60-4ba0-a3ec-e94d9ea7490e.png)

タイトルの重複が発生しないように story の export 方法を変更する。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- Layout 配下の story を `Layout.stories.tsx` で export し直す形に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
