### PR TITLE
test: export テストをホワイトリスト形式に変更 (SHRUI-503)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,18 +6,19 @@ import path from 'path'
 const readFile = util.promisify(fs.readFile)
 const readdir = util.promisify(fs.readdir)
 
+const IGNORE_COMPONENTS = ['Downloader', 'ProgressBar']
+const IGNORE_INNER_DIRS = ['FlashMessage/FlashMessageList']
+
 describe('index', () => {
   const indexPath = './src/index.ts'
   const componentsPath = './src/components'
 
-  const IGNORE_COMPONENTS = ['Downloader', 'ProgressBar']
   it('src/components 配下に存在する全てのディレクトリからコンポーネントが export されていること', async () => {
     const exported = await getExportedComponents(indexPath)
     const componentDirs = await getComponentDirs(componentsPath, IGNORE_COMPONENTS)
     expect(componentDirs.sort()).toEqual(exported.sort())
   })
 
-  const IGNORE_INNER_DIRS = ['FlashMessageList']
   it('各コンポーネントディレクトリ直下に存在する子ディレクトリ名と同名のコンポーネントが export されていること', async () => {
     const componentDirs = await getComponentDirs(componentsPath, IGNORE_COMPONENTS)
     componentDirs.forEach(async (dirName) => {
@@ -88,7 +89,7 @@ const getComponentDirs = async (dirPath: string, ignoreDirs: string[] = []) => {
       (file) =>
         file.isDirectory() &&
         !file.name.match(/^__.+__$/) && // __tests__ や __snapshots__ ディレクトリを除外
-        !ignoreDirs.includes(file.name),
+        !ignoreDirs.find((ignoreDir) => path.join(dirPath, file.name).match(`${ignoreDir}$`)),
     )
     .map((file) => file.name)
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,40 +1,52 @@
 import ts from 'typescript'
 import util from 'util'
 import fs from 'fs'
+import path from 'path'
 
 const readFile = util.promisify(fs.readFile)
 const readdir = util.promisify(fs.readdir)
 
-const IGNORE_DIRS = ['__tests__', 'Downloader', 'ProgressBar']
-
 describe('index', () => {
-  it('should export all components in the components directory from index.ts', async () => {
-    const actual = await getExportedComponents('./src/index.ts')
-    const expected = await getExistingComponents('./src/components/', IGNORE_DIRS)
-    expect(expected.sort()).toEqual(actual.sort())
+  const indexPath = './src/index.ts'
+  const componentsPath = './src/components'
+
+  const IGNORE_COMPONENTS = ['Downloader', 'ProgressBar']
+  it('src/components 配下に存在する全てのディレクトリからコンポーネントが export されていること', async () => {
+    const exported = await getExportedComponents(indexPath)
+    const componentDirs = await getComponentDirs(componentsPath, IGNORE_COMPONENTS)
+    expect(componentDirs.sort()).toEqual(exported.sort())
   })
 
-  describe('Layout', () => {
-    const IGNORE_FILES = ['index.ts', 'type.ts', 'Layout.stories.tsx']
-
-    it('components/Layout ディレクトリの全てのコンポーネントが components/Layout/index.ts 経由で index.ts から export されていること', async () => {
-      const actual = await getExportedDirectoryComponents('./src/index.ts', './components/Layout')
-      const expected = await getExistingComponents('./src/components/Layout/', IGNORE_FILES)
-      expect(expected.sort()).toEqual(actual.sort())
+  const IGNORE_INNER_DIRS = ['FlashMessageList']
+  it('各コンポーネントディレクトリ直下に存在する子ディレクトリ名と同名のコンポーネントが export されていること', async () => {
+    const componentDirs = await getComponentDirs(componentsPath, IGNORE_COMPONENTS)
+    componentDirs.forEach(async (dirName) => {
+      const componentDirPath = path.join(componentsPath, dirName)
+      const innerComponents = await getComponentDirs(componentDirPath, IGNORE_INNER_DIRS)
+      if (innerComponents.length === 0) {
+        return
+      }
+      const exportedCompoenntsFromInnerDir = await getExportedDirectoryComponents(
+        indexPath,
+        `./components/${dirName}`,
+      )
+      expect(exportedCompoenntsFromInnerDir.sort()).toEqual(
+        expect.arrayContaining(innerComponents.sort()),
+      )
     })
   })
 })
 
 const getExportPath = (node: ts.ExportDeclaration) => {
-  let path = ''
+  let exportPath = ''
 
   node.forEachChild((child: ts.Node) => {
     if (ts.isStringLiteral(child)) {
-      path = `${child.text}`
+      exportPath = `${child.text}`
     }
   })
 
-  return path
+  return exportPath
 }
 
 const getAllExportPaths = (sourceFile: ts.SourceFile): string[] => {
@@ -69,9 +81,16 @@ const getExportedComponents = async (file: string): Promise<string[]> => {
   return files.filter(isNonComponentsExports).map(getComponentName)
 }
 
-const getExistingComponents = async (file: string, filterDirs: string[]): Promise<string[]> => {
-  const dirs = await readdir(file)
-  return dirs.filter((dir) => !filterDirs.includes(dir))
+const getComponentDirs = async (dirPath: string, ignoreDirs: string[] = []) => {
+  const files = await readdir(dirPath, { withFileTypes: true })
+  return files
+    .filter(
+      (file) =>
+        file.isDirectory() &&
+        !file.name.match(/^__.+__$/) && // __tests__ や __snapshots__ ディレクトリを除外
+        !ignoreDirs.includes(file.name),
+    )
+    .map((file) => file.name)
 }
 
 const getExportedDirectoryComponents = async (


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-503
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、 `src/components` 配下にあるコンポーネントが `index.ts` から export されているかどうかはテストで担保されています。
また、 `src/components/Layout` 配下の `Cluster` や `LineUp` などのような多重のディレクトリ構成に対するテストも用意されていますが、こちらはブラックリスト形式になっており、新たに子ディレクトリを切った時そのディレクトリを検証対象として追加しなければテストされず、作業者がそのことに気付けないという課題感がありました。

この PR では、その多重ディレクトリに対する export 確認テストをホワイトリスト形式に変更し、ディレクトリを切った段階で検証対象に追加され、検証したくないディレクトリを IGNORE で管理する形にすることで export 漏れを回避しやすくなるように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `src/components` 配下の各コンポーネントディレクトリ内の子コンポーネントを探索して、export と突き合わせる形に変更
  - 無視したい子ディレクトリは `IGNORE_INNER_DIRS` で管理
- ディレクトリ取得ロジックを改善
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
