### PR TITLE
WIP feat: improve warning color contrast ratio

### DIFF
--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -35,8 +35,9 @@ const Wrapper = styled.span<{ themes: Theme }>`
       box-sizing: border-box;
       display: inline-block;
       margin: 0;
-      border: 1px solid transparent;
-      padding: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
+      border: 2px solid transparent;
+      padding: ${spacingByChar(0.25)} calc(${spacingByChar(0.5)} - 1px)
+        calc(${spacingByChar(0.25)} - 2px);
       background-color: ${color.WHITE};
       text-align: center;
       white-space: nowrap;
@@ -56,8 +57,8 @@ const Wrapper = styled.span<{ themes: Theme }>`
       }
 
       &.process {
-        border-color: ${color.WARNING};
-        color: ${color.WARNING};
+        border-color: #ffcc17;
+        color: ${color.TEXT_GREY};
       }
 
       &.required {
@@ -76,8 +77,8 @@ const Wrapper = styled.span<{ themes: Theme }>`
       }
 
       &.warning {
-        background-color: ${color.WARNING};
-        color: ${color.TEXT_WHITE};
+        background-color: #ffcc17;
+        color: ${color.TEXT_BLACK};
       }
 
       &.error {

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -50,7 +50,7 @@ const baseColor = {
   BASE_GREY: '#f5f4f3',
   MAIN: '#0077c7',
   DANGER: '#e01e5a',
-  WARNING: '#ff8800',
+  WARNING: '#f56121',
   SCRIM: 'rgba(0,0,0,0.5)',
   OVERLAY: 'rgba(0,0,0,0.15)',
   BRAND: '#00c4cc',


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-371

## Overview

- use `sunlight` color to `color.warning` 
- use `TEXT_BLACK` to `process`
- make wide border

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
