### PR TITLE
test: reg-suit を実行する docker イメージを変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,20 +79,12 @@ jobs:
       - run-npm-test
   reg-suit:
     docker:
-      - image: cimg/node:16.14
+      - image: cimg/node:16.14-browsers
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
     working_directory: ~/repo
     steps:
-      - run:
-          name: Install System Dependencies
-          command: |
-            sudo apt-get update -y && sudo apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget libgbm-dev
       - install-noto-sans-cjk-jp
       - run-reg-suit
 


### PR DESCRIPTION
## Related URL

なし

## Overview

ブラウザ動作に必要なパッケージが入っているイメージを使うことで手動で reg-suit に必要なパッケージを入れる処理を消したい。
プロダクト側で @f440 さんがやってくれた対応を輸入しています。

## What I did

- reg-suit を実行する docker イメージの変更
- 手動でインストールしていた処理を削除

reg-suit が動いていれば問題ないです。

## Capture

なし