### PR TITLE
fix: Safari で `SegmentedControl` の隙間ができないようにする

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -151,6 +151,7 @@ const Container = styled.div`
 const Button = styled(SecondaryButton)<{ themes: Theme }>(
   ({ themes: { border, color, radius, shadow } }) =>
     css`
+      margin: 0;
       border-radius: 0;
 
       &[aria-checked='true'] {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Safari において、 `SegmentedControl` のボタン間に隙間が生じてしまっているため、 UA スタイルを打ち消して隙間ができないように修正します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 該当箇所の button に対する margin を 0 に上書き
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
※ Safari にてキャプチャ
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/142342163-fc0e2466-47a3-4886-9aa5-295fa7045134.png) | ![image](https://user-images.githubusercontent.com/270422/142342214-881ad482-2f95-4f27-82c8-ac9f46ae6982.png) |
<!--
Please attach a capture if it looks different.
-->
