### PR TITLE
fix: `TabBar` のモバイル表示調整 (SHRUI-539)

### DIFF
--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
+import { Reel } from '../Layout'
 
 type Props = {
   children: ReactNode
@@ -19,21 +20,23 @@ export const TabBar: VFC<Props & ElementProps> = ({
 }) => {
   const theme = useTheme()
   const classNames = useClassNames().tabBar
-  const wrapperClass = `${className} ${bordered ? 'bordered' : ''} ${classNames.wrapper}`
+  const wrapperClass = `${className} ${classNames.wrapper}`
 
   return (
-    <Wrapper {...props} role="tablist" className={wrapperClass} themes={theme}>
-      {children}
-    </Wrapper>
+    <Reel {...props} role="tablist" className={wrapperClass}>
+      <Inner className={bordered ? 'bordered' : undefined} themes={theme}>
+        {children}
+      </Inner>
+    </Reel>
   )
 }
 
-const Wrapper = styled.div<{ themes: Theme }>`
+const Inner = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
     const { border } = themes
 
     return css`
-      display: flex;
+      flex-grow: 1;
 
       &.bordered {
         position: relative;

--- a/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TabBar should be match snapshot 1`] = `
-.c1 {
+.c2 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -20,18 +20,18 @@ exports[`TabBar should be match snapshot 1`] = `
   transition: background-color .3s ease-out,color .3s ease-out;
 }
 
-.c1.selected {
+.c2.selected {
   position: relative;
   color: #23221f;
   border-color: #0077c7;
 }
 
-.c1:hover {
+.c2:hover {
   background-color: #f8f7f6;
   color: #23221f;
 }
 
-.c1:disabled {
+.c2:disabled {
   background-color: transparent;
   color: rgba(112,109,101,0.5);
   cursor: not-allowed;
@@ -42,13 +42,34 @@ exports[`TabBar should be match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  gap: 8px;
+  padding: 0;
 }
 
-.c0.bordered {
+.c0 > * {
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+}
+
+.c0:empty {
+  gap: 0;
+}
+
+.c1 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c1.bordered {
   position: relative;
 }
 
-.c0.bordered::before {
+.c1.bordered::before {
   position: absolute;
   left: 0;
   right: 0;
@@ -58,38 +79,42 @@ exports[`TabBar should be match snapshot 1`] = `
 }
 
 <div
-  className="c0  bordered smarthr-ui-TabBar"
+  className="c0  smarthr-ui-TabBar"
   role="tablist"
 >
-  <button
-    aria-selected={false}
-    className="c1   smarthr-ui-TabItem"
-    disabled={false}
-    onClick={[Function]}
-    role="tab"
-    type="button"
+  <div
+    className="c1 bordered"
   >
-    Tab
-  </button>
-  <button
-    aria-selected={true}
-    className="c1  selected smarthr-ui-TabItem"
-    disabled={false}
-    onClick={[Function]}
-    role="tab"
-    type="button"
-  >
-    Selected
-  </button>
-  <button
-    aria-selected={false}
-    className="c1   smarthr-ui-TabItem"
-    disabled={true}
-    onClick={[Function]}
-    role="tab"
-    type="button"
-  >
-    Disabled
-  </button>
+    <button
+      aria-selected={false}
+      className="c2   smarthr-ui-TabItem"
+      disabled={false}
+      onClick={[Function]}
+      role="tab"
+      type="button"
+    >
+      Tab
+    </button>
+    <button
+      aria-selected={true}
+      className="c2  selected smarthr-ui-TabItem"
+      disabled={false}
+      onClick={[Function]}
+      role="tab"
+      type="button"
+    >
+      Selected
+    </button>
+    <button
+      aria-selected={false}
+      className="c2   smarthr-ui-TabItem"
+      disabled={true}
+      onClick={[Function]}
+      role="tab"
+      type="button"
+    >
+      Disabled
+    </button>
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-539
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`TabBar` のモバイル表示を想定した微調整を行います。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Reel` で囲って、幅がウィンドウサイズを超える時に単体で横スクロールするように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
