### PR TITLE
fix: NotificationBar の閉じるボタンが縮まないように修正

### DIFF
--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -166,6 +166,8 @@ const CloseButton = styled(TextButton)<{
   themes: Theme
 }>(
   ({ colorSet: { fgColor, bgColor }, themes: { color, spacingByChar } }) => css`
+    flex-shrink: 0;
+
     margin-top: ${spacingByChar(-0.5)};
     margin-right: ${spacingByChar(-0.5)};
     margin-bottom: ${spacingByChar(-0.5)};


### PR DESCRIPTION
一部環境で NotificationBar の CloseButton が潰れるらしい（手元では確認できず）。
パッと思いついたところを修正。
![image](https://user-images.githubusercontent.com/19403400/164151595-5d71cca1-6903-4921-a968-4ed15245d624.png)