### PR TITLE
fix: `MultiComboBox` においてフォーカス中に高さが変わった時にリストボックスの位置を再計算するように修正

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -213,7 +213,8 @@ export function MultiComboBox<T>({
     if (outerRef.current && isFocused) {
       calculateDropdownRect(outerRef.current)
     }
-  }, [calculateDropdownRect, isFocused])
+    // 選択済みアイテムによってコンボボックスの高さが変わりうるので selectedItems を依存に含める
+  }, [calculateDropdownRect, isFocused, selectedItems])
 
   return (
     <Container


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`MultiComboBox` において、アイテムを選択してコンポーネントの高さが変わった時、リストボックスの座標が再計算されないバグが生じているため、修正します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 選択済みアイテムが変更された時にリストボックスの座標を再計算するように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

### 再現方法と修正後

以下の例では、3つ目のアイテムとして `option 4` を選択した時、コンボボックス内のコンテンツに改行が発生してコンポーネントの高さが変わる操作を行っています。この時、

- before では、リストボックスが1行目基準の位置のまま表示されている
- after では、リストボックスは2行目基準の位置に再計算されて表示されている

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/143530977-689debb1-6190-4d8b-b4d4-c506c8b55039.png) | ![image](https://user-images.githubusercontent.com/270422/143530832-34c9ba0a-58da-4942-ba33-8f9b3d26f544.png) |


<!--
Please attach a capture if it looks different.
-->
