### PR TITLE
fix: Balloon の三角形関連のスタイルを改善

### DIFF
--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -40,21 +40,21 @@ export const Balloon: VFC<Props & ElementProps> = ({
 
 const Base = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { color, border, fontSize, shadow } = themes
+    const { color, fontSize } = themes
 
     return css`
       position: relative;
       display: inline-block;
       font-size: ${fontSize.S};
       border-radius: 4px;
-      box-shadow: ${shadow.LAYER2};
+      filter: drop-shadow(0 2px 2.5px rgba(0, 0, 0, 0.33));
       white-space: nowrap;
 
       &::before {
         display: block;
         position: absolute;
-        border-style: ${border.lineStyle};
         content: '';
+        background-color: ${color.WHITE};
       }
 
       background-color: ${color.WHITE};
@@ -62,20 +62,18 @@ const Base = styled.div<{ themes: Theme }>`
 
       &.top {
         &::before {
-          border-width: 0 5px 5px;
-        }
-        &::before {
           top: -5px;
-          border-color: transparent transparent ${color.BORDER};
+          width: 10px;
+          height: 5px;
+          clip-path: polygon(50% 0, 100% 100%, 0 100%);
         }
       }
       &.bottom {
         &::before {
-          border-width: 5px 5px 0;
-        }
-        &::before {
           bottom: -5px;
-          border-color: ${color.BORDER} transparent transparent;
+          width: 10px;
+          height: 5px;
+          clip-path: polygon(0 0, 100% 0, 50% 100%);
         }
       }
 
@@ -103,20 +101,18 @@ const Base = styled.div<{ themes: Theme }>`
         }
         &.left {
           &::before {
-            border-width: 5px 5px 5px 0;
-          }
-          &::before {
             left: -5px;
-            border-color: transparent ${color.BORDER} transparent transparent;
+            width: 5px;
+            height: 10px;
+            clip-path: polygon(100% 0, 100% 100%, 0 50%);
           }
         }
         &.right {
           &::before {
-            border-width: 5px 0 5px 5px;
-          }
-          &::before {
             right: -5px;
-            border-color: transparent transparent transparent ${color.BORDER};
+            width: 5px;
+            height: 10px;
+            clip-path: polygon(0 0, 100% 50%, 0 100%);
           }
         }
       }

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -49,6 +49,7 @@ const Base = styled.div<{ themes: Theme }>`
       border-radius: 4px;
       filter: drop-shadow(0 2px 2.5px rgba(0, 0, 0, 0.33));
       white-space: nowrap;
+      transform: translateZ(0); /* safari で filter を正しく描画するために必要 */
 
       &::before {
         display: block;

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -50,8 +50,7 @@ const Base = styled.div<{ themes: Theme }>`
       box-shadow: ${shadow.LAYER2};
       white-space: nowrap;
 
-      &::before,
-      &::after {
+      &::before {
         display: block;
         position: absolute;
         border-style: ${border.lineStyle};
@@ -62,86 +61,62 @@ const Base = styled.div<{ themes: Theme }>`
       color: ${color.TEXT_BLACK};
 
       &.top {
-        &::before,
-        &::after {
+        &::before {
           border-width: 0 5px 5px;
         }
         &::before {
           top: -5px;
           border-color: transparent transparent ${color.BORDER};
         }
-        &::after {
-          top: -4px;
-          border-color: transparent transparent ${color.WHITE};
-        }
       }
       &.bottom {
-        &::before,
-        &::after {
+        &::before {
           border-width: 5px 5px 0;
         }
         &::before {
           bottom: -5px;
           border-color: ${color.BORDER} transparent transparent;
         }
-        &::after {
-          bottom: -4px;
-          border-color: ${color.WHITE} transparent transparent;
-        }
       }
 
       &.right {
-        &::before,
-        &::after {
+        &::before {
           right: 24px;
         }
       }
       &.center {
-        &::before,
-        &::after {
+        &::before {
           left: 50%;
           transform: translateX(-5px);
         }
       }
       &.left {
-        &::before,
-        &::after {
+        &::before {
           left: 24px;
         }
       }
 
       &.middle {
-        &::before,
-        &::after {
+        &::before {
           top: 50%;
           transform: translateY(-5px);
         }
         &.left {
-          &::before,
-          &::after {
+          &::before {
             border-width: 5px 5px 5px 0;
           }
           &::before {
             left: -5px;
             border-color: transparent ${color.BORDER} transparent transparent;
           }
-          &::after {
-            left: -4px;
-            border-color: transparent ${color.WHITE} transparent transparent;
-          }
         }
         &.right {
-          &::before,
-          &::after {
+          &::before {
             border-width: 5px 0 5px 5px;
           }
           &::before {
             right: -5px;
             border-color: transparent transparent transparent ${color.BORDER};
-          }
-          &::after {
-            right: -4px;
-            border-color: transparent transparent transparent ${color.WHITE};
           }
         }
       }

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -63,56 +63,56 @@ const Base = styled.div<{ themes: Theme }>`
 
       &.top {
         &::before {
-          top: -5px;
-          width: 10px;
-          height: 5px;
+          top: -4px;
+          width: 8px;
+          height: 4px;
           clip-path: polygon(50% 0, 100% 100%, 0 100%);
         }
       }
       &.bottom {
         &::before {
-          bottom: -5px;
-          width: 10px;
-          height: 5px;
+          bottom: -4px;
+          width: 8px;
+          height: 4px;
           clip-path: polygon(0 0, 100% 0, 50% 100%);
         }
       }
 
       &.right {
         &::before {
-          right: 24px;
+          right: 25px;
         }
       }
       &.center {
         &::before {
           left: 50%;
-          transform: translateX(-5px);
+          transform: translateX(-4px);
         }
       }
       &.left {
         &::before {
-          left: 24px;
+          left: 25px;
         }
       }
 
       &.middle {
         &::before {
           top: 50%;
-          transform: translateY(-5px);
+          transform: translateY(-4px);
         }
         &.left {
           &::before {
-            left: -5px;
-            width: 5px;
-            height: 10px;
+            left: -4px;
+            width: 4px;
+            height: 8px;
             clip-path: polygon(100% 0, 100% 100%, 0 50%);
           }
         }
         &.right {
           &::before {
-            right: -5px;
-            width: 5px;
-            height: 10px;
+            right: -4px;
+            width: 4px;
+            height: 8px;
             clip-path: polygon(0 0, 100% 50%, 0 100%);
           }
         }

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -47,7 +47,9 @@ const Base = styled.div<{ themes: Theme }>`
       display: inline-block;
       font-size: ${fontSize.S};
       border-radius: 4px;
-      filter: drop-shadow(0 2px 2.5px rgba(0, 0, 0, 0.33));
+      filter: drop-shadow(
+        0 2px 2.5px rgba(0, 0, 0, 0.33)
+      ); /* drop-shadow は spread-radius を受け付けないので shadow.LAYER2 に近い値をハードコーディングしている */
       white-space: nowrap;
       transform: translateZ(0); /* safari で filter を正しく描画するために必要 */
 


### PR DESCRIPTION
## Overview

Bolloon コンポーネントの三角形部分のスタイルを改善しました。

## What I did

具体的には、下記の2つを実施しました。

- 三角形の描画は border ではなく clip-path を使って描画するように変更
    - border による三角形の描画はややハック寄りの書き方であるため
- 影は box-shadow ではなく filter の drop-shadow を使って描画するように変更
    - drop-shadow であれば、三角形部分を含めた影も正しく描画できるため

## Capture

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14817308/157377766-129a3ea3-482a-4681-8783-082dee4d124a.png) | ![image](https://user-images.githubusercontent.com/14817308/157377816-b195741c-dd39-45c7-bb1f-c1e20b4be8f6.png) |