### PR TITLE
fix: disabled なボタンに表示するツールチップが正常に動作するように修正 (SHRUI-529)

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -9,7 +9,6 @@ import {
   FaArrowAltCircleUpIcon,
 } from '../Icon'
 import { SecondaryButton } from '../Button'
-import { Cluster } from '../Layout'
 import { Tooltip } from './Tooltip'
 
 import readme from './README.md'
@@ -186,16 +185,11 @@ storiesOf('Tooltip', module)
           <FaArrowAltCircleDownIcon visuallyHiddenText="フォーカスすると情報が表示されます" />
         </Tooltip>
       </dd>
-      <dt>ボタン</dt>
+      <dt>disabled ボタン</dt>
       <dd>
-        <Cluster>
-          <Tooltip message="ボタンに表示するツールチップです">
-            <SecondaryButton>ボタン</SecondaryButton>
-          </Tooltip>
-          <Tooltip message="disabled なボタンに表示するツールチップです">
-            <SecondaryButton disabled>ボタン</SecondaryButton>
-          </Tooltip>
-        </Cluster>
+        <Tooltip message="disabled なボタンに表示するツールチップです">
+          <SecondaryButton disabled>ボタン</SecondaryButton>
+        </Tooltip>
       </dd>
       <dt>自動位置決め</dt>
       {[undefined, 'center', 'right'].map((className) => (

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -8,6 +8,8 @@ import {
   FaArrowAltCircleRightIcon,
   FaArrowAltCircleUpIcon,
 } from '../Icon'
+import { SecondaryButton } from '../Button'
+import { Cluster } from '../Layout'
 import { Tooltip } from './Tooltip'
 
 import readme from './README.md'
@@ -183,6 +185,17 @@ storiesOf('Tooltip', module)
         >
           <FaArrowAltCircleDownIcon visuallyHiddenText="フォーカスすると情報が表示されます" />
         </Tooltip>
+      </dd>
+      <dt>ボタン</dt>
+      <dd>
+        <Cluster>
+          <Tooltip message="ボタンに表示するツールチップです">
+            <SecondaryButton>ボタン</SecondaryButton>
+          </Tooltip>
+          <Tooltip message="disabled なボタンに表示するツールチップです">
+            <SecondaryButton disabled>ボタン</SecondaryButton>
+          </Tooltip>
+        </Cluster>
       </dd>
       <dt>自動位置決め</dt>
       {[undefined, 'center', 'right'].map((className) => (

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -93,10 +93,10 @@ export const Tooltip: VFC<Props & ElementProps> = ({
       {...props}
       aria-describedby={isVisible ? tooltipId : undefined}
       ref={ref}
-      onMouseEnter={getHandlerToShow(onMouseEnter)}
+      onPointerEnter={getHandlerToShow(onMouseEnter)}
       onTouchStart={getHandlerToShow(onTouchStart)}
       onFocus={getHandlerToShow(onFocus)}
-      onMouseLeave={getHandlerToHide(onMouseLeave)}
+      onPointerLeave={getHandlerToHide(onMouseLeave)}
       onTouchEnd={getHandlerToHide(onTouchEnd)}
       onBlur={getHandlerToHide(onBlur)}
       isIcon={isIcon}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -29,8 +29,8 @@ export const Tooltip: VFC<Props & ElementProps> = ({
   vertical = 'bottom',
   tabIndex = 0,
   className = '',
-  onMouseEnter,
-  onMouseLeave,
+  onPointerEnter,
+  onPointerLeave,
   onTouchStart,
   onTouchEnd,
   onFocus,
@@ -93,10 +93,10 @@ export const Tooltip: VFC<Props & ElementProps> = ({
       {...props}
       aria-describedby={isVisible ? tooltipId : undefined}
       ref={ref}
-      onPointerEnter={getHandlerToShow(onMouseEnter)}
+      onPointerEnter={getHandlerToShow(onPointerEnter)}
       onTouchStart={getHandlerToShow(onTouchStart)}
       onFocus={getHandlerToShow(onFocus)}
-      onPointerLeave={getHandlerToHide(onMouseLeave)}
+      onPointerLeave={getHandlerToHide(onPointerLeave)}
       onTouchEnd={getHandlerToHide(onTouchEnd)}
       onBlur={getHandlerToHide(onBlur)}
       isIcon={isIcon}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-529
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Tooltip` コンポーネントは、disabled なボタンに対して設定すると、hover 時に表示されるが leave 時に非表示ならない不具合が発生するため、修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 表示制御のイベントを変更
  - `onMouseEnter` → `onPointerEnter`
  - `onMouseLeave` → `onPointerLeave`
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
