### PR TITLE
fix: LineClamp と Tooltip の baseline ズレを修正

### DIFF
--- a/src/components/LineClamp/LineClamp.tsx
+++ b/src/components/LineClamp/LineClamp.tsx
@@ -87,5 +87,9 @@ const Wrapper = styled.span<{ maxLines: number }>`
           -webkit-line-clamp: ${maxLines};
           /* stylelint-enable */
           overflow-y: hidden;
+
+          /* inline-block に overflow: visible 以外を指定すると、vertical-align が bottom margin edge に揃ってしまう
+           * https://ja.stackoverflow.com/questions/2603/ */
+          vertical-align: bottom;
         `}
 `

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -136,6 +136,11 @@ const Wrapper = styled.div<{ isIcon?: boolean }>`
   display: inline-block;
   max-width: 100%;
   overflow-y: hidden;
+
+  /* inline-block に overflow: visible 以外を指定すると、vertical-align が bottom margin edge に揃ってしまう
+   * https://ja.stackoverflow.com/questions/2603/ */
+  vertical-align: bottom;
+
   ${({ isIcon }) =>
     isIcon &&
     css`


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

#2074 で LineClamp や Tooltip の wrapper に overflow が追加したが、[CSS の仕様](https://www.w3.org/TR/CSS2/visudet.html#:~:text=the%20baseline%20is%20the%20bottom%20margin%20edge0)により inline-block 要素に overflow: visible 以外を充てると baseline が bottom margin の端に揃うらしい。

参考： https://codepen.io/uknmr/pen/OJxXMWg

## What I did

影響範囲はわからないが、特段問題はなさそうなので vertical-align: bottom を指定した。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
