### PR TITLE
feat: change to ReactNode for i18n

### DIFF
--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -9,7 +9,7 @@ import { FaExclamationCircleIcon } from '../Icon'
 type innerMarginType = 'XXS' | 'XS' | 'S'
 type Props = {
   /** グループのタイトル名 */
-  title: string
+  title: ReactNode
   /** タイトルの見出しのタイプ */
   titleType?: HeadingTypes
   /** label 要素に適用する `htmlFor` 値 */


### PR DESCRIPTION
## Related URL



## Overview

FormGroupの `title` が `string` のみを受け付けており属性を自由に付与しにくいため ReactNode へ変更しました。

FormGroup title props changed to ReactNode because `title` of FormGroup only accepts `string` and it's hard to give attributes freely.

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
