### PR TITLE
feat: `FlashMessage` に autoClose オプションを追加 (SHRUI-512)

### DIFF
--- a/src/components/FlashMessage/FlashMessage.stories.tsx
+++ b/src/components/FlashMessage/FlashMessage.stories.tsx
@@ -67,6 +67,7 @@ None.args = { animation: 'none' }
 
 export const Demo: Story = () => {
   const [visible, setVisible] = React.useState<boolean>(true)
+  const [autoClose, setAutoClose] = React.useState<boolean>(true)
   const [type, setType] = React.useState<Props['type']>('success')
   const [animation, setAnimation] = React.useState<Props['animation']>('bounce')
   const [text, setText] = React.useState<string>('自動保存しました')
@@ -83,19 +84,30 @@ export const Demo: Story = () => {
     <div style={{ padding: '20px' }}>
       <p>
         <label>
-          visible
           <input
             type="checkbox"
             name="visible"
             checked={visible}
             onChange={() => setVisible(!visible)}
           />
+          visible
         </label>
       </p>
       <p>
         <label>
           text
           <input type="text" value={text} onChange={(e) => setText(e.currentTarget.value)} />
+        </label>
+      </p>
+      <p>
+        <label>
+          <input
+            type="checkbox"
+            name="autoClose"
+            checked={autoClose}
+            onChange={(e) => setAutoClose(e.target.checked)}
+          />
+          auto close
         </label>
       </p>
       <fieldset>
@@ -130,6 +142,7 @@ export const Demo: Story = () => {
 
       <FlashMessage
         visible={visible}
+        autoClose={autoClose}
         type={type}
         text={text}
         animation={animation}

--- a/src/components/FlashMessage/FlashMessage.tsx
+++ b/src/components/FlashMessage/FlashMessage.tsx
@@ -32,6 +32,8 @@ export type Props = {
   className?: string
   /** 閉じるボタンを押下、または表示してから8秒後に発火するコールバック関数 */
   onClose: () => void
+  /** FlashMessage が表示されてから一定時間後に自動で閉じるかどうか */
+  autoClose?: boolean
 }
 
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
@@ -46,13 +48,14 @@ export const FlashMessage: VFC<Props & ElementProps> = ({
   role = 'alert',
   className = '',
   onClose,
+  autoClose = true,
   ...props
 }) => {
   const theme = useTheme()
   const classNames = useClassNames()
 
   useEffect(() => {
-    if (!visible) {
+    if (!visible || !autoClose) {
       return
     }
     const timerId = setTimeout(onClose, REMOVE_DELAY)
@@ -60,7 +63,7 @@ export const FlashMessage: VFC<Props & ElementProps> = ({
     return () => {
       clearTimeout(timerId)
     }
-  }, [onClose, visible])
+  }, [autoClose, onClose, visible])
 
   if (!visible) return null
 


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-512
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、 `FlashMessage` コンポーネントは表示8秒後に自動で閉じることを抑止できませんが、これを抑止できるようにオプションを追加します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `autoClose` オプションを追加
  - `true` のとき、表示8秒後に `onClose` を発火（デフォルト）
  - `false` のとき、時間経過での `onClose` 発火を行わない
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
