### PR TITLE
fix: `Input`のwidthをデフォルト値より小さく設定すると表示が崩れる不具合の修正

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -31,8 +31,12 @@ storiesOf('Input', module).add('all', () => {
         <Input placeholder="string" />
       </li>
       <li>
-        <Txt>width</Txt>
+        <Txt>width (with %)</Txt>
         <Input defaultValue="width: 100%" width="100%" />
+      </li>
+      <li>
+        <Txt>width (with px)</Txt>
+        <Input defaultValue="width: 100px" width="100px" />
       </li>
       <li>
         <Txt>onChange</Txt>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -130,6 +130,7 @@ const StyledInput = styled.input<Props & { themes: Theme }>(
       font-size: ${fontSize.M};
       line-height: ${leading.NONE};
       color: ${color.TEXT_BLACK};
+      width: 100%;
 
       /* font-size * line-height で高さが思うように行かないので、相対値の font-size で高さを指定 */
       height: ${fontSize.M};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

プロダクト側でのsmarthr-uiの14.4.0 -> 15.3.0のアップデート対応で表示崩れが発生していることに気づいたので修正しました 🙏 

`Input`の`width`属性に184px以下の値を設定した場合、下記のcaptureに記載のスクショの通りinputタグの幅がwrapperのspanタグの幅を超えてしまいます。

おそらく#1909 のデグレだと思われます。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

inputタグに`width: 100%`を設定し、親のwrapperのspanタグのwidthに追従するように修正しました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

| before | after |
| - | - |
| ![スクリーンショット 2021-12-09 10 44 36](https://user-images.githubusercontent.com/32166731/145320775-39660389-6ba9-45e1-b95d-10bf7d472c15.png) | ![スクリーンショット 2021-12-09 10 45 00](https://user-images.githubusercontent.com/32166731/145320724-8be50463-52b9-42e1-bff2-7475fe85e164.png) |

<!--
Please attach a capture if it looks different.
-->
