### PR TITLE
fix: `Dropdown` のモバイル表示調整 (SHRUI-536)

### DIFF
--- a/e2e/components/Dropdown.test.ts
+++ b/e2e/components/Dropdown.test.ts
@@ -13,10 +13,22 @@ test('ボタンがクリックされるとドロップダウンが開くこと',
     .ok()
 })
 
-test('ドロップダウンが展開されるとドロップダウン内のフォーカス可能な要素にフォーカスが移動すること', async (t) => {
+test('トリガとドロップダウン間でフォーカスの行き来ができること', async (t) => {
+  const trigger = Selector('#dropdown-button-1')
+  const firstFocusable = Selector('#dropdown-list-item-1')
   await t
-    .click(Selector('#dropdown-button-1'))
-    .expect(Selector('#dropdown-list-item-1').focused)
+    .click(trigger)
+    // Tab キーを押下すると、ドロップダウン内の最初のフォーカス可能要素にフォーカスが移動すること
+    .pressKey('tab')
+    .expect(firstFocusable.focused)
+    .ok()
+    // 最初のフォーカス可能要素がフォーカスされた状態で Shift + Tab キーを押下すると、トリガにフォーカスが移動すること
+    .pressKey('shift+tab')
+    .expect(trigger.focused)
+    .ok()
+    // ドロップダウンが展開されていてトリガがフォーカスされている状態で Tab キーを押下すると、ドロップダウン内の最初のフォーカス可能要素にフォーカスが移動すること
+    .pressKey('tab')
+    .expect(firstFocusable.focused)
     .ok()
 })
 

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -94,7 +94,6 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
   const classNames = useClassNames().dialog
   const theme = useTheme()
   const innerRef = useRef<HTMLDivElement>(null)
-  const focusTarget = useRef<HTMLDivElement>(null)
   useHandleEscape(
     useCallback(() => {
       if (!isOpen) {
@@ -120,23 +119,19 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
             themes={theme}
             className={classNames.background}
           />
-          <FocusTrap>
-            <Inner
-              $width={width}
-              ref={innerRef}
-              themes={theme}
-              role="dialog"
-              aria-label={ariaLabel}
-              aria-labelledby={ariaLabelledby}
-              aria-modal="true"
-              className={`${className} ${classNames.dialog}`}
-              {...props}
-            >
-              {/* dummy element for focus management. */}
-              <div ref={focusTarget} tabIndex={-1} aria-label={ariaLabel}></div>
-              {children}
-            </Inner>
-          </FocusTrap>
+          <Inner
+            $width={width}
+            ref={innerRef}
+            themes={theme}
+            role="dialog"
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            aria-modal="true"
+            className={`${className} ${classNames.dialog}`}
+            {...props}
+          >
+            <FocusTrap>{children}</FocusTrap>
+          </Inner>
           {/* Suppresses scrolling of body while modal is displayed */}
           <BodyScrollSuppressor />
         </Layout>

--- a/src/components/Dialog/FocusTrap.tsx
+++ b/src/components/Dialog/FocusTrap.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, VFC, useCallback, useEffect, useRef, useState } from 'react'
+import React, { ReactNode, VFC, useCallback, useEffect, useRef } from 'react'
 
 import { tabbable } from '../../libs/tabbable'
 
@@ -37,11 +37,17 @@ export const FocusTrap: VFC<Props> = ({ children }) => {
     }
   }, [handleKeyDown])
 
-  const { returnFocusToTrigger } = useTriggerFocusControl()
   useEffect(() => {
+    const triggerElement = document.activeElement
     focusTargetRef.current?.focus()
-    return returnFocusToTrigger
-  }, [returnFocusToTrigger])
+
+    return () => {
+      // フォーカストラップ終了時にトリガにフォーカスを戻す
+      if (triggerElement instanceof HTMLElement) {
+        triggerElement.focus()
+      }
+    }
+  }, [])
 
   return (
     <div ref={ref}>
@@ -50,17 +56,4 @@ export const FocusTrap: VFC<Props> = ({ children }) => {
       {children}
     </div>
   )
-}
-
-export function useTriggerFocusControl() {
-  const [triggerElement, setTriggerElement] = useState<Element | null>(null)
-
-  const returnFocusToTrigger = useCallback(() => {
-    if (triggerElement instanceof HTMLElement) {
-      triggerElement.focus()
-    }
-    setTriggerElement(null)
-  }, [triggerElement])
-
-  return { returnFocusToTrigger }
 }

--- a/src/components/Dialog/FocusTrap.tsx
+++ b/src/components/Dialog/FocusTrap.tsx
@@ -8,6 +8,7 @@ type Props = {
 
 export const FocusTrap: VFC<Props> = ({ children }) => {
   const ref = useRef<HTMLDivElement | null>(null)
+  const focusTargetRef = useRef<HTMLDivElement>(null)
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key !== 'Tab' || ref.current === null) {
@@ -36,32 +37,23 @@ export const FocusTrap: VFC<Props> = ({ children }) => {
     }
   }, [handleKeyDown])
 
-  const { moveFocusFromTrigger, returnFocusToTrigger } = useTriggerFocusControl(ref)
+  const { returnFocusToTrigger } = useTriggerFocusControl()
   useEffect(() => {
-    moveFocusFromTrigger()
+    focusTargetRef.current?.focus()
     return returnFocusToTrigger
-  }, [moveFocusFromTrigger, returnFocusToTrigger])
+  }, [returnFocusToTrigger])
 
