### PR TITLE
fix: Input の useMemo 記述漏れ依存配列を追記

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -55,7 +55,10 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       return (e: FocusEvent<HTMLInputElement>) => onBlur(e)
     }, [onBlur])
 
-    const handleWheel = useMemo(() => (props.type === 'number' ? disableWheel : undefined), [])
+    const handleWheel = useMemo(
+      () => (props.type === 'number' ? disableWheel : undefined),
+      [props.type],
+    )
 
     useEffect(() => {
       if (autoFocus && innerRef.current) {


### PR DESCRIPTION
`useMemo` の dependency に対象のオブジェクトを追加しました。
#2233 の対応で漏れてました。