### PR TITLE
fix: BottomFixedArea のシャドウを調整する

### DIFF
--- a/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -100,6 +100,10 @@ const Base = styled(BaseComponent)<{ themes: Theme; zIndex: number }>`
       padding: ${spacingByChar(1.5)};
       text-align: center;
       z-index: ${zIndex};
+      /* 再利用の可能性がいまのところないのと、シャドウのルール整備できていないので一旦テーマに入れずにハードコーディング */
+      box-shadow: 0 -4px 8px 2px rgba(0, 0, 0, 0.24);
+      border-radius: none;
+      box-sizing: border-box;
     `
   }}
 `

--- a/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -100,7 +100,6 @@ const Base = styled(BaseComponent)<{ themes: Theme; zIndex: number }>`
       padding: ${spacingByChar(1.5)};
       text-align: center;
       z-index: ${zIndex};
-      /* 再利用の可能性がいまのところないのと、シャドウのルール整備できていないので一旦テーマに入れずにハードコーディング */
       box-shadow: 0 -4px 8px 2px rgba(0, 0, 0, 0.24);
       border-radius: 0;
       box-sizing: border-box;

--- a/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -102,7 +102,7 @@ const Base = styled(BaseComponent)<{ themes: Theme; zIndex: number }>`
       z-index: ${zIndex};
       /* 再利用の可能性がいまのところないのと、シャドウのルール整備できていないので一旦テーマに入れずにハードコーディング */
       box-shadow: 0 -4px 8px 2px rgba(0, 0, 0, 0.24);
-      border-radius: none;
+      border-radius: 0;
       box-sizing: border-box;
     `
   }}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- shadow を定数にしたことにより、BottomFixedArea の shadow が見えなくなってしまったので修正

## What I did

- BottomFixedArea の Base の shadow の値を変更
  - Theme のルールに含められなかったので一旦コンポーネント内にハードコーディング
- 同 Base の border-radius を削除
  - BottomFixedArea では不要のため
- 同 Base に `box-sizing: border-box` を追加
  - padding の分幅が伸び、中央がずれていたので

## Capture

### before

![image](https://user-images.githubusercontent.com/1614892/151120891-66b11c8c-83ba-40d0-a021-612a9807577b.png)

### after

![image](https://user-images.githubusercontent.com/1614892/151120828-a07f05b9-18e1-4542-a70b-963b97487f7a.png)

