### PR TITLE
fix: ballonのtriangleがretinaディスプレイなどで条件が揃うと表示崩れするバグを修正

### DIFF
--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -82,25 +82,25 @@ const Base = styled.div<{ themes: Theme }>`
 
       &.right {
         &::before {
-          right: 25px;
+          right: 24px;
         }
       }
       &.center {
         &::before {
           left: 50%;
-          transform: translateX(-4px);
+          transform: translateX(-5px);
         }
       }
       &.left {
         &::before {
-          left: 25px;
+          left: 24px;
         }
       }
 
       &.middle {
         &::before {
           top: 50%;
-          transform: translateY(-4px);
+          transform: translateY(-5px);
         }
         &.left {
           &::before {

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -38,6 +38,8 @@ export const Balloon: VFC<Props & ElementProps> = ({
   return <Base className={classNames} themes={themes} {...props} />
 }
 
+// HINT: trianble部分はRetinaディスプレイなどで途切れてしまう場合があるので
+// 1pxほど大きめに描画してbody部分と被るようにしています。
 const Base = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
     const { color, fontSize } = themes

--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -66,16 +66,16 @@ const Base = styled.div<{ themes: Theme }>`
       &.top {
         &::before {
           top: -4px;
-          width: 8px;
-          height: 4px;
+          width: 10px;
+          height: 5px;
           clip-path: polygon(50% 0, 100% 100%, 0 100%);
         }
       }
       &.bottom {
         &::before {
           bottom: -4px;
-          width: 8px;
-          height: 4px;
+          width: 10px;
+          height: 5px;
           clip-path: polygon(0 0, 100% 0, 50% 100%);
         }
       }
@@ -105,16 +105,16 @@ const Base = styled.div<{ themes: Theme }>`
         &.left {
           &::before {
             left: -4px;
-            width: 4px;
-            height: 8px;
+            width: 5px;
+            height: 10px;
             clip-path: polygon(100% 0, 100% 100%, 0 50%);
           }
         }
         &.right {
           &::before {
             right: -4px;
-            width: 4px;
-            height: 8px;
+            width: 5px;
+            height: 10px;
             clip-path: polygon(0 0, 100% 50%, 0 100%);
           }
         }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- ballonのtriangle部分がRetinaディスプレイで表示崩れ場合がある
- 詳細な条件までは調べきれていませんが、画面幅などが影響しており、おそらく計算結果の小数点以下の数値が影響していそう
- triangle部分を1pxほど大きくしてballonのbody部分をかぶらせておくことで途切れないようにしたい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

### 修正前
![スクリーンショット 2022-03-31 13 38 41](https://user-images.githubusercontent.com/773467/160977858-39b35547-60f5-4edc-9730-68d1733d7da1.png)

### 修正後
![スクリーンショット 2022-03-31 13 38 59](https://user-images.githubusercontent.com/773467/160977822-82611e6e-9fb2-4fd4-8e0b-133e451ab58a.png)