-  return <div ref={ref}>{children}</div>
+  return (
+    <div ref={ref}>
+      {/* dummy element for focus management. */}
+      <div ref={focusTargetRef} tabIndex={-1} />
+      {children}
+    </div>
+  )
 }
 
-export function useTriggerFocusControl(targetRef: React.RefObject<HTMLElement>) {
+export function useTriggerFocusControl() {
   const [triggerElement, setTriggerElement] = useState<Element | null>(null)
-
-  const moveFocusFromTrigger = useCallback(() => {
-    setTriggerElement(document.activeElement)
-    setTimeout(() => {
-      // delay focus on the first element so that is occurs last
-      if (targetRef.current === null) {
-        return
-      }
-      const tabbables = tabbable(targetRef.current)
-      const firstTabbale = tabbables[0]
-      if (firstTabbale) {
-        firstTabbale.focus()
-      }
-    }, 1)
-  }, [targetRef])
 
   const returnFocusToTrigger = useCallback(() => {
     if (triggerElement instanceof HTMLElement) {
@@ -70,5 +62,5 @@ export function useTriggerFocusControl(targetRef: React.RefObject<HTMLElement>) 
     setTriggerElement(null)
   }, [triggerElement])
 
-  return { moveFocusFromTrigger, returnFocusToTrigger }
+  return { returnFocusToTrigger }
 }

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -18,7 +18,6 @@ import { Base, BaseElementProps } from '../Base'
 import { SecondaryButton } from '../Button'
 import { FaGripHorizontalIcon, FaTimesIcon } from '../Icon'
 import { DialogOverlap } from './DialogOverlap'
-import { useTriggerFocusControl } from './FocusTrap'
 import { useClassNames } from './useClassNames'
 
 type Props = {
@@ -95,6 +94,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
 }) => {
   const portalContainer = useRef(document.createElement('div')).current
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const focusTargetRef = useRef<HTMLDivElement>(null)
   const [wrapperPosition, setWrapperPosition] = useState<DOMRect | undefined>(undefined)
   const [centering, setCentering] = useState<{
     top?: number
@@ -129,13 +129,12 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     }, [isOpen, onPressEscape]),
   )
 
