### PR TITLE
feat: NotificationBar を作成｜SHRUI-508

### DIFF
--- a/src/components/Layout/Cluster/Cluster.tsx
+++ b/src/components/Layout/Cluster/Cluster.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 import { useSpacing } from '../../../hooks/useSpacing'
 import type { Gap, SeparateGap } from '../type'
@@ -6,17 +6,7 @@ import type { Gap, SeparateGap } from '../type'
 type alignMethod = 'normal' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch'
 type justifyMethod = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around'
 
-/**
- * @param gap 間隔の指定（基準フォントサイズの相対値または抽象値）
- * @param rowGap 垂直方向の間隔の指定（基準フォントサイズの相対値または抽象値）
- * @param columnGap 水平方向の間隔の指定（基準フォントサイズの相対値または抽象値）
- * @param align 垂直方向の揃え方（align-items）
- * @param justify 水平方向の揃え方（justify-content）
- * @param as ネガティブマージンを隠す要素の HTML タグ名
- * @param bodyAs Cluster 本体の HTML タグ名
- * @param children 均等に間隔を空けたい要素群
- */
-export const Cluster: React.VFC<{
+type Props = {
   /** 間隔の指定（基準フォントサイズの相対値または抽象値） */
   gap?: Gap | SeparateGap
   /** 垂直方向の揃え方（align-items） */
@@ -29,8 +19,29 @@ export const Cluster: React.VFC<{
   bodyAs?: React.ElementType
   /** 均等に間隔を空けたい要素群 */
   children?: React.ReactNode
-}> = ({ gap = 0.5, align, justify, as, bodyAs, children }) => (
-  <Wrapper as={as}>
+}
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+
+/**
+ * @param gap 間隔の指定（基準フォントサイズの相対値または抽象値）
+ * @param rowGap 垂直方向の間隔の指定（基準フォントサイズの相対値または抽象値）
+ * @param columnGap 水平方向の間隔の指定（基準フォントサイズの相対値または抽象値）
+ * @param align 垂直方向の揃え方（align-items）
+ * @param justify 水平方向の揃え方（justify-content）
+ * @param as ネガティブマージンを隠す要素の HTML タグ名
+ * @param bodyAs Cluster 本体の HTML タグ名
+ * @param children 均等に間隔を空けたい要素群
+ */
+export const Cluster: React.VFC<Props & ElementProps> = ({
+  gap = 0.5,
+  align,
+  justify,
+  as,
+  bodyAs,
+  children,
+  ...props
+}) => (
+  <Wrapper as={as} {...props}>
     <Body as={bodyAs} gap={gap} align={align} justify={justify}>
       {children}
     </Body>

--- a/src/components/Layout/Cluster/Cluster.tsx
+++ b/src/components/Layout/Cluster/Cluster.tsx
@@ -1,5 +1,7 @@
 import React, { HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
+
+import { useClassNames } from './useClassNames'
 import { useSpacing } from '../../../hooks/useSpacing'
 import type { Gap, SeparateGap } from '../type'
 
@@ -39,14 +41,19 @@ export const Cluster: React.VFC<Props & ElementProps> = ({
   as,
   bodyAs,
   children,
+  className,
   ...props
-}) => (
-  <Wrapper as={as} {...props}>
-    <Body as={bodyAs} gap={gap} align={align} justify={justify}>
-      {children}
-    </Body>
-  </Wrapper>
-)
+}) => {
+  const classNames = useClassNames()
+
+  return (
+    <Wrapper as={as} {...props} className={`${classNames.wrapper}${className && ` ${className}`}`}>
+      <Body as={bodyAs} gap={gap} align={align} justify={justify} className={`${classNames.body}`}>
+        {children}
+      </Body>
+    </Wrapper>
+  )
+}
 
 // gap のネガティブマージンを隠すための要素、gap が利用できる場合は不要
 // Wrapper to hide the negative margin of gap, not required if gap is available.

--- a/src/components/Layout/Cluster/useClassNames.ts
+++ b/src/components/Layout/Cluster/useClassNames.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../../hooks/useClassNameGenerator'
+import { Cluster } from './Cluster'
+
+export const useClassNames = () => {
+  const generate = useClassNameGenerator(Cluster.displayName || 'Cluster')
+
+  return useMemo(
+    () => ({
+      wrapper: generate('wrapper'),
+      // Wrapper は意識しないはずなので Body に無印を与える
+      body: generate(),
+    }),
+    [generate],
+  )
+}

--- a/src/components/NotificationBar/NotificationBar.stories.tsx
+++ b/src/components/NotificationBar/NotificationBar.stories.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Story } from '@storybook/react'
+
+import { NotificationBar } from './NotificationBar'
+import readme from './README.md'
+
+import { LineClamp } from '../LineClamp'
+import { SecondaryButton } from '../Button'
+import { Stack } from '../Layout'
+import { Text } from '../Text'
+import { TextLink as shrTextLink } from '../TextLink'
+
+export default {
+  title: 'NotificationBar',
+  component: NotificationBar,
+  parameters: {
+    readme: {
+      sidebar: readme,
+    },
+  },
+}
+
+const TextLink = styled(shrTextLink)`
+  color: inherit;
+
+  &:hover,
+  &:focus {
+    color: inherit;
+  }
+`
+
+const Actions = () => (
+  <>
+    <SecondaryButton size="s">編集</SecondaryButton>
+    <TextLink href="#">
+      <Text size="S">ヘルプ</Text>
+    </TextLink>
+  </>
+)
+
+export const all: Story = () => {
+  const onClose = () => console.log('close')
+
+  return (
+    <Stack gap={0}>
+      <NotificationBar type="info" message="バックグラウンド処理中です。" onClose={onClose} />
+      <NotificationBar type="success" message="タスクの削除に成功しました。" onClose={onClose} />
+      <NotificationBar type="error" message="タスクの削除に失敗しました。" onClose={onClose} />
+      <NotificationBar
+        type="warning"
+        message="評価開始中にタスクの削除を実行すると、情報の整合性が取れなくなる可能性があります。"
+        onClose={onClose}
+      />
+      <NotificationBar
+        type="info"
+        message="表じゃなくなるのでborder-collapseプロパティー等に影響があるけど、子のtd要素等にはその影響は波及しないのであまり問題もなさそう。"
+        onClose={onClose}
+      >
+        <Actions />
+      </NotificationBar>
+      <NotificationBar
+        type="success"
+        message="Float Label Patternはかっこよくて、単にラベルをプレースホルダーにするよりはマシなので使いたくなる。"
+        onClose={onClose}
+      >
+        <Actions />
+      </NotificationBar>
+      <NotificationBar
+        type="error"
+        message="実装の基本的な部分での至らなさなので、こっちの修正が完了するまでは上記のようなCSSで一部ごまかすしかなさそう。"
+        onClose={onClose}
+      >
+        <Actions />
+      </NotificationBar>
+      <NotificationBar
+        type="warning"
+        message="履歴の共有は、検索結果の最適化やアプリの推薦などまで考えると、真価を発揮すると思う。"
+        onClose={onClose}
+      >
+        <Actions />
+      </NotificationBar>
+      <NotificationBar type="info" message="onClose を省略すると、閉じるボタンが消えます" />
+      <NotificationBar
+        type="success"
+        message={
+          <LineClamp maxLines={1} withTooltip>
+            非推奨ですが、LineClamp
+            を使用して省略もできます。そのでっかい領域によるヘッダー（のナビゲーション）へのアクセス性の低下をフォローするために多くのウェブサイトはヘッダーを固定しちゃうわけなんだけど、それでは同時にコンテンツの閲覧性に影響を与えてしまう。
+          </LineClamp>
+        }
+        onClose={onClose}
+      />
+    </Stack>
+  )
+}

--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -91,7 +91,7 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
       <ContentsWrapper align="center">
         <Icon color={iconColor} />
         <MessageWrapper align="center" gap={{ row: 0.75, column: 1 }} right>
-          <Text>{message}</Text>
+          <Text leading="TIGHT">{message}</Text>
           {children && (
             <ActionWrapper
               themes={theme}
@@ -106,7 +106,7 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
       </ContentsWrapper>
       {onClose && (
         <CloseButton
-          bgColor={colorSet.bgColor}
+          colorSet={colorSet}
           themes={theme}
           onClick={onClose}
           className={classNames.closeButton}
@@ -158,17 +158,19 @@ const ActionWrapper = styled(Cluster)<{
   `,
 )
 const CloseButton = styled(TextButton)<{
-  bgColor: string
+  colorSet: { fgColor: string; bgColor: string }
   themes: Theme
 }>(
-  ({ bgColor, themes: { color, spacingByChar } }) => css`
+  ({ colorSet: { fgColor, bgColor }, themes: { color, spacingByChar } }) => css`
     margin-top: ${spacingByChar(-0.5)};
     margin-right: ${spacingByChar(-0.5)};
     margin-bottom: ${spacingByChar(-0.5)};
+    color: ${fgColor};
 
     &:hover,
     &:focus {
       background-color: ${color.hoverColor(bgColor)};
+      color: ${fgColor};
     }
   `,
 )

--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -1,0 +1,171 @@
+import React, { HTMLAttributes, useMemo } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+import { useClassNames } from './useClassNames'
+
+import {
+  FaCheckCircleIcon,
+  FaExclamationCircleIcon,
+  FaExclamationTriangleIcon,
+  FaInfoCircleIcon,
+  FaTimesIcon,
+} from '../Icon'
+import { Cluster, Sidebar } from '../Layout'
+import { Text } from '../Text'
+import { TextButton } from '../Button'
+
+export const messageTypes = ['info', 'success', 'error', 'warning'] as const
+
+type Props = {
+  /** メッセージの種類 */
+  type: typeof messageTypes[number]
+  /** メッセージ */
+  message: React.ReactNode
+  /** 閉じるボタン押下時に発火させる関数 */
+  onClose?: () => void
+  /** アクション群 */
+  children?: React.ReactNode
+  /** role 属性 */
+  role?: 'alert' | 'status'
+}
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+
+export const NotificationBar: React.VFC<Props & ElementProps> = ({
+  type,
+  message,
+  onClose,
+  children,
+  role = type === 'info' ? 'status' : 'alert',
+  className,
+  ...props
+}) => {
+  const theme = useTheme()
+  const { color } = theme
+  const classNames = useClassNames()
+
+  const { Icon, iconColor, ...colorSet } = useMemo(() => {
+    switch (type) {
+      case 'info':
+        return {
+          Icon: FaInfoCircleIcon,
+          iconColor: color.MAIN,
+          fgColor: color.TEXT_BLACK,
+          bgColor: color.WHITE,
+        }
+      case 'success':
+        return {
+          Icon: FaCheckCircleIcon,
+          iconColor: color.WHITE,
+          fgColor: color.TEXT_WHITE,
+          bgColor: color.MAIN,
+        }
+      case 'error':
+        return {
+          Icon: FaExclamationCircleIcon,
+          iconColor: color.WHITE,
+          fgColor: color.TEXT_WHITE,
+          bgColor: color.DANGER,
+        }
+      case 'warning':
+        return {
+          Icon: FaExclamationTriangleIcon,
+          iconColor: color.TEXT_BLACK,
+          fgColor: color.TEXT_BLACK,
+          // FIXME: WARNING の色を見直す時に定数化する
+          bgColor: '#ffcc17',
+        }
+    }
+  }, [type])
+
+  return (
+    <Wrapper
+      {...props}
+      className={`${type} ${classNames.wrapper}${className && ` ${className}`}`}
+      role={role}
+      themes={theme}
+      colorSet={colorSet}
+    >
+      <ContentsWrapper>
+        <Icon color={iconColor} />
+        <MessageWrapper>
+          <Text>{message}</Text>
+          {children && (
+            <ActionWrapper themes={theme} className={classNames.actions}>
+              {children}
+            </ActionWrapper>
+          )}
+        </MessageWrapper>
+      </ContentsWrapper>
+      {onClose && (
+        <CloseButton
+          bgColor={colorSet.bgColor}
+          themes={theme}
+          onClick={onClose}
+          className={classNames.closeButton}
+        >
+          <FaTimesIcon visuallyHiddenText="閉じる" />
+        </CloseButton>
+      )}
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled(Cluster).attrs({ align: 'center', justify: 'space-between' })<{
+  themes: Theme
+  colorSet: { fgColor: string; bgColor: string }
+}>(
+  ({ themes: { spacingByChar }, colorSet: { fgColor, bgColor } }) => css`
+    background-color: ${bgColor};
+    padding-top: ${spacingByChar(0.75)};
+    padding-right: ${spacingByChar(1)};
+    padding-bottom: ${spacingByChar(0.75)};
+    padding-left: ${spacingByChar(0.75)};
+    color: ${fgColor};
+
+    .smarthr-ui-Cluster {
+      flex-wrap: revert;
+    }
+  `,
+)
+const ContentsWrapper = styled(Cluster).attrs({ align: 'center' })`
+  flex-grow: 1;
+  /* flexbox で ellipsis するために min-width をつけて幅の計算を発生させている */
+  min-width: 0;
+
+  .smarthr-ui-Icon {
+    flex-shrink: 0;
+  }
+`
+const MessageWrapper = styled(Sidebar).attrs({
+  align: 'center',
+  gap: { row: 0.75, column: 1 },
+  right: true,
+})`
+  flex-grow: 1;
+  /* flexbox で ellipsis するために min-width をつけて幅の計算を発生させている */
+  min-width: 0;
+`
+const ActionWrapper = styled(Cluster).attrs({ align: 'center', justify: 'flex-end' })<{
+  themes: Theme
+}>(
+  ({ themes: { spacingByChar } }) => css`
+    margin-top: ${spacingByChar(-0.5)};
+    margin-bottom: ${spacingByChar(-0.5)};
+  `,
+)
+const CloseButton = styled(TextButton).attrs({ size: 's' })<{
+  bgColor: string
+  themes: Theme
+}>(
+  ({ bgColor, themes: { color, spacingByChar } }) => css`
+    margin-top: ${spacingByChar(-0.5)};
+    margin-right: ${spacingByChar(-0.5)};
+    margin-bottom: ${spacingByChar(-0.5)};
+
+    &:hover,
+    &:focus {
+      background-color: ${color.hoverColor(bgColor)};
+    }
+  `,
+)

--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -85,13 +85,20 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
       role={role}
       themes={theme}
       colorSet={colorSet}
+      align="center"
+      justify="space-between"
     >
-      <ContentsWrapper>
+      <ContentsWrapper align="center">
         <Icon color={iconColor} />
-        <MessageWrapper>
+        <MessageWrapper align="center" gap={{ row: 0.75, column: 1 }} right>
           <Text>{message}</Text>
           {children && (
-            <ActionWrapper themes={theme} className={classNames.actions}>
+            <ActionWrapper
+              themes={theme}
+              className={classNames.actions}
+              align="center"
+              justify="flex-end"
+            >
               {children}
             </ActionWrapper>
           )}
@@ -103,6 +110,7 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
           themes={theme}
           onClick={onClose}
           className={classNames.closeButton}
+          size="s"
         >
           <FaTimesIcon visuallyHiddenText="閉じる" />
         </CloseButton>
@@ -111,16 +119,13 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
   )
 }
 
-const Wrapper = styled(Cluster).attrs({ align: 'center', justify: 'space-between' })<{
+const Wrapper = styled(Cluster)<{
   themes: Theme
   colorSet: { fgColor: string; bgColor: string }
 }>(
   ({ themes: { spacingByChar }, colorSet: { fgColor, bgColor } }) => css`
     background-color: ${bgColor};
-    padding-top: ${spacingByChar(0.75)};
-    padding-right: ${spacingByChar(1)};
-    padding-bottom: ${spacingByChar(0.75)};
-    padding-left: ${spacingByChar(0.75)};
+    padding: ${spacingByChar(0.75)};
     color: ${fgColor};
 
     .smarthr-ui-Cluster {
@@ -128,8 +133,9 @@ const Wrapper = styled(Cluster).attrs({ align: 'center', justify: 'space-between
     }
   `,
 )
-const ContentsWrapper = styled(Cluster).attrs({ align: 'center' })`
+const ContentsWrapper = styled(Cluster)`
   flex-grow: 1;
+
   /* flexbox で ellipsis するために min-width をつけて幅の計算を発生させている */
   min-width: 0;
 
@@ -137,16 +143,13 @@ const ContentsWrapper = styled(Cluster).attrs({ align: 'center' })`
     flex-shrink: 0;
   }
 `
-const MessageWrapper = styled(Sidebar).attrs({
-  align: 'center',
-  gap: { row: 0.75, column: 1 },
-  right: true,
-})`
+const MessageWrapper = styled(Sidebar)`
   flex-grow: 1;
+
   /* flexbox で ellipsis するために min-width をつけて幅の計算を発生させている */
   min-width: 0;
 `
-const ActionWrapper = styled(Cluster).attrs({ align: 'center', justify: 'flex-end' })<{
+const ActionWrapper = styled(Cluster)<{
   themes: Theme
 }>(
   ({ themes: { spacingByChar } }) => css`
@@ -154,7 +157,7 @@ const ActionWrapper = styled(Cluster).attrs({ align: 'center', justify: 'flex-en
     margin-bottom: ${spacingByChar(-0.5)};
   `,
 )
-const CloseButton = styled(TextButton).attrs({ size: 's' })<{
+const CloseButton = styled(TextButton)<{
   bgColor: string
   themes: Theme
 }>(

--- a/src/components/NotificationBar/README.md
+++ b/src/components/NotificationBar/README.md
@@ -1,0 +1,13 @@
+# NotificationBar
+
+FlashMessage の代替コンポーネントです。
+AppNavi の直下でアプリケーション全体の通知メッセージとして使用したり、ダイアログやテーブルなど特定のコンテキスト下におけるメッセージとしても使えます。
+
+<details>
+<summary>使い方</summary>
+
+```tsx
+import { NotificationBar } from 'smarthr-ui'
+```
+
+</details>

--- a/src/components/NotificationBar/index.ts
+++ b/src/components/NotificationBar/index.ts
@@ -1,0 +1,1 @@
+export { NotificationBar } from './NotificationBar'

--- a/src/components/NotificationBar/useClassNames.ts
+++ b/src/components/NotificationBar/useClassNames.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+import { NotificationBar } from './NotificationBar'
+
+export const useClassNames = () => {
+  const generate = useClassNameGenerator(NotificationBar.displayName || 'NotificationBar')
+
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+      actions: generate('actions'),
+      closeButton: generate('closeButton'),
+    }),
+    [generate],
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export { SideNav } from './components/SideNav'
 export { CompactInformationPanel } from './components/CompactInformationPanel'
 export { Text } from './components/Text'
 export { LineClamp } from './components/LineClamp'
+export { NotificationBar } from './components/NotificationBar'
 
 // layout components
 export { Cluster, LineUp, Stack, Sidebar } from './components/Layout'


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-508
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FlashMessage の代替として NotificationBar を作成しました。
表示制御は各アプリケーションに委ねます。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- コンポーネントの新規作成
- Cluster に HTML 属性や className を渡すように修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

コンテンツ量と幅に依ってレイアウトが変わります。

![image](https://user-images.githubusercontent.com/19403400/149702959-c0e19f0d-b0b5-4165-ac3d-0ddfbc38a632.png)
![image](https://user-images.githubusercontent.com/19403400/149703056-f161ac84-d5b0-424a-ade7-1cebef66da15.png)
メッセー欄の幅がアクション群よりも狭くなる場合は、アクション群が折り返されます。
![image](https://user-images.githubusercontent.com/19403400/149703397-b0fbae2e-588a-4f2d-adbb-1b1e45143876.png)
