### PR TITLE
fix: ComboBox の Item 型名を明示的に ComboBoxItem とする

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -18,17 +18,17 @@ import { FaCaretDownIcon } from '../Icon'
 import { useListBox } from './useListBox'
 import { MultiSelectedItem } from './MultiSelectedItem'
 import { convertMatchableString } from './comboBoxHelper'
-import { Item } from './types'
+import { ComboBoxItem } from './types'
 
 type Props<T> = {
   /**
    * 選択可能なアイテムのリスト
    */
-  items: Array<Item<T>>
+  items: Array<ComboBoxItem<T>>
   /**
    * 選択されているアイテムのリスト
    */
-  selectedItems: Array<Item<T> & { deletable?: boolean }>
+  selectedItems: Array<ComboBoxItem<T> & { deletable?: boolean }>
   /**
    * input 要素の `name` 属性の値
    */
@@ -86,15 +86,15 @@ type Props<T> = {
   /**
    * 選択されているアイテムの削除ボタンがクリックされた時に発火するコールバック関数
    */
-  onDelete?: (item: Item<T>) => void
+  onDelete?: (item: ComboBoxItem<T>) => void
   /**
    * アイテムが選択された時に発火するコールバック関数
    */
-  onSelect?: (item: Item<T>) => void
+  onSelect?: (item: ComboBoxItem<T>) => void
   /**
    * 選択されているアイテムのリストが変わった時に発火するコールバック関数
    */
-  onChangeSelected?: (selectedItems: Array<Item<T>>) => void
+  onChangeSelected?: (selectedItems: Array<ComboBoxItem<T>>) => void
   /**
    * コンポーネントがフォーカスされたときに発火するコールバック関数
    */

--- a/src/components/ComboBox/MultiSelectedItemInner.tsx
+++ b/src/components/ComboBox/MultiSelectedItemInner.tsx
@@ -6,12 +6,12 @@ import { useClassNames } from './useClassNames'
 
 import { FaTimesCircleIcon } from '../Icon'
 import { UnstyledButton } from '../Button'
-import { Item } from './types'
+import { ComboBoxItem } from './types'
 
 export type Props<T> = {
-  item: Item<T> & { deletable?: boolean }
+  item: ComboBoxItem<T> & { deletable?: boolean }
   disabled: boolean
-  onDelete: (item: Item<T>) => void
+  onDelete: (item: ComboBoxItem<T>) => void
   enableEllipsis?: boolean
   onEllipsis?: () => void
 }

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -18,17 +18,17 @@ import { FaCaretDownIcon, FaTimesCircleIcon } from '../Icon'
 import { UnstyledButton } from '../Button'
 import { useListBox } from './useListBox'
 import { convertMatchableString } from './comboBoxHelper'
-import { Item } from './types'
+import { ComboBoxItem } from './types'
 
 type Props<T> = {
   /**
    * 選択可能なアイテムのリスト
    */
-  items: Array<Item<T>>
+  items: Array<ComboBoxItem<T>>
   /**
    * 選択されているアイテムのリスト
    */
-  selectedItem: Item<T> | null
+  selectedItem: ComboBoxItem<T> | null
   /**
    * input 要素の `name` 属性の値
    */
@@ -77,7 +77,7 @@ type Props<T> = {
   /**
    * アイテムが選択された時に発火するコールバック関数
    */
-  onSelect?: (item: Item<T>) => void
+  onSelect?: (item: ComboBoxItem<T>) => void
   /**
    * 選択されているアイテムがクリアされた時に発火するコールバック関数
    */
@@ -85,7 +85,7 @@ type Props<T> = {
   /**
    * 選択されているアイテムのリストが変わった時に発火するコールバック関数
    */
-  onChangeSelected?: (selectedItem: Item<T> | null) => void
+  onChangeSelected?: (selectedItem: ComboBoxItem<T> | null) => void
 }
 
 type ElementProps<T> = Omit<HTMLAttributes<HTMLDivElement>, keyof Props<T>>

--- a/src/components/ComboBox/types.ts
+++ b/src/components/ComboBox/types.ts
@@ -1,4 +1,4 @@
-export type Item<T> = {
+export type ComboBoxItem<T> = {
   value: string
   label: string
   disabled?: boolean

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -5,7 +5,7 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { usePortal } from '../../hooks/usePortal'
 import { useId } from '../../hooks/useId'
-import { Item } from './types'
+import { ComboBoxItem } from './types'
 
 import { FaPlusCircleIcon } from '../Icon'
 import { Loader } from '../Loader'
@@ -13,10 +13,10 @@ import { Loader } from '../Loader'
 const OPTION_INCREMENT_AMOUNT = 100
 
 type Args<T> = {
-  items: Array<Item<T> & { isSelected?: boolean }>
+  items: Array<ComboBoxItem<T> & { isSelected?: boolean }>
   inputValue?: string
   onAdd?: (label: string) => void
-  onSelect: (item: Item<T>) => void
+  onSelect: (item: ComboBoxItem<T>) => void
   isExpanded: boolean
   isAddable: boolean
   isDuplicate: boolean
@@ -30,12 +30,12 @@ type Args<T> = {
   }
 }
 
-type Option<T> = Item<T> & {
+type Option<T> = ComboBoxItem<T> & {
   isAdding?: boolean
   isSelected?: boolean
 }
 
-function optionToItem<T>(option: Option<T>): Item<T> {
+function optionToItem<T>(option: Option<T>): ComboBoxItem<T> {
   const { isAdding, isSelected, ...props } = option
   return { ...props }
 }


### PR DESCRIPTION
SmartHR Design System から抽出する際により具体的な名前である必要があったため。
名前以外の変更はありません。