### PR TITLE
fix: Safari にて `InputFile` の onAdd がループしないように修正

### DIFF
--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -35,6 +35,7 @@ export const InputFile: VFC<Props> = ({
   const theme = useTheme()
   const FileButtonWrapperClassName = `${disabled ? 'disabled' : ''}`
   const FileButtonClassName = `${size}`
+  const isUpdatingFiles = React.useRef(false)
 
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -45,7 +46,9 @@ export const InputFile: VFC<Props> = ({
         buff.items.add(file)
       })
 
+      isUpdatingFiles.current = true
       inputRef.current.files = buff.files
+      isUpdatingFiles.current = false
     }
   }, [files])
 
@@ -59,7 +62,7 @@ export const InputFile: VFC<Props> = ({
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (onAdd && e.target.files && e.target.files?.length > 0) {
+    if (!isUpdatingFiles.current && onAdd && e.target.files && e.target.files?.length > 0) {
       const uploadFile = Array.from(e.target.files)
       onAdd(uploadFile)
     }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
Safari にて、 `InputFile` コンポーネントでファイル選択を行うと更新処理がループして動作不能になる問題に対処します。

### 再現方法
同一の `InputFile` に対して、2回ファイル選択を行うと発生します。

### 原因
Safari においてのみ、 input[type=file] 要素の files プロパティに代入を行ったときに onChange が発火する動作をするため、 ファイル選択 → onChange → onAdd → useEffect で代入 → onChange → onAdd  → useEffect で代入... とループしてしまう。

### 対処
まずは暫定対応として、代入時に onAdd が発火することを抑止する方針で問題を回避します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- input.files への代入時には onAdd が発火しないように変更
  - 代入中かどうかをフラグで管理
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
