### PR TITLE
feat!: ダイアログのデフォルト幅を変更 (SHRUI-535)

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -10,7 +10,15 @@ type Props = Omit<ActionDialogContentInnerProps, 'titleId'> & {
   portalParent?: HTMLElement
 } & Pick<
     DialogContentInnerProps,
-    'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
+    | 'isOpen'
+    | 'onClickOverlay'
+    | 'onPressEscape'
+    | 'width'
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'left'
+    | 'id'
   >
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 

--- a/src/components/Dialog/ActionDialogContent.tsx
+++ b/src/components/Dialog/ActionDialogContent.tsx
@@ -6,7 +6,7 @@ import { ActionDialogContentInner, BaseProps } from './ActionDialogContentInner'
 import { useId } from '../../hooks/useId'
 
 type Props = Omit<BaseProps, 'titleId'> &
-  Pick<DialogContentInnerProps, 'top' | 'right' | 'bottom' | 'left' | 'id'>
+  Pick<DialogContentInnerProps, 'width' | 'top' | 'right' | 'bottom' | 'left' | 'id'>
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const ActionDialogContent: React.VFC<Props & ElementProps> = ({

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -372,9 +372,33 @@ Uncontrolled.parameters = {
   },
 }
 
-export const Position: Story = () => {
+export const WidthAndPosition: Story = () => {
   return (
     <TriggerList>
+      <li>
+        <DialogWrapper>
+          <DialogTrigger>
+            <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-width-1">
+              幅 400px
+            </SecondaryButton>
+          </DialogTrigger>
+          <DialogContent width={400} id="dialog-width-1">
+            <Description>幅 400px のダイアログ</Description>
+          </DialogContent>
+        </DialogWrapper>
+      </li>
+      <li>
+        <DialogWrapper>
+          <DialogTrigger>
+            <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-width-2">
+              幅 80%
+            </SecondaryButton>
+          </DialogTrigger>
+          <DialogContent width="80%" id="dialog-width-2">
+            <Description>幅 80% のダイアログ</Description>
+          </DialogContent>
+        </DialogWrapper>
+      </li>
       <li>
         <DialogWrapper>
           <DialogTrigger>
@@ -402,7 +426,7 @@ export const Position: Story = () => {
     </TriggerList>
   )
 }
-Position.parameters = {
+WidthAndPosition.parameters = {
   docs: {
     description: {
       story: 'The position of Dialog can be changed.',
@@ -546,6 +570,30 @@ export const Modeless_Dialog: Story = () => {
         </ModelessDialog>
       </li>
     </TriggerList>
+  )
+}
+
+export const RegDialogOpenedDialog: Story = () => {
+  return (
+    <Dialog isOpen>
+      <Description>{dummyText}</Description>
+    </Dialog>
+  )
+}
+
+export const RegDialogOpenedDialogWidth: Story = () => {
+  return (
+    <Dialog isOpen width={500}>
+      <Description>{dummyText}</Description>
+    </Dialog>
+  )
+}
+
+export const RegDialogOpenedDialogPosition: Story = () => {
+  return (
+    <Dialog isOpen top={20} right={40} bottom={60} left={80}>
+      <Description>{dummyText}</Description>
+    </Dialog>
   )
 }
 

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -15,7 +15,7 @@ export const DialogContentContext = createContext<DialogContentContextType>({
 
 type Props = Pick<
   DialogContentInnerProps,
-  'top' | 'right' | 'bottom' | 'left' | 'id' | 'ariaLabel' | 'ariaLabelledby' | 'children'
+  'width' | 'top' | 'right' | 'bottom' | 'left' | 'id' | 'ariaLabel' | 'ariaLabelledby' | 'children'
 >
 
 export const DialogContent: React.VFC<Props> = ({ children, ...props }) => {

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -177,7 +177,7 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
               100vw - max(${left || 0}px, ${spacingByChar(0.5)}) -
                 max(${right || 0}px, ${spacingByChar(0.5)})
             ),
-            800px
+            800px /* TODO: 幅の定義が決まり theme に入ったら差し替える */
           );
         `
 

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -23,6 +23,10 @@ export type DialogContentInnerProps = {
    */
   isOpen: boolean
   /**
+   * ダイアログの幅
+   */
+  width?: string | number
+  /**
    * Specifies the top position of the Dialog content.
    */
   top?: number
@@ -62,6 +66,7 @@ export type DialogContentInnerProps = {
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof DialogContentInnerProps>
 
 type StyleProps = {
+  $width?: string | number
   top?: number
   right?: number
   bottom?: number
@@ -79,6 +84,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
   },
   isOpen,
   id,
+  width,
   ariaLabel,
   ariaLabelledby,
   children,
@@ -116,6 +122,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
           />
           <FocusTrap>
             <Inner
+              $width={width}
               ref={innerRef}
               themes={theme}
               role="dialog"
@@ -146,24 +153,33 @@ const Layout = styled.div`
   left: 0;
 `
 const Inner = styled.div<StyleProps & { themes: Theme }>`
-  ${({ themes, top, right, bottom, left }) => {
-    const { color, radius, shadow } = themes
+  ${({ themes, $width, top, right, bottom, left }) => {
+    const { color, radius, shadow, spacingByChar } = themes
     const positionRight = exist(right) ? `${right}px` : 'auto'
     const positionBottom = exist(bottom) ? `${bottom}px` : 'auto'
-    let positionTop = exist(top) ? `${top}px` : 'auto'
-    let positionLeft = exist(left) ? `${left}px` : 'auto'
-    let translateX = '0'
-    let translateY = '0'
+    const positionTop = exist(top) ? `${top}px` : 'auto'
+    const positionLeft = exist(left) ? `${left}px` : 'auto'
+    const translateX = exist(right) || exist(left) ? '0' : 'calc((100vw - 100%) / 2)'
+    const translateY = exist(top) || exist(bottom) ? '0' : 'calc((100vh - 100%) / 2)'
 
-    if (top === undefined && bottom === undefined) {
-      positionTop = '50%'
-      translateY = '-50%'
-    }
-
-    if (right === undefined && left === undefined) {
-      positionLeft = '50%'
-      translateX = '-50%'
-    }
+    const widthStyles = exist($width)
+      ? // width が指定されているときは width 設定
+        css`
+          width: ${typeof $width === 'number' ? `${$width}px` : $width};
+        `
+      : exist(left) && exist(right)
+      ? // left, right が両方指定されているときは、それに任せる
+        null
+      : // 幅を確定できる指定がされていない場合は、viewport を超えないように上限設定
+        css`
+          max-width: min(
+            calc(
+              100vw - max(${left || 0}px, ${spacingByChar(0.5)}) -
+                max(${right || 0}px, ${spacingByChar(0.5)})
+            ),
+            800px
+          );
+        `
 
     return css`
       position: absolute;
@@ -171,6 +187,7 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
       right: ${positionRight};
       bottom: ${positionBottom};
       left: ${positionLeft};
+      ${widthStyles};
       border-radius: ${radius.m};
       background-color: ${color.WHITE};
       box-shadow: ${shadow.LAYER3};

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -10,7 +10,15 @@ import {
 type Props = MessageDialogContentInnerProps &
   Pick<
     DialogContentInnerProps,
-    'isOpen' | 'onClickOverlay' | 'onPressEscape' | 'top' | 'right' | 'bottom' | 'left' | 'id'
+    | 'isOpen'
+    | 'onClickOverlay'
+    | 'onPressEscape'
+    | 'width'
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'left'
+    | 'id'
   > & { portalParent?: HTMLElement }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 

--- a/src/components/Dialog/MessageDialogContent.tsx
+++ b/src/components/Dialog/MessageDialogContent.tsx
@@ -4,7 +4,8 @@ import { DialogContext } from './DialogWrapper'
 import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
 import { BaseProps, MessageDialogContentInner } from './MessageDialogContentInner'
 
-type Props = BaseProps & Pick<DialogContentInnerProps, 'top' | 'right' | 'bottom' | 'left' | 'id'>
+type Props = BaseProps &
+  Pick<DialogContentInnerProps, 'width' | 'top' | 'right' | 'bottom' | 'left' | 'id'>
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const MessageDialogContent: React.VFC<Props & ElementProps> = ({

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -226,7 +226,13 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
           aria-labelledby={labelId}
           {...props}
         >
-          <Box className={classNames.box}>
+          <Box
+            isWidthAuto={width === undefined}
+            left={left}
+            right={right}
+            themes={theme}
+            className={classNames.box}
+          >
             <div tabIndex={-1}>{/* dummy element for focus management. */}</div>
             <Header className={classNames.header} themes={theme}>
               <Title id={labelId} themes={theme}>
@@ -276,12 +282,33 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
 const Layout = styled.div`
   position: fixed;
 `
-const Box = styled(Base).attrs({ radius: 'm', layer: 3 })`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  max-height: 100vh;
+const Box = styled(Base).attrs({ radius: 'm', layer: 3 })<{
+  isWidthAuto: boolean
+  left?: string | number
+  right?: string | number
+  themes: Theme
+}>`
+  ${({ isWidthAuto, left = 0, right = 0, themes: { spacingByChar } }) => {
+    const leftMargin = typeof left === 'number' ? `${left}px` : left
+    const rightMargin = typeof right === 'number' ? `${right}px` : right
+
+    return css`
+      display: flex;
+      flex-direction: column;
+      ${isWidthAuto &&
+      css`
+        max-width: min(
+          calc(
+            100vw - max(${leftMargin}, ${spacingByChar(0.5)}) -
+              max(${rightMargin}, ${spacingByChar(0.5)})
+          ),
+          800px
+        );
+      `}
+      height: 100%;
+      max-height: 100vh;
+    `
+  }}
 `
 const Header = styled.div<{ themes: Theme }>`
   ${({ themes: { border, spacingByChar } }) => css`
@@ -334,6 +361,7 @@ const CloseButtonLayout = styled.div`
   margin-left: auto;
 `
 const Content = styled.div`
+  flex: 1;
   overflow: auto;
 `
 const Footer = styled.div<{ themes: Theme }>`

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -302,7 +302,7 @@ const Box = styled(Base).attrs({ radius: 'm', layer: 3 })<{
             100vw - max(${leftMargin}, ${spacingByChar(0.5)}) -
               max(${rightMargin}, ${spacingByChar(0.5)})
           ),
-          800px
+          800px /* TODO: 幅の定義が決まり theme に入ったら差し替える */
         );
       `}
       height: 100%;


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-535
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、モーダルダイアログ系のコンポーネントは、中央寄せの時のダイアログの幅が viewport の50%になっています。
これは特にモバイルにおいて表示幅が非常に狭くなってしまう問題をはらんでいるため、デフォルトの表示幅を

- ダイアログ内のコンテンツの幅
- viewport から左右の spacing を引いた幅
- `800px`

のうちから最小のもので表示するように変更します。

**[BREAKING CHANGE] ダイアログの幅を指定するとき Extending Styles ではなく `width` props で行うように変更します。引き続き Extending Styles で指定する場合は、デフォルトで設定される `max-width` を考慮して設定する必要があります。**


### 幅が50%になる原因
中央寄せのために `left: 50%` のスタイルを指定していることによって、表示領域が残りの右側50%になってしまうため
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- 中央寄せのためのスタイル指定を `left: 50%` を使わないものに変更
- 幅の拡張を行いやすくするために `width` Props を追加
  - `max-width` の指定が加わることによって extending styles による拡張が煩雑になるため
  - extending styles の方法が変わるので BREAKING CHANGE にすべきかどうか
- ダイアログの幅指定が切り替わるように変更
  - `ModelessDialog` の最大幅も併せて変更
- Story を追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/155641873-c860d888-9b79-4420-b868-216292531054.png) | ![image](https://user-images.githubusercontent.com/270422/155641895-e4b262cd-87a5-4fd0-beef-3b15ddcf2f14.png) |
<!--
Please attach a capture if it looks different.
-->
