### PR TITLE
test: reg-suit の variants で CSS アニメーションが有効にならないようにする

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -54,6 +54,34 @@ export const parameters = {
     variants: {
       mobile: {
         viewport: 'iPhone 5',
+        /**
+         * storycap にて、初回以降の variants で CSS アニメーションを無効にするスタイルが効かないバグが存在するようなので、
+         * キャプチャ前に DOM にスタイルを差し込む処理を追加
+         * 参考: https://github.com/reg-viz/storycap/issues/327
+         */
+        waitFor: () =>
+          new Promise((resolve) => {
+            const stylesId = 'smarthr-ui-storycap-disable-css-animation'
+            if (!document.getElementById(stylesId)) {
+              const styles = document.createElement('style')
+              styles.setAttribute('id', stylesId)
+              styles.appendChild(
+                document.createTextNode(`
+                  *,
+                  *::before,
+                  *::after {
+                    transition: none !important;
+                    animation: none !important;
+                  }
+                  input {
+                    caret-color: transparent !important;
+                  }
+                `),
+              )
+              document.querySelector('head').appendChild(styles)
+            }
+            resolve()
+          }),
       },
     },
   },


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
以前の対応で、reg-suit でモバイルの viewport でも比較する設定を追加しましたが、モバイル viewport の比較のうちアニメーションをもつコンポーネントで毎回差分が検出される状態になってしまっています。

原因としては、スクリーンショットを行う storycap にて、初回以降の variants には CSS アニメーションが無効化されない問題が存在していて、スクリーンショットを行うタイミングのズレによってアニメーション中の表示差分が生まれているようです。

この問題の対処を行います。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- ワークアラウンドとして、モバイル viewport のキャプチャ前に CSS アニメーション無効のスタイルを差し込むことで、アニメーションが起きないようにします
  - [storycap の waitFor](https://github.com/reg-viz/storycap#type-screenshotoptions)
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
