### PR TITLE
feat: `SingleComboBox`にprefix、showClearを追加

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -171,7 +171,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
-          placeholder="入力でフィルタリングできます"
+          placeholder="入力で検索できます"
           prefix={<FaSearchIcon />}
           showClear={false}
           onSelect={handleSelectItem}

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
 
 import { MultiComboBox, SingleComboBox } from '.'
+import { FaSearchIcon } from '../..'
 
 import readme from './README.md'
 
@@ -160,6 +161,19 @@ export const Single: Story = () => {
           selectedItem={selectedItem}
           width="100%"
           placeholder="入力でフィルタリングできます"
+          onSelect={handleSelectItem}
+          onClear={handleClear}
+        />
+      </dd>
+      <dt>アイコン設定、クリアボタンの非表示</dt>
+      <dd>
+        <SingleComboBox
+          items={items}
+          selectedItem={selectedItem}
+          width={400}
+          placeholder="入力でフィルタリングできます"
+          prefix={<FaSearchIcon />}
+          showClear={false}
           onSelect={handleSelectItem}
           onClear={handleClear}
         />

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -1,6 +1,7 @@
 import React, {
   ChangeEvent,
   HTMLAttributes,
+  ReactNode,
   useCallback,
   useLayoutEffect,
   useMemo,
@@ -62,6 +63,14 @@ type Props<T> = {
    */
   className?: string
   /**
+   * インプット内の接頭辞に入る要素。通常はアイコン挿入用として使う
+   */
+  prefix?: ReactNode
+  /**
+   * `true` のとき、クリアボタンを表示する
+   */
+  showClear?: boolean
+  /**
    * input 要素の `value` が変わった時に発火するコールバック関数
    * @deprecated `onChange` は非推奨なため、 代わりに `onChangeInput` を使用してください。
    */
@@ -101,6 +110,8 @@ export function SingleComboBox<T>({
   isLoading,
   width = 'auto',
   className = '',
+  prefix,
+  showClear = true,
   onChange,
   onChangeInput,
   onAdd,
@@ -226,24 +237,27 @@ export function SingleComboBox<T>({
         disabled={disabled}
         error={error}
         placeholder={placeholder}
+        prefix={prefix}
         suffix={
           <>
-            <ClearButton
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                onClear && onClear()
-                onChangeSelected && onChangeSelected(null)
-                if (isFocused) {
-                  setIsExpanded(true)
-                }
-              }}
-              ref={clearButtonRef}
-              themes={theme}
-              className={`${needsClearButton ? '' : 'hidden'} ${classNames.clearButton}`}
-            >
-              <FaTimesCircleIcon color={theme.color.TEXT_BLACK} visuallyHiddenText="clear" />
-            </ClearButton>
+            {showClear && (
+              <ClearButton
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onClear && onClear()
+                  onChangeSelected && onChangeSelected(null)
+                  if (isFocused) {
+                    setIsExpanded(true)
+                  }
+                }}
+                ref={clearButtonRef}
+                themes={theme}
+                className={`${needsClearButton ? '' : 'hidden'} ${classNames.clearButton}`}
+              >
+                <FaTimesCircleIcon color={theme.color.TEXT_BLACK} visuallyHiddenText="clear" />
+              </ClearButton>
+            )}
             <CaretDownLayout themes={theme}>
               <CaretDownWrapper themes={theme}>
                 <FaCaretDownIcon color={caretIconColor} />


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

* 「検索できる」ことを想起しにくい問題
  * ユーザーテストから`SingleComboBox`が、選択だけでなく、検索できることが伝わりにくいというフィードバックをもらった
* クリアボタン
  * TBD

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

* `SingleComboBox`に`prefix`を設定できるようにした
* `SingleComboBox`に`showClear `フラグを追加し、クリアボタンの表示非表示をコントロールできるようにした

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
