### PR TITLE
feat: Change <ActionDialog>'s string props to ReactNode

### DIFF
--- a/e2e/components/Dialog/ActionDialog.test.ts
+++ b/e2e/components/Dialog/ActionDialog.test.ts
@@ -10,7 +10,9 @@ test('ダイアログが開閉できること', async (t) => {
   const trigger = Selector('[data-test=dialog-trigger]')
   const content = Selector('[data-test=dialog-content]')
   const closer = content.find('.smarthr-ui-Dialog-closeButton')
-  const background = content.parent('[role=dialog]').find('.smarthr-ui-Dialog-background')
+  const background = content
+    .parent('.smarthr-ui-Dialog-wrapper')
+    .find('.smarthr-ui-Dialog-background')
 
   await t
     .click(trigger)

--- a/e2e/components/Dialog/Dialog.test.ts
+++ b/e2e/components/Dialog/Dialog.test.ts
@@ -10,7 +10,9 @@ test('ダイアログが開閉できること', async (t) => {
   const trigger = Selector('[data-test=dialog-trigger]')
   const content = Selector('[data-test=dialog-content]')
   const closer = Selector('[data-test=dialog-closer]')
-  const background = content.parent('[role=dialog]').find('.smarthr-ui-Dialog-background')
+  const background = content
+    .parent('.smarthr-ui-Dialog-wrapper')
+    .find('.smarthr-ui-Dialog-background')
 
   await t
     .click(trigger)

--- a/e2e/components/Dialog/DialogWrapper.test.ts
+++ b/e2e/components/Dialog/DialogWrapper.test.ts
@@ -10,7 +10,9 @@ test('DialogContent が開閉できること', async (t) => {
   const trigger = Selector('[data-test=dialog-trigger]')
   const content = Selector('[data-test=dialog-content]')
   const closer = Selector('[data-test=dialog-closer]')
-  const background = content.parent('[role=dialog]').find('.smarthr-ui-Dialog-background')
+  const background = content
+    .parent('.smarthr-ui-Dialog-wrapper')
+    .find('.smarthr-ui-Dialog-background')
 
   await t
     .click(trigger)
@@ -35,7 +37,9 @@ test('MessageDialogContent が開閉できること', async (t) => {
   const trigger = Selector('[data-test=message-dialog-trigger]')
   const content = Selector('[data-test=message-dialog-content]')
   const closer = content.find('.smarthr-ui-Dialog-closeButton')
-  const background = content.parent('[role=dialog]').find('.smarthr-ui-Dialog-background')
+  const background = content
+    .parent('.smarthr-ui-Dialog-wrapper')
+    .find('.smarthr-ui-Dialog-background')
 
   await t
     .click(trigger)
@@ -60,7 +64,9 @@ test('ActionDialogContent が開閉できること', async (t) => {
   const trigger = Selector('[data-test=action-dialog-trigger]')
   const content = Selector('[data-test=action-dialog-content]')
   const closer = content.find('.smarthr-ui-Dialog-closeButton')
-  const background = content.parent('[role=dialog]').find('.smarthr-ui-Dialog-background')
+  const background = content
+    .parent('.smarthr-ui-Dialog-wrapper')
+    .find('.smarthr-ui-Dialog-background')
 
   await t
     .click(trigger)

--- a/e2e/components/Dialog/MessageDialog.test.ts
+++ b/e2e/components/Dialog/MessageDialog.test.ts
@@ -10,7 +10,9 @@ test('ダイアログが開閉できること', async (t) => {
   const trigger = Selector('[data-test=dialog-trigger]')
   const content = Selector('[data-test=dialog-content]')
   const closer = content.find('.smarthr-ui-Dialog-closeButton')
-  const background = content.parent('[role=dialog]').find('.smarthr-ui-Dialog-background')
+  const background = content
+    .parent('.smarthr-ui-Dialog-wrapper')
+    .find('.smarthr-ui-Dialog-background')
 
   await t
     .click(trigger)

--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -1,10 +1,11 @@
 import React, { HTMLAttributes, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
+import { useId } from '../../hooks/useId'
 import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
 import { ActionDialogContentInner, ActionDialogContentInnerProps } from './ActionDialogContentInner'
 
-type Props = ActionDialogContentInnerProps & {
+type Props = Omit<ActionDialogContentInnerProps, 'titleId'> & {
   onClickClose: () => void
   portalParent?: HTMLElement
 } & Pick<
@@ -30,6 +31,7 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   ...props
 }) => {
   const portalContainer = useRef(document.createElement('div')).current
+  const titleId = useId()
 
   useEffect(() => {
     // SSR を考慮し、useEffect 内で初期値 document.body を指定
@@ -55,13 +57,10 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   }, [onClickAction, onClickClose, props.isOpen])
 
   return createPortal(
-    <DialogContentInner
-      ariaLabel={subtitle ? `${subtitle} ${title}` : title}
-      className={className}
-      {...props}
-    >
+    <DialogContentInner ariaLabelledby={titleId} className={className} {...props}>
       <ActionDialogContentInner
         title={title}
+        titleId={titleId}
         subtitle={subtitle}
         closeText={closeText}
         actionText={actionText}

--- a/src/components/Dialog/ActionDialogContent.tsx
+++ b/src/components/Dialog/ActionDialogContent.tsx
@@ -3,8 +3,10 @@ import React, { HTMLAttributes, useCallback, useContext } from 'react'
 import { DialogContext } from './DialogWrapper'
 import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
 import { ActionDialogContentInner, BaseProps } from './ActionDialogContentInner'
+import { useId } from '../../hooks/useId'
 
-type Props = BaseProps & Pick<DialogContentInnerProps, 'top' | 'right' | 'bottom' | 'left' | 'id'>
+type Props = Omit<BaseProps, 'titleId'> &
+  Pick<DialogContentInnerProps, 'top' | 'right' | 'bottom' | 'left' | 'id'>
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
@@ -34,18 +36,21 @@ export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
     onClickAction(onClickClose)
   }, [active, onClickAction, onClickClose])
 
+  const titleId = useId()
+
   return (
     <DialogContentRoot>
       <DialogContentInner
         onClickOverlay={onClickClose}
         onPressEscape={onClickClose}
         isOpen={active}
-        ariaLabel={title}
+        ariaLabelledby={titleId}
         className={className}
         {...props}
       >
         <ActionDialogContentInner
           title={title}
+          titleId={titleId}
           closeText={closeText}
           actionText={actionText}
           actionTheme={actionTheme}

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -21,6 +21,7 @@ export type BaseProps = {
    */
   title: string
   subtitle?: string
+  titleId: string
   /**
    * Label of close button.
    */
@@ -68,6 +69,7 @@ export type ActionDialogContentInnerProps = BaseProps & {
 export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   children,
   title,
+  titleId,
   subtitle,
   closeText,
   actionText,
@@ -99,7 +101,7 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
             {subtitle}
           </Text>
         )}
-        <Text as="p" size="L" leading="TIGHT" className={classNames.title}>
+        <Text id={titleId} as="p" size="L" leading="TIGHT" className={classNames.title}>
           {title}
         </Text>
       </TitleArea>

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { VFC, useCallback } from 'react'
+import React, { ReactNode, VFC, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -15,21 +15,21 @@ export type BaseProps = {
   /**
    * Body of the dialog.
    */
-  children: React.ReactNode
+  children: ReactNode
   /**
    * Title of the dialog.
    */
-  title: string
-  subtitle?: string
+  title: ReactNode
+  subtitle?: ReactNode
   titleId: string
   /**
    * Label of close button.
    */
-  closeText: string
+  closeText: ReactNode
   /**
    * Label of action button.
    */
-  actionText: string
+  actionText: ReactNode
   /**
    * Action button style theme.
    */

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -108,14 +108,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
   return (
     <DialogPositionProvider top={props.top} bottom={props.bottom}>
       <DialogOverlap isOpen={isOpen}>
-        <Layout
-          className={classNames.wrapper}
-          id={id}
-          role="dialog"
-          aria-modal="true"
-          aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledby}
-        >
+        <Layout className={classNames.wrapper} id={id}>
           <Background
             onClick={handleClickOverlay}
             themes={theme}
@@ -126,6 +119,8 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
               ref={innerRef}
               themes={theme}
               role="dialog"
+              aria-label={ariaLabel}
+              aria-labelledby={ariaLabelledby}
               aria-modal="true"
               className={`${className} ${classNames.dialog}`}
               {...props}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-516

## Overview & What I did

For internationalization, change string props to ReactNode.

ActionDialog accessibility name ware named by `title` and `subTitle` strings.
Change ActionDialog to be named by `aria-labelledby`.

and fix role, aria-label, aria-labelledby attribute position
