### PR TITLE
chore: allow any patch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "url": "https://github.com/kufu/smarthr-ui/issues"
   },
   "engines": {
-    "node": ">=v14.18.3"
+    "node": ">=v14.18.x"
   },
   "files": [
     "esm",


### PR DESCRIPTION
## Related URL

undefined

## Overview

- smarthr-uiのサポートするnode versionの制約を緩めたい
  - ホスティング環境によっては、nodeのアップデートにラグがあり、最新のsmarthr-uiをインストールできないことがある
  - 元々以下のrenovateのPRによって固定されただけで、厳格に制約をかけたい意図はない
    - https://github.com/kufu/smarthr-ui/pull/1853

## What I did

- `>=14.18.3` → `>=14.18.x`に緩めたよ

## Capture

- 適当なパッケージをnpmに公開して、npm, yarn共に期待通りに機能することを確認
  - npm の場合は `--engine-strict`のオプション要
- `renovate`が固定に走らないかは未確認だけどさすがに大丈夫やろ…

<img width="726" alt="image" src="https://user-images.githubusercontent.com/5195381/153213392-4497194b-d46b-4479-bd43-a35476c1c8dc.png">

<img width="729" alt="image" src="https://user-images.githubusercontent.com/5195381/153214037-491e5923-3e82-49a5-b92f-6267d21846e4.png">
