### PR TITLE
feat: ダイアログにおいて最初にフォーカスする要素を指定できるようにする (SHRUI-562)

### DIFF
--- a/e2e/components/Dialog/Dialog.test.ts
+++ b/e2e/components/Dialog/Dialog.test.ts
@@ -47,3 +47,10 @@ test('フォーカストラップが動作すること', async (t) => {
     .expect(datePicker.focused)
     .ok()
 })
+
+test('開いた時に特定の要素をフォーカスできること', async (t) => {
+  const trigger = Selector('[data-test=dialog-focus-trigger]')
+  const input = Selector('[data-test=input-focus-target]')
+
+  await t.click(trigger).expect(input.focused).ok()
+})

--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -1,25 +1,12 @@
-import React, { HTMLAttributes, RefObject, useCallback } from 'react'
+import React, { HTMLAttributes, useCallback } from 'react'
 
 import { useId } from '../../hooks/useId'
+import { DialogProps } from './types'
 import { useDialogPortal } from './useDialogPortal'
-import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
+import { DialogContentInner } from './DialogContentInner'
 import { ActionDialogContentInner, ActionDialogContentInnerProps } from './ActionDialogContentInner'
 
-type Props = Omit<ActionDialogContentInnerProps, 'titleId'> & {
-  onClickClose: () => void
-  portalParent?: HTMLElement | RefObject<HTMLElement>
-} & Pick<
-    DialogContentInnerProps,
-    | 'isOpen'
-    | 'onClickOverlay'
-    | 'onPressEscape'
-    | 'width'
-    | 'top'
-    | 'right'
-    | 'bottom'
-    | 'left'
-    | 'id'
-  >
+type Props = Omit<ActionDialogContentInnerProps, 'titleId'> & DialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const ActionDialog: React.VFC<Props & ElementProps> = ({

--- a/src/components/Dialog/ActionDialogContent.tsx
+++ b/src/components/Dialog/ActionDialogContent.tsx
@@ -1,12 +1,13 @@
 import React, { HTMLAttributes, useCallback, useContext } from 'react'
 
+import { UncontrolledDialogProps } from './types'
+import { useDialogPortal } from './useDialogPortal'
 import { DialogContext } from './DialogWrapper'
-import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
+import { DialogContentInner } from './DialogContentInner'
 import { ActionDialogContentInner, BaseProps } from './ActionDialogContentInner'
 import { useId } from '../../hooks/useId'
 
-type Props = Omit<BaseProps, 'titleId'> &
-  Pick<DialogContentInnerProps, 'width' | 'top' | 'right' | 'bottom' | 'left' | 'id'>
+type Props = Omit<BaseProps, 'titleId'> & UncontrolledDialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
@@ -17,10 +18,12 @@ export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
   actionTheme,
   onClickAction,
   actionDisabled = false,
+  portalParent,
   className = '',
   ...props
 }) => {
-  const { DialogContentRoot, onClickClose, active } = useContext(DialogContext)
+  const { onClickClose, active } = useContext(DialogContext)
+  const { Portal } = useDialogPortal(portalParent)
 
   const handleClickClose = useCallback(() => {
     if (!active) {
@@ -39,7 +42,7 @@ export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
   const titleId = useId()
 
   return (
-    <DialogContentRoot>
+    <Portal>
       <DialogContentInner
         onClickOverlay={onClickClose}
         onPressEscape={onClickClose}
@@ -61,6 +64,6 @@ export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
           {children}
         </ActionDialogContentInner>
       </DialogContentInner>
-    </DialogContentRoot>
+    </Portal>
   )
 }

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -16,7 +16,8 @@ import {
   ModelessDialog,
 } from '.'
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { SecondaryButton } from '../Button'
+import { Button } from '../Button'
+import { Input } from '../Input'
 import { RadioButton } from '../RadioButton'
 import { DatePicker } from '../DatePicker'
 import { LineUp, Stack } from '../Layout'
@@ -50,68 +51,98 @@ export default {
 }
 
 export const Default: Story = () => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [opened, setOpended] = useState<'default' | 'focus' | null>(null)
   const [value, setValue] = useState('Apple')
   const [date, setDate] = useState<Date | null>(null)
-  const onClickOpen = () => setIsOpen(true)
-  const onClickClose = () => setIsOpen(false)
+  const onClickClose = () => setOpended(null)
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
+  const inputRef = useRef<HTMLInputElement>(null)
   const themes = useTheme()
 
   return (
-    <>
-      <SecondaryButton
-        onClick={onClickOpen}
-        aria-haspopup="dialog"
-        aria-controls="dialog-default"
-        data-test="dialog-trigger"
-      >
-        Dialog
-      </SecondaryButton>
-      <Dialog
-        isOpen={isOpen}
-        onClickOverlay={onClickClose}
-        onPressEscape={onClickClose}
-        id="dialog-default"
-        ariaLabel="Dialog"
-        data-test="dialog-content"
-      >
-        <Title themes={themes}>Dialog</Title>
-        <Description>
-          The value of isOpen must be managed by you, but you can customize content freely.
-        </Description>
-        <Content>
-          <DatePicker
-            value={date?.toDateString()}
-            formatDate={(_date) => (_date ? _date.toDateString() : '')}
-            onChangeDate={(_date) => setDate(_date)}
-            data-test="dialog-datepicker"
-          />
-        </Content>
-        <RadioList>
-          <li>
-            <RadioButton name="Apple" checked={value === 'Apple'} onChange={onChangeValue}>
-              Apple
-            </RadioButton>
-          </li>
-          <li>
-            <RadioButton name="Orange" checked={value === 'Orange'} onChange={onChangeValue}>
-              Orange
-            </RadioButton>
-          </li>
-          <li>
-            <RadioButton name="Grape" checked={value === 'Grape'} onChange={onChangeValue}>
-              Grape
-            </RadioButton>
-          </li>
-        </RadioList>
-        <Footer themes={themes}>
-          <SecondaryButton onClick={onClickClose} data-test="dialog-closer">
-            close
-          </SecondaryButton>
-        </Footer>
-      </Dialog>
-    </>
+    <TriggerList>
+      <li>
+        <Button
+          onClick={() => setOpended('default')}
+          aria-haspopup="dialog"
+          aria-controls="dialog-default"
+          data-test="dialog-trigger"
+        >
+          Dialog
+        </Button>
+        <Dialog
+          isOpen={opened === 'default'}
+          onClickOverlay={onClickClose}
+          onPressEscape={onClickClose}
+          id="dialog-default"
+          ariaLabel="Dialog"
+          data-test="dialog-content"
+        >
+          <Title themes={themes}>Dialog</Title>
+          <Description>
+            The value of isOpen must be managed by you, but you can customize content freely.
+          </Description>
+          <Content>
+            <DatePicker
+              value={date?.toDateString()}
+              formatDate={(_date) => (_date ? _date.toDateString() : '')}
+              onChangeDate={(_date) => setDate(_date)}
+              data-test="dialog-datepicker"
+            />
+          </Content>
+          <RadioList>
+            <li>
+              <RadioButton name="Apple" checked={value === 'Apple'} onChange={onChangeValue}>
+                Apple
+              </RadioButton>
+            </li>
+            <li>
+              <RadioButton name="Orange" checked={value === 'Orange'} onChange={onChangeValue}>
+                Orange
+              </RadioButton>
+            </li>
+            <li>
+              <RadioButton name="Grape" checked={value === 'Grape'} onChange={onChangeValue}>
+                Grape
+              </RadioButton>
+            </li>
+          </RadioList>
+          <Footer themes={themes}>
+            <Button onClick={onClickClose} data-test="dialog-closer">
+              close
+            </Button>
+          </Footer>
+        </Dialog>
+      </li>
+      <li>
+        <Button
+          onClick={() => setOpended('focus')}
+          aria-haspopup="dialog"
+          aria-controls="dialog-focus"
+          data-test="dialog-focus-trigger"
+        >
+          特定の要素をフォーカス
+        </Button>
+        <Dialog
+          isOpen={opened === 'focus'}
+          onClickOverlay={onClickClose}
+          onPressEscape={onClickClose}
+          firstFocusTarget={inputRef}
+          id="dialog-focus"
+          ariaLabel="特定の要素をフォーカスするダイアログ"
+        >
+          <Title themes={themes}>特定の要素をフォーカスするダイアログ</Title>
+          <Content>
+            <Input ref={inputRef} data-test="input-focus-target" />
+          </Content>
+          <Footer themes={themes}>
+            <Button onClick={onClickClose} data-test="dialog-closer">
+              close
+            </Button>
+          </Footer>
+        </Dialog>
+      </li>
+    </TriggerList>
   )
 }
 
@@ -138,14 +169,14 @@ export const Message_Dialog: Story = () => {
 
   return (
     <>
-      <SecondaryButton
+      <Button
         onClick={onClickOpen}
         aria-haspopup="dialog"
         aria-controls="dialog-message"
         data-test="dialog-trigger"
       >
         MessageDialog
-      </SecondaryButton>
+      </Button>
       <MessageDialog
         isOpen={isOpen}
         title="MessageDialog"
@@ -185,14 +216,14 @@ export const Action_Dialog: Story = () => {
 
   return (
     <>
-      <SecondaryButton
+      <Button
         onClick={onClickOpen}
         aria-haspopup="dialog"
         aria-controls="dialog-action"
         data-test="dialog-trigger"
       >
         ActionDialog
-      </SecondaryButton>
+      </Button>
       <ActionDialog
         isOpen={isOpen}
         title="ActionDialog"
@@ -231,7 +262,7 @@ export const Action_Dialog: Story = () => {
         </RadioList>
         <Buttons>
           <p>切り替えボタン：</p>
-          <SecondaryButton
+          <Button
             onClick={() =>
               setResponseMessage({
                 status: 'success',
@@ -240,8 +271,8 @@ export const Action_Dialog: Story = () => {
             }
           >
             保存
-          </SecondaryButton>
-          <SecondaryButton
+          </Button>
+          <Button
             onClick={() =>
               setResponseMessage({
                 status: 'error',
@@ -250,8 +281,8 @@ export const Action_Dialog: Story = () => {
             }
           >
             エラー
-          </SecondaryButton>
-          <SecondaryButton
+          </Button>
+          <Button
             onClick={() =>
               setResponseMessage({
                 status: 'processing',
@@ -260,7 +291,7 @@ export const Action_Dialog: Story = () => {
             }
           >
             保存中
-          </SecondaryButton>
+          </Button>
         </Buttons>
       </ActionDialog>
     </>
@@ -288,19 +319,19 @@ export const Uncontrolled: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton
+            <Button
               aria-haspopup="dialog"
               aria-controls="dialog-uncontrolled"
               data-test="dialog-trigger"
             >
               Dialog
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <DialogContent id="dialog-uncontrolled" data-test="dialog-content">
             <Description>Uncontrolled Dialog.</Description>
             <Content>
               <DialogCloser>
-                <SecondaryButton data-test="dialog-closer">Close</SecondaryButton>
+                <Button data-test="dialog-closer">Close</Button>
               </DialogCloser>
             </Content>
           </DialogContent>
@@ -309,13 +340,13 @@ export const Uncontrolled: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton
+            <Button
               aria-haspopup="dialog"
               aria-controls="dialog-uncontrolled-message"
               data-test="message-dialog-trigger"
             >
               MessageDialog
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <MessageDialogContent
             title="Uncontrolled Message Dialog"
@@ -329,13 +360,13 @@ export const Uncontrolled: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton
+            <Button
               aria-haspopup="dialog"
               aria-controls="dialog-uncontrolled-action"
               data-test="action-dialog-trigger"
             >
               ActionDialog
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <ActionDialogContent
             title="Uncontrolled Action Dialog"
@@ -379,9 +410,9 @@ export const WidthAndPosition: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-width-1">
+            <Button aria-haspopup="dialog" aria-controls="dialog-width-1">
               幅 400px
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <DialogContent width={400} id="dialog-width-1">
             <Description>幅 400px のダイアログ</Description>
@@ -391,9 +422,9 @@ export const WidthAndPosition: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-width-2">
+            <Button aria-haspopup="dialog" aria-controls="dialog-width-2">
               幅 80%
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <DialogContent width="80%" id="dialog-width-2">
             <Description>幅 80% のダイアログ</Description>
@@ -403,9 +434,9 @@ export const WidthAndPosition: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-position-1">
+            <Button aria-haspopup="dialog" aria-controls="dialog-position-1">
               top-left
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <DialogContent top={50} left={200} id="dialog-position-1">
             <Description>This Dialog is set to `top: 50px, left: 200px`.</Description>
@@ -415,9 +446,9 @@ export const WidthAndPosition: Story = () => {
       <li>
         <DialogWrapper>
           <DialogTrigger>
-            <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-position-2">
+            <Button aria-haspopup="dialog" aria-controls="dialog-position-2">
               bottom-right
-            </SecondaryButton>
+            </Button>
           </DialogTrigger>
           <DialogContent right={50} bottom={100} id="dialog-position-2">
             <Description>This Dialog is set to `right: 50px, bottom: 100px`.</Description>
@@ -444,9 +475,9 @@ export const WithScroll: Story = () => {
       </BorderedWrapper>
       <DialogWrapper>
         <DialogTrigger>
-          <SecondaryButton aria-haspopup="dialog" aria-controls="dialog-with-scroll-1">
+          <Button aria-haspopup="dialog" aria-controls="dialog-with-scroll-1">
             Open Dialog
-          </SecondaryButton>
+          </Button>
         </DialogTrigger>
         <DialogContent id="dialog-with-scroll-1">
           <ContentWrapper>
@@ -489,13 +520,13 @@ export const Modeless_Dialog: Story = () => {
   return (
     <TriggerList style={{ height: '200vh' }}>
       <li>
-        <SecondaryButton
+        <Button
           onClick={() => setIsOpen1(!isOpen1)}
           aria-haspopup="dialog"
           aria-controls="modeless-dialog-1"
         >
           中央表示
-        </SecondaryButton>
+        </Button>
         <ModelessDialog
           isOpen={isOpen1}
           header={<ModelessHeading>モードレスダイアログ（中央表示）</ModelessHeading>}
@@ -546,14 +577,14 @@ export const Modeless_Dialog: Story = () => {
         </ModelessDialog>
       </li>
       <li>
-        <SecondaryButton
+        <Button
           onClick={() => setIsOpen2(!isOpen2)}
           data-test="dialog-trigger"
           aria-haspopup="dialog"
           aria-controls="modeless-dialog-2"
         >
           座標指定
-        </SecondaryButton>
+        </Button>
         <ModelessDialog
           isOpen={isOpen2}
           header={<ModelessHeading>座標指定表示</ModelessHeading>}
@@ -673,37 +704,37 @@ export const Body以外のPortalParent: Story = () => {
   return (
     <div ref={portalParentRef}>
       <Stack align="flex-start">
-        <SecondaryButton
+        <Button
           onClick={() => onClickOpen('deault')}
           aria-haspopup="dialog"
           aria-controls="portal-default"
           data-test="dialog-trigger"
         >
           Dialog を開く
-        </SecondaryButton>
-        <SecondaryButton
+        </Button>
+        <Button
           onClick={() => onClickOpen('actiion')}
           aria-haspopup="dialog"
           aria-controls="portal-action"
           data-test="dialog-trigger"
         >
           ActionDialog を開く
-        </SecondaryButton>
-        <SecondaryButton
+        </Button>
+        <Button
           onClick={() => onClickOpen('message')}
           aria-haspopup="dialog"
           aria-controls="portal-message"
           data-test="dialog-trigger"
         >
           MessageDialog を開く
-        </SecondaryButton>
-        <SecondaryButton
+        </Button>
+        <Button
           onClick={() => onClickOpen('modeless')}
           aria-haspopup="dialog"
           aria-controls="portal-modeless"
         >
           ModelessDialog を開く
-        </SecondaryButton>
+        </Button>
       </Stack>
 
       <Dialog
@@ -720,9 +751,9 @@ export const Body以外のPortalParent: Story = () => {
           <p>Dialog を近接要素に生成しています。</p>
         </Content>
         <Footer themes={themes}>
-          <SecondaryButton onClick={onClickClose} data-test="dialog-closer">
+          <Button onClick={onClickClose} data-test="dialog-closer">
             閉じる
-          </SecondaryButton>
+          </Button>
         </Footer>
       </Dialog>
       <ActionDialog

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,9 +1,10 @@
-import React, { HTMLAttributes, RefObject } from 'react'
+import React, { HTMLAttributes } from 'react'
 
+import { DialogProps, DireactChildren } from './types'
 import { useDialogPortal } from './useDialogPortal'
-import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
+import { DialogContentInner } from './DialogContentInner'
 
-type Props = DialogContentInnerProps & { portalParent?: HTMLElement | RefObject<HTMLElement> }
+type Props = DialogProps & DireactChildren
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const Dialog: React.VFC<Props & ElementProps> = ({

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -1,7 +1,9 @@
 import React, { createContext, useContext } from 'react'
 
+import { DireactChildren, UncontrolledDialogProps } from './types'
+import { useDialogPortal } from './useDialogPortal'
 import { DialogContext } from './DialogWrapper'
-import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
+import { DialogContentInner } from './DialogContentInner'
 
 type DialogContentContextType = {
   onClickClose: () => void
@@ -13,16 +15,14 @@ export const DialogContentContext = createContext<DialogContentContextType>({
   },
 })
 
-type Props = Pick<
-  DialogContentInnerProps,
-  'width' | 'top' | 'right' | 'bottom' | 'left' | 'id' | 'ariaLabel' | 'ariaLabelledby' | 'children'
->
+type Props = UncontrolledDialogProps & DireactChildren
 
-export const DialogContent: React.VFC<Props> = ({ children, ...props }) => {
-  const { DialogContentRoot, onClickClose, active } = useContext(DialogContext)
+export const DialogContent: React.VFC<Props> = ({ portalParent, children, ...props }) => {
+  const { onClickClose, active } = useContext(DialogContext)
+  const { Portal } = useDialogPortal(portalParent)
 
   return (
-    <DialogContentRoot>
+    <Portal>
       <DialogContentContext.Provider value={{ onClickClose }}>
         <DialogContentInner
           isOpen={active}
@@ -33,6 +33,6 @@ export const DialogContent: React.VFC<Props> = ({ children, ...props }) => {
           {children}
         </DialogContentInner>
       </DialogContentContext.Provider>
-    </DialogContentRoot>
+    </Portal>
   )
 }

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactNode, VFC, useCallback, useRef } from 'react'
+import React, { HTMLAttributes, ReactNode, RefObject, VFC, useCallback, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -47,6 +47,10 @@ export type DialogContentInnerProps = {
    */
   id?: string
   /**
+   * ダイアログを開いた時にフォーカスする対象
+   */
+  firstFocusTarget?: RefObject<HTMLElement>
+  /**
    * `aria-label` of the component.
    */
   ariaLabel?: string
@@ -85,6 +89,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
   isOpen,
   id,
   width,
+  firstFocusTarget,
   ariaLabel,
   ariaLabelledby,
   children,
@@ -130,7 +135,7 @@ export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = (
             className={`${className} ${classNames.dialog}`}
             {...props}
           >
-            <FocusTrap>{children}</FocusTrap>
+            <FocusTrap firstFocusTarget={firstFocusTarget}>{children}</FocusTrap>
           </Inner>
           {/* Suppresses scrolling of body while modal is displayed */}
           <BodyScrollSuppressor />

--- a/src/components/Dialog/DialogWrapper.tsx
+++ b/src/components/Dialog/DialogWrapper.tsx
@@ -1,11 +1,8 @@
-import React, { createContext, useMemo, useState } from 'react'
-
-import { useDialogPortal } from './useDialogPortal'
+import React, { createContext, useState } from 'react'
 
 type DialogContextType = {
   onClickTrigger: () => void
   onClickClose: () => void
-  DialogContentRoot: React.VFC<{ children: React.ReactNode }>
   active: boolean
 }
 
@@ -16,30 +13,17 @@ export const DialogContext = createContext<DialogContextType>({
   onClickClose: () => {
     /* noop */
   },
-  DialogContentRoot: () => null,
   active: false,
 })
 
 export const DialogWrapper: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
   const [active, setActive] = useState(false)
-  const { Portal } = useDialogPortal()
-
-  // This is the root container of a dialog content located in outside the DOM tree
-  const DialogContentRoot = useMemo<React.VFC<{ children: React.ReactNode }>>(
-    () => (props) => {
-      return <Portal>{props.children}</Portal>
-    },
-    [Portal],
-  )
-  // set the displayName explicit for DevTools
-  DialogContentRoot.displayName = 'DialogContentRoot'
 
   return (
     <DialogContext.Provider
       value={{
         onClickTrigger: () => setActive(true),
         onClickClose: () => setActive(false),
-        DialogContentRoot,
         active,
       }}
     >

--- a/src/components/Dialog/FocusTrap.tsx
+++ b/src/components/Dialog/FocusTrap.tsx
@@ -1,14 +1,15 @@
-import React, { ReactNode, VFC, useCallback, useEffect, useRef } from 'react'
+import React, { ReactNode, RefObject, VFC, useCallback, useEffect, useRef } from 'react'
 
 import { tabbable } from '../../libs/tabbable'
 
 type Props = {
+  firstFocusTarget?: RefObject<HTMLElement>
   children: ReactNode
 }
 
-export const FocusTrap: VFC<Props> = ({ children }) => {
+export const FocusTrap: VFC<Props> = ({ firstFocusTarget, children }) => {
   const ref = useRef<HTMLDivElement | null>(null)
-  const focusTargetRef = useRef<HTMLDivElement>(null)
+  const dummyFocusRef = useRef<HTMLDivElement>(null)
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key !== 'Tab' || ref.current === null) {
@@ -23,7 +24,7 @@ export const FocusTrap: VFC<Props> = ({ children }) => {
     const currentFocused = Array.from(tabbables).find((elm) => elm === e.target)
     if (
       e.shiftKey &&
-      (currentFocused === firstTabbale || document.activeElement === focusTargetRef.current)
+      (currentFocused === firstTabbale || document.activeElement === dummyFocusRef.current)
     ) {
       lastTabbale.focus()
       e.preventDefault()
@@ -42,7 +43,11 @@ export const FocusTrap: VFC<Props> = ({ children }) => {
 
   useEffect(() => {
     const triggerElement = document.activeElement
-    focusTargetRef.current?.focus()
+    if (firstFocusTarget?.current) {
+      firstFocusTarget.current.focus()
+    } else {
+      dummyFocusRef.current?.focus()
+    }
 
     return () => {
       // フォーカストラップ終了時にトリガにフォーカスを戻す
@@ -50,12 +55,12 @@ export const FocusTrap: VFC<Props> = ({ children }) => {
         triggerElement.focus()
       }
     }
-  }, [])
+  }, [firstFocusTarget])
 
   return (
     <div ref={ref}>
       {/* dummy element for focus management. */}
-      <div ref={focusTargetRef} tabIndex={-1} />
+      <div ref={dummyFocusRef} tabIndex={-1} />
       {children}
     </div>
   )

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -1,26 +1,15 @@
-import React, { HTMLAttributes, RefObject, useCallback } from 'react'
+import React, { HTMLAttributes, useCallback } from 'react'
 
+import { DialogProps } from './types'
 import { useDialogPortal } from './useDialogPortal'
-import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
+import { DialogContentInner } from './DialogContentInner'
 import {
   MessageDialogContentInner,
   MessageDialogContentInnerProps,
 } from './MessageDialogContentInner'
 import { useId } from '../../hooks/useId'
 
-type Props = Omit<MessageDialogContentInnerProps, 'titleId'> &
-  Pick<
-    DialogContentInnerProps,
-    | 'isOpen'
-    | 'onClickOverlay'
-    | 'onPressEscape'
-    | 'width'
-    | 'top'
-    | 'right'
-    | 'bottom'
-    | 'left'
-    | 'id'
-  > & { portalParent?: HTMLElement | RefObject<HTMLElement> }
+type Props = Omit<MessageDialogContentInnerProps, 'titleId'> & DialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const MessageDialog: React.VFC<Props & ElementProps> = ({

--- a/src/components/Dialog/MessageDialogContent.tsx
+++ b/src/components/Dialog/MessageDialogContent.tsx
@@ -1,22 +1,25 @@
 import React, { HTMLAttributes, useCallback, useContext } from 'react'
 
+import { UncontrolledDialogProps } from './types'
+import { useDialogPortal } from './useDialogPortal'
 import { DialogContext } from './DialogWrapper'
-import { DialogContentInner, DialogContentInnerProps } from './DialogContentInner'
+import { DialogContentInner } from './DialogContentInner'
 import { BaseProps, MessageDialogContentInner } from './MessageDialogContentInner'
 import { useId } from '../../hooks/useId'
 
-type Props = Omit<BaseProps, 'titleId'> &
-  Pick<DialogContentInnerProps, 'width' | 'top' | 'right' | 'bottom' | 'left' | 'id'>
+type Props = Omit<BaseProps, 'titleId'> & UncontrolledDialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
   title,
   description,
   closeText,
+  portalParent,
   className = '',
   ...props
 }) => {
-  const { DialogContentRoot, onClickClose, active } = useContext(DialogContext)
+  const { onClickClose, active } = useContext(DialogContext)
+  const { Portal } = useDialogPortal(portalParent)
 
   const handleClickClose = useCallback(() => {
     if (!active) {
@@ -27,7 +30,7 @@ export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
   const titleId = useId()
 
   return (
-    <DialogContentRoot>
+    <Portal>
       <DialogContentInner
         onClickOverlay={onClickClose}
         onPressEscape={onClickClose}
@@ -43,6 +46,6 @@ export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
           onClickClose={handleClickClose}
         />
       </DialogContentInner>
-    </DialogContentRoot>
+    </Portal>
   )
 }

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -1,0 +1,30 @@
+import { RefObject } from 'react'
+
+import { DialogContentInnerProps } from './DialogContentInner'
+
+type CommonProps = Pick<
+  DialogContentInnerProps,
+  | 'width'
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'id'
+  | 'firstFocusTarget'
+  | 'ariaLabel'
+  | 'ariaLabelledby'
+>
+
+type ControlledProps = Pick<DialogContentInnerProps, 'isOpen' | 'onClickOverlay' | 'onPressEscape'>
+
+type PortalProps = {
+  /**
+   * DOM 上でダイアログの要素を追加する親要素
+   */
+  portalParent?: HTMLElement | RefObject<HTMLElement>
+}
+
+export type DialogProps = CommonProps & ControlledProps & PortalProps
+export type UncontrolledDialogProps = CommonProps & PortalProps
+
+export type DireactChildren = Pick<DialogContentInnerProps, 'children'>


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-562
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状ダイアログコンポーネントは、開いた時にダイアログ内の先頭にあるダミー要素をフォーカスする挙動をしますが、オプションとして特定の要素を指定できるように機能追加します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `firstFocusTarget?: RefObject<HTMLElement>` Props を追加
- 同じ意味の型定義が散在していたのを集約

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## やらなかったこと
- `firstFocusTarget` は `RefObject` のみを許容し、`HTMLElement` は許容しませんでした
  - 現状のダイアログの実装では、ダイアログ非表示時にはダイアログコンテンツの DOM は追加されいない関係で、コンテンツ内の特定のフォームの `ref.current` を指定できるようにしても適切に動作しないことと、`RefObejct` を渡せるようにしておけば問題は無さそうに思えたので `RefObject` のみを許容する形にしています。
- `ActionDialog` におけるアクションボタン・閉じるボタンなど、コンポーネント内に閉じている要素を指定できるオプションの追加はしませんでした
  - つまり `firstFocusTarget?: RefObject | 'actionButton' | 'closeButton'` みたいな形にはしなかった
  - 現状では考慮し過ぎ感があり、必要になれば跡から型変更で追加できるので現状での実装は見送りました


## Capture

<!--
Please attach a capture if it looks different.
-->