-  const { moveFocusFromTrigger } = useTriggerFocusControl(wrapperRef)
   useLayoutEffect(() => {
     if (isOpen) {
       setPosition({ x: 0, y: 0 })
-      moveFocusFromTrigger()
+      focusTargetRef.current?.focus()
     }
-  }, [isOpen, moveFocusFromTrigger])
+  }, [isOpen])
 
   useEffect(() => {
     // 中央寄せの座標計算を行う
@@ -233,7 +232,9 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
             themes={theme}
             className={classNames.box}
           >
-            <div tabIndex={-1}>{/* dummy element for focus management. */}</div>
+            <div tabIndex={-1} ref={focusTargetRef}>
+              {/* dummy element for focus management. */}
+            </div>
             <Header className={classNames.header} themes={theme}>
               <Title id={labelId} themes={theme}>
                 {header}

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -13,7 +13,7 @@ import { DropdownScrollArea } from './DropdownScrollArea'
 import { PrimaryButton, SecondaryButton } from '../Button'
 import { RadioButton } from '../RadioButton'
 import { Input } from '../Input'
-import { Stack } from '../Layout'
+import { Cluster, Stack } from '../Layout'
 import { Text } from '../Text'
 import { FaCaretDownIcon } from '../Icon'
 
@@ -100,13 +100,15 @@ const ControllableDropdown = () => {
             </RadioButtonList>
           </ControllableBoxMain>
           <ControllableBoxBottom themes={themes}>
-            <DropdownCloser>
-              <SecondaryButton>Close only</SecondaryButton>
-            </DropdownCloser>
-            <DropdownCloser>
-              <PrimaryButton onClick={action('clicked button 1')}>Action and close</PrimaryButton>
-            </DropdownCloser>
-            <PrimaryButton onClick={action('clicked button 2')}>Action only</PrimaryButton>
+            <Cluster justify="flex-end">
+              <DropdownCloser>
+                <SecondaryButton>Close only</SecondaryButton>
+              </DropdownCloser>
+              <DropdownCloser>
+                <PrimaryButton onClick={action('clicked button 1')}>Action and close</PrimaryButton>
+              </DropdownCloser>
+              <PrimaryButton onClick={action('clicked button 2')}>Action only</PrimaryButton>
+            </Cluster>
           </ControllableBoxBottom>
         </DropdownScrollArea>
       </DropdownContent>
@@ -253,15 +255,8 @@ const ControllableBoxMain = styled(Stack)`
   padding: 24px;
 `
 const ControllableBoxBottom = styled.div<{ themes: Theme }>`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
   border-top: ${({ themes }) => themes.border.shorthand};
   padding: 16px 24px;
-
-  & > *:not(:first-child) {
-    margin-left: 16px;
-  }
 `
 const RightAlign = styled.div`
   display: flex;

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -1,9 +1,9 @@
-import React, { VFC, createContext, useCallback, useLayoutEffect, useRef, useState } from 'react'
+import React, { VFC, createContext, useLayoutEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
-import { ContentBoxStyle, Rect, getContentBoxStyle, getFirstTabbable } from './dropdownHelper'
+import { ContentBoxStyle, Rect, getContentBoxStyle } from './dropdownHelper'
 import { DropdownCloser } from './DropdownCloser'
 import { useKeyboardNavigation } from './useKeyboardNavigation'
 
@@ -37,6 +37,7 @@ export const DropdownContentInner: VFC<Props> = ({
     maxHeight: '',
   })
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const focusTargetRef = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
     if (wrapperRef.current) {
@@ -61,29 +62,11 @@ export const DropdownContentInner: VFC<Props> = ({
     }
   }, [triggerRect])
 
-  const focusContent = useCallback(() => {
-    // delay for waiting to change the inner contents to visible
-    const firstTabbale = getFirstTabbable(wrapperRef)
-    if (firstTabbale) {
-      firstTabbale.focus()
-      return true
-    }
-    return false
-  }, [])
-
   useLayoutEffect(() => {
-    if (isActive) {
-      // when the dropdwon content becomes active, focus a first tabbable element in it
-      setTimeout(() => {
-        // delay for waiting to change the inner contents to visible
-        if (!focusContent()) {
-          setTimeout(() => {
-            focusContent()
-          }, 100)
-        }
-      }, 30)
+    if (isActive && focusTargetRef.current) {
+      focusTargetRef.current.focus()
     }
-  }, [isActive, focusContent])
+  }, [isActive])
 
   useKeyboardNavigation(wrapperRef)
 
@@ -94,6 +77,8 @@ export const DropdownContentInner: VFC<Props> = ({
       className={`${className} ${isActive ? 'active' : ''}`}
       themes={theme}
     >
+      {/* dummy element for focus management. */}
+      <div tabIndex={-1} ref={focusTargetRef} />
       {controllable ? (
         <ControllableWrapper scrollable={scrollable} contentBox={contentBox}>
           {children}

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -63,8 +63,8 @@ export const DropdownContentInner: VFC<Props> = ({
   }, [triggerRect])
 
   useLayoutEffect(() => {
-    if (isActive && focusTargetRef.current) {
-      focusTargetRef.current.focus()
+    if (isActive) {
+      focusTargetRef.current?.focus()
     }
   }, [isActive])
 

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -33,8 +33,7 @@ export const DropdownContentInner: VFC<Props> = ({
   const theme = useTheme()
   const [isActive, setIsActive] = useState(false)
   const [contentBox, setContentBox] = useState<ContentBoxStyle>({
-    top: '0',
-    left: '0',
+    top: 'auto',
     maxHeight: '',
   })
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -49,12 +48,12 @@ export const DropdownContentInner: VFC<Props> = ({
             height: wrapperRef.current.offsetHeight,
           },
           {
-            width: innerWidth,
+            width: document.body.clientWidth,
             height: innerHeight,
           },
           {
-            top: pageYOffset,
-            left: pageXOffset,
+            top: scrollY,
+            left: scrollX,
           },
         ),
       )
@@ -113,7 +112,11 @@ const Wrapper = styled.div<{
   contentBox: ContentBoxStyle
 }>`
   ${({ contentBox, themes }) => {
-    const { color, radius, zIndex, shadow } = themes
+    const { color, radius, zIndex, shadow, spacingByChar } = themes
+    const leftMargin =
+      contentBox.left === undefined ? spacingByChar(0.5) : `max(${contentBox.left}, 0px)`
+    const rightMargin =
+      contentBox.right === undefined ? spacingByChar(0.5) : `max(${contentBox.right}, 0px)`
 
     return css`
       display: flex;
@@ -121,11 +124,19 @@ const Wrapper = styled.div<{
       z-index: ${zIndex.OVERLAP_BASE};
       position: absolute;
       top: ${contentBox.top};
-      left: ${contentBox.left};
+      ${contentBox.left !== undefined &&
+      css`
+        left: ${contentBox.left};
+      `}
+      ${contentBox.right !== undefined &&
+      css`
+        right: ${contentBox.right};
+      `}
+      max-width: calc(100% - ${leftMargin} - ${rightMargin});
+      word-break: break-word;
       border-radius: ${radius.m};
       box-shadow: ${shadow.LAYER3};
       background-color: ${color.WHITE};
-      white-space: nowrap;
 
       &.active {
         visibility: visible;

--- a/src/components/Dropdown/dropdownHelper.test.ts
+++ b/src/components/Dropdown/dropdownHelper.test.ts
@@ -9,7 +9,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '135px', // 140 - 5
-        left: '0px', // = trigger left
+        left: '-5px', // trigger left - 5
         maxHeight: '',
       })
     })
@@ -21,7 +21,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '205px', // 600 - 400 + 5
-        left: '0px', // = trigger left
+        left: '-5px', // trigger left - 5
         maxHeight: '',
       })
     })
@@ -33,7 +33,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '135px', // 140 - 5
-        left: '0px', // = trigger left
+        left: '-5px', // trigger left - 5
         maxHeight: '220px', // 370 - 140 - 10
       })
     })
@@ -45,7 +45,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '15px', // 0 + 10 + 5
-        left: '0px', // = trigger left
+        left: '-5px', // trigger left - 5
         maxHeight: '190px', // 200 - 10
       })
     })
@@ -57,7 +57,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '135px', // 140 - 5
-        right: '380px', // window width - trigger right
+        right: '375px', // window width - trigger right - 5
         maxHeight: '',
       })
     })
@@ -69,7 +69,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 500, left: 600 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '635px', // 140 - 5 + 500
-        left: '600px', // trigger left + scroll left
+        left: '595px', // trigger left + scroll left - 5
         maxHeight: '',
       })
     })

--- a/src/components/Dropdown/dropdownHelper.test.ts
+++ b/src/components/Dropdown/dropdownHelper.test.ts
@@ -9,7 +9,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '135px', // 140 - 5
-        left: '-5px', // 0 - 5
+        left: '0px', // = trigger left
         maxHeight: '',
       })
     })
@@ -21,7 +21,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '205px', // 600 - 400 + 5
-        left: '-5px', // 0 - 5
+        left: '0px', // = trigger left
         maxHeight: '',
       })
     })
@@ -33,7 +33,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '135px', // 140 - 5
-        left: '-5px', // 0 - 5
+        left: '0px', // = trigger left
         maxHeight: '220px', // 370 - 140 - 10
       })
     })
@@ -45,7 +45,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '15px', // 0 + 10 + 5
-        left: '-5px', // 0 - 5
+        left: '0px', // = trigger left
         maxHeight: '190px', // 200 - 10
       })
     })
@@ -57,7 +57,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '135px', // 140 - 5
-        left: '325px', // 620 - 300 + 5
+        right: '380px', // window width - trigger right
         maxHeight: '',
       })
     })
@@ -69,7 +69,7 @@ describe('dropdownHelper', () => {
       const scroll = { top: 500, left: 600 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
         top: '635px', // 140 - 5 + 500
-        left: '595px', // 0 - 5 + 600
+        left: '600px', // trigger left + scroll left
         maxHeight: '',
       })
     })

--- a/src/components/Dropdown/dropdownHelper.ts
+++ b/src/components/Dropdown/dropdownHelper.ts
@@ -61,10 +61,10 @@ export function getContentBoxStyle(
 
   if (triggerAlignCenter <= windowSize.width / 2) {
     // トリガが画面左寄りの場合
-    contentBox.left = `${scroll.left + triggerRect.left}px`
+    contentBox.left = `${scroll.left + triggerRect.left - 5}px`
   } else {
     // トリガが画面右寄りの場合
-    contentBox.right = `${windowSize.width - triggerRect.right - scroll.left}px`
+    contentBox.right = `${windowSize.width - triggerRect.right - scroll.left - 5}px`
   }
 
   return contentBox

--- a/src/components/Dropdown/dropdownHelper.ts
+++ b/src/components/Dropdown/dropdownHelper.ts
@@ -11,7 +11,8 @@ export type Rect = {
 type Size = { width: number; height: number }
 export type ContentBoxStyle = {
   top: string
-  left: string
+  left?: string
+  right?: string
   maxHeight: string
 }
 
@@ -32,21 +33,25 @@ export function getContentBoxStyle(
 ) {
   const contentBox: ContentBoxStyle = {
     top: 'auto',
-    left: 'auto',
     maxHeight: '',
   }
 
   if (triggerRect.bottom + contentSize.height <= windowSize.height) {
+    // ドロップダウンのサイズがトリガの下側の領域に収まる場合
     contentBox.top = `${scroll.top + triggerRect.bottom - 5}px`
   } else if (triggerRect.top - contentSize.height >= 0) {
+    // ドロップダウンのサイズがトリガの上川の領域に収まる場合
     contentBox.top = `${scroll.top + triggerRect.top - contentSize.height + 5}px`
   } else {
     const padding = 10
+    const triggerHeight = triggerRect.bottom - triggerRect.top
 
-    if (triggerRect.top + (triggerRect.bottom - triggerRect.top) / 2 < windowSize.height / 2) {
+    if (triggerRect.top + triggerHeight / 2 < windowSize.height / 2) {
+      // 下側の領域のほうが広い場合
       contentBox.top = `${scroll.top + triggerRect.bottom - 5}px`
       contentBox.maxHeight = `${windowSize.height - triggerRect.bottom - padding}px`
     } else {
+      // 上側の領域のほうが広い場合
       contentBox.top = `${scroll.top + padding + 5}px`
       contentBox.maxHeight = `${triggerRect.top - padding}px`
     }
@@ -55,9 +60,11 @@ export function getContentBoxStyle(
   const triggerAlignCenter = triggerRect.left + (triggerRect.right - triggerRect.left) / 2
 
   if (triggerAlignCenter <= windowSize.width / 2) {
-    contentBox.left = `${scroll.left + triggerRect.left - 5}px`
+    // トリガが画面左寄りの場合
+    contentBox.left = `${scroll.left + triggerRect.left}px`
   } else {
-    contentBox.left = `${scroll.left + triggerRect.right - contentSize.width + 5}px`
+    // トリガが画面右寄りの場合
+    contentBox.right = `${windowSize.width - triggerRect.right - scroll.left}px`
   }
 
   return contentBox

--- a/src/libs/tabbable.ts
+++ b/src/libs/tabbable.ts
@@ -24,7 +24,9 @@ export function tabbable(el: HTMLElement, option?: Partial<Option>) {
     ...defaultOption,
     ...option,
   }
-  const candidates = Array.from(el.querySelectorAll<HTMLElement>(candidateSelector))
+  const candidates = Array.from(el.querySelectorAll<HTMLElement>(candidateSelector)).filter(
+    (element) => element.tabIndex >= 0,
+  )
   if (mergedOption.shouldIgnoreVisibility) {
     return candidates
   }


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-536
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Dropdown` コンポーネントのパネル部分の幅がウィンドウサイズを超えるとページに横スクロールが発生するため、折り返して表示するように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- トリガが右寄りの場合、 `position: absolute` の `right` で位置を決定するように変更
- `max-width` でウィンドウサイズを超えないように制限
- Story 側に、ドロップダウン内のコンテンツが折り返される記述を追加
- ドロップダウンを開いた時に、コンテンツ内先頭に配置したダミー要素をフォーカスするように変更
  - 関連して、`tabindex="-1"` の要素が tabbale に補足されないように修正（本来 tabindex="-1" はタブ移動可能ではないはずなのでこれが正しそう）
  - また、↑の変更によりモーダルダイアログの開いたときのフォーカス移動がおかしくなったので、フォーカス用ダミー要素を `FocusTrap` 内に内包させ、フォーカスされた要素がダイアログ内のコンテンツだと認識されるように `FocusTrap` が `role=dialog` の配下になるように構造を変更

### やってないこと
ドロップダウン部分の ARIA における role や名前付けは変更前からされておらず、本 PR で追加もしていません。
[Disclosure パターン](https://www.w3.org/TR/wai-aria-practices-1.2/#disclosure) に則れば、トリガとなるボタンとドロップダウンのパネルが `aria-controls` で結ばれていれば良く、その制御は既に入っているので問題ないと判断しました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/156696324-af77715a-770e-45b4-98f6-38395688f4c0.png) | ![image](https://user-images.githubusercontent.com/270422/156696273-f8303fae-a24d-4970-9332-aff879f72072.png) |
<!--
Please attach a capture if it looks different.
-->
