### PR TITLE
fix: `AppNavi` のアイテムのテキストが折り返されないように修正

### DIFF
--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -150,6 +150,7 @@ const Wrapper = styled.div<{ themes: Theme }>`
 
     return css`
       padding: 32px 0;
+      overflow-x: auto;
       background-color: ${color.BACKGROUND};
     `
   }}

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -144,16 +144,31 @@ export const NoIconAndCaret: Story = () => {
 }
 NoIconAndCaret.storyName = 'アイコンありドロップダウン示唆なし'
 
+export const ContainerScrollX: Story = () => {
+  const theme = useTheme()
+
+  return (
+    <OverflowWrapper themes={theme}>
+      <AppNavi label="機能名" buttons={withoutIconButtons} displayDrodownCaret>
+        <Child>Some child components</Child>
+      </AppNavi>
+    </OverflowWrapper>
+  )
+}
+ContainerScrollX.storyName = '横スクロールさせる場合'
+
 const Wrapper = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
     const { color } = themes
 
     return css`
       padding: 32px 0;
-      overflow-x: auto;
       background-color: ${color.BACKGROUND};
     `
   }}
+`
+const OverflowWrapper = styled(Wrapper)`
+  overflow-x: auto;
 `
 const Child = styled.p`
   margin: 0 0 0 auto;

--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -125,6 +125,7 @@ const Wrapper = styled.nav<{ themes: Theme }>`
     return css`
       display: flex;
       align-items: center;
+      min-width: max-content;
       box-shadow: ${shadow.LAYER1};
       background-color: ${color.WHITE};
       padding-right: ${spacingByChar(1.5)};

--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -142,8 +142,9 @@ const StatusLabel = styled(StatusLabelComponent)<{ themes: Theme }>`
 const Buttons = styled.ul<{ themes: Theme }>`
   ${({ themes: { spacingByChar } }) => {
     return css`
+      align-self: stretch;
       display: flex;
-      align-items: center;
+      align-items: stretch;
       gap: ${spacingByChar(1)};
       margin: 0;
       padding: 0;

--- a/src/components/AppNavi/AppNaviButton.tsx
+++ b/src/components/AppNavi/AppNaviButton.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '../../hooks/useTheme'
 import { ComponentProps as IconProps } from '../Icon'
 import { ItemStyleProps, getIconComponent, getItemStyle } from './appNaviHelper'
 import { useClassNames } from './useClassNames'
+import { UnstyledButton } from '../Button'
 
 export type AppNaviButtonProps = {
   /** ボタンのテキスト */
@@ -48,4 +49,4 @@ export const AppNaviButton: VFC<InnerProps> = ({
   )
 }
 
-const Button = styled.button<ItemStyleProps>((props) => getItemStyle(props))
+const Button = styled(UnstyledButton)<ItemStyleProps>((props) => getItemStyle(props))

--- a/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/src/components/AppNavi/AppNaviDropdown.tsx
@@ -34,7 +34,7 @@ export const AppNaviDropdown: VFC<InnerProps> = ({
 
   return (
     <Dropdown>
-      <DropdownTrigger>
+      <StyledDropdownTrigger>
         <TriggerButton
           themes={theme}
           aria-current={current ? 'page' : undefined}
@@ -48,13 +48,16 @@ export const AppNaviDropdown: VFC<InnerProps> = ({
           {children}
           {displayCaret && <FaCaretDownIcon />}
         </TriggerButton>
-      </DropdownTrigger>
+      </StyledDropdownTrigger>
 
       <DropdownContent>{dropdownContent}</DropdownContent>
     </Dropdown>
   )
 }
 
+const StyledDropdownTrigger = styled(DropdownTrigger)`
+  height: 100%;
+`
 const TriggerButton = styled.button<ItemStyleProps & { displayCaret?: boolean }>(
   ({ displayCaret, ...props }) => css`
     ${getItemStyle(props)}

--- a/src/components/AppNavi/appNaviHelper.tsx
+++ b/src/components/AppNavi/appNaviHelper.tsx
@@ -46,6 +46,8 @@ export const getItemStyle = ({
     display: flex;
     align-items: center;
     gap: ${spacingByChar(0.5)};
+    height: 100%;
+    box-sizing: border-box;
     margin: 0;
     border: none;
     background-color: transparent;
@@ -55,6 +57,7 @@ export const getItemStyle = ({
     font-weight: bold;
     line-height: ${leading.NONE};
     color: ${TEXT_GREY};
+    white-space: nowrap;
 
     ${isActive &&
     css`


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-532
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`AppNavi` コンポーネントにおいて、モバイルなど表示幅が狭い場合にアイテムのテキストが折り返されて表示されているのを、折り返さないように修正します。

![アイテムのテキストが折り返される](https://user-images.githubusercontent.com/270422/154419007-9245cd50-ca09-4cd1-bbf5-2a495c725a0b.png)

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- アイテム内のテキストを折り返さないように変更
  - コンテナが内容に応じて伸びるように `max-content` スタイルを追加
  - 各 story に横スクロール表示対応
- 各アイテムの高さが、コンテナの高さいっぱいまで広がるように修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
![修正後のAppNavi](https://user-images.githubusercontent.com/270422/154419350-21d2c62e-7e45-4a52-a880-6df714c613a2.png)

<!--
Please attach a capture if it looks different.
-->
