### PR TITLE
fix: style of `defaultChecked`

### DIFF
--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -35,11 +35,9 @@ export const CheckBoxInput: VFC<Props> = ({ mixed = false, onChange, ...props })
         {...(mixed && { 'aria-checked': 'mixed' })}
       />
       <Box className={boxClassName} themes={theme} />
-      {checked && (
-        <IconWrap themes={theme}>
-          {mixed ? <FaMinusIcon color="TEXT_WHITE" /> : <FaCheckIcon color="TEXT_WHITE" />}
-        </IconWrap>
-      )}
+      <IconWrap themes={theme}>
+        {mixed ? <FaMinusIcon color="TEXT_WHITE" /> : <FaCheckIcon color="TEXT_WHITE" />}
+      </IconWrap>
     </Wrapper>
   )
 }
@@ -47,6 +45,7 @@ export const CheckBoxInput: VFC<Props> = ({ mixed = false, onChange, ...props })
 const Wrapper = styled.span<{ themes: Theme }>`
   ${({ themes }) => {
     const { fontSize } = themes
+
     return css`
       position: relative;
       display: inline-block;
@@ -70,16 +69,15 @@ const Box = styled.span<{ themes: Theme }>`
       background-color: ${color.WHITE};
       box-sizing: border-box;
       pointer-events: none;
-      &.active {
+
+      input:checked + & {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
       }
-      &.disabled {
+
+      input[disabled] + & {
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};
-        &.active {
-          border-color: ${color.BORDER};
-        }
       }
     `
   }}
@@ -122,6 +120,11 @@ const IconWrap = styled.span<{ themes: Theme }>`
       font-size: ${fontSize.XXS};
       transform: translate(-50%, -50%);
       pointer-events: none;
+
+      input:not(:checked) ~ & > svg {
+        fill: transparent;
+      }
+
       & > svg {
         vertical-align: top;
       }

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,81 +1,79 @@
 import React, { ChangeEvent, useState } from 'react'
 import styled from 'styled-components'
-import { storiesOf } from '@storybook/react'
+import { Story } from '@storybook/react'
 
 import readme from './README.md'
 
 import { RadioButton } from './RadioButton'
 
-storiesOf('RadioButton', module)
-  .addParameters({
+export default {
+  title: 'RadioButton',
+  component: RadioButton,
+  parameters: {
     readme: {
       sidebar: readme,
     },
-  })
-  .add('all', () => {
-    const [checkedName, setCheckedName] = useState<string | null>(null)
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => setCheckedName(e.currentTarget.name)
+  },
+}
 
-    return (
-      <WrapperList>
-        <li>
-          <Title>With children prop</Title>
+export const All: Story = () => {
+  const [checkedName, setCheckedName] = useState<string | null>(null)
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => setCheckedName(e.currentTarget.name)
 
-          <InnerList>
-            <li>
-              <RadioButton name="1" checked={checkedName === '1'} onChange={handleChange}>
-                RadioButton
-              </RadioButton>
-            </li>
+  return (
+    <WrapperList>
+      <li>
+        <Title>With children prop</Title>
 
-            <li>
-              <RadioButton name="2" checked={checkedName === '2'} disabled onChange={handleChange}>
-                RadioButton / disabled
-              </RadioButton>
-            </li>
-          </InnerList>
-        </li>
+        <InnerList>
+          <li>
+            <RadioButton name="1" checked={checkedName === '1'} onChange={handleChange}>
+              RadioButton
+            </RadioButton>
+          </li>
 
-        <li>
-          <Title>Without children prop</Title>
+          <li>
+            <RadioButton name="2" checked={checkedName === '2'} disabled onChange={handleChange}>
+              RadioButton / disabled
+            </RadioButton>
+          </li>
+        </InnerList>
+      </li>
 
-          <InnerList>
-            <li>
-              <RadioButton name="3" checked={checkedName === '3'} onChange={handleChange} />
-            </li>
+      <li>
+        <Title>Without children prop</Title>
 
-            <li>
-              <RadioButton
-                name="4"
-                checked={checkedName === '4'}
-                disabled
-                onChange={handleChange}
-              />
-            </li>
-          </InnerList>
-        </li>
+        <InnerList>
+          <li>
+            <RadioButton name="3" checked={checkedName === '3'} onChange={handleChange} />
+          </li>
 
-        <li>
-          <Title>With multiline text</Title>
+          <li>
+            <RadioButton name="4" checked={checkedName === '4'} disabled onChange={handleChange} />
+          </li>
+        </InnerList>
+      </li>
 
-          <InnerList>
-            <li>
-              <RadioButton name="5" checked={checkedName === '5'} onChange={handleChange}>
-                Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
-                Ipsum has been the industry&apos;s standard dummy text ever since the 1500s, when an
-                unknown printer took a galley of type and scrambled it to make a type specimen book.
-                It has survived not only five centuries, but also the leap into electronic
-                typesetting, remaining essentially unchanged. It was popularised in the 1960s with
-                the release of Letraset sheets containing Lorem Ipsum passages, and more recently
-                with desktop publishing software like Aldus PageMaker including versions of Lorem
-                Ipsum.
-              </RadioButton>
-            </li>
-          </InnerList>
-        </li>
-      </WrapperList>
-    )
-  })
+      <li>
+        <Title>With multiline text</Title>
+
+        <InnerList>
+          <li>
+            <RadioButton name="5" checked={checkedName === '5'} onChange={handleChange}>
+              Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
+              has been the industry&apos;s standard dummy text ever since the 1500s, when an unknown
+              printer took a galley of type and scrambled it to make a type specimen book. It has
+              survived not only five centuries, but also the leap into electronic typesetting,
+              remaining essentially unchanged. It was popularised in the 1960s with the release of
+              Letraset sheets containing Lorem Ipsum passages, and more recently with desktop
+              publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+            </RadioButton>
+          </li>
+        </InnerList>
+      </li>
+    </WrapperList>
+  )
+}
 
 const WrapperList = styled.ul`
   padding: 0 24px;

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -59,7 +59,7 @@ const Box = styled.span<{ themes: Theme }>`
       background-color: ${color.WHITE};
       box-sizing: border-box;
 
-      &.active {
+      input:checked + & {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
 
@@ -77,7 +77,7 @@ const Box = styled.span<{ themes: Theme }>`
         }
       }
 
-      &.disabled {
+      input[disabled] + & {
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};
         cursor: not-allowed;


### PR DESCRIPTION
## Related URL

[非制御コンポーネント – React](https://ja.reactjs.org/docs/uncontrolled-components.html)

## Overview

`<RadioButton>` と `<Checkbox>` で React の `defaultChecked` が `true` のときにチェックが入っているスタイルになってなかったのを修正しました。

Fixed that `<RadioButton>` and `<Checkbox>` were not styled to be checked when React's `defaultChecked` was `true`.

## What I did

チェックが入っているスタイルは `.active` によって適用されていた。ただし `.active` は `checked` が `true` のときのみしか適用されない（ defaultChecked では適用されていなかった）。

チェックされた時のスタイルに `:checked` 擬似クラスを利用した。

----

checked styles was applied by `.active` class. However, `.active` is only applied when `checked` props is `true` (defaultChecked was not).

I used `:checked` pseudo-class for the style when checked.

## Other

- refactor RadioButton Story to CSF.
- I will write Story that contain defaultChecked RadioButton by another PR
