### PR TITLE
feat: コンボボックスが全半角大小文字を区別せずマッチするように変更

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -17,6 +17,7 @@ import { useClassNames } from './useClassNames'
 import { FaCaretDownIcon } from '../Icon'
 import { useListBox } from './useListBox'
 import { MultiSelectedItem } from './MultiSelectedItem'
+import { convertMatchableString } from './comboBoxHelper'
 import { Item } from './types'
 
 type Props<T> = {
@@ -145,7 +146,7 @@ export function MultiComboBox<T>({
   const filteredItems = items.filter(({ label }) => {
     if (selectedLabels.includes(label)) return false
     if (!inputValue) return true
-    return label.includes(inputValue)
+    return convertMatchableString(label).includes(convertMatchableString(inputValue))
   })
   const isDuplicate = items.some((item) => item.label === inputValue)
   const hasSelectableExactMatch = filteredItems.some((item) => item.label === inputValue)

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -17,6 +17,7 @@ import { Input } from '../Input'
 import { FaCaretDownIcon, FaTimesCircleIcon } from '../Icon'
 import { UnstyledButton } from '../Button'
 import { useListBox } from './useListBox'
+import { convertMatchableString } from './comboBoxHelper'
 import { Item } from './types'
 
 type Props<T> = {
@@ -131,7 +132,7 @@ export function SingleComboBox<T>({
 
     return itemsWithSelected.filter(({ label }) => {
       if (!inputValue) return true
-      return label.includes(inputValue)
+      return convertMatchableString(label).includes(convertMatchableString(inputValue))
     })
   }, [inputValue, isEditing, items, selectedItem])
   const isDuplicate = items.some((item) => item.label === inputValue)

--- a/src/components/ComboBox/comboBoxHelper.ts
+++ b/src/components/ComboBox/comboBoxHelper.ts
@@ -1,0 +1,15 @@
+export function convertMatchableString(original: string) {
+  return (
+    original
+      .replace(/\s/g, ' ')
+      .replace(/’/g, "'")
+      .replace(/[”“]/g, '"')
+      .replace(/｀/g, '`')
+      .replace(/￥/g, '¥')
+      .replace(/−/g, '-')
+      .replace(/〜/g, '~')
+      // unicode で [！] から [｝] の間に定義されている英数・記号を半角に変換
+      .replace(/[！-｝]/g, (str) => String.fromCharCode(str.charCodeAt(0) - 0xfee0))
+      .toLowerCase()
+  )
+}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-504
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現在のコンボボックスは入力によってリストをフィルタリングする際に、全角半角・大文字小文字を区別した部分一致で判定していますが、これらを区別せずマッチしてフィルタリングするように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 文字列を半角・小文字に変換してからマッチングするように変更
  - 英数と記号を対象とする

### やっていないこと
- 半角カナには触れていません

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
- 全角
![image](https://user-images.githubusercontent.com/270422/145537658-b115ca23-1667-4ff3-9663-bc9659b48b7b.png)
- 大文字
![image](https://user-images.githubusercontent.com/270422/145537683-98441504-61c1-4fcb-9ce6-2a6259155d27.png)

<!--
Please attach a capture if it looks different.
-->
