### PR TITLE
fix: make `<Text>` as props like a styled-components

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -16,8 +16,11 @@ export default {
 
 export const Default: Story = () => (
   <>
-    <Text>
-      デフォルトの出力要素は <code>span</code> で、文字サイズは <code>M</code>、行間は{' '}
+    <Text as="h1" size="XXL" leading="TIGHT">
+      &lt;Text&gt;
+    </Text>
+    <Text as="p">
+      デフォルトの出力要素は <code>span</code> で、文字サイズは <code>M</code>、行間は
       <code>NORMAL</code>、色は <code>inherit</code> です。
     </Text>
     <Text as="p">
@@ -28,14 +31,14 @@ export const Default: Story = () => (
       <Text whiteSpace="nowrap">ホワイトスペース</Text>を変えられます。
     </Text>
     <Text as="p">
-      <code>emphasis</code> を渡すとそのテキストは<Text emphasis>強調</Text>を示し、<code>em</code>{' '}
+      <code>emphasis</code> を渡すとそのテキストは<Text emphasis>強調</Text>を示し、<code>em</code>
       要素の太字装飾で出力します。
     </Text>
     <Text as="p">
       <Text emphasis>入れ子</Text>もできますが、
       <Text color="TEXT_LINK" weight="bold">
         Valid
-      </Text>{' '}
+      </Text>
       な HTML になるよう注意してください。
     </Text>
   </>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import { FontSizes } from '../../themes/createFontSize'
 import { TextColors } from '../../themes/createColor'
 import { Leadings } from '../../themes/createLeading'
 
-export type TextProps = {
+type TextProps = {
   size?: FontSizes
   weight?: 'normal' | 'bold' | 'inherit'
   italic?: boolean
@@ -15,6 +15,12 @@ export type TextProps = {
   emphasis?: boolean
 }
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof TextProps>
+
+export type Props = TextProps &
+  ElementProps & {
+    as?: string | React.ComponentType<any> | undefined
+    children: React.ReactNode
+  }
 
 /**
  * @param [size] フォントサイズの抽象値（font-size）
@@ -27,13 +33,7 @@ type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof TextProps>
  * @param [as] テキストコンポーネントの HTML タグ名。初期値は span
  * @param [children]
  */
-export const Text: React.VFC<
-  TextProps &
-    ElementProps & {
-      as?: 'address' | 'b' | 'em' | 'i' | 'mark' | 'p' | 'q' | 'small' | 'span' | 'strong' | 'time'
-      children: React.ReactNode
-    }
-> = ({ as = 'span', ...props }) => {
+export const Text: React.VFC<Props> = ({ as = 'span', ...props }) => {
   return <Wrapper as={props.emphasis ? 'em' : as} {...props} />
 }
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,7 +7,7 @@ import { Leadings } from '../../themes/createLeading'
 
 type TextProps = {
   size?: FontSizes
-  weight?: 'normal' | 'bold' | 'inherit'
+  weight?: CSSProperties['fontWeight']
   italic?: boolean
   color?: TextColors | 'inherit'
   leading?: Leadings


### PR DESCRIPTION
## Overview

`<Text>` 要素の `as` で指定できる要素に限りをなくしました。

## What I did

- `as` props の型を styled-components の as と同じにしました。
- `weight` propsもCSSProperties を参照するようにしました。

---

- change type of `as` props to the same type as `as` in styled-components.
- `weight` props refers to CSSProperties.