### PR TITLE
chore!: IE のサポートを終了する (SHRUI-505)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        browser: [ie, chrome]
+        browser: [chrome]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta

--- a/scripts/build-test.ts
+++ b/scripts/build-test.ts
@@ -6,9 +6,9 @@ const MemoryFS = require('memory-fs')
 const compiler = webpack({
   mode: 'development',
   entry: path.resolve('src', 'index.ts'),
-  target: ['web', 'es5'],
+  target: ['web', 'es2020'],
   devtool: 'nosources-source-map',
-  plugins: [new ECMAVersionValidatorPlugin()],
+  plugins: [new ECMAVersionValidatorPlugin({ ecmaVersion: 2020 })],
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "lib": ["es2018", "dom"],
-    "target": "es5",
+    "lib": ["es2020", "dom"],
+    "target": "es2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-505
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
プロダクト側の IE サポート終了に合わせて UI も IE のサポートを終了します。

※: 念の為 BREAKING CHANGE にしています
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- IE の e2e テストを削除
- build-test のターゲットを es5 から es2020 に変更
- tsc の target と lib を es2020 に変更

### やってないこと
各フォールバックの削除は別途行います

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
