### PR TITLE
feat: :focus を :focus-visible に置き換える｜SHRUI-553

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -103,13 +103,12 @@ const Button = styled.button<{ themes: Theme }>`
       font-size: inherit;
       text-align: left;
 
-      &:hover,
-      &:focus:not(:focus-visible) {
+      &:hover {
         background-color: ${color.hoverColor(color.WHITE)};
         box-shadow: none;
       }
 
-      &:focus {
+      &:focus-visible {
         ${shadow.focusIndicatorStyles}
       }
 

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -117,7 +117,7 @@ const Base: any = styled.div<{ themes: Theme; wide: boolean }>`
         background-clip: padding-box;
       }
 
-      &:focus {
+      &:focus-visible {
         ${shadow.focusIndicatorStyles}
       }
 

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -42,7 +42,7 @@ const dangerStyle = css`
       background-color: ${color.DANGER};
       color: ${color.TEXT_WHITE};
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         border-color: ${color.hoverColor(color.DANGER)};
         background-color: ${color.hoverColor(color.DANGER)};

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -50,7 +50,7 @@ const primaryStyle = css`
       background-color: ${color.MAIN};
       color: ${color.TEXT_WHITE};
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         border-color: ${color.hoverColor(color.MAIN)};
         background-color: ${color.hoverColor(color.MAIN)};

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -52,7 +52,7 @@ const secondaryStyle = css`
       background-color: ${color.WHITE};
       color: ${color.TEXT_BLACK};
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         border-color: ${color.hoverColor(color.BORDER)};
         background-color: ${color.hoverColor(color.WHITE)};

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -42,7 +42,7 @@ const skeletonStyle = css`
       background-color: transparent;
       color: ${color.TEXT_WHITE};
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         border-color: ${color.hoverColor(color.WHITE)};
         background-color: ${color.OVERLAY};

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -49,7 +49,7 @@ const textStyle = css`
       background-color: transparent;
       color: ${color.TEXT_BLACK};
 
-      &:focus,
+      &:focus-visible,
       &:hover {
         background-color: ${color.hoverColor(color.WHITE)};
         color: ${color.TEXT_BLACK};

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -100,8 +100,8 @@ const Input = styled.input<{ themes: Theme }>`
       &:hover + span {
         box-shadow: 0 0 0 2px ${transparentize(0.78, color.MAIN)};
       }
-      &:focus + span {
-        box-shadow: ${shadow.OUTLINE};
+      &:focus-visible + span {
+        box-shadow: ${shadow.focusIndicatorStyles};
       }
     `
   }}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -128,7 +128,7 @@ const Wrapper = styled.span<{
     width: ${typeof $width === 'number' ? `${$width}px` : $width};
 
     &:focus-within {
-      box-shadow: ${shadow.OUTLINE};
+      ${shadow.focusIndicatorStyles};
     }
 
     ${!$disabled &&

--- a/src/components/NotificationBar/NotificationBar.stories.tsx
+++ b/src/components/NotificationBar/NotificationBar.stories.tsx
@@ -24,8 +24,7 @@ export default {
 const TextLink = styled(shrTextLink)`
   color: inherit;
 
-  &:hover,
-  &:focus {
+  &:hover {
     color: inherit;
   }
 `

--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -172,7 +172,7 @@ const CloseButton = styled(TextButton)<{
     color: ${fgColor};
 
     &:hover,
-    &:focus {
+    &:focus-visible {
       background-color: ${color.hoverColor(bgColor)};
       color: ${fgColor};
     }

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, InputHTMLAttributes, VFC, useCallback } from 'react'
 import styled, { css } from 'styled-components'
+import { transparentize } from 'polished'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
@@ -94,9 +95,7 @@ const Box = styled.span<{ themes: Theme }>`
   }}
 `
 const Input = styled.input<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { OUTLINE } = themes.shadow
-
+  ${({ themes: { color, shadow } }) => {
     return css`
       opacity: 0;
       position: absolute;
@@ -110,9 +109,11 @@ const Input = styled.input<{ themes: Theme }>`
       &[disabled] {
         pointer-events: none;
       }
-
-      &:focus + span {
-        box-shadow: ${OUTLINE};
+      &:hover:not([disabled]) + span {
+        box-shadow: 0 0 0 2px ${transparentize(0.78, color.MAIN)};
+      }
+      &:focus-visible + span {
+        box-shadow: ${shadow.focusIndicatorStyles};
       }
     `
   }}

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -174,7 +174,7 @@ const Button = styled(SecondaryButton)<{ themes: Theme }>(
         }
       }
 
