### PR TITLE
fix:`FlashMessage` の Wrapper に ElementProps が渡るように修正 (SHRUI-502)

### DIFF
--- a/src/components/FlashMessage/FlashMessage.tsx
+++ b/src/components/FlashMessage/FlashMessage.tsx
@@ -39,6 +39,7 @@ export const FlashMessage: VFC<Props & ElementProps> = ({
   role = 'alert',
   className = '',
   onClose,
+  ...props
 }) => {
   const theme = useTheme()
   const classNames = useClassNames()
@@ -80,6 +81,7 @@ export const FlashMessage: VFC<Props & ElementProps> = ({
 
   return (
     <Wrapper
+      {...props}
       className={`${type} ${classNames.wrapper}  ${className}`}
       themes={theme}
       animation={animation}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-502
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、 `FlashMessage` に div のデフォルト属性を渡しても DOM に反映されていないので、反映されるように修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `ElementProps` が Wrapper に渡されるように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
