### PR TITLE
fix: `Footer` のレイアウト修正

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -41,18 +41,18 @@ export const Footer: VFC<ElementProps> = ({ className = '', ...props }) => {
 
 const Wrapper = styled.footer<{ themes: Theme }>`
   ${({ themes: { color, fontSize, spacingByChar } }) => css`
-    overflow: hidden;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
     padding: ${spacingByChar(1)} ${spacingByChar(1.5)};
     background-color: ${color.BRAND};
     color: ${color.TEXT_WHITE};
     font-size: ${fontSize.M};
-    white-space: nowrap;
   `}
 `
 
 const List = styled.ul<{ themes: Theme }>`
   ${({ themes: { spacingByChar } }) => css`
-    float: left;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -95,7 +95,7 @@ const ItemPart = styled.a<{ themes: Theme }>`
 
 const Copy = styled.small<{ themes: Theme }>`
   ${({ themes }) => css`
-    float: right;
+    margin-left: auto;
     font-size: ${themes.fontSize.M};
   `}
 `


### PR DESCRIPTION
## Related URL
#2129 
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Footer` コンポーネント内のレイアウトが float で行われていたので flex に変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- レイアウトを flex に変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
