### PR TITLE
docs: delete deperecated Component

### DIFF
--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -1,21 +1,9 @@
 # Tooltip
 
 ```tsx
-import { LightTooltip, DarkTooltip } from 'smarthr-ui'
+import { Tooltip } from 'smarthr-ui'
 
-// LightTooltip
-<LightTooltip message="Text in tooltip">
-  Displayed text
-</LightTooltip>
-
-// DarkTooltip
-<DarkTooltip
-  message={<span>You can also add ReactNode</span>}
-  horizontal="right"
-  vertical="middle"
->
-  Displayed text
-</DarkTooltip>
+;<Tooltip message="Text in tooltip">Displayed text</Tooltip>
 ```
 
 ## props


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Delete deprecated component from Tooltip README

## What I did

Replace `<LightTooltip>`, `<DarkTooltip>` to `<Tooltip>`

## Capture

<!--
Please attach a capture if it looks different.
-->
