### PR TITLE
fix: Story 内の styled-component に theme の型を効かせる

### DIFF
--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { TextLink } from './TextLink'
 import { FaFlagIcon } from '../Icon'
 import readme from './README.md'
@@ -44,11 +44,13 @@ storiesOf('TextLink', module)
     </Wrapper>
   ))
 
-const Wrapper = styled.ul`
-  list-style: none;
-  margin: 24px;
+const Wrapper = styled.ul(
+  ({ theme: { spacingByChar } }) => css`
+    list-style: none;
+    margin: ${spacingByChar(1.5)};
 
-  li + li {
-    margin-top: 16px;
-  }
-`
+    li + li {
+      margin-top: ${spacingByChar(1)};
+    }
+  `,
+)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+import { CreatedTheme } from './themes/createTheme'
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends CreatedTheme {}
+}


### PR DESCRIPTION
`preview.js` の `addDecorator` で `theme` 自体は渡っていたので型定義を足しました。