### PR TITLE
feat: `Button`, `AnchorButton` コンポーネントを追加 (SHRUI-545)

### DIFF
--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -1,6 +1,7 @@
 import React, { AnchorHTMLAttributes, VFC } from 'react'
 
 import { BaseProps } from './types'
+import { useClassNames } from './useClassNames'
 import { ButtonWrapper } from './ButtonWrapper'
 import { ButtonInner } from './ButtonInner'
 
@@ -17,6 +18,8 @@ export const AnchorButton: VFC<BaseProps & ElementProps> = ({
   children,
   ...props
 }) => {
+  const classNames = useClassNames().anchorButton
+
   return (
     <ButtonWrapper
       {...props}
@@ -24,7 +27,7 @@ export const AnchorButton: VFC<BaseProps & ElementProps> = ({
       square={square}
       wide={wide}
       variant={variant}
-      className={className}
+      className={`${className} ${classNames.wrapper}`}
       isAnchor
     >
       <ButtonInner prefix={prefix} suffix={suffix}>

--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -1,0 +1,35 @@
+import React, { AnchorHTMLAttributes, VFC } from 'react'
+
+import { BaseProps } from './types'
+import { ButtonWrapper } from './ButtonWrapper'
+import { ButtonInner } from './ButtonInner'
+
+type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
+
+export const AnchorButton: VFC<BaseProps & ElementProps> = ({
+  size = 'default',
+  square = false,
+  prefix,
+  suffix,
+  wide = false,
+  variant = 'secondary',
+  className = '',
+  children,
+  ...props
+}) => {
+  return (
+    <ButtonWrapper
+      {...props}
+      size={size}
+      square={square}
+      wide={wide}
+      variant={variant}
+      className={className}
+      isAnchor
+    >
+      <ButtonInner prefix={prefix} suffix={suffix}>
+        {children}
+      </ButtonInner>
+    </ButtonWrapper>
+  )
+}

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,116 +3,100 @@ import React from 'react'
 import { action } from '@storybook/addon-actions'
 import styled, { css } from 'styled-components'
 
-import {
-  DangerButton,
-  DangerButtonAnchor,
-  PrimaryButton,
-  PrimaryButtonAnchor,
-  SecondaryButton,
-  SecondaryButtonAnchor,
-  SkeletonButton,
-  SkeletonButtonAnchor,
-  TextButton,
-  TextButtonAnchor,
-} from '.'
+import { AnchorButton, Button } from '.'
 import { FaPlusCircleIcon, FaPlusIcon, FaPlusSquareIcon } from '../Icon'
-import { AnchorProps, ButtonProps } from './BaseButton'
 import { LineUp, Stack } from '../Layout'
 
 export default {
   title: 'Button',
-  component: PrimaryButton,
+  component: Button,
   subcomponents: {
-    PrimaryButtonAnchor,
-    SecondaryButton,
-    SecondaryButtonAnchor,
-    DangerButton,
-    DangerButtonAnchor,
-    SkeletonButton,
-    SkeletonButtonAnchor,
-    TextButton,
-    TextButtonAnchor,
+    AnchorButton,
   },
 }
 
+type ButtonProps = React.ComponentProps<typeof Button>
+type AnchorButtonProps = React.ComponentProps<typeof AnchorButton>
+
 export const _PrimaryButton: Story = () => {
-  return renderButtons(PrimaryButton, ExPrimaryButton)
+  return renderButtons('primary')
 }
 
 export const _PrimaryButtonAnchor: Story = () => {
-  return renderAnchors(PrimaryButtonAnchor, ExPrimaryButtonAnchor)
+  return renderAnchors('primary')
 }
 
 export const _SecondaryButton: Story = () => {
-  return renderButtons(SecondaryButton, ExSecondaryButton)
+  return renderButtons('secondary')
 }
 
 export const _SecondaryButtonAnchor: Story = () => {
-  return renderAnchors(SecondaryButtonAnchor, ExSecondaryButtonAnchor)
+  return renderAnchors('secondary')
 }
 
 export const _DangerButton: Story = () => {
-  return renderButtons(DangerButton, ExDangerButton)
+  return renderButtons('danger')
 }
 
 export const _DangerButtonAnchor: Story = () => {
-  return renderAnchors(DangerButtonAnchor, ExDangerButtonAnchor)
+  return renderAnchors('danger')
 }
 
 export const _SkeletonButton: Story = () => {
-  return <DarkBackground>{renderButtons(SkeletonButton, ExSkeletonButton)}</DarkBackground>
+  return <DarkBackground>{renderButtons('skeleton')}</DarkBackground>
 }
 
 export const _SkeletonButtonAnchor: Story = () => {
-  return (
-    <DarkBackground>{renderAnchors(SkeletonButtonAnchor, ExSkeletonButtonAnchor)}</DarkBackground>
-  )
+  return <DarkBackground>{renderAnchors('skeleton')}</DarkBackground>
 }
 
 export const _TextButton: Story = () => {
-  return renderButtons(TextButton, ExTextButton, true)
+  return renderButtons('text', true)
 }
 
 export const _TextButtonAnchor: Story = () => {
-  return renderAnchors(TextButtonAnchor, ExTextButtonAnchor, true)
+  return renderAnchors('text', true)
 }
 
-function renderButtons(
-  Button: React.VFC<ButtonProps>,
-  ExButton: React.VFC<ButtonProps>,
-  noSquare = false,
-) {
+function renderButtons(variant: ButtonProps['variant'], noSquare = false) {
   return (
     <List>
       <dt>Default</dt>
       <dd>
         <Stack>
           <WrapLineUp vAlign="center">
-            <Button onClick={action('clicked')}>ボタン</Button>
-            <Button prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <Button variant={variant} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            <Button variant={variant} prefix={<FaPlusIcon />} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={variant} suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             {!noSquare && (
-              <Button square onClick={action('clicked')}>
+              <Button variant={variant} square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
           <WrapLineUp vAlign="center">
-            <Button disabled onClick={action('clicked')}>
+            <Button variant={variant} disabled onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <Button variant={variant} disabled prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            <Button
+              variant={variant}
+              disabled
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
             </Button>
             {!noSquare && (
-              <Button disabled square onClick={action('clicked')}>
+              <Button variant={variant} disabled square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
@@ -124,33 +108,50 @@ function renderButtons(
       <dd>
         <Stack>
           <WrapLineUp vAlign="center">
-            <Button size="s" onClick={action('clicked')}>
+            <Button variant={variant} size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <Button variant={variant} size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button size="s" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            <Button
+              variant={variant}
+              size="s"
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
             </Button>
             {!noSquare && (
-              <Button size="s" square onClick={action('clicked')}>
+              <Button variant={variant} size="s" square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
           </WrapLineUp>
           <WrapLineUp vAlign="center">
-            <Button disabled size="s" onClick={action('clicked')}>
+            <Button variant={variant} disabled size="s" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button disabled size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <Button
+              variant={variant}
+              disabled
+              size="s"
+              prefix={<FaPlusIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
             </Button>
-            <Button disabled size="s" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            <Button
+              variant={variant}
+              disabled
+              size="s"
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
             </Button>
             {!noSquare && (
-              <Button disabled size="s" square onClick={action('clicked')}>
+              <Button variant={variant} disabled size="s" square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
               </Button>
             )}
@@ -161,16 +162,16 @@ function renderButtons(
       <dt>Wide</dt>
       <dd>
         <Stack>
-          <Button wide onClick={action('clicked')}>
+          <Button variant={variant} wide onClick={action('clicked')}>
             ボタン
           </Button>
-          <Button disabled wide onClick={action('clicked')}>
+          <Button variant={variant} disabled wide onClick={action('clicked')}>
             ボタン
           </Button>
-          <Button size="s" wide onClick={action('clicked')}>
+          <Button variant={variant} size="s" wide onClick={action('clicked')}>
             ボタン
           </Button>
-          <Button disabled size="s" wide onClick={action('clicked')}>
+          <Button variant={variant} disabled size="s" wide onClick={action('clicked')}>
             ボタン
           </Button>
         </Stack>
@@ -178,50 +179,64 @@ function renderButtons(
 
       <dt>Extending Style</dt>
       <dd>
-        <ExButton onClick={action('clicked')}>width: 300px</ExButton>
+        <ExtendingButton variant={variant} onClick={action('clicked')}>
+          width: 300px
+        </ExtendingButton>
       </dd>
     </List>
   )
 }
 
-function renderAnchors(
-  Anchor: React.VFC<AnchorProps>,
-  ExAnchor: React.VFC<AnchorProps>,
-  noSquare = false,
-) {
+function renderAnchors(variant: AnchorButtonProps['variant'], noSquare = false) {
   return (
     <List>
       <dt>Default</dt>
       <dd>
         <Stack>
           <WrapLineUp vAlign="center">
-            <Anchor href="#" onClick={action('clicked')}>
+            <AnchorButton variant={variant} href="#" onClick={action('clicked')}>
               ボタン
-            </Anchor>
-            <Anchor href="#" prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              href="#"
+              prefix={<FaPlusIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
-            </Anchor>
-            <Anchor href="#" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              href="#"
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
-            </Anchor>
+            </AnchorButton>
             {!noSquare && (
-              <Anchor href="#" square onClick={action('clicked')}>
+              <AnchorButton variant={variant} href="#" square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Anchor>
+              </AnchorButton>
             )}
           </WrapLineUp>
           <WrapLineUp vAlign="center">
-            <Anchor onClick={action('clicked')}>ボタン</Anchor>
-            <Anchor prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <AnchorButton variant={variant} onClick={action('clicked')}>
               ボタン
-            </Anchor>
-            <Anchor suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton variant={variant} prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
-            </Anchor>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </AnchorButton>
             {!noSquare && (
-              <Anchor square onClick={action('clicked')}>
+              <AnchorButton variant={variant} square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Anchor>
+              </AnchorButton>
             )}
           </WrapLineUp>
         </Stack>
@@ -231,35 +246,57 @@ function renderAnchors(
       <dd>
         <Stack>
           <WrapLineUp vAlign="center">
-            <Anchor size="s" href="#" onClick={action('clicked')}>
+            <AnchorButton variant={variant} size="s" href="#" onClick={action('clicked')}>
               ボタン
-            </Anchor>
-            <Anchor size="s" href="#" prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              size="s"
+              href="#"
+              prefix={<FaPlusIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
-            </Anchor>
-            <Anchor size="s" href="#" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              size="s"
+              href="#"
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
-            </Anchor>
+            </AnchorButton>
             {!noSquare && (
-              <Anchor size="s" href="#" square onClick={action('clicked')}>
+              <AnchorButton variant={variant} size="s" href="#" square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Anchor>
+              </AnchorButton>
             )}
           </WrapLineUp>
           <WrapLineUp vAlign="center">
-            <Anchor size="s" onClick={action('clicked')}>
+            <AnchorButton variant={variant} size="s" onClick={action('clicked')}>
               ボタン
-            </Anchor>
-            <Anchor size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              size="s"
+              prefix={<FaPlusIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
-            </Anchor>
-            <Anchor size="s" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            </AnchorButton>
+            <AnchorButton
+              variant={variant}
+              size="s"
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
               ボタン
-            </Anchor>
+            </AnchorButton>
             {!noSquare && (
-              <Anchor size="s" square onClick={action('clicked')}>
+              <AnchorButton variant={variant} size="s" square onClick={action('clicked')}>
                 <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Anchor>
+              </AnchorButton>
             )}
           </WrapLineUp>
         </Stack>
@@ -268,27 +305,27 @@ function renderAnchors(
       <dt>Wide</dt>
       <dd>
         <Stack>
-          <Anchor href="#" wide onClick={action('clicked')}>
+          <AnchorButton variant={variant} href="#" wide onClick={action('clicked')}>
             ボタン
-          </Anchor>
+          </AnchorButton>
 
-          <Anchor wide onClick={action('clicked')}>
+          <AnchorButton variant={variant} wide onClick={action('clicked')}>
             ボタン
-          </Anchor>
-          <Anchor size="s" href="#" wide onClick={action('clicked')}>
+          </AnchorButton>
+          <AnchorButton variant={variant} size="s" href="#" wide onClick={action('clicked')}>
             ボタン
-          </Anchor>
-          <Anchor size="s" wide onClick={action('clicked')}>
+          </AnchorButton>
+          <AnchorButton variant={variant} size="s" wide onClick={action('clicked')}>
             ボタン
-          </Anchor>
+          </AnchorButton>
         </Stack>
       </dd>
 
       <dt>Extending Style</dt>
       <dd>
-        <ExAnchor href="#" onClick={action('clicked')}>
+        <ExtendingAnchorButton variant={variant} href="#" onClick={action('clicked')}>
           width: 300px
-        </ExAnchor>
+        </ExtendingAnchorButton>
       </dd>
     </List>
   )
@@ -315,33 +352,9 @@ const DarkBackground = styled.div`
 const extendingStyle = css`
   width: 300px;
 `
-const ExPrimaryButton = styled(PrimaryButton)`
+const ExtendingButton = styled(Button)`
   ${extendingStyle}
 `
-const ExPrimaryButtonAnchor = styled(PrimaryButtonAnchor)`
-  ${extendingStyle}
-`
-const ExSecondaryButton = styled(SecondaryButton)`
-  ${extendingStyle}
-`
-const ExSecondaryButtonAnchor = styled(SecondaryButtonAnchor)`
-  ${extendingStyle}
-`
-const ExDangerButton = styled(DangerButton)`
-  ${extendingStyle}
-`
-const ExDangerButtonAnchor = styled(DangerButtonAnchor)`
-  ${extendingStyle}
-`
-const ExSkeletonButton = styled(SkeletonButton)`
-  ${extendingStyle}
-`
-const ExSkeletonButtonAnchor = styled(SkeletonButtonAnchor)`
-  ${extendingStyle}
-`
-const ExTextButton = styled(TextButton)`
-  ${extendingStyle}
-`
-const ExTextButtonAnchor = styled(TextButtonAnchor)`
+const ExtendingAnchorButton = styled(AnchorButton)`
   ${extendingStyle}
 `

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,34 @@
+import React, { ButtonHTMLAttributes, VFC } from 'react'
+
+import { BaseProps } from './types'
+import { ButtonWrapper } from './ButtonWrapper'
+import { ButtonInner } from './ButtonInner'
+
+type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
+
+export const Button: VFC<BaseProps & ElementProps> = ({
+  size = 'default',
+  square = false,
+  prefix,
+  suffix,
+  wide = false,
+  variant = 'secondary',
+  className = '',
+  children,
+  ...props
+}) => {
+  return (
+    <ButtonWrapper
+      {...props}
+      size={size}
+      square={square}
+      wide={wide}
+      variant={variant}
+      className={className}
+    >
+      <ButtonInner prefix={prefix} suffix={suffix}>
+        {children}
+      </ButtonInner>
+    </ButtonWrapper>
+  )
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React, { ButtonHTMLAttributes, VFC } from 'react'
 
 import { BaseProps } from './types'
+import { useClassNames } from './useClassNames'
 import { ButtonWrapper } from './ButtonWrapper'
 import { ButtonInner } from './ButtonInner'
 
@@ -17,6 +18,8 @@ export const Button: VFC<BaseProps & ElementProps> = ({
   children,
   ...props
 }) => {
+  const classNames = useClassNames().button
+
   return (
     <ButtonWrapper
       {...props}
@@ -24,7 +27,7 @@ export const Button: VFC<BaseProps & ElementProps> = ({
       square={square}
       wide={wide}
       variant={variant}
-      className={className}
+      className={`${className} ${classNames.wrapper}`}
     >
       <ButtonInner prefix={prefix} suffix={suffix}>
         {children}

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -1,0 +1,28 @@
+import React, { VFC } from 'react'
+import styled from 'styled-components'
+
+export type Props = {
+  prefix?: React.ReactNode
+  suffix?: React.ReactNode
+  children?: React.ReactNode
+}
+
+export const ButtonInner: VFC<Props> = ({ prefix, suffix, children }) => {
+  return (
+    <>
+      {prefix}
+      <TextLabel>{children}</TextLabel>
+      {suffix}
+    </>
+  )
+}
+
+const TextLabel = styled.span`
+  /* LineClamp を併用する場合に、幅を計算してもらうために指定 */
+  min-width: 0;
+
+  .s & {
+    /* FIXME! SVG とテキストコンテンツの縦位置が揃わないので暫定対応 */
+    line-height: 0;
+  }
+`

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -65,7 +65,7 @@ const baseStyles = css<StyleProps>(({ wide, themes }) => {
       min-height: calc(${fontSize.S} + ${spacingByChar(1)} + (${border.lineWidth} * 2));
     }
 
-    &:focus {
+    &:focus-visible {
       ${shadow.focusIndicatorStyles}
     }
 
@@ -83,7 +83,7 @@ const Button = styled.button<StyleProps>(({ variant, themes }) => {
     ${baseStyles}
     ${styles.default}
 
-    &:focus,
+    &:focus-visible,
     &:hover {
       ${styles.focus}
     }
@@ -104,7 +104,7 @@ const Anchor = styled.a<StyleProps>(({ variant, themes }) => {
     ${styles.default}
     text-decoration: none;
 
-    &:focus,
+    &:focus-visible,
     &:hover {
       ${styles.focus}
     }

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -92,7 +92,7 @@ const Button = styled.button<StyleProps>(({ variant, themes }) => {
       ${styles.disabled}
 
       /* alpha color を使用しているので、背景色と干渉させない */
-        background-clip: padding-box;
+      background-clip: padding-box;
     }
   `
 })
@@ -113,7 +113,7 @@ const Anchor = styled.a<StyleProps>(({ variant, themes }) => {
       ${styles.disabled}
 
       /* alpha color を使用しているので、背景色と干渉させない */
-        background-clip: padding-box;
+      background-clip: padding-box;
     }
   `
 })

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -1,0 +1,208 @@
+import React, { ReactNode, useMemo } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import { Variant } from './types'
+
+type Props = {
+  size: 'default' | 's'
+  square: boolean
+  wide: boolean
+  variant: Variant
+  className: string
+  children: ReactNode
+  isAnchor?: boolean
+}
+type StyleProps = Pick<Props, 'wide' | 'variant'> & { themes: Theme }
+
+export function ButtonWrapper<T extends Props>({ size, square, className, isAnchor, ...props }: T) {
+  const theme = useTheme()
+  const buttonClassName = useMemo(
+    () => `${size} ${className} ${square ? 'square' : ''}`,
+    [className, size, square],
+  )
+
+  return isAnchor ? (
+    <Anchor {...props} className={buttonClassName} themes={theme} />
+  ) : (
+    <Button {...props} className={buttonClassName} themes={theme} />
+  )
+}
+
+const baseStyles = css<StyleProps>(({ wide, themes }) => {
+  const { border, fontSize, leading, radius, shadow, spacingByChar } = themes
+
+  return css`
+    box-sizing: border-box;
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    gap: ${spacingByChar(0.5)};
+    text-align: center;
+    white-space: nowrap;
+    border-radius: ${radius.m};
+
+    /* ボタンの高さを合わせるために指定 */
+    border: ${border.lineWidth} ${border.lineStyle} transparent;
+    padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
+    font-family: inherit;
+    font-size: ${fontSize.M};
+    font-weight: bold;
+    line-height: ${leading.NONE};
+    ${wide && 'width: 100%;'}
+
+    &.square {
+      padding: ${spacingByChar(0.75)};
+    }
+
+    &.s {
+      padding: ${spacingByChar(0.5)};
+      font-size: ${fontSize.S};
+
+      /* ボタンラベルの line-height を 0 にしたため、高さを担保する */
+      min-height: calc(${fontSize.S} + ${spacingByChar(1)} + (${border.lineWidth} * 2));
+    }
+
+    &:focus {
+      ${shadow.focusIndicatorStyles}
+    }
+
+    /* baseline より下の leading などの余白を埋める */
+    .smarthr-ui-Icon,
+    svg {
+      display: block;
+    }
+  `
+})
+
+const Button = styled.button<StyleProps>(({ variant, themes }) => {
+  const styles = variantStyles(variant, themes)
+  return css`
+    ${baseStyles}
+    ${styles.default}
+
+    &:focus,
+    &:hover {
+      ${styles.focus}
+    }
+    &[disabled] {
+      cursor: not-allowed;
+      ${styles.disabled}
+
+      /* alpha color を使用しているので、背景色と干渉させない */
+        background-clip: padding-box;
+    }
+  `
+})
+
+const Anchor = styled.a<StyleProps>(({ variant, themes }) => {
+  const styles = variantStyles(variant, themes)
+  return css`
+    ${baseStyles}
+    ${styles.default}
+    text-decoration: none;
+
+    &:focus,
+    &:hover {
+      ${styles.focus}
+    }
+    &:not([href]) {
+      cursor: not-allowed;
+      ${styles.disabled}
+
+      /* alpha color を使用しているので、背景色と干渉させない */
+        background-clip: padding-box;
+    }
+  `
+})
+
+function variantStyles(variant: Variant, theme: Theme) {
+  const { color } = theme
+  switch (variant) {
+    case 'primary':
+      return {
+        default: css`
+          border-color: ${color.MAIN};
+          background-color: ${color.MAIN};
+          color: ${color.TEXT_WHITE};
+        `,
+        focus: css`
+          border-color: ${color.hoverColor(color.MAIN)};
+          background-color: ${color.hoverColor(color.MAIN)};
+        `,
+        disabled: css`
+          border-color: ${color.disableColor(color.MAIN)};
+          background-color: ${color.disableColor(color.MAIN)};
+          color: ${color.disableColor(color.TEXT_WHITE)};
+        `,
+      }
+    case 'secondary':
+      return {
+        default: css`
+          border-color: ${color.BORDER};
+          background-color: ${color.WHITE};
+          color: ${color.TEXT_BLACK};
+        `,
+        focus: css`
+          border-color: ${color.hoverColor(color.BORDER)};
+          background-color: ${color.hoverColor(color.WHITE)};
+        `,
+        disabled: css`
+          border-color: ${color.disableColor(color.BORDER)};
+          background-color: ${color.disableColor(color.WHITE)};
+          color: ${color.TEXT_DISABLED};
+        `,
+      }
+    case 'danger':
+      return {
+        default: css`
+          border-color: ${color.DANGER};
+          background-color: ${color.DANGER};
+          color: ${color.TEXT_WHITE};
+        `,
+        focus: css`
+          border-color: ${color.hoverColor(color.DANGER)};
+          background-color: ${color.hoverColor(color.DANGER)};
+        `,
+        disabled: css`
+          border-color: ${color.disableColor(color.DANGER)};
+          background-color: ${color.disableColor(color.DANGER)};
+          color: ${color.disableColor(color.TEXT_WHITE)};
+        `,
+      }
+    case 'skeleton':
+      return {
+        default: css`
+          border-color: ${color.WHITE};
+          background-color: transparent;
+          color: ${color.TEXT_WHITE};
+        `,
+        focus: css`
+          border-color: ${color.hoverColor(color.WHITE)};
+          background-color: ${color.OVERLAY};
+          color: ${color.hoverColor(color.TEXT_WHITE)};
+        `,
+        disabled: css`
+          border-color: ${color.disableColor(color.WHITE)};
+          background-color: transparent;
+          color: ${color.disableColor(color.TEXT_WHITE)};
+        `,
+      }
+    case 'text':
+      return {
+        default: css`
+          background-color: transparent;
+          color: ${color.TEXT_BLACK};
+        `,
+        focus: css`
+          background-color: ${color.hoverColor(color.WHITE)};
+        `,
+        disabled: css`
+          background-color: transparent;
+          color: ${color.TEXT_DISABLED};
+        `,
+      }
+  }
+}

--- a/src/components/Button/DangerButton.tsx
+++ b/src/components/Button/DangerButton.tsx
@@ -6,6 +6,9 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
 import { useClassNames } from './useClassNames'
 
+/**
+ * @deprecated `DangerButton` コンポーネントは非推奨です。代わりに `Button` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const DangerButton: VFC<ButtonProps> = ({ type = 'button', className = '', ...props }) => {
   const theme = useTheme()
   const { dangerButton } = useClassNames()
@@ -20,6 +23,9 @@ export const DangerButton: VFC<ButtonProps> = ({ type = 'button', className = ''
   )
 }
 
+/**
+ * @deprecated `DangerButtonAnchor` コンポーネントは非推奨です。代わりに `AnchorButton` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const DangerButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props }) => {
   const theme = useTheme()
   const { dangerButtonAnchor } = useClassNames()

--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -6,6 +6,9 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
 import { useClassNames } from './useClassNames'
 
+/**
+ * @deprecated `PrimaryButton` コンポーネントは非推奨です。代わりに `Button` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const PrimaryButton: VFC<ButtonProps> = ({ type = 'button', className = '', ...props }) => {
   const theme = useTheme()
   const { primaryButton } = useClassNames()
@@ -24,6 +27,9 @@ export const PrimaryButton: VFC<ButtonProps> = ({ type = 'button', className = '
 // This is for error message of BottomFixedArea component.
 PrimaryButton.displayName = 'PrimaryButton'
 
+/**
+ * @deprecated `PrimaryButtonAnchor` コンポーネントは非推奨です。代わりに `AnchorButton` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const PrimaryButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props }) => {
   const theme = useTheme()
   const { primaryButtonAnchor } = useClassNames()

--- a/src/components/Button/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton.tsx
@@ -6,6 +6,9 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
 import { useClassNames } from './useClassNames'
 
+/**
+ * @deprecated `SecondaryButton` コンポーネントは非推奨です。代わりに `Button` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const SecondaryButton: VFC<ButtonProps> = ({
   type = 'button',
   className = '',
@@ -27,6 +30,9 @@ export const SecondaryButton: VFC<ButtonProps> = ({
 // This is for error message of BottomFixedArea component.
 SecondaryButton.displayName = 'SecondaryButton'
 
+/**
+ * @deprecated `SecondaryButtonAnchor` コンポーネントは非推奨です。代わりに `AnchorButton` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const SecondaryButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props }) => {
   const theme = useTheme()
   const { secondaryButtonAnchor } = useClassNames()

--- a/src/components/Button/SkeletonButton.tsx
+++ b/src/components/Button/SkeletonButton.tsx
@@ -6,6 +6,9 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { AnchorProps, BaseButton, BaseButtonAnchor, ButtonProps } from './BaseButton'
 import { useClassNames } from './useClassNames'
 
+/**
+ * @deprecated `SkeletonButton` コンポーネントは非推奨です。代わりに `Button` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const SkeletonButton: VFC<ButtonProps> = ({ type = 'button', className = '', ...props }) => {
   const theme = useTheme()
   const { skeletonButton } = useClassNames()
@@ -20,6 +23,9 @@ export const SkeletonButton: VFC<ButtonProps> = ({ type = 'button', className = 
   )
 }
 
+/**
+ * @deprecated `SkeletonButtonAnchor` コンポーネントは非推奨です。代わりに `AnchorButton` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const SkeletonButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props }) => {
   const theme = useTheme()
   const { skeletonButtonAnchor } = useClassNames()

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -14,6 +14,9 @@ import { useClassNames } from './useClassNames'
 type ButtonProps = Omit<BaseButtonProps, 'square'>
 type AnchorProps = Omit<BaseAnchorProps, 'square'>
 
+/**
+ * @deprecated `TextButton` コンポーネントは非推奨です。代わりに `Button` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const TextButton: VFC<ButtonProps> = ({ type = 'button', className = '', ...props }) => {
   const theme = useTheme()
   const { textButton } = useClassNames()
@@ -28,6 +31,9 @@ export const TextButton: VFC<ButtonProps> = ({ type = 'button', className = '', 
   )
 }
 
+/**
+ * @deprecated `TextButtonAnchor` コンポーネントは非推奨です。代わりに `AnchorButton` コンポーネントと `variant` プロパティを使用してください。
+ */
 export const TextButtonAnchor: VFC<AnchorProps> = ({ className = '', ...props }) => {
   const theme = useTheme()
   const { textButtonAnchor } = useClassNames()

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,3 +1,5 @@
+export { Button } from './Button'
+export { AnchorButton } from './AnchorButton'
 export { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
 export { SecondaryButton, SecondaryButtonAnchor } from './SecondaryButton'
 export { DangerButton, DangerButtonAnchor } from './DangerButton'

--- a/src/components/Button/style.tsx
+++ b/src/components/Button/style.tsx
@@ -1,5 +1,7 @@
 import React, { VFC } from 'react'
 import {
+  AnchorButton,
+  Button,
   DangerButton,
   DangerButtonAnchor,
   PrimaryButton,
@@ -15,6 +17,8 @@ import {
 
 export const Style: VFC = () => (
   <>
+    <Button />
+    <AnchorButton />
     <PrimaryButton />
     <PrimaryButtonAnchor />
     <SecondaryButton />

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -1,0 +1,38 @@
+export type BaseProps = {
+  /**
+   * ボタンの大きさ
+   */
+  size?: 'default' | 's'
+  /**
+   * ボタン内に表示する内容
+   */
+  children?: React.ReactNode
+  /**
+   * コンポーネントに適用するクラス名
+   */
+  className?: string
+  /**
+   * ボタン内の先頭に表示する内容。
+   * 通常は、アイコンを表示するために用いる。
+   */
+  prefix?: React.ReactNode
+  /**
+   * ボタン内の末尾に表示する内容。
+   * 通常は、アイコンを表示するために用いる。
+   */
+  suffix?: React.ReactNode
+  /**
+   * `true` のとき、ボタンを正方形にする。
+   */
+  square?: boolean
+  /**
+   * `true` のとき、ボタンの `width` を 100% にする。
+   */
+  wide?: boolean
+  /**
+   * ボタンのスタイルの種類
+   */
+  variant?: Variant
+}
+
+export type Variant = 'primary' | 'secondary' | 'danger' | 'skeleton' | 'text'

--- a/src/components/Button/useClassNames.ts
+++ b/src/components/Button/useClassNames.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+import { AnchorButton, Button } from './'
 import { PrimaryButton, PrimaryButtonAnchor } from './PrimaryButton'
 import { SecondaryButton, SecondaryButtonAnchor } from './SecondaryButton'
 import { DangerButton, DangerButtonAnchor } from './DangerButton'
@@ -8,6 +9,8 @@ import { SkeletonButton, SkeletonButtonAnchor } from './SkeletonButton'
 import { TextButton, TextButtonAnchor } from './TextButton'
 
 export const useClassNames = () => {
+  const generateButotn = useClassNameGenerator(Button.displayName || 'Button')
+  const generateAnchorButotn = useClassNameGenerator(AnchorButton.displayName || 'AnchorButton')
   const generatePrimaryButton = useClassNameGenerator(PrimaryButton.displayName || 'PrimaryButton')
   const generatePrimaryButtonAnchor = useClassNameGenerator(
     PrimaryButtonAnchor.displayName || 'PrimaryButtonAnchor',
@@ -35,6 +38,12 @@ export const useClassNames = () => {
 
   return useMemo(
     () => ({
+      button: {
+        wrapper: generateButotn(),
+      },
+      anchorButton: {
+        wrapper: generateAnchorButotn(),
+      },
       primaryButton: {
         wrapper: generatePrimaryButton(),
       },
@@ -67,6 +76,8 @@ export const useClassNames = () => {
       },
     }),
     [
+      generateAnchorButotn,
+      generateButotn,
       generateDangerButton,
       generateDangerButtonAnchor,
       generatePrimaryButton,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ export {
 export { Pagination } from './components/Pagination'
 export { RadioButton } from './components/RadioButton'
 export {
+  AnchorButton,
+  Button,
   PrimaryButton,
   PrimaryButtonAnchor,
   SecondaryButton,


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-545
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
既存のボタンコンポーネントは `PrimaryButton`, `SecondaryButton` など種類毎に別コンポーネントになっていますが、コンポーネントを `Button` と `AnchorButton` に統一し、`variant` Props で種類を選べるように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Button`, `AnchorButton` を追加
  - `variant?: 'primary' | 'secondary' | 'danger' | 'skeleton' | 'text'` 、デフォルトは `secondary`
- 既存のボタンを非推奨化
  - `PrimaryButton`
  - `PrimaryButtonAnchor`
  - `SecondaryButton`
  - `SecondaryButtonAnchor`
  - `DangerButton`
  - `DangerButtonAnchor`
  - `SkeletonButton`
  - `SkeletonButtonAnchor`
  - `TextButton`
  - `TextButtonAnchor`
- テキストボタンの disabled 時の文字色が `color.disableColor(color.TEXT_DISABLED)` で二重に色が薄くなっていたので、単に `TEXT_DISABLED` になるように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
