### PR TITLE
feat: Storybookにcontrols addonを追加

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,11 +4,9 @@ module.exports = {
     'storybook-readme',
     {
       name: '@storybook/addon-essentials',
-      options: {
-        controls: false,
-      },
     },
     '@storybook/addon-a11y',
+    '@storybook/addon-controls',
     'storycap',
   ],
 }

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,11 +1,9 @@
 import { Story } from '@storybook/react'
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { AnchorButton, Button } from '.'
-import { FaPlusCircleIcon, FaPlusIcon, FaPlusSquareIcon } from '../Icon'
-import { LineUp, Stack } from '../Layout'
 
 export default {
   title: 'Button',
@@ -13,348 +11,40 @@ export default {
   subcomponents: {
     AnchorButton,
   },
+  argTypes: {
+    children: { control: 'text' },
+    prefix: { control: 'text' },
+    suffix: { control: 'text' },
+  },
 }
 
 type ButtonProps = React.ComponentProps<typeof Button>
 type AnchorButtonProps = React.ComponentProps<typeof AnchorButton>
 
-export const _PrimaryButton: Story = () => {
-  return renderButtons('primary')
-}
-
-export const _PrimaryButtonAnchor: Story = () => {
-  return renderAnchors('primary')
-}
-
-export const _SecondaryButton: Story = () => {
-  return renderButtons('secondary')
-}
-
-export const _SecondaryButtonAnchor: Story = () => {
-  return renderAnchors('secondary')
-}
-
-export const _DangerButton: Story = () => {
-  return renderButtons('danger')
-}
-
-export const _DangerButtonAnchor: Story = () => {
-  return renderAnchors('danger')
-}
-
-export const _SkeletonButton: Story = () => {
-  return <DarkBackground>{renderButtons('skeleton')}</DarkBackground>
-}
-
-export const _SkeletonButtonAnchor: Story = () => {
-  return <DarkBackground>{renderAnchors('skeleton')}</DarkBackground>
-}
-
-export const _TextButton: Story = () => {
-  return renderButtons('text', true)
-}
-
-export const _TextButtonAnchor: Story = () => {
-  return renderAnchors('text', true)
-}
-
-function renderButtons(variant: ButtonProps['variant'], noSquare = false) {
+export const _Button: Story = (args: ButtonProps) => {
   return (
-    <List>
-      <dt>Default</dt>
-      <dd>
-        <Stack>
-          <WrapLineUp vAlign="center">
-            <Button variant={variant} onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button variant={variant} prefix={<FaPlusIcon />} onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button variant={variant} suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
-              ボタン
-            </Button>
-            {!noSquare && (
-              <Button variant={variant} square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Button>
-            )}
-          </WrapLineUp>
-          <WrapLineUp vAlign="center">
-            <Button variant={variant} disabled onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button variant={variant} disabled prefix={<FaPlusIcon />} onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button
-              variant={variant}
-              disabled
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </Button>
-            {!noSquare && (
-              <Button variant={variant} disabled square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Button>
-            )}
-          </WrapLineUp>
-        </Stack>
-      </dd>
-
-      <dt>Small</dt>
-      <dd>
-        <Stack>
-          <WrapLineUp vAlign="center">
-            <Button variant={variant} size="s" onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button variant={variant} size="s" prefix={<FaPlusIcon />} onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button
-              variant={variant}
-              size="s"
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </Button>
-            {!noSquare && (
-              <Button variant={variant} size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Button>
-            )}
-          </WrapLineUp>
-          <WrapLineUp vAlign="center">
-            <Button variant={variant} disabled size="s" onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button
-              variant={variant}
-              disabled
-              size="s"
-              prefix={<FaPlusIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </Button>
-            <Button
-              variant={variant}
-              disabled
-              size="s"
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </Button>
-            {!noSquare && (
-              <Button variant={variant} disabled size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </Button>
-            )}
-          </WrapLineUp>
-        </Stack>
-      </dd>
-
-      <dt>Wide</dt>
-      <dd>
-        <Stack>
-          <Button variant={variant} wide onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button variant={variant} disabled wide onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button variant={variant} size="s" wide onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button variant={variant} disabled size="s" wide onClick={action('clicked')}>
-            ボタン
-          </Button>
-        </Stack>
-      </dd>
-
-      <dt>Extending Style</dt>
-      <dd>
-        <ExtendingButton variant={variant} onClick={action('clicked')}>
-          width: 300px
-        </ExtendingButton>
-      </dd>
-    </List>
+    <Wrapper>
+      <Button onClick={action('clicked')} {...args}>
+        ボタン
+      </Button>
+    </Wrapper>
   )
 }
 
-function renderAnchors(variant: AnchorButtonProps['variant'], noSquare = false) {
+export const _ButtonAnchor: Story = (args: AnchorButtonProps) => {
   return (
-    <List>
-      <dt>Default</dt>
-      <dd>
-        <Stack>
-          <WrapLineUp vAlign="center">
-            <AnchorButton variant={variant} href="#" onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              href="#"
-              prefix={<FaPlusIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              href="#"
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            {!noSquare && (
-              <AnchorButton variant={variant} href="#" square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </AnchorButton>
-            )}
-          </WrapLineUp>
-          <WrapLineUp vAlign="center">
-            <AnchorButton variant={variant} onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-            <AnchorButton variant={variant} prefix={<FaPlusIcon />} onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            {!noSquare && (
-              <AnchorButton variant={variant} square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </AnchorButton>
-            )}
-          </WrapLineUp>
-        </Stack>
-      </dd>
-
-      <dt>Small</dt>
-      <dd>
-        <Stack>
-          <WrapLineUp vAlign="center">
-            <AnchorButton variant={variant} size="s" href="#" onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              size="s"
-              href="#"
-              prefix={<FaPlusIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              size="s"
-              href="#"
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            {!noSquare && (
-              <AnchorButton variant={variant} size="s" href="#" square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </AnchorButton>
-            )}
-          </WrapLineUp>
-          <WrapLineUp vAlign="center">
-            <AnchorButton variant={variant} size="s" onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              size="s"
-              prefix={<FaPlusIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            <AnchorButton
-              variant={variant}
-              size="s"
-              suffix={<FaPlusSquareIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </AnchorButton>
-            {!noSquare && (
-              <AnchorButton variant={variant} size="s" square onClick={action('clicked')}>
-                <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
-              </AnchorButton>
-            )}
-          </WrapLineUp>
-        </Stack>
-      </dd>
-
-      <dt>Wide</dt>
-      <dd>
-        <Stack>
-          <AnchorButton variant={variant} href="#" wide onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-
-          <AnchorButton variant={variant} wide onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton variant={variant} size="s" href="#" wide onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton variant={variant} size="s" wide onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-        </Stack>
-      </dd>
-
-      <dt>Extending Style</dt>
-      <dd>
-        <ExtendingAnchorButton variant={variant} href="#" onClick={action('clicked')}>
-          width: 300px
-        </ExtendingAnchorButton>
-      </dd>
-    </List>
+    <Wrapper>
+      <AnchorButton href="#" onClick={action('clicked')} {...args}>
+        ボタン
+      </AnchorButton>
+    </Wrapper>
   )
 }
 
-const List = styled.dl`
-  margin: 0;
-  padding: 1rem;
-  dt {
-    margin: 0 0 1rem;
-  }
-  dd {
-    margin: 0 0 1rem;
-  }
-`
-const WrapLineUp = styled(LineUp)`
-  flex-wrap: wrap;
-`
-const DarkBackground = styled.div`
-  background-color: #5c5c5c;
-  color: #fff;
-`
+const Wrapper = styled.div`
+  padding: 24px;
 
-const extendingStyle = css`
-  width: 300px;
-`
-const ExtendingButton = styled(Button)`
-  ${extendingStyle}
-`
-const ExtendingAnchorButton = styled(AnchorButton)`
-  ${extendingStyle}
+  > * + * {
+    margin-top: 24px;
+  }
 `

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,9 +1,11 @@
 import { Story } from '@storybook/react'
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { AnchorButton, Button } from '.'
+import { Cluster, Stack } from '../Layout'
+import { FaPlusCircleIcon, FaPlusIcon, FaPlusSquareIcon } from '../Icon'
 
 export default {
   title: 'Button',
@@ -11,17 +13,149 @@ export default {
   subcomponents: {
     AnchorButton,
   },
-  argTypes: {
-    children: { control: 'text' },
-    prefix: { control: 'text' },
-    suffix: { control: 'text' },
-  },
 }
 
 type ButtonProps = React.ComponentProps<typeof Button>
 type AnchorButtonProps = React.ComponentProps<typeof AnchorButton>
 
-export const _Button: Story = (args: ButtonProps) => {
+export const _Button: Story = () => {
+  return (
+    <List>
+      <dt>Default</dt>
+      <dd>
+        <Stack>
+          <Cluster>
+            <Button variant={'primary'} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'primary'} prefix={<FaPlusIcon />} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'primary'} suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'primary'} square onClick={action('clicked')}>
+              <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
+            </Button>
+          </Cluster>
+          <Cluster>
+            <Button variant={'primary'} disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button
+              variant={'primary'}
+              disabled
+              prefix={<FaPlusIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </Button>
+            <Button
+              variant={'primary'}
+              disabled
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </Button>
+            <Button variant={'primary'} disabled square onClick={action('clicked')}>
+              <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
+            </Button>
+          </Cluster>
+        </Stack>
+      </dd>
+
+      <dt>Variants</dt>
+      <dd>
+        <Stack>
+          <Cluster>
+            <Button variant={'primary'} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'primary'} disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+          <Cluster>
+            <Button variant={'secondary'} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'secondary'} disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+          <Cluster>
+            <Button variant={'danger'} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'danger'} disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+          <DarkBackground>
+            <Cluster>
+              <Button variant={'skeleton'} onClick={action('clicked')}>
+                ボタン
+              </Button>
+              <Button variant={'skeleton'} disabled onClick={action('clicked')}>
+                ボタン
+              </Button>
+            </Cluster>
+          </DarkBackground>
+          <Cluster>
+            <Button variant={'text'} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant={'text'} disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+        </Stack>
+      </dd>
+
+      <dt>Small</dt>
+      <dd>
+        <Stack>
+          <Cluster>
+            <Button variant={'primary'} size="s" onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+          <Cluster>
+            <Button variant={'primary'} disabled size="s" onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+        </Stack>
+      </dd>
+
+      <dt>Wide</dt>
+      <dd>
+        <Stack>
+          <Button variant={'primary'} wide onClick={action('clicked')}>
+            ボタン
+          </Button>
+          <Button variant={'primary'} disabled wide onClick={action('clicked')}>
+            ボタン
+          </Button>
+        </Stack>
+      </dd>
+
+      <dt>Extending Style</dt>
+      <dd>
+        <ExtendingButton variant={'primary'} onClick={action('clicked')}>
+          width: 300px
+        </ExtendingButton>
+      </dd>
+    </List>
+  )
+}
+
+_Button.parameters = {
+  controls: { hideNoControlsWarning: true },
+}
+
+export const _ButtonControl: Story = (args: ButtonProps) => {
   return (
     <Wrapper>
       <Button onClick={action('clicked')} {...args}>
@@ -31,7 +165,154 @@ export const _Button: Story = (args: ButtonProps) => {
   )
 }
 
-export const _ButtonAnchor: Story = (args: AnchorButtonProps) => {
+_ButtonControl.argTypes = {
+  children: { control: 'text' },
+  prefix: { control: 'text' },
+  suffix: { control: 'text' },
+}
+
+export const _ButtonAnchor: Story = () => {
+  return (
+    <List>
+      <dt>Default</dt>
+      <dd>
+        <Stack>
+          <Cluster>
+            <AnchorButton href="#" variant={'primary'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton
+              href="#"
+              variant={'primary'}
+              prefix={<FaPlusIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </AnchorButton>
+            <AnchorButton
+              href="#"
+              variant={'primary'}
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </AnchorButton>
+            <AnchorButton href="#" variant={'primary'} square onClick={action('clicked')}>
+              <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
+            </AnchorButton>
+          </Cluster>
+          <Cluster>
+            <AnchorButton variant={'primary'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant={'primary'} prefix={<FaPlusIcon />} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton
+              variant={'primary'}
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant={'primary'} square onClick={action('clicked')}>
+              <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
+            </AnchorButton>
+          </Cluster>
+        </Stack>
+      </dd>
+
+      <dt>Variants</dt>
+      <dd>
+        <Stack>
+          <Cluster>
+            <AnchorButton href="#" variant={'primary'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant={'primary'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+          <Cluster>
+            <AnchorButton href="#" variant={'secondary'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant={'secondary'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+          <Cluster>
+            <AnchorButton href="#" variant={'danger'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant={'danger'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+          <DarkBackground>
+            <Cluster>
+              <AnchorButton href="#" variant={'skeleton'} onClick={action('clicked')}>
+                ボタン
+              </AnchorButton>
+              <AnchorButton variant={'skeleton'} onClick={action('clicked')}>
+                ボタン
+              </AnchorButton>
+            </Cluster>
+          </DarkBackground>
+          <Cluster>
+            <AnchorButton href="#" variant={'text'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant={'text'} onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+        </Stack>
+      </dd>
+
+      <dt>Small</dt>
+      <dd>
+        <Stack>
+          <Cluster>
+            <AnchorButton href="#" variant={'primary'} size="s" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+          <Cluster>
+            <AnchorButton variant={'primary'} size="s" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+        </Stack>
+      </dd>
+
+      <dt>Wide</dt>
+      <dd>
+        <Stack>
+          <AnchorButton href="#" variant={'primary'} wide onClick={action('clicked')}>
+            ボタン
+          </AnchorButton>
+          <AnchorButton variant={'primary'} wide onClick={action('clicked')}>
+            ボタン
+          </AnchorButton>
+        </Stack>
+      </dd>
+
+      <dt>Extending Style</dt>
+      <dd>
+        <ExtendingAnchorButton href="#" variant={'primary'} onClick={action('clicked')}>
+          width: 300px
+        </ExtendingAnchorButton>
+      </dd>
+    </List>
+  )
+}
+
+_ButtonAnchor.parameters = {
+  controls: { hideNoControlsWarning: true },
+}
+
+export const _ButtonAnchorControl: Story = (args: AnchorButtonProps) => {
   return (
     <Wrapper>
       <AnchorButton href="#" onClick={action('clicked')} {...args}>
@@ -41,10 +322,41 @@ export const _ButtonAnchor: Story = (args: AnchorButtonProps) => {
   )
 }
 
+_ButtonAnchorControl.argTypes = {
+  children: { control: 'text' },
+  prefix: { control: 'text' },
+  suffix: { control: 'text' },
+}
+
 const Wrapper = styled.div`
   padding: 24px;
 
   > * + * {
     margin-top: 24px;
   }
+`
+const List = styled.dl`
+  margin: 0;
+  padding: 1rem;
+  dt {
+    margin: 0 0 1rem;
+  }
+  dd {
+    margin: 0 0 1rem;
+  }
+`
+const DarkBackground = styled.div`
+  padding: 1rem;
+  background-color: #5c5c5c;
+  color: #fff;
+`
+
+const extendingStyle = css`
+  width: 300px;
+`
+const ExtendingButton = styled(Button)`
+  ${extendingStyle}
+`
+const ExtendingAnchorButton = styled(AnchorButton)`
+  ${extendingStyle}
 `

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -25,40 +25,35 @@ export const _Button: Story = () => {
       <dd>
         <Stack>
           <Cluster>
-            <Button variant={'primary'} onClick={action('clicked')}>
+            <Button variant="primary" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant={'primary'} prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <Button variant="primary" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant={'primary'} suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
+            <Button variant="primary" suffix={<FaPlusSquareIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant={'primary'} square onClick={action('clicked')}>
+            <Button variant="primary" square onClick={action('clicked')}>
               <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
             </Button>
           </Cluster>
           <Cluster>
-            <Button variant={'primary'} disabled onClick={action('clicked')}>
+            <Button variant="primary" disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant="primary" disabled prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </Button>
             <Button
-              variant={'primary'}
-              disabled
-              prefix={<FaPlusIcon />}
-              onClick={action('clicked')}
-            >
-              ボタン
-            </Button>
-            <Button
-              variant={'primary'}
+              variant="primary"
               disabled
               suffix={<FaPlusSquareIcon />}
               onClick={action('clicked')}
             >
               ボタン
             </Button>
-            <Button variant={'primary'} disabled square onClick={action('clicked')}>
+            <Button variant="primary" disabled square onClick={action('clicked')}>
               <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
             </Button>
           </Cluster>
@@ -69,44 +64,44 @@ export const _Button: Story = () => {
       <dd>
         <Stack>
           <Cluster>
-            <Button variant={'primary'} onClick={action('clicked')}>
+            <Button variant="primary" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant={'primary'} disabled onClick={action('clicked')}>
-              ボタン
-            </Button>
-          </Cluster>
-          <Cluster>
-            <Button variant={'secondary'} onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button variant={'secondary'} disabled onClick={action('clicked')}>
+            <Button variant="primary" disabled onClick={action('clicked')}>
               ボタン
             </Button>
           </Cluster>
           <Cluster>
-            <Button variant={'danger'} onClick={action('clicked')}>
+            <Button variant="secondary" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant={'danger'} disabled onClick={action('clicked')}>
+            <Button variant="secondary" disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+          <Cluster>
+            <Button variant="danger" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant="danger" disabled onClick={action('clicked')}>
               ボタン
             </Button>
           </Cluster>
           <DarkBackground>
             <Cluster>
-              <Button variant={'skeleton'} onClick={action('clicked')}>
+              <Button variant="skeleton" onClick={action('clicked')}>
                 ボタン
               </Button>
-              <Button variant={'skeleton'} disabled onClick={action('clicked')}>
+              <Button variant="skeleton" disabled onClick={action('clicked')}>
                 ボタン
               </Button>
             </Cluster>
           </DarkBackground>
           <Cluster>
-            <Button variant={'text'} onClick={action('clicked')}>
+            <Button variant="text" onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant={'text'} disabled onClick={action('clicked')}>
+            <Button variant="text" disabled onClick={action('clicked')}>
               ボタン
             </Button>
           </Cluster>
@@ -117,12 +112,12 @@ export const _Button: Story = () => {
       <dd>
         <Stack>
           <Cluster>
-            <Button variant={'primary'} size="s" onClick={action('clicked')}>
+            <Button variant="primary" size="s" onClick={action('clicked')}>
               ボタン
             </Button>
           </Cluster>
           <Cluster>
-            <Button variant={'primary'} disabled size="s" onClick={action('clicked')}>
+            <Button variant="primary" disabled size="s" onClick={action('clicked')}>
               ボタン
             </Button>
           </Cluster>
@@ -132,10 +127,10 @@ export const _Button: Story = () => {
       <dt>Wide</dt>
       <dd>
         <Stack>
-          <Button variant={'primary'} wide onClick={action('clicked')}>
+          <Button variant="primary" wide onClick={action('clicked')}>
             ボタン
           </Button>
-          <Button variant={'primary'} disabled wide onClick={action('clicked')}>
+          <Button variant="primary" disabled wide onClick={action('clicked')}>
             ボタン
           </Button>
         </Stack>
@@ -143,7 +138,7 @@ export const _Button: Story = () => {
 
       <dt>Extending Style</dt>
       <dd>
-        <ExtendingButton variant={'primary'} onClick={action('clicked')}>
+        <ExtendingButton variant="primary" onClick={action('clicked')}>
           width: 300px
         </ExtendingButton>
       </dd>
@@ -159,14 +154,14 @@ export const _ButtonControl: Story = (args: ButtonProps) => {
   return (
     <Wrapper>
       <Button onClick={action('clicked')} {...args}>
-        ボタン
+        {args.children}
       </Button>
     </Wrapper>
   )
 }
 
 _ButtonControl.argTypes = {
-  children: { control: 'text' },
+  children: { control: 'text', defaultValue: 'ボタン' },
   prefix: { control: 'text' },
   suffix: { control: 'text' },
 }
@@ -178,12 +173,12 @@ export const _ButtonAnchor: Story = () => {
       <dd>
         <Stack>
           <Cluster>
-            <AnchorButton href="#" variant={'primary'} onClick={action('clicked')}>
+            <AnchorButton href="#" variant="primary" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
             <AnchorButton
               href="#"
-              variant={'primary'}
+              variant="primary"
               prefix={<FaPlusIcon />}
               onClick={action('clicked')}
             >
@@ -191,31 +186,31 @@ export const _ButtonAnchor: Story = () => {
             </AnchorButton>
             <AnchorButton
               href="#"
-              variant={'primary'}
+              variant="primary"
               suffix={<FaPlusSquareIcon />}
               onClick={action('clicked')}
             >
               ボタン
             </AnchorButton>
-            <AnchorButton href="#" variant={'primary'} square onClick={action('clicked')}>
+            <AnchorButton href="#" variant="primary" square onClick={action('clicked')}>
               <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
             </AnchorButton>
           </Cluster>
           <Cluster>
-            <AnchorButton variant={'primary'} onClick={action('clicked')}>
+            <AnchorButton variant="primary" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
-            <AnchorButton variant={'primary'} prefix={<FaPlusIcon />} onClick={action('clicked')}>
+            <AnchorButton variant="primary" prefix={<FaPlusIcon />} onClick={action('clicked')}>
               ボタン
             </AnchorButton>
             <AnchorButton
-              variant={'primary'}
+              variant="primary"
               suffix={<FaPlusSquareIcon />}
               onClick={action('clicked')}
             >
               ボタン
             </AnchorButton>
-            <AnchorButton variant={'primary'} square onClick={action('clicked')}>
+            <AnchorButton variant="primary" square onClick={action('clicked')}>
               <FaPlusCircleIcon visuallyHiddenText="プラスボタン" />
             </AnchorButton>
           </Cluster>
@@ -226,44 +221,44 @@ export const _ButtonAnchor: Story = () => {
       <dd>
         <Stack>
           <Cluster>
-            <AnchorButton href="#" variant={'primary'} onClick={action('clicked')}>
+            <AnchorButton href="#" variant="primary" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
-            <AnchorButton variant={'primary'} onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-          </Cluster>
-          <Cluster>
-            <AnchorButton href="#" variant={'secondary'} onClick={action('clicked')}>
-              ボタン
-            </AnchorButton>
-            <AnchorButton variant={'secondary'} onClick={action('clicked')}>
+            <AnchorButton variant="primary" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
           </Cluster>
           <Cluster>
-            <AnchorButton href="#" variant={'danger'} onClick={action('clicked')}>
+            <AnchorButton href="#" variant="secondary" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
-            <AnchorButton variant={'danger'} onClick={action('clicked')}>
+            <AnchorButton variant="secondary" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+          </Cluster>
+          <Cluster>
+            <AnchorButton href="#" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton variant="danger" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
           </Cluster>
           <DarkBackground>
             <Cluster>
-              <AnchorButton href="#" variant={'skeleton'} onClick={action('clicked')}>
+              <AnchorButton href="#" variant="skeleton" onClick={action('clicked')}>
                 ボタン
               </AnchorButton>
-              <AnchorButton variant={'skeleton'} onClick={action('clicked')}>
+              <AnchorButton variant="skeleton" onClick={action('clicked')}>
                 ボタン
               </AnchorButton>
             </Cluster>
           </DarkBackground>
           <Cluster>
-            <AnchorButton href="#" variant={'text'} onClick={action('clicked')}>
+            <AnchorButton href="#" variant="text" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
-            <AnchorButton variant={'text'} onClick={action('clicked')}>
+            <AnchorButton variant="text" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
           </Cluster>
@@ -274,12 +269,12 @@ export const _ButtonAnchor: Story = () => {
       <dd>
         <Stack>
           <Cluster>
-            <AnchorButton href="#" variant={'primary'} size="s" onClick={action('clicked')}>
+            <AnchorButton href="#" variant="primary" size="s" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
           </Cluster>
           <Cluster>
-            <AnchorButton variant={'primary'} size="s" onClick={action('clicked')}>
+            <AnchorButton variant="primary" size="s" onClick={action('clicked')}>
               ボタン
             </AnchorButton>
           </Cluster>
@@ -289,10 +284,10 @@ export const _ButtonAnchor: Story = () => {
       <dt>Wide</dt>
       <dd>
         <Stack>
-          <AnchorButton href="#" variant={'primary'} wide onClick={action('clicked')}>
+          <AnchorButton href="#" variant="primary" wide onClick={action('clicked')}>
             ボタン
           </AnchorButton>
-          <AnchorButton variant={'primary'} wide onClick={action('clicked')}>
+          <AnchorButton variant="primary" wide onClick={action('clicked')}>
             ボタン
           </AnchorButton>
         </Stack>
@@ -300,7 +295,7 @@ export const _ButtonAnchor: Story = () => {
 
       <dt>Extending Style</dt>
       <dd>
-        <ExtendingAnchorButton href="#" variant={'primary'} onClick={action('clicked')}>
+        <ExtendingAnchorButton href="#" variant="primary" onClick={action('clicked')}>
           width: 300px
         </ExtendingAnchorButton>
       </dd>
@@ -316,24 +311,20 @@ export const _ButtonAnchorControl: Story = (args: AnchorButtonProps) => {
   return (
     <Wrapper>
       <AnchorButton href="#" onClick={action('clicked')} {...args}>
-        ボタン
+        {args.children}
       </AnchorButton>
     </Wrapper>
   )
 }
 
 _ButtonAnchorControl.argTypes = {
-  children: { control: 'text' },
+  children: { control: 'text', defaultValue: 'ボタン' },
   prefix: { control: 'text' },
   suffix: { control: 'text' },
 }
 
 const Wrapper = styled.div`
   padding: 24px;
-
-  > * + * {
-    margin-top: 24px;
-  }
 `
 const List = styled.dl`
   margin: 0;


### PR DESCRIPTION
## Overview
Storybook上でpropsを変更しながら挙動を確認できる、controls addonを有効化しました。

## What I did
#2443 にてButtonコンポーネントのインターフェースが変わったということなので、まずButtonコンポーネントに試験実装しています。
controlsタブで`variant` Propsを動的に変更できるようになるため、表示されるコンポーネントは1つだけにしています。

- controls addonを有効にすると、すべてのストーリーでControlsタブが表示され、何も設定がない場合には"This story is not configured to handle controls."という黄色いwarningが表示されてしまうようです。各ストーリーに`hideNoControlsWarning: true`というオプションを設定する必要があるかもしれません。
- `ReactNode` typeのPropsの場合、controlsにはデフォルトでJSONエディタが表示されてしまい、Storybookがエラーを表示するという問題があるため、`children` `suffix` `prefix`の3つについては、`{ control: 'text' }`を明示的に指定しています。
  - 関連するissue
    - https://github.com/storybookjs/storybook/issues/11428
    - https://github.com/storybookjs/storybook/issues/13551

## Capture
https://deploy-preview-2488--smarthr-ui.netlify.app/?path=/story/button--button

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/7822534/169259551-c168241d-95a0-431a-b19e-328816d14ca9.png">