### PR TITLE
fix!: `AppNavi` の props 名の typo を修正

### DIFF
--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -88,7 +88,7 @@ export const WithChildren: Story = () => {
 
   return (
     <Wrapper themes={theme}>
-      <AppNavi label="機能名" buttons={withoutIconButtons} displayDrodownCaret>
+      <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret>
         <Child>Some child components</Child>
       </AppNavi>
     </Wrapper>
@@ -101,7 +101,7 @@ export const WithoutChildren: Story = () => {
 
   return (
     <Wrapper themes={theme}>
-      <AppNavi label="機能名" buttons={withoutIconButtons} displayDrodownCaret />
+      <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret />
     </Wrapper>
   )
 }
@@ -124,7 +124,7 @@ export const UnclickableCurrent: Story = () => {
               return item
             })}
             isCurrentUnclickable
-            displayDrodownCaret
+            displayDropdownCaret
           />
         </InnerWrapper>
       ))}
@@ -149,7 +149,7 @@ export const ContainerScrollX: Story = () => {
 
   return (
     <OverflowWrapper themes={theme}>
-      <AppNavi label="機能名" buttons={withoutIconButtons} displayDrodownCaret>
+      <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret>
         <Child>Some child components</Child>
       </AppNavi>
     </OverflowWrapper>

--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -24,7 +24,7 @@ type Props = {
   /** コンポーネントに適用するクラス名 */
   className?: string
   /** ドロップダウンにキャレットを表示するかどうか */
-  displayDrodownCaret?: boolean
+  displayDropdownCaret?: boolean
 }
 
 export const AppNavi: VFC<Props & ElementProps> = ({
@@ -33,7 +33,7 @@ export const AppNavi: VFC<Props & ElementProps> = ({
   isCurrentUnclickable,
   className = '',
   children = null,
-  displayDrodownCaret = false,
+  displayDropdownCaret = false,
   ...props
 }) => {
   const theme = useTheme()
@@ -74,7 +74,7 @@ export const AppNavi: VFC<Props & ElementProps> = ({
                     icon={button.icon}
                     current={button.current}
                     isUnclickable={isUnclickable}
-                    displayCaret={displayDrodownCaret}
+                    displayCaret={displayDropdownCaret}
                   >
                     {button.children}
                   </AppNaviDropdown>


### PR DESCRIPTION
## Related URL

無し

## Overview

`AppNavi` コンポーネントの props である `displayDrodownCaret` が typo でした。
正しくは `displayDropdownCaret` なので直したい。

**BREAKING CHANGE: props 名が変わるのでこれまで `displayDrodownCaret` を使っていたプロダクトには影響があります。**

## What I did

typo 修正

## Capture

なし