-      &:focus {
+      &:focus-visible {
         ${shadow.focusIndicatorStyles}
       }
       &:first-child {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -65,17 +65,12 @@ export function Select<T extends string>({
   const classNames = useClassNames()
 
   return (
-    <Wrapper
-      className={`${className} ${classNames.wrapper}`}
-      $width={widthStyle}
-      error={error}
-      disabled={disabled}
-      themes={theme}
-    >
+    <Wrapper className={`${className} ${classNames.wrapper}`} $width={widthStyle}>
       <SelectBox
         onChange={handleChange}
         aria-invalid={error || undefined}
         themes={theme}
+        error={error}
         disabled={disabled}
         {...props}
       >
@@ -107,59 +102,33 @@ export function Select<T extends string>({
         }
       </SelectBox>
       <IconWrap themes={theme}>
-        <FaSortIcon color="inherit" />
+        <FaSortIcon />
       </IconWrap>
     </Wrapper>
   )
 }
 
-const Wrapper = styled.div<{
-  $width: string
-  error?: boolean
-  disabled?: boolean
-  themes: Theme
-}>(({ $width, error, disabled, themes }) => {
-  const { border, color, radius, shadow } = themes
+const Wrapper = styled.div<{ $width: string }>(({ $width }) => {
   return css`
     box-sizing: border-box;
     position: relative;
-    border-radius: ${radius.m};
-    border: ${border.shorthand};
-    background-color: ${color.WHITE};
     width: ${$width};
-
-    &:hover {
-      ${!disabled &&
-      css`
-        background-color: ${color.hoverColor(color.WHITE)};
-      `}
-    }
-    &:focus-within {
-      ${shadow.focusIndicatorStyles}
-    }
-
-    ${error &&
-    css`
-      border-color: ${color.DANGER};
-    `}
-    ${disabled &&
-    css`
-      background-color: ${color.COLUMN};
-      color: ${color.TEXT_DISABLED};
-    `}
   `
 })
-const SelectBox = styled.select<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color, fontSize, leading, spacingByChar } = themes
+const SelectBox = styled.select<{
+  error?: boolean
+  themes: Theme
+}>`
+  ${({ error, themes }) => {
+    const { border, color, fontSize, leading, radius, shadow, spacingByChar } = themes
 
     return css`
       appearance: none;
       cursor: pointer;
-      display: inline-block;
       outline: none;
-      border: none;
-      background-color: transparent;
+      border-radius: ${radius.m};
+      border: ${border.shorthand};
+      background-color: ${color.WHITE};
       padding: ${spacingByChar(0.75)};
       padding-right: ${spacingByChar(2)};
       padding-left: ${spacingByChar(0.5)};
@@ -168,14 +137,23 @@ const SelectBox = styled.select<{ themes: Theme }>`
       line-height: ${leading.NONE};
       width: 100%;
 
-      &::placeholder {
-        color: ${color.TEXT_GREY};
+      ${error &&
+      css`
+        border-color: ${color.DANGER};
+      `}
+
+      &:hover {
+        background-color: ${color.hoverColor(color.WHITE)};
       }
 
-      &[disabled] {
+      &:focus-visible {
+        ${shadow.focusIndicatorStyles}
+      }
+
+      &:disabled {
         pointer-events: none;
-        cursor: not-allowed;
         opacity: 1;
+        background-color: ${color.COLUMN};
         color: ${color.TEXT_DISABLED};
       }
     `
@@ -198,7 +176,7 @@ const IconWrap = styled.span<{ themes: Theme }>`
       ${SelectBox}:disabled + & {
         color: ${color.TEXT_DISABLED};
       }
-      ${SelectBox}:focus + & {
+      ${SelectBox}:focus-visible + & {
         color: ${color.TEXT_BLACK};
       }
     `

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -51,7 +51,7 @@ export const SideNavItem: VFC<Props> = ({
 
 const Wrapper = styled.li<{ themes: Theme }>`
   ${({ themes }) => {
-    const { color, interaction, shadow } = themes
+    const { color, interaction } = themes
 
     return css`
       color: ${color.TEXT_BLACK};
@@ -79,17 +79,13 @@ const Wrapper = styled.li<{ themes: Theme }>`
           content: '';
         }
       }
-
-      &:focus-within {
-        ${shadow.focusIndicatorStyles}
-      }
     `
   }}
 `
 
 const Button = styled(UnstyledButton)<{ themes: Theme }>`
   ${({ themes }) => {
-    const { fontSize, spacingByChar } = themes
+    const { fontSize, shadow, spacingByChar } = themes
 
     return css`
       outline: none;
@@ -106,6 +102,10 @@ const Button = styled(UnstyledButton)<{ themes: Theme }>`
       &.s {
         padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
         font-size: ${fontSize.S};
+      }
+
+      &:focus-visible {
+        ${shadow.focusIndicatorStyles}
       }
     `
   }}

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -76,7 +76,7 @@ export const Textarea: VFC<Props & ElementProps> = ({
 const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: string | number }>`
   ${(props) => {
     const { themes, textAreaWidth = 'auto', error } = props
-    const { fontSize, spacingByChar, border, radius, color } = themes
+    const { fontSize, spacingByChar, border, radius, color, shadow } = themes
 
     return css`
       padding: ${spacingByChar(0.5)};
@@ -88,20 +88,18 @@ const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: 
       border: ${border.shorthand};
       box-sizing: border-box;
       opacity: 1;
-      ${error
-        ? css`
-            border-color: ${color.DANGER};
-          `
-        : css`
-            &:focus {
-              border-color: ${color.hoverColor(color.MAIN)};
-            }
-          `}
 
+      ${error &&
+      css`
+        border-color: ${color.DANGER};
+      `}
       &::placeholder {
         color: ${color.TEXT_GREY};
       }
-      &[disabled] {
+      &:focus-visible {
+        ${shadow.focusIndicatorStyles}
+      }
+      &:disabled {
         background-color: ${color.COLUMN};
         pointer-events: none;
 


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-553

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`:focus` を `:focus-visible` に置き換えました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Input はスタイリングの都合上 `focus-visible-within` 的なものがないと対応できないため保留
- MultiComboBox は #2427 で大きく手が入りそうなため保留
- Select のスタイリングを見直したので reg 差分が出ています

ほか AccordionPanel の `:focus:not(:focus-visible)` なスタイルは UA に任せる方針とし、`:focus-visible` に寄せました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
