### PR TITLE
SideNavItemコンポーネントのfocus-visible時に擬似要素に対するカラー変更を行う

### DIFF
--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -60,17 +60,25 @@ const Wrapper = styled.li<{ themes: Theme }>`
       &.selected {
         background-color: ${color.MAIN};
         color: ${color.TEXT_WHITE};
-        position: relative;
 
-        &::after {
-          position: absolute;
-          top: 50%;
-          right: -4px;
-          transform: translate(0, -50%);
-          border-style: solid;
-          border-width: 4px 0 4px 4px;
-          border-color: transparent transparent transparent ${color.MAIN};
-          content: '';
+        > button {
+          position: relative;
+          &::after {
+            position: absolute;
+            top: 50%;
+            right: -4px;
+            transform: translate(0, -50%);
+            border-style: solid;
+            border-width: 4px 0 4px 4px;
+            border-color: transparent transparent transparent ${color.MAIN};
+            content: '';
+          }
+
+          &:focus-visible {
+            &::after {
+              border-color: transparent transparent transparent ${color.FOCUS};
+            }
+          }
         }
       }
     `

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -23,6 +23,7 @@ type Palette = {
   OVERLAY: string
   BRAND: string
   OUTLINE: string
+  FOCUS: string
 }
 
 export type ColorProperty = Partial<Palette>
@@ -54,6 +55,7 @@ const baseColor = {
   SCRIM: 'rgba(0,0,0,0.5)',
   OVERLAY: 'rgba(0,0,0,0.15)',
   BRAND: '#00c4cc',
+  FOCUS: 'rgb(0, 95, 204)',
 }
 
 export const defaultColor = { ...baseColor, OUTLINE: baseColor.MAIN }


### PR DESCRIPTION
## summary
SideNavItemコンポーネントのfocus-visible時に擬似要素に対するカラー変更を行う。

## description
- SideNavItemコンポーネントのfocus-visibleの際にボーダーに色がつくようになっているが、擬似要素の吹き出しの色と違うので少し違和感を感じました。下記に画像を用意しましたので一度ご確認いただけますと幸いです。
- 変更に合わせてFOCUSというカラー定数を追加させていただきました。
- `selected > button > focus-visible > after`という形で指定をしたく、cssの指定方法を若干変更をさせていただきました。確認をする分には特に問題ないと思っているのですが、念のためご確認いただけますと助かります🙏
## question
- Paletteという型が作成をされているのですが、baseColorとほぼ同様であることから、baseColorから型を生成する形にしても良いのかな？と思ったのですが、今回のPRとして対応をしたい項目と異なったため現状で対応はしておりません。

## check page 
- https://deploy-preview-2099--smarthr-ui.netlify.app/?path=/story/sidenav--all

## IMAGE
### before 
<img width="754" alt="スクリーンショット 2021-12-09 2 33 20" src="https://user-images.githubusercontent.com/45672476/145256074-091de8f8-89b3-4be7-932a-ec24229ba111.png">

### after
<img width="764" alt="スクリーンショット 2021-12-09 2 30 10" src="https://user-images.githubusercontent.com/45672476/145256092-36d7dce7-b35a-4f92-8a2b-76c65f5770ef.png">
 