### PR TITLE
fix: `Pagination` のモバイル表示調整 (SHRUI-538)

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 import { range } from '../../libs/lodash'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
+import { Reel } from '../Layout'
 
 import { PaginationItem } from './PaginationItem'
 import { PaginationControllerItem } from './PaginationControllerItem'
@@ -102,17 +103,20 @@ export const Pagination: VFC<Props & ElementProps> = ({
       aria-label="ページネーション"
       {...props}
     >
-      <List className={withoutNumbers ? 'withoutNumbers' : ''} themes={theme}>
-        {prevPage}
-        {pages}
-        {nextPage}
-      </List>
+      <Reel>
+        <List className={withoutNumbers ? 'withoutNumbers' : ''} themes={theme}>
+          {prevPage}
+          {pages}
+          {nextPage}
+        </List>
+      </Reel>
     </Wrapper>
   )
 }
 
 const Wrapper = styled.nav`
   display: inline-block;
+  max-width: 100%;
 `
 const List = styled.ul<{ themes: Theme }>`
   ${({ themes: { spacingByChar } }) => {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-538
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、`Pagination` コンポーネントの幅がウィンドウサイズを超えるとき、はみ出して横スクロールが発生してしまうため、その影響を限定的にする対応を行います。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Reel` を用い、単体で横スクロールするように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
