### PR TITLE
chore: CircleCI上の使用イメージを `cimg/node` に変更する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
 jobs:
   node-v14:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.18
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -69,7 +69,7 @@ jobs:
       - run-npm-test
   node-v16:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -79,7 +79,7 @@ jobs:
       - run-npm-test
   reg-suit:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - run-npm-test
   node-v16:
     docker:
-      - image: cimg/node:16
+      - image: cimg/node:16.13
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
@@ -79,7 +79,7 @@ jobs:
       - run-npm-test
   reg-suit:
     docker:
-      - image: cimg/node:16
+      - image: cimg/node:16.13
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "url": "https://github.com/kufu/smarthr-ui/issues"
   },
   "engines": {
-    "node": ">=v14.18.1"
+    "node": ">=v14.18.2"
   },
   "files": [
     "esm",


### PR DESCRIPTION
## Related URL
- 派生元ブランチ
    - https://github.com/kufu/smarthr-ui/pull/2091
- cimg/node
    - https://circleci.com/developer/ja/images/image/cimg/node

## Overview
- CircleCI上のdocker imageを `circleci/node` から `cimg/node` に変更します
- node v14系を `14.18.2` にアップデートします

## What I did
- package.jsonのnode versionを更新
- circleciのconfigを更新

## Capture