### PR TITLE
fix: TextLink のアイコン縦位置を正す

### DIFF
--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -85,10 +85,12 @@ const StyledAncher = styled.a<{ themes: Theme }>`
 const PrefixWrapper = styled.span<{ themes: Theme }>(
   ({ themes: { spacingByChar } }) => css`
     margin-right: ${spacingByChar(0.25)};
+    vertical-align: middle;
   `,
 )
 const SuffixWrapper = styled.span<{ themes: Theme }>(
   ({ themes: { spacingByChar } }) => css`
     margin-left: ${spacingByChar(0.25)};
+    vertical-align: middle;
   `,
 )


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

TextLink のアイコンと文字の縦位置がずれていて気になるので、テキストの縦位置中央で揃えたい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

TextLink 内のアイコン（実際には wrapper）に `vertical-align: middle` を指定。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

before | after
--- | ---
![image](https://user-images.githubusercontent.com/19403400/145270242-24499ac8-829f-4686-8453-c62c572ffda1.png) | ![image](https://user-images.githubusercontent.com/19403400/145269976-c57f8bea-d2c4-4f45-aacd-53815419ed52.png)