### PR TITLE
fix: workaround empty flex gap bug

### DIFF
--- a/src/components/Layout/Cluster/Cluster.tsx
+++ b/src/components/Layout/Cluster/Cluster.tsx
@@ -23,5 +23,13 @@ export const Cluster = styled.div<{
     ${justify && `justify-content: ${justify};`}
     row-gap: ${rowGap};
     column-gap: ${columnGap};
+
+    /* 
+      Chromeで空の要素にflex-gapがあると印刷時にレイアウトが崩れるので gap の値を0にする
+      See https://bugs.chromium.org/p/chromium/issues/detail?id=1161709
+    */
+    &:empty {
+      gap: 0;
+    }
   `
 })

--- a/src/components/Layout/LineUp/LineUp.tsx
+++ b/src/components/Layout/LineUp/LineUp.tsx
@@ -24,30 +24,11 @@ export const LineUp = styled.div<{
   /** 縦位置の揃え方（align-items） */
   vAlign?: verticalAlignMethod
 }>(({ inline = false, gap = 0.5, reverse, align = 'flex-start', vAlign = 'normal' }) => {
-  const direction = reverse ? 'right' : 'left'
-
   return css`
     display: ${inline ? 'inline-flex' : 'flex'};
     ${reverse && 'flex-direction: row-reverse;'}
     ${align && `justify-content: ${align};`}
     ${vAlign && `align-items: ${vAlign};`}
-
-    /* For greater specificity than element type selectors */
-    &&& {
-      ${(align === 'flex-start' || align === 'flex-end' || align === 'center') &&
-      css`
-          > * + * {
-            margin-${direction}: ${useSpacing(gap)};
-          }
-      `}
-
-      @supports (gap: 1px) {
-        gap: ${useSpacing(gap)};
-
-        > * + * {
-          ${`margin-${direction}: revert`}
-        }
-      }
-    }
+    gap: ${useSpacing(gap)};
   `
 })

--- a/src/components/Layout/LineUp/LineUp.tsx
+++ b/src/components/Layout/LineUp/LineUp.tsx
@@ -30,5 +30,13 @@ export const LineUp = styled.div<{
     ${align && `justify-content: ${align};`}
     ${vAlign && `align-items: ${vAlign};`}
     gap: ${useSpacing(gap)};
+
+    /* 
+      Chromeで空の要素にflex-gapがあると印刷時にレイアウトが崩れるので gap の値を0にする
+      See https://bugs.chromium.org/p/chromium/issues/detail?id=1161709
+    */
+    &:empty {
+      gap: 0;
+    }
   `
 })

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -47,6 +47,14 @@ export const Sidebar = styled.div<Props>(
       & > *:first-child {
         ${right ? mainContentsValue : sidebarValue}
       }
+
+      /* 
+      Chromeで空の要素にflex-gapがあると印刷時にレイアウトが崩れるので gap の値を0にする
+      See https://bugs.chromium.org/p/chromium/issues/detail?id=1161709
+      */
+      &:empty {
+        gap: 0;
+      }
     `
   },
 )


### PR DESCRIPTION
## Related URL

- https://bugs.chromium.org/p/chromium/issues/detail?id=1161709

## Overview

add Workaround for chromium bug that empty element has flex gap break layout.

## What I did

Add `:empty { gap: 0 }` workaround to Component has possible empty element and has gap property. and remove gap fallback from `<LineUp>`.