### PR TITLE
fix: `ModelessDialog` を閉じた時にトリガにフォーカスを戻さないように変更 (SHRUI-479)

### DIFF
--- a/e2e/components/Dialog/ModelessDialog.test.ts
+++ b/e2e/components/Dialog/ModelessDialog.test.ts
@@ -24,7 +24,4 @@ test('ダイアログが開閉できること', async (t) => {
     .click(closer)
     .expect(dialog.exists)
     .notOk()
-    // ダイアログを閉じた後、トリガがフォーカスされること
-    .expect(trigger.focused)
-    .ok()
 })

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -129,15 +129,13 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     }, [isOpen, onPressEscape]),
   )
 
-  const { moveFocusFromTrigger, returnFocusToTrigger } = useTriggerFocusControl(wrapperRef)
+  const { moveFocusFromTrigger } = useTriggerFocusControl(wrapperRef)
   useLayoutEffect(() => {
     if (isOpen) {
       setPosition({ x: 0, y: 0 })
       moveFocusFromTrigger()
-    } else {
-      returnFocusToTrigger()
     }
-  }, [isOpen, moveFocusFromTrigger, returnFocusToTrigger])
+  }, [isOpen, moveFocusFromTrigger])
 
   useEffect(() => {
     // 中央寄せの座標計算を行う


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-479
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`ModelessDialog` は開いている間も外側の要素を操作できるので、 `ModelessDialog` を閉じた時にトリガにフォーカスが戻るのは不自然な動作と言えるので、 `ModlessDialog` を閉じたときはフォーカスを移動させないように変更します。
<!-- 
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `ModlessDialog`を閉じたときのフォーカス移動処理を削除
- 閉じたときのフォーカス移動を担保するテストを削除 
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
