### PR TITLE
feat: Change `<StatusLabel>`, `<AppNavi>`'s string props to ReactNode

### DIFF
--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -12,7 +12,7 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 type Props = {
   /** ラベルのテキスト */
-  label?: string
+  label?: ReactNode
   /** 表示するボタンの Props の配列 */
   buttons?: Array<
     AppNaviButtonProps | AppNaviAnchorProps | AppNaviDropdownProps | AppNaviCustomTagProps

--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, VFC } from 'react'
+import React, { HTMLAttributes, ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -7,7 +7,7 @@ import { useClassNames } from './useClassNames'
 type Props = {
   type?: 'done' | 'success' | 'process' | 'required' | 'disabled' | 'must' | 'warning' | 'error'
   className?: string
-  children: string
+  children: ReactNode
 }
 type ElementProps = Omit<HTMLAttributes<HTMLSpanElement>, keyof Props>
 


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-514

## Overview

For internationalization, change string props to ReactNode

## What I did

- Change `<AppNavi>` label props
- Change `<StatusLabel>` children props