### PR TITLE
fix: NotificationBar の useMemo dependency 漏れを追記

### DIFF
--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -76,7 +76,7 @@ export const NotificationBar: React.VFC<Props & ElementProps> = ({
           bgColor: '#ffcc17',
         }
     }
-  }, [type])
+  }, [color, type])
 
   return (
     <Wrapper


### PR DESCRIPTION
useMemo の依存が漏れていたので追記しました。