### PR TITLE
fix: actionDialogのLoaderの表示崩れを修正

### DIFF
--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -187,8 +187,8 @@ const MessageWrapper = styled.div<{ themes: Theme }>`
 const Spinner = styled(Loader)<{ themes: Theme }>`
   &&& {
     > div {
-      width: 1rem;
-      height: 1rem;
+      width: 18px;
+      height: 18px;
     }
 
     > div > div {


### PR DESCRIPTION
## Related URL

## Overview
- ActionDialogのローダーのアイコン部分が崩れていたので修正しました。

## What I did
- サイズを `1rem` -> `18px` に修正

## Capture

|before|after|
|:---|:---|
|![image](https://user-images.githubusercontent.com/5885283/147033751-d85b994a-eaa9-40f0-a975-d0422c051c74.png)|![image](https://user-images.githubusercontent.com/5885283/149459641-0e1df748-b0c8-4cc0-9401-5a72acd5708c.png)|
