### PR TITLE
fix: safariで表示されるLineClampのheightが折り畳み前の高さを維持する不具合を修正

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -135,6 +135,7 @@ export const DarkTooltip = tooltipFactory('dark')
 const Wrapper = styled.div<{ isIcon?: boolean }>`
   display: inline-block;
   max-width: 100%;
+  overflow-y: hidden;
   ${({ isIcon }) =>
     isIcon &&
     css`


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

LineClampは複数行になる長文を渡した際に、任意の行数で文を切り詰めて、代わりにフォーカス時にTooltipで全文を表示するcomponentである。
このcomponentをsafariで表示すると、切り詰める前の要素の高さを維持する不具合があったため、これを修正した。

なお、chromeではこの不具合は発生しない。

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->
LineClamp内部で使用しているdiv要素(Tooltip)にて、切り詰めて見えなくなっている要素がある場合は親要素でも見えないようにoverflowを適用するようにした。

## Capture

<!--
Please attach a capture if it looks different.
-->

|before|after|
|-|-
|<img width="992" alt="スクリーンショット 2021-11-24 17 23 16" src="https://user-images.githubusercontent.com/1688137/143203959-51241992-a28c-4999-99fe-cbbf1eb552a1.png">|<img width="991" alt="スクリーンショット 2021-11-24 17 23 34" src="https://user-images.githubusercontent.com/1688137/143203969-1de93331-6b5f-45e4-95b8-26b8c2a3d9a9.png">|

