### PR TITLE
fix: `FloatArea` のモバイルでのレイアウト崩れを修正 (SHRUI-381)

### DIFF
--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -10,7 +10,7 @@ import styled, { css } from 'styled-components'
 import { DialogBase as BaseComponent } from '../Base'
 import { FaExclamationCircleIcon, FaExclamationTriangleIcon } from '../Icon'
 import { Text } from '../Text'
-import { LineUp } from '../Layout'
+import { Cluster, LineUp } from '../Layout'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
@@ -64,19 +64,23 @@ export const FloatArea: VFC<Props & ElementProps> = ({
 
   return (
     <Base themes={theme} className={`${className} ${classNames.wrapper}`} $width={width} {...props}>
-      <LineUp align="space-between" vAlign="center">
+      <Cluster gap={1}>
         {tertiaryButton && tertiaryButton}
-        <RightSide gap={1} vAlign="center">
-          {errorText && (
-            <ErrorMessage gap={0.25} vAlign="center" as="p" className={classNames.errorText}>
-              {errorIcon && <ErrorIcon themes={theme}>{errorIcon}</ErrorIcon>}
-              <Text size="S">{errorText}</Text>
-            </ErrorMessage>
-          )}
-          {secondaryButton && secondaryButton}
-          {primaryButton && primaryButton}
+        <RightSide>
+          <Cluster gap={1}>
+            {errorText && (
+              <ErrorMessage gap={0.25} vAlign="center" as="p" className={classNames.errorText}>
+                {errorIcon && <ErrorIcon themes={theme}>{errorIcon}</ErrorIcon>}
+                <Text size="S">{errorText}</Text>
+              </ErrorMessage>
+            )}
+            <Cluster gap={1}>
+              {secondaryButton && secondaryButton}
+              {primaryButton && primaryButton}
+            </Cluster>
+          </Cluster>
         </RightSide>
-      </LineUp>
+      </Cluster>
     </Base>
   )
 }
@@ -92,7 +96,7 @@ const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string 
       padding: ${spacingByChar(1)};
     `}
 `
-const RightSide = styled(LineUp)`
+const RightSide = styled.div`
   margin-left: auto;
 `
 const ErrorMessage = styled(LineUp)`


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-381
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`FloatArea` コンポーネントをモバイル端末で表示するとレイアウトが崩れるのを修正します。

※ この PR では表示崩れに対する暫定的な対応のみ行い、モバイル表示に対する本質的な対応は別チケットで行うことを想定しています。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 表示領域が狭い場合は改行して表示するように変更
  - 以下の3つの領域単位で改行されるように、 Cluster を3層追加
    - Tertiary ボタン
    - エラーメッセージ
    - Primary と Secondary ボタン
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/148025433-99aaef1f-9afa-4899-8898-563c88fdadb1.png) | ![image](https://user-images.githubusercontent.com/270422/148025332-b445b3c8-3d47-4fb8-a5aa-834077e6ce91.png) |
| ![image](https://user-images.githubusercontent.com/270422/148025407-44f9cb89-7edb-4be0-8a1e-9e0ae19ec811.png) | ![image](https://user-images.githubusercontent.com/270422/148025371-a65e8068-6ab7-4c8a-b72a-cc6ed6751b18.png) |
<!--
Please attach a capture if it looks different.
-->
