### PR TITLE
fix: SideNav のフォーカスインジケーターを新しい装飾に置き換える

### DIFF
--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -45,7 +45,7 @@ export const SideNavItem: VFC<Props> = ({
 
 const Wrapper = styled.li<{ themes: Theme }>`
   ${({ themes }) => {
-    const { color, interaction } = themes
+    const { color, interaction, shadow } = themes
 
     return css`
       color: ${color.TEXT_BLACK};
@@ -73,6 +73,10 @@ const Wrapper = styled.li<{ themes: Theme }>`
           content: '';
         }
       }
+
+      &:focus-within {
+        ${shadow.focusIndicatorStyles}
+      }
     `
   }}
 `
@@ -82,6 +86,7 @@ const Button = styled(UnstyledButton)<{ themes: Theme }>`
     const { fontSize, spacingByChar } = themes
 
     return css`
+      outline: none;
       width: 100%;
       line-height: 1;
       box-sizing: border-box;


### PR DESCRIPTION
## Related URL

#2099 

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

#2099 で指摘いただいたフォーカスインジケーターを修正しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- SideNavItem の `focus-within` に `theme.shadow.focusIndicatorStyles` を追加
- 実態であるボタンのフォーカスインジケーターを削除

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

before | after
--- |---
![image](https://user-images.githubusercontent.com/19403400/145502075-e8f151bf-ce00-4b63-a95d-accb5237e3ac.png) | ![image](https://user-images.githubusercontent.com/19403400/145501966-85a9add3-2451-4dda-9a4c-6d1a6d713687.png)


<!--
Please attach a capture if it looks different.
-->
