### PR TITLE
feat: ActionDialog と MessageDialog の良いデフォルトを実装

### DIFF
--- a/e2e/components/Dialog/ActionDialog.test.ts
+++ b/e2e/components/Dialog/ActionDialog.test.ts
@@ -24,11 +24,4 @@ test('ダイアログが開閉できること', async (t) => {
     // ダイアログを閉じた後、トリガがフォーカスされることを確認
     .expect(trigger.focused)
     .ok()
-
-  // 背景クリックでダイアログが閉じることを確認
-  await t
-    .click(trigger)
-    .click(background, { offsetX: 0, offsetY: 0 })
-    .expect(content.exists)
-    .notOk()
 })

--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -31,6 +31,7 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   actionTheme,
   onClickAction,
   onClickClose,
+  onPressEscape = onClickClose,
   responseMessage,
   actionDisabled = false,
   closeDisabled,
@@ -57,7 +58,12 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
 
   return (
     <Portal>
-      <DialogContentInner ariaLabelledby={titleId} className={className} {...props}>
+      <DialogContentInner
+        ariaLabelledby={titleId}
+        className={className}
+        onPressEscape={onPressEscape}
+        {...props}
+      >
         <ActionDialogContentInner
           title={title}
           titleId={titleId}

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -25,7 +25,7 @@ export type BaseProps = {
   /**
    * Label of close button.
    */
-  closeText: ReactNode
+  closeText?: ReactNode
   /**
    * Label of action button.
    */
@@ -33,7 +33,7 @@ export type BaseProps = {
   /**
    * Action button style theme.
    */
-  actionTheme: 'primary' | 'secondary' | 'danger'
+  actionTheme?: 'primary' | 'secondary' | 'danger'
   /**
    * Handler function when clicking on action button.<br />
    * Accepts a function that closes dialog as an argument.
@@ -71,9 +71,9 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   title,
   titleId,
   subtitle,
-  closeText,
+  closeText = 'キャンセル',
   actionText,
-  actionTheme,
+  actionTheme = 'primary',
   onClickAction,
   onClickClose,
   responseMessage,

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -151,10 +151,8 @@ export const Message_Dialog: Story = () => {
         title="MessageDialog"
         subtitle="副題"
         description={<p>{dummyText} </p>}
-        closeText="Close"
         onClickClose={onClickClose}
         onClickOverlay={onClickClose}
-        onPressEscape={onClickClose}
         id="dialog-message"
         data-test="dialog-content"
       />
@@ -197,17 +195,13 @@ export const Action_Dialog: Story = () => {
         isOpen={isOpen}
         title="ActionDialog"
         subtitle="副題"
-        closeText="Close"
-        actionText="Execute"
-        actionTheme="primary"
+        actionText="保存"
         onClickAction={(closeDialog) => {
           action('executed')()
           setResponseMessage(undefined)
           closeDialog()
         }}
         onClickClose={onClickClose}
-        onClickOverlay={onClickClose}
-        onPressEscape={onClickClose}
         responseMessage={responseMessage}
         id="dialog-action"
         data-test="dialog-content"
@@ -320,7 +314,6 @@ export const Uncontrolled: Story = () => {
           <MessageDialogContent
             title="Uncontrolled Message Dialog"
             description={<p>{dummyText} </p>}
-            closeText="Close"
             id="dialog-uncontrolled-message"
             data-test="message-dialog-content"
           />
@@ -339,9 +332,7 @@ export const Uncontrolled: Story = () => {
           </DialogTrigger>
           <ActionDialogContent
             title="Uncontrolled Action Dialog"
-            closeText="Close"
-            actionText="Execute"
-            actionTheme="primary"
+            actionText="実行"
             actionDisabled={false}
             onClickAction={(closeDialog) => {
               action('executed')()
@@ -604,7 +595,6 @@ export const RegOpendMessage: Story = () => {
       isOpen={true}
       title="MessageDialog"
       description={<p>{dummyText}</p>}
-      closeText="close"
       onClickClose={action('clicked close')}
     />
   )
@@ -616,9 +606,7 @@ export const RegOpendAction: Story = () => {
     <ActionDialog
       isOpen={true}
       title="ActionDialog"
-      closeText="close"
-      actionText="execute"
-      actionTheme="primary"
+      actionText="保存"
       onClickAction={action('clicked action')}
       onClickClose={action('clicked close')}
     >
@@ -728,16 +716,12 @@ export const Body以外のPortalParent: Story = () => {
       <ActionDialog
         isOpen={isOpen === 'actiion'}
         title="ActionDialog"
-        closeText="閉じる"
-        actionText="実行"
-        actionTheme="primary"
+        actionText="保存"
         onClickAction={(closeDialog) => {
           action('executed')()
           closeDialog()
         }}
         onClickClose={onClickClose}
-        onClickOverlay={onClickClose}
-        onPressEscape={onClickClose}
         id="portal-action"
         data-test="dialog-content"
         portalParent={portalParentRef}
@@ -750,10 +734,8 @@ export const Body以外のPortalParent: Story = () => {
         isOpen={isOpen === 'message'}
         title="MessageDialog"
         description={<p>MessageDialog を近接要素に生成しています</p>}
-        closeText="閉じる"
         onClickClose={onClickClose}
         onClickOverlay={onClickClose}
-        onPressEscape={onClickClose}
         id="portal-message"
         data-test="dialog-content"
         portalParent={portalParentRef}

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -29,6 +29,7 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
   description,
   closeText,
   onClickClose,
+  onPressEscape = onClickClose,
   className = '',
   portalParent,
   ...props
@@ -44,7 +45,12 @@ export const MessageDialog: React.VFC<Props & ElementProps> = ({
 
   return (
     <Portal>
-      <DialogContentInner aria-labelledby={titleId} className={className} {...props}>
+      <DialogContentInner
+        aria-labelledby={titleId}
+        className={className}
+        onPressEscape={onPressEscape}
+        {...props}
+      >
         <MessageDialogContentInner
           title={title}
           titleId={titleId}

--- a/src/components/Dialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialogContentInner.tsx
@@ -23,7 +23,7 @@ export type BaseProps = {
   /**
    * Label of close button.
    */
-  closeText: React.ReactNode
+  closeText?: React.ReactNode
 }
 
 export type MessageDialogContentInnerProps = BaseProps & {
@@ -38,7 +38,7 @@ export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
   subtitle,
   titleId,
   description,
-  closeText,
+  closeText = '閉じる',
   onClickClose,
 }) => {
   const classNames = useClassNames().dialog


### PR DESCRIPTION
デザインシステムに則り、ActionDialog と MessageDialog に良いデフォルトを作ります。
ダイアログの挙動をプロダクト間で少しでも近づけたいと考えています。
https://smarthr.design/products/components/dialog/

- ActionDialog も MessageDialog も共に Escape キーを押した場合はデフォルトで閉じるボタンと同等にします
- ActionDialog のデフォルト theme は `primary` にします
- ActionDialog の閉じるボタンラベルはデフォルト「キャンセル」にします
- MessageDialog の閉じるボタンラベルはデフォルト「閉じる」にします