### PR TITLE
fix: Input[type=number] のスクロールで数値が変更されるのを防ぐ

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -7,6 +7,7 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react'
 import styled, { css } from 'styled-components'
@@ -49,15 +50,11 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       [onBlur],
     )
 
-    const handleWheel = useCallback(
-      (e: WheelEvent) => {
-        if (props.type === 'number') {
-          // wheel イベントに preventDefault はないため
-          e.target && (e.target as HTMLInputElement).blur()
-        }
-      },
-      [props.type],
-    )
+    const disableWheel = useCallback((e: WheelEvent) => {
+      // wheel イベントに preventDefault はないため
+      e.target && (e.target as HTMLInputElement).blur()
+    }, [])
+    const handleWheel = useMemo(() => (props.type === 'number' ? disableWheel : null), [])
 
     useEffect(() => {
       if (autoFocus && innerRef.current) {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -2,7 +2,9 @@ import React, {
   FocusEvent,
   InputHTMLAttributes,
   ReactNode,
+  WheelEvent,
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -45,6 +47,16 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       onBlur && onBlur(e)
     }
 
+    const handleWheel = useCallback(
+      (e: WheelEvent) => {
+        if (props.type === 'number') {
+          // wheel イベントに preventDefault はないため
+          e.target && (e.target as HTMLInputElement).blur()
+        }
+      },
+      [props.type],
+    )
+
     useEffect(() => {
       if (autoFocus && innerRef.current) {
         innerRef.current.focus()
@@ -70,6 +82,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
         <StyledInput
           onFocus={handleFocus}
           onBlur={handleBlur}
+          onWheel={handleWheel}
           {...props}
           ref={innerRef}
           themes={theme}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -39,13 +39,15 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       () => innerRef.current,
     )
 
-    const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
-      onFocus && onFocus(e)
-    }
+    const handleFocus = useCallback(
+      (e: FocusEvent<HTMLInputElement>) => onFocus && onFocus(e),
+      [onFocus],
+    )
 
-    const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
-      onBlur && onBlur(e)
-    }
+    const handleBlur = useCallback(
+      (e: FocusEvent<HTMLInputElement>) => onBlur && onBlur(e),
+      [onBlur],
+    )
 
     const handleWheel = useCallback(
       (e: WheelEvent) => {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -52,7 +52,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
         return undefined
       }
 
-      return (e: FocusEvent<HTMLInputElement>) => onBlur && onBlur(e)
+      return (e: FocusEvent<HTMLInputElement>) => onBlur(e)
     }, [onBlur])
 
     const handleWheel = useMemo(() => (props.type === 'number' ? disableWheel : undefined), [])

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,7 +4,6 @@ import React, {
   ReactNode,
   WheelEvent,
   forwardRef,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -40,21 +39,23 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       () => innerRef.current,
     )
 
-    const handleFocus = useCallback(
-      (e: FocusEvent<HTMLInputElement>) => onFocus && onFocus(e),
-      [onFocus],
-    )
+    const handleFocus = useMemo(() => {
+      if (!onFocus) {
+        return undefined
+      }
 
-    const handleBlur = useCallback(
-      (e: FocusEvent<HTMLInputElement>) => onBlur && onBlur(e),
-      [onBlur],
-    )
+      return (e: FocusEvent<HTMLInputElement>) => onFocus(e)
+    }, [onFocus])
 
-    const disableWheel = useCallback((e: WheelEvent) => {
-      // wheel イベントに preventDefault はないため
-      e.target && (e.target as HTMLInputElement).blur()
-    }, [])
-    const handleWheel = useMemo(() => (props.type === 'number' ? disableWheel : null), [])
+    const handleBlur = useMemo(() => {
+      if (!onBlur) {
+        return undefined
+      }
+
+      return (e: FocusEvent<HTMLInputElement>) => onBlur && onBlur(e)
+    }, [onBlur])
+
+    const handleWheel = useMemo(() => (props.type === 'number' ? disableWheel : undefined), [])
 
     useEffect(() => {
       if (autoFocus && innerRef.current) {
@@ -97,6 +98,11 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     )
   },
 )
+
+const disableWheel = (e: WheelEvent) => {
+  // wheel イベントに preventDefault はないため
+  e.target && (e.target as HTMLInputElement).blur()
+}
 
 const Wrapper = styled.span<{
   themes: Theme


### PR DESCRIPTION

input[type=number] にフォーカスがある状態でポインティングデバイスに依るホイールイベントが発生すると数値が変化してしまう。
これを防ぐために input[type=number] の場合に限り、wheel イベントが発生したら Blur する※。

※ これは wheel イベントに preventDefault がないため
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->