### PR TITLE
docs: Monpei を追加

### DIFF
--- a/src/composite/Monpei/Dougubako.tsx
+++ b/src/composite/Monpei/Dougubako.tsx
@@ -1,0 +1,52 @@
+import React, { ComponentProps, ReactElement } from 'react'
+import styled from 'styled-components'
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownTrigger,
+  FaCaretDownIcon,
+  SecondaryButton,
+  SecondaryButtonAnchor,
+  Stack,
+} from '../..'
+
+type Actions = ActionItem | ActionItem[]
+// TODO: これでコンポーネントを絞れるわけではないので linter を書く
+type ActionItem =
+  | ReactElement<ComponentProps<typeof SecondaryButton>>
+  | ReactElement<ComponentProps<typeof SecondaryButtonAnchor>>
+type Props = {
+  /** 引き金となるボタンラベル。デフォルトは “その他の操作” */
+  label?: string
+  /** 操作群 */
+  children: Actions
+}
+
+export const Dougubako: React.VFC<Props> = ({ label = 'その他の操作', children }) => (
+  <Dropdown>
+    <DropdownTrigger>
+      <SecondaryButton suffix={<FaCaretDownIcon visuallyHiddenText="候補を開く" />}>
+        {label}
+      </SecondaryButton>
+    </DropdownTrigger>
+    <DropdownContent>
+      <ActionList as="ul" gap={0}>
+        {React.Children.map(children, (action, i) => (
+          <ActionItem key={i}>{action}</ActionItem>
+        ))}
+      </ActionList>
+    </DropdownContent>
+  </Dropdown>
+)
+
+const ActionList = styled(Stack)`
+  list-style: none;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 0;
+
+  .smarthr-ui-SecondaryButton {
+    border: none;
+  }
+`
+const ActionItem = styled.li``

--- a/src/composite/Monpei/Monpei.stories.tsx
+++ b/src/composite/Monpei/Monpei.stories.tsx
@@ -1,0 +1,39 @@
+import { Story } from '@storybook/react'
+import React from 'react'
+
+import { Monpei } from './Monpei'
+
+import { SecondaryButton } from '../..'
+import { Dougubako } from './Dougubako'
+
+export default {
+  title: 'Composite/Monpei',
+  component: Monpei,
+}
+
+const dummy = {
+  title: '従業員サーベイ',
+  description:
+    '一部の数値データにおいて、クロス集計する際の集計単位を変更できます例えば「年齢」を「60」以上をまとめる、「20」以下をまとめる、「10」単位でまとめるのように設定すると、以下のように出力されます。',
+  actions: () => (
+    <>
+      <SecondaryButton>共有</SecondaryButton>
+      <Dougubako>
+        <SecondaryButton>削除</SecondaryButton>
+      </Dougubako>
+    </>
+  ),
+}
+
+export const Default: Story = () => (
+  <Monpei title={dummy.title} description={dummy.description}>
+    <dummy.actions />
+  </Monpei>
+)
+export const 操作なし: Story = () => <Monpei title={dummy.title} description={dummy.description} />
+export const 説明なし: Story = () => (
+  <Monpei title={dummy.title}>
+    <dummy.actions />
+  </Monpei>
+)
+export const 見出しのみ: Story = () => <Monpei title={dummy.title} />

--- a/src/composite/Monpei/Monpei.tsx
+++ b/src/composite/Monpei/Monpei.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Cluster, Heading, Stack, Text } from '../..'
+import { HeadingTagTypes } from '../../components/Heading'
+
+type Props = {
+  /* 見出し */
+  title: string
+  /* 見出しとなる HTML 要素（h1–h6） */
+  titleTag?: HeadingTagTypes
+  /** 説明 */
+  description?: string
+  /** 操作群 */
+  children?: React.ReactNode
+}
+
+/**
+ * Monpei
+ * 表札に呼び鈴、門扉、塀という家の顔である門塀。見出しとその操作、説明は利用者がまず目にするページの顔になります。
+ */
+export const Monpei: React.VFC<Props> = ({ title, description, children }) => (
+  <Stack style={{ margin: '1.5em' }}>
+    <Cluster align="center" justify="space-between">
+      <Heading>{title}</Heading>
+      {children && (
+        <Actions>
+          <Cluster justify="flex-end" gap={0.75}>
+            {children}
+          </Cluster>
+        </Actions>
+      )}
+    </Cluster>
+    {description && <Text>{description}</Text>}
+  </Stack>
+)
+const Actions = styled.div`
+  flex-grow: 1;
+`


### PR DESCRIPTION
## Overview

Component の複合で作る実装パターンを書く場所として Composite を提案します。

Monpei（門塀）：
利用者がはじめて目にするページの顔でもある見出しや説明、操作のセットを、家の顔である門塀に例えています。

実装パターンとして機能するかどうかのレビューをお願いします。
以下のような意見がもらえると嬉しいです。
- 実装例として Heading が h1 固定なのどうなの
- button[size=s] なパターンはいらないの
  
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-523
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

