### PR TITLE
feat: 色のデザイントークンを整理｜SHRUI-560

### DIFF
--- a/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -22,13 +22,13 @@ exports[`TabBar should be match snapshot 1`] = `
 
 .c2.selected {
   position: relative;
-  color: #23221f;
+  color: #23221e;
   border-color: #0077c7;
 }
 
 .c2:hover {
   background-color: #f8f7f6;
-  color: #23221f;
+  color: #23221e;
 }
 
 .c2:disabled {

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -34,29 +34,55 @@ export type CreatedColorTheme = Palette & {
 
 export type TextColors = 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
 
-const baseColor = {
-  TEXT_BLACK: '#23221f',
-  TEXT_WHITE: '#fff',
-  TEXT_GREY: '#706d65',
-  TEXT_DISABLED: '#c1bdb7',
-  TEXT_LINK: '#0071c1',
+const BLACK = '#23221f'
+const greyScale = {
+  GREY_5: '#f8f7f6',
+  GREY_6: '#f5f4f3',
+  GREY_7: '#f2f1f0',
+  GREY_9: '#edebe8',
+  GREY_20: '#d6d3d0',
+  GREY_30: '#c1bdb7',
+  GREY_65: '#706d65',
+}
+const transparencyScale = {
+  TRANSPARENCY_15: rgba(BLACK, 0.15),
+  TRANSPARENCY_30: rgba(BLACK, 0.3),
+  TRANSPARENCY_50: rgba(BLACK, 0.5),
+}
+const primitiveTokens = {
   WHITE: '#fff',
-  BORDER: '#d6d3d0',
-  ACTION_BACKGROUND: '#d6d3d0',
-  BACKGROUND: '#f8f7f6',
-  COLUMN: '#f8f7f6',
-  OVER_BACKGROUND: '#f2f1f0',
-  HEAD: '#edebe8',
-  BASE_GREY: '#f5f4f3',
-  MAIN: '#0077c7',
-  DANGER: '#e01e5a',
-  WARNING: '#ff8800',
-  SCRIM: 'rgba(0,0,0,0.5)',
-  OVERLAY: 'rgba(0,0,0,0.15)',
-  BRAND: '#00c4cc',
+  BLACK,
+  BLUE_100: '#0077c7',
+  BLUE_101: '#0071c1',
+  RED_100: '#e01e5a',
+  ORANGE_100: '#ff8800',
+  SMARTHR_BLUE: '#00c4cc',
 }
 
-export const defaultColor = { ...baseColor, OUTLINE: baseColor.MAIN }
+const semanticTokens = {
+  TEXT_BLACK: primitiveTokens.BLACK,
+  TEXT_WHITE: primitiveTokens.WHITE,
+  TEXT_GREY: greyScale.GREY_65,
+  TEXT_DISABLED: greyScale.GREY_30,
+  TEXT_LINK: primitiveTokens.BLUE_101,
+  WHITE: primitiveTokens.WHITE,
+  BACKGROUND: greyScale.GREY_5,
+  COLUMN: greyScale.GREY_5,
+  BASE_GREY: greyScale.GREY_6,
+  OVER_BACKGROUND: greyScale.GREY_7,
+  HEAD: greyScale.GREY_9,
+  BORDER: greyScale.GREY_20,
+  ACTION_BACKGROUND: greyScale.GREY_20,
+  MAIN: primitiveTokens.BLUE_100,
+  OUTLINE: primitiveTokens.BLUE_100,
+  DANGER: primitiveTokens.RED_100,
+  WARNING: primitiveTokens.ORANGE_100,
+  OVERLAY: transparencyScale.TRANSPARENCY_15,
+  SCRIM: transparencyScale.TRANSPARENCY_50,
+  BRAND: primitiveTokens.SMARTHR_BLUE,
+}
+
+export const defaultColor = { ...semanticTokens, ...greyScale, ...transparencyScale }
 
 export const createColor = (userColor: ColorProperty = {}) => {
   const created: CreatedColorTheme = merge(

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -34,15 +34,16 @@ export type CreatedColorTheme = Palette & {
 
 export type TextColors = 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
 
-const BLACK = '#23221f'
+const BLACK = '#030302' // hwb(56, 17, 1)
 const greyScale = {
-  GREY_5: '#f8f7f6',
-  GREY_6: '#f5f4f3',
-  GREY_7: '#f2f1f0',
-  GREY_9: '#edebe8',
-  GREY_20: '#d6d3d0',
-  GREY_30: '#c1bdb7',
-  GREY_65: '#706d65',
+  GREY_5: '#f8f7f6', // hwb(31, 1, 97)
+  GREY_6: '#f5f4f3', // hwb(31, 1, 96)
+  GREY_7: '#f2f1f0', // hwb(31, 1, 95)
+  GREY_9: '#edebe8', // hwb(31, 2, 92)
+  GREY_20: '#d6d3d0', // hwb(33, 3, 84)
+  GREY_30: '#c1bdb7', // hwb(36, 5, 76)
+  GREY_65: '#706d65', // hwb(44, 10, 44)
+  GREY_100: '#23221e', // hwb(52, 15, 14)
 }
 const transparencyScale = {
   TRANSPARENCY_15: rgba(BLACK, 0.15),
@@ -51,7 +52,6 @@ const transparencyScale = {
 }
 const primitiveTokens = {
   WHITE: '#fff',
-  BLACK,
   BLUE_100: '#0077c7',
   BLUE_101: '#0071c1',
   RED_100: '#e01e5a',
@@ -60,7 +60,7 @@ const primitiveTokens = {
 }
 
 const semanticTokens = {
-  TEXT_BLACK: primitiveTokens.BLACK,
+  TEXT_BLACK: greyScale.GREY_100,
   TEXT_WHITE: primitiveTokens.WHITE,
   TEXT_GREY: greyScale.GREY_65,
   TEXT_DISABLED: greyScale.GREY_30,

--- a/src/themes/createPalette.ts
+++ b/src/themes/createPalette.ts
@@ -49,7 +49,7 @@ export interface CreatedPaletteTheme {
  * @deprecated The defaultPelette will be deprecated, please use defaultColor instead
  */
 export const defaultPalette = {
-  TEXT_BLACK: '#23221f',
+  TEXT_BLACK: '#23221e',
   TEXT_GREY: '#706d65',
   TEXT_DISABLED: '#c1bdb7',
   TEXT_LINK: '#0071c1',
@@ -63,8 +63,8 @@ export const defaultPalette = {
   MAIN: '#0077c7',
   DANGER: '#e01e5a',
   WARNING: '#ff8800',
-  SCRIM: rgba('#23221f', 0.5),
-  OVERLAY: rgba('#23221f', 0.15),
+  SCRIM: rgba('#030302', 0.5),
+  OVERLAY: rgba('#030302', 0.15),
   BRAND: '#00c4cc',
 }
 

--- a/src/themes/createPalette.ts
+++ b/src/themes/createPalette.ts
@@ -63,8 +63,8 @@ export const defaultPalette = {
   MAIN: '#0077c7',
   DANGER: '#e01e5a',
   WARNING: '#ff8800',
-  SCRIM: 'rgba(0,0,0,0.5)',
-  OVERLAY: 'rgba(0,0,0,0.15)',
+  SCRIM: rgba('#23221f', 0.5),
+  OVERLAY: rgba('#23221f', 0.15),
   BRAND: '#00c4cc',
 }
 

--- a/src/themes/createShadow.ts
+++ b/src/themes/createShadow.ts
@@ -40,13 +40,13 @@ export interface CreatedShadowTheme {
 const defaultOutline = `0 0 0 2px white, 0 0 0 4px ${defaultColor.OUTLINE}`
 
 export const defaultShadow = {
-  BASE: 'rgba(51, 51, 51, 0.15) 0 0 4px 0',
-  DIALOG: 'rgba(51, 51, 51, 0.3) 0 4px 10px 0',
+  BASE: `${defaultColor.TRANSPARENCY_15} 0 0 4px 0`,
+  DIALOG: `${defaultColor.TRANSPARENCY_30} 0 4px 10px 0`,
   LAYER0: 'none',
-  LAYER1: '0 1px 2px 0 rgba(0,0,0,0.24)',
-  LAYER2: '0 2px 4px 1px rgba(0,0,0,0.24)',
-  LAYER3: '0 4px 8px 2px rgba(0,0,0,0.24)',
-  LAYER4: '0 8px 16px 4px rgba(0,0,0,0.24)',
+  LAYER1: `0 1px 2px 0 ${defaultColor.TRANSPARENCY_30}`,
+  LAYER2: `0 2px 4px 1px ${defaultColor.TRANSPARENCY_30}`,
+  LAYER3: `0 4px 8px 2px ${defaultColor.TRANSPARENCY_30}`,
+  LAYER4: `0 8px 16px 4px ${defaultColor.TRANSPARENCY_30}`,
   OUTLINE: defaultOutline,
 }
 


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-560

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

灰色のプリミティブトークンをプロダクトでも使用したかったが、現状抽象値しかなかったためプリミティブトークンを用意し公開することにした。
合わせて既存の色についてもプリミティブトークンを作成した。

また、影の定義も算出した最も暗い灰色を参照するように変更した。
reg-suit に差があるので要確認。
※ プロデザ確認済み

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

