### PR TITLE
fix: `BottomFixedArea` のモバイル表示調整

### DIFF
--- a/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
@@ -23,18 +23,6 @@ export const _BottomFixedArea: Story = () => {
       description="This is description."
       primaryButton={<PrimaryButton>Primary Button</PrimaryButton>}
       secondaryButton={<SecondaryButton>Secondary Button</SecondaryButton>}
-      tertiaryLinks={[{ text: 'Tertiary_1', icon: FaTrashIcon, onClick: action('click_1') }]}
-    />
-  )
-}
-_BottomFixedArea.storyName = 'BottomFixedArea'
-
-export const MobileViewport: Story = () => {
-  return (
-    <BottomFixedArea
-      description="This is description."
-      primaryButton={<PrimaryButton>Primary Button</PrimaryButton>}
-      secondaryButton={<SecondaryButton>Secondary Button</SecondaryButton>}
       tertiaryLinks={[
         { text: 'Tertiary_1', icon: FaTrashIcon, onClick: action('click_1') },
         { text: 'Tertiary_2', icon: FaTrashIcon, onClick: action('click_2') },
@@ -44,8 +32,4 @@ export const MobileViewport: Story = () => {
     />
   )
 }
-MobileViewport.parameters = {
-  viewport: {
-    defaultViewport: 'iphone5',
-  },
-}
+_BottomFixedArea.storyName = 'BottomFixedArea'

--- a/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
@@ -28,3 +28,24 @@ export const _BottomFixedArea: Story = () => {
   )
 }
 _BottomFixedArea.storyName = 'BottomFixedArea'
+
+export const MobileViewport: Story = () => {
+  return (
+    <BottomFixedArea
+      description="This is description."
+      primaryButton={<PrimaryButton>Primary Button</PrimaryButton>}
+      secondaryButton={<SecondaryButton>Secondary Button</SecondaryButton>}
+      tertiaryLinks={[
+        { text: 'Tertiary_1', icon: FaTrashIcon, onClick: action('click_1') },
+        { text: 'Tertiary_2', icon: FaTrashIcon, onClick: action('click_2') },
+        { text: 'Tertiary_3', icon: FaTrashIcon, onClick: action('click_3') },
+        { text: 'Tertiary_4', icon: FaTrashIcon, onClick: action('click_4') },
+      ]}
+    />
+  )
+}
+MobileViewport.parameters = {
+  viewport: {
+    defaultViewport: 'iphone5',
+  },
+}

--- a/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -18,6 +18,7 @@ import {
   SecondaryButton,
   SecondaryButtonAnchor,
 } from '../Button'
+import { Cluster, Stack } from '../Layout'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
@@ -69,22 +70,24 @@ export const BottomFixedArea: VFC<Props & ElementProps> = ({
       className={`${className} ${classNames.wrapper}`}
       {...props}
     >
-      {description && <Text className={classNames.description}>{description}</Text>}
-      {(secondaryButton || primaryButton) && (
-        <ButtonList themes={theme} className={classNames.buttonList}>
-          {secondaryButton && <li className={classNames.secondaryButton}>{secondaryButton}</li>}
-          {primaryButton && <li className={classNames.primaryButton}>{primaryButton}</li>}
-        </ButtonList>
-      )}
-      {tertiaryLinks && tertiaryLinks.length > 0 && (
-        <TertiaryList themes={theme} className={classNames.tertiaryList}>
-          {tertiaryLinks.map((tertiaryLink, index) => (
-            <li key={index} className={classNames.tertiaryListItem}>
-              <TertiaryLink {...tertiaryLink} />
-            </li>
-          ))}
-        </TertiaryList>
-      )}
+      <Stack>
+        {description && <Text className={classNames.description}>{description}</Text>}
+        {(secondaryButton || primaryButton) && (
+          <ListCluster justify="center" gap={{ row: 0.5, column: 1 }}>
+            {secondaryButton && <li className={classNames.secondaryButton}>{secondaryButton}</li>}
+            {primaryButton && <li className={classNames.primaryButton}>{primaryButton}</li>}
+          </ListCluster>
+        )}
+        {tertiaryLinks && tertiaryLinks.length > 0 && (
+          <ListCluster justify="center" gap={{ row: 0.5, column: 1 }}>
+            {tertiaryLinks.map((tertiaryLink, index) => (
+              <li key={index} className={classNames.tertiaryListItem}>
+                <TertiaryLink {...tertiaryLink} />
+              </li>
+            ))}
+          </ListCluster>
+        )}
+      </Stack>
     </Base>
   )
 }
@@ -92,8 +95,6 @@ export const BottomFixedArea: VFC<Props & ElementProps> = ({
 const Base = styled(BaseComponent)<{ themes: Theme; zIndex: number }>`
   ${({ themes: { spacingByChar }, zIndex }) => {
     return css`
-      display: flex;
-      flex-direction: column;
       position: fixed;
       bottom: 0;
       width: 100%;
@@ -109,41 +110,10 @@ const Base = styled(BaseComponent)<{ themes: Theme; zIndex: number }>`
 const Text = styled.div`
   margin: 0;
 `
-const ButtonList = styled.ul<{ themes: Theme }>`
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      margin: ${spacingByChar(1)} 0 0 0;
-      padding: 0;
-      display: flex;
-      justify-content: center;
-
-      > li {
-        list-style: none;
-        margin-right: ${spacingByChar(1)};
-
-        &:last-of-type {
-          margin-right: 0;
-        }
-      }
-    `
-  }}
-`
-const TertiaryList = styled.ul<{ themes: Theme }>`
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      margin: ${spacingByChar(1)} 0 0 0;
-      padding: 0;
-      display: flex;
-      justify-content: center;
-
-      > li {
-        list-style: none;
-        margin-right: ${spacingByChar(1)};
-
-        &:last-of-type {
-          margin-right: 0;
-        }
-      }
-    `
-  }}
+const ListCluster = styled(Cluster).attrs({
+  as: 'ul',
+})`
+  list-style: none;
+  margin: 0;
+  padding: 0;
 `


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-534
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`BottomFixedArea` コンポーネントでは、モバイルなどで表示可能幅が狭い場合にコンテンツが隠れてしまう問題があるので、修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- ボタン類を折り返して表示するように変更

### やらなかったこと
- モバイル viewport の story 追加は、 #2286 で行います

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/154626384-aed1ef53-4d4f-411b-9a1a-5393871b2a83.png) | ![image](https://user-images.githubusercontent.com/270422/154626275-dcbeb16e-091d-410f-9e2e-dac1aef69f2b.png) |
<!--
Please attach a capture if it looks different.
-->
