### PR TITLE
fix: `MultiComboBox` のアクセシビリティ改善

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -95,10 +95,7 @@ export const Single: Story = () => {
           placeholder="入力でフィルタリングできます"
           onSelect={handleSelectItem}
           onClear={handleClear}
-          onChangeSelected={(item) => {
-            action('onChangeSelected')(item)
-            setSelectedItem(item)
-          }}
+          onChangeSelected={action('onChangeSelected')}
           data-test="single-combobox-default"
         />
       </dd>
@@ -226,10 +223,7 @@ export const Multi: Story = () => {
           placeholder="入力でフィルタリングできます"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
-          onChangeSelected={(selected) => {
-            action('onChangeSelected')(selected)
-            setSelectedItems(selected)
-          }}
+          onChangeSelected={action('onChangeSelected')}
           onFocus={action('onFocus')}
           onBlur={action('onBlur')}
           data-test="multi-combobox-default"
@@ -318,10 +312,6 @@ export const Multi: Story = () => {
           placeholder="入力でフィルタリングできます"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
-          onChangeSelected={(selected) => {
-            action('onChangeSelected')(selected)
-            setSelectedItems(selected)
-          }}
           inputValue={controlledInputValue}
           onChangeInput={(e) => {
             setControlledInputValue(e.target.value)

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -180,33 +180,64 @@ export const Single: Story = () => {
 
 export const Multi: Story = () => {
   const [items, setItems] = useState(defaultItems)
-  const [selectedItems, setSelectedItems] = useState<Item[]>([])
+  const [selectedItems, setSelectedItems] = useState<{
+    default: Item[]
+    creatable: Item[]
+    disabled: Item[]
+    error: Item[]
+    tooltip: Item[]
+    loading: Item[]
+    undeletable: Item[]
+    controllable: Item[]
+    fullWidth: Item[]
+  }>({
+    default: [],
+    creatable: [],
+    disabled: [],
+    error: [],
+    tooltip: [],
+    loading: [],
+    undeletable: [],
+    controllable: [],
+    fullWidth: [],
+  })
   const [seq, setSeq] = useState(0)
   const [controlledInputValue, setControlledInputValue] = useState<string>('')
 
   const handleSelectItem = useCallback(
-    (item: Item) => {
+    (key: keyof typeof selectedItems) => (item: Item) => {
       action('onSelect')(item)
-      setSelectedItems([...selectedItems, item])
+      const oldSelected = selectedItems[key] || []
+      setSelectedItems({
+        ...selectedItems,
+        [key]: [...oldSelected, item],
+      })
     },
     [selectedItems],
   )
   const handleDelete = useCallback(
-    (deleted) => {
+    (key: keyof typeof selectedItems) => (deleted: Item) => {
       action('onDelete')()
-      setSelectedItems(selectedItems.filter((item) => item.value !== deleted.value))
+      setSelectedItems({
+        ...selectedItems,
+        [key]: selectedItems[key].filter((item) => item.value !== deleted.value),
+      })
     },
     [selectedItems],
   )
   const handleAddItem = useCallback(
-    (label: string) => {
+    (key: keyof typeof selectedItems) => (label: string) => {
       action('onAdd')(label)
       const newItem = {
         label,
         value: `new-value-${seq}`,
       }
       setItems([...items, newItem])
-      setSelectedItems([...selectedItems, newItem])
+      const oldSelected = selectedItems[key] || []
+      setSelectedItems({
+        ...selectedItems,
+        [key]: [...oldSelected, newItem],
+      })
       setSeq(seq + 1)
     },
     [items, selectedItems, seq],
@@ -218,11 +249,11 @@ export const Multi: Story = () => {
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['default']}
           width={400}
           placeholder="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('default')}
+          onSelect={handleSelectItem('default')}
           onChangeSelected={action('onChangeSelected')}
           onFocus={action('onFocus')}
           onBlur={action('onBlur')}
@@ -233,13 +264,13 @@ export const Multi: Story = () => {
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['creatable']}
           width={400}
           placeholder="新しいアイテムを追加できます"
           creatable
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          onAdd={handleAddItem}
+          onDelete={handleDelete('creatable')}
+          onSelect={handleSelectItem('creatable')}
+          onAdd={handleAddItem('creatable')}
           data-test="multi-combobox-creatable"
         />
       </dd>
@@ -247,12 +278,12 @@ export const Multi: Story = () => {
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['disabled']}
           width={400}
           placeholder="Disabled なコンボボックス"
           disabled
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('disabled')}
+          onSelect={handleSelectItem('disabled')}
           data-test="multi-combobox-disabled"
         />
       </dd>
@@ -260,23 +291,23 @@ export const Multi: Story = () => {
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['error']}
           width={400}
           placeholder="入力でフィルタリングできます"
           error
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('error')}
+          onSelect={handleSelectItem('error')}
         />
       </dd>
       <dt>選択済みアイテムを省略表示 + ツールチップ</dt>
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['tooltip']}
           width={400}
           placeholder="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('tooltip')}
+          onSelect={handleSelectItem('tooltip')}
           selectedItemEllipsis
         />
       </dd>
@@ -284,34 +315,37 @@ export const Multi: Story = () => {
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['loading']}
           width={400}
           placeholder="入力でフィルタリングできます"
           isLoading
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('loading')}
+          onSelect={handleSelectItem('loading')}
         />
       </dd>
       <dt>選択解除ボタンを非表示</dt>
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems.map((item) => ({ ...item, deletable: false }))}
+          selectedItems={selectedItems['undeletable'].map((item) => ({
+            ...item,
+            deletable: false,
+          }))}
           width={400}
           placeholder="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('undeletable')}
+          onSelect={handleSelectItem('undeletable')}
         />
       </dd>
       <dt>テキストボックスの挙動を制御</dt>
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['controllable']}
           width={400}
           placeholder="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('controllable')}
+          onSelect={handleSelectItem('controllable')}
           inputValue={controlledInputValue}
           onChangeInput={(e) => {
             setControlledInputValue(e.target.value)
@@ -323,11 +357,11 @@ export const Multi: Story = () => {
       <dd>
         <MultiComboBox
           items={items}
-          selectedItems={selectedItems}
+          selectedItems={selectedItems['fullWidth']}
           width="100%"
           placeholder="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
+          onDelete={handleDelete('fullWidth')}
+          onSelect={handleSelectItem('fullWidth')}
         />
       </dd>
       <dt>アイテム数が多い時</dt>

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -248,7 +248,7 @@ export function MultiComboBox<T>({
       }}
     >
       <InputArea themes={theme}>
-        <SelectedList themes={theme} aria-label="選択済みの項目" aria-live="polite">
+        <SelectedList themes={theme} aria-label="選択済みの項目" aria-live="polite" aria-atomic>
           {selectedItems.map((selectedItem) => (
             <li key={selectedItem.label}>
               <MultiSelectedItem

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -248,7 +248,7 @@ export function MultiComboBox<T>({
       }}
     >
       <InputArea themes={theme}>
-        <SelectedList themes={theme} aria-label="選択済みの項目">
+        <SelectedList themes={theme} aria-label="選択済みの項目" aria-live="polite">
           {selectedItems.map((selectedItem) => (
             <li key={selectedItem.label}>
               <MultiSelectedItem
@@ -270,7 +270,7 @@ export function MultiComboBox<T>({
             </li>
           ))}
         </SelectedList>
-        <MultiOffScreenSelectedLive selectedLabels={selectedLabels} />
+        {/* <MultiOffScreenSelectedLive selectedLabels={selectedLabels} /> */}
 
         <InputWrapper className={isFocused ? undefined : 'hidden'}>
           <Input

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -366,20 +366,12 @@ const Container = styled.div<{ themes: Theme; width: number | string }>`
 const InputArea = styled.div<{ themes: Theme }>`
   ${({ themes: { spacingByChar } }) => css`
     flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
     overflow-y: auto;
     max-height: 300px;
     padding: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
-
-    /**
-     * for IE
-     * display: contents がサポートされていれば（IE以外）、 input要素は flex によって選択済み項目リストの横に並べて配置するが、
-     * IE では flex レイアウトを使わずに、input要素は選択済み項目リストの下に配置する。
-     */
-    @supports (display: contents) and (gap: 1px) {
-      display: flex;
-      flex-wrap: wrap;
-      gap: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
-    }
   `}
 `
 const SelectedList = styled.ul<{ themes: Theme }>`
@@ -387,28 +379,12 @@ const SelectedList = styled.ul<{ themes: Theme }>`
     const { spacingByChar } = themes
 
     return css`
+      display: contents;
       padding: 0;
       list-style: none;
 
-      /* for IE: gap フォールバック用の margin の外側の打ち消し */
-      margin: calc(-${spacingByChar(0.25)} / 2) calc(-${spacingByChar(0.5)} / 2);
       > li {
         max-width: calc(100% - ${spacingByChar(0.5)});
-
-        /* for IE: gap のフォールバック */
-        margin: calc(${spacingByChar(0.25)} / 2) calc(${spacingByChar(0.5)} / 2);
-      }
-
-      display: flex;
-      flex-wrap: wrap;
-      @supports (display: contents) and (gap: 1px) {
-        display: contents;
-
-        /* for IE の gap フォールバックを打ち消し */
-        flex-wrap: revert;
-        > li {
-          margin: revert;
-        }
       }
     `
   }}

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -19,6 +19,7 @@ import { useListBox } from './useListBox'
 import { MultiSelectedItem } from './MultiSelectedItem'
 import { convertMatchableString } from './comboBoxHelper'
 import { ComboBoxItem } from './types'
+import { MultiOffScreenSelectedLive } from './MultiOffScreenSelectedLive'
 
 type Props<T> = {
   /**
@@ -243,15 +244,9 @@ export function MultiComboBox<T>({
           blur()
         }
       }}
-      role="combobox"
-      aria-owns={aria.listBoxId}
-      aria-haspopup="listbox"
-      aria-expanded={isFocused}
-      aria-invalid={error || undefined}
-      aria-disabled={disabled}
     >
       <InputArea themes={theme}>
-        <SelectedList themes={theme}>
+        <SelectedList themes={theme} aria-label="選択済みの項目">
           {selectedItems.map((selectedItem) => (
             <li key={selectedItem.label}>
               <MultiSelectedItem
@@ -273,6 +268,7 @@ export function MultiComboBox<T>({
             </li>
           ))}
         </SelectedList>
+        <MultiOffScreenSelectedLive selectedLabels={selectedLabels} />
 
         <InputWrapper className={isFocused ? undefined : 'hidden'}>
           <Input
@@ -307,6 +303,12 @@ export function MultiComboBox<T>({
               handleInputKeyDown(e)
             }}
             autoComplete="off"
+            role="combobox"
+            aria-owns={aria.listBoxId}
+            aria-haspopup="listbox"
+            aria-expanded={isFocused}
+            aria-invalid={error || undefined}
+            aria-disabled={disabled}
             aria-activedescendant={aria.activeDescendant}
             aria-autocomplete="list"
             aria-controls={aria.listBoxId}

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -222,13 +222,15 @@ export function MultiComboBox<T>({
     // 選択済みアイテムによってコンボボックスの高さが変わりうるので selectedItems を依存に含める
   }, [calculateDropdownRect, isFocused, selectedItems])
 
+  const disabledClassName = useMemo(() => (disabled ? 'disabled' : ''), [disabled])
+
   return (
     <Container
       {...props}
       themes={theme}
       width={width}
       ref={outerRef}
-      className={`${className} ${classNames.wrapper}`}
+      className={`${className} ${classNames.wrapper} ${disabledClassName}`}
       onClick={(e) => {
         if (
           !hasParentElementByClassName(e.target as HTMLElement, classNames.deleteButton) &&
@@ -317,7 +319,7 @@ export function MultiComboBox<T>({
         </InputWrapper>
 
         {selectedItems.length === 0 && placeholder && !isFocused && (
-          <Placeholder themes={theme} className={classNames.placeholder}>
+          <Placeholder themes={theme} className={`${classNames.placeholder} ${disabledClassName}`}>
             {placeholder}
           </Placeholder>
         )}
@@ -354,8 +356,8 @@ const Container = styled.div<{ themes: Theme; width: number | string }>`
         border-color: ${color.DANGER};
       }
 
-      &[aria-disabled='true'] {
-        background-color: ${color.COLUMN};
+      &.disabled {
+        background-color: ${color.hoverColor(color.WHITE)};
         cursor: not-allowed;
       }
     `
@@ -450,6 +452,10 @@ const Placeholder = styled.p<{ themes: Theme }>`
       color: ${color.TEXT_GREY};
       font-size: ${fontSize.M};
       line-height: ${leading.NONE};
+
+      &.disabled {
+        color: ${color.TEXT_DISABLED};
+      }
     `
   }}
 `

--- a/src/components/ComboBox/MultiOffScreenSelectedLive.tsx
+++ b/src/components/ComboBox/MultiOffScreenSelectedLive.tsx
@@ -1,0 +1,29 @@
+import React, { VFC, memo } from 'react'
+import styled from 'styled-components'
+
+import { VISUALLY_HIDDEN_STYLE } from '../../constants'
+
+type Props = {
+  selectedLabels: string[]
+}
+
+export const MultiOffScreenSelectedLive: VFC<Props> = memo(({ selectedLabels }) => {
+  return (
+    <OffScreen aria-live="polite" aria-atomic>
+      {selectedLabels.length > 0 ? (
+        <>
+          選択済みの項目
+          {selectedLabels.map((selectedLabel, i) => (
+            <p key={i}>{selectedLabel}</p>
+          ))}
+        </>
+      ) : (
+        <p>選択済みの項目はありません</p>
+      )}
+    </OffScreen>
+  )
+})
+
+const OffScreen = styled.div`
+  ${VISUALLY_HIDDEN_STYLE}
+`

--- a/src/components/ComboBox/MultiSelectedItem.tsx
+++ b/src/components/ComboBox/MultiSelectedItem.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import styled from 'styled-components'
 
 import { Tooltip } from '../Tooltip'
 import { Props as InnerProps, MultiSelectedItemInner } from './MultiSelectedItemInner'
@@ -12,10 +13,14 @@ export function MultiSelectedItem<T>(props: Props<T>) {
   }, [])
 
   return props.enableEllipsis && hasEllipsis ? (
-    <Tooltip message={props.item.label} multiLine>
+    <StyledTooltip message={props.item.label} multiLine>
       <MultiSelectedItemInner {...props} />
-    </Tooltip>
+    </StyledTooltip>
   ) : (
     <MultiSelectedItemInner {...props} onEllipsis={handleEllipsis} />
   )
 }
+
+const StyledTooltip = styled(Tooltip)`
+  display: block;
+`

--- a/src/components/ComboBox/MultiSelectedItemInner.tsx
+++ b/src/components/ComboBox/MultiSelectedItemInner.tsx
@@ -73,25 +73,28 @@ export function MultiSelectedItemInner<T>({
 
 const Wrapper = styled.div<{ themes: Theme; disabled?: boolean }>`
   ${({ themes, disabled }) => {
-    const { border, color, fontSize } = themes
+    const { border, color, fontSize, leading, spacingByChar } = themes
 
     return css`
       position: relative;
       display: flex;
+      align-items: center;
+      min-height: calc(${leading.NONE}rem + ${spacingByChar(0.5)} * 2);
       border-radius: 1rem;
+      box-sizing: border-box;
       border: ${border.shorthand};
       background-color: ${disabled ? color.disableColor(color.WHITE) : color.WHITE};
       color: ${disabled ? color.TEXT_DISABLED : color.TEXT_BLACK};
       font-size: ${fontSize.S};
-      line-height: 1;
+      line-height: ${leading.NORMAL};
     `
   }}
 `
 const ItemLabel = styled.div<{ enableEllipsis?: boolean; themes: Theme }>`
   ${({ enableEllipsis, themes: { border, spacingByChar } }) => {
     return css`
-      flex: 1 1 0;
-      padding: calc(${spacingByChar(0.5)} - ${border.lineWidth});
+      flex-grow: 1;
+      padding: calc(${spacingByChar(0.25)} - ${border.lineWidth}) ${spacingByChar(0.5)};
 
       ${enableEllipsis &&
       css`
@@ -105,8 +108,8 @@ const ItemLabel = styled.div<{ enableEllipsis?: boolean; themes: Theme }>`
 const DeleteButton = styled(UnstyledButton)<{ themes: Theme; disabled?: boolean }>`
   ${({ themes: { border, spacingByChar, shadow }, disabled }) => {
     return css`
-      flex: 0 1 0;
-      padding: calc(${spacingByChar(0.5)} - ${border.lineWidth});
+      flex-grow: 0;
+      padding: calc(${spacingByChar(0.25)} - ${border.lineWidth}) ${spacingByChar(0.5)};
       border-radius: 50%;
       cursor: ${disabled ? 'not-allowed' : 'pointer'};
       line-height: 0;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、 `MultiComboBox` の操作を行う時、どのような変化が行ったのかが晴眼者以外に十分に明示できていないので、改善します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- DOM 構造の整理
  - 構造変更に合わせてスタイルも現行の方法に変更
- 選択済みの項目が更新されたことを伝えるための要素をオフスクリーンかつ `aria-live=polite` で追加
- storybook 上の各 `MultiComboBox` が単独で動作するようにステートを分離

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
