### PR TITLE
fix: NotificationBar の className に undefined が混じるバグを修正

### DIFF
--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -37,7 +37,7 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
   onClose,
   children,
   role = type === 'info' ? 'status' : 'alert',
-  className,
+  className = '',
   ...props
 }) => {
   const theme = useTheme()


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

NotificationBar の className が `smarthr-ui-NotificationBarundefined` となっていた。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

className のデフォルト値を空文字とし、`undefined` が文字列として表示されないようにした。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
