### PR TITLE
feat: use ReactNode for i18n

### DIFF
--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -6,8 +6,9 @@ import {
   MessageDialogContentInner,
   MessageDialogContentInnerProps,
 } from './MessageDialogContentInner'
+import { useId } from '../../hooks/useId'
 
-type Props = MessageDialogContentInnerProps &
+type Props = Omit<MessageDialogContentInnerProps, 'titleId'> &
   Pick<
     DialogContentInnerProps,
     | 'isOpen'
@@ -39,16 +40,14 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
     }
     onClickClose()
   }, [onClickClose, props.isOpen])
+  const titleId = useId()
 
   return (
     <Portal>
-      <DialogContentInner
-        ariaLabel={subtitle ? `${subtitle} ${title}` : title}
-        className={className}
-        {...props}
-      >
+      <DialogContentInner aria-labelledby={titleId} className={className} {...props}>
         <MessageDialogContentInner
           title={title}
+          titleId={titleId}
           subtitle={subtitle}
           description={description}
           closeText={closeText}

--- a/src/components/Dialog/MessageDialogContent.tsx
+++ b/src/components/Dialog/MessageDialogContent.tsx
@@ -3,8 +3,9 @@ import React, { HTMLAttributes, useCallback, useContext } from 'react'
 import { DialogContext } from './DialogWrapper'
 import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
 import { BaseProps, MessageDialogContentInner } from './MessageDialogContentInner'
+import { useId } from '../../hooks/useId'
 
-type Props = BaseProps &
+type Props = Omit<BaseProps, 'titleId'> &
   Pick<DialogContentInnerProps, 'width' | 'top' | 'right' | 'bottom' | 'left' | 'id'>
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
@@ -23,6 +24,7 @@ export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
     }
     onClickClose()
   }, [active, onClickClose])
+  const titleId = useId()
 
   return (
     <DialogContentRoot>
@@ -30,12 +32,12 @@ export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
         onClickOverlay={onClickClose}
         onPressEscape={onClickClose}
         isOpen={active}
-        ariaLabel={title}
         className={className}
         {...props}
       >
         <MessageDialogContentInner
           title={title}
+          titleId={titleId}
           description={description}
           closeText={closeText}
           onClickClose={handleClickClose}

--- a/src/components/Dialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialogContentInner.tsx
@@ -13,8 +13,9 @@ export type BaseProps = {
   /**
    * Title of the dialog.
    */
-  title: string
-  subtitle?: string
+  title: React.ReactNode
+  subtitle?: React.ReactNode
+  titleId: string
   /**
    * Description of the dialog.
    */
@@ -22,7 +23,7 @@ export type BaseProps = {
   /**
    * Label of close button.
    */
-  closeText: string
+  closeText: React.ReactNode
 }
 
 export type MessageDialogContentInnerProps = BaseProps & {
@@ -35,6 +36,7 @@ export type MessageDialogContentInnerProps = BaseProps & {
 export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
   title,
   subtitle,
+  titleId,
   description,
   closeText,
   onClickClose,
@@ -51,7 +53,7 @@ export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
             {subtitle}
           </Text>
         )}
-        <Text as="p" size="L" leading="TIGHT" className={classNames.title}>
+        <Text as="p" id={titleId} size="L" leading="TIGHT" className={classNames.title}>
           {title}
         </Text>
       </TitleArea>


### PR DESCRIPTION
## Related URL

similar pull request:
feat: Change <ActionDialog>'s string props to ReactNode #2117

## Overview

- Changed UI label props from string to ReactNode to make `MessageDialog` multilingual.
- Change `MessageDialog` Accessibility name from aria-label to `aria-labelledby` to refer to the title.

----

- `MessageDialog` を多言語対応するためにUIラベルのPropsをstringからReactNodeに変更
- `MessageDialog` の Accessibility name を `aria-label` から `aria-labelledby` で title を参照する形に変更