### PR TITLE
refactor: Heading の内部実装を Text で置き換え

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,8 +1,10 @@
-import React, { HTMLAttributes, ReactNode, VFC } from 'react'
-import styled, { css } from 'styled-components'
+import React, { HTMLAttributes, ReactNode, VFC, useMemo } from 'react'
+import styled from 'styled-components'
 
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
+
+import { Text } from '../Text'
+import { TextProps } from '../Text/Text'
 
 export type Props = {
   /** 表示するテキスト */
@@ -22,71 +24,60 @@ export type HeadingTypes =
   | 'subBlockTitle'
   | 'subSubBlockTitle'
 
-export type HeadingTagTypes = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span'
+export type HeadingTagTypes = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'legend'
 
-type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>
+type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props | keyof TextProps>
 
 export const Heading: VFC<Props & ElementProps> = ({
   tag = 'h1',
   type = 'screenTitle',
   className = '',
-  children,
   ...props
 }) => {
-  const theme = useTheme()
   const classNames = useClassNames()
+  const textProps = useMemo<TextProps>(() => {
+    switch (type) {
+      case 'screenTitle':
+        return {
+          size: 'XL',
+          weight: 'normal',
+        }
+      case 'sectionTitle':
+        return {
+          size: 'L',
+          weight: 'normal',
+        }
+      case 'blockTitle':
+        return {
+          size: 'M',
+          weight: 'bold',
+        }
+      case 'subBlockTitle':
+        return {
+          size: 'M',
+          weight: 'bold',
+          color: 'TEXT_GREY',
+        }
+      case 'subSubBlockTitle':
+        return {
+          size: 'S',
+          weight: 'bold',
+          color: 'TEXT_GREY',
+        }
+    }
+  }, [type])
 
   return (
-    <Wrapper
-      as={tag}
-      {...props}
+    <ResetText
+      forwardedAs={tag}
+      leading="TIGHT"
       className={`${type} ${className} ${classNames.wrapper}`}
-      themes={theme}
-    >
-      {children}
-    </Wrapper>
+      {...props}
+      {...textProps}
+    />
   )
 }
 
-const Wrapper = styled.h1<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color, fontSize } = themes
-
-    return css`
-      display: block;
-      margin: 0;
-      padding: 0;
-      line-height: 1;
-
-      &.screenTitle {
-        color: ${color.TEXT_BLACK};
-        font-size: ${fontSize.XL};
-        font-weight: normal;
-      }
-
-      &.sectionTitle {
-        color: ${color.TEXT_BLACK};
-        font-size: ${fontSize.L};
-        font-weight: normal;
-      }
-
-      &.blockTitle {
-        color: ${color.TEXT_BLACK};
-        font-size: ${fontSize.M};
-        font-weight: bold;
-      }
-
-      &.subBlockTitle {
-        color: ${color.TEXT_GREY};
-        font-size: ${fontSize.M};
-        font-weight: bold;
-      }
-
-      &.subSubBlockTitle {
-        color: ${color.TEXT_GREY};
-        font-size: ${fontSize.S};
-        font-weight: bold;
-      }
-    `
-  }}
+const ResetText = styled(Text)`
+  margin: unset;
 `

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import { FontSizes } from '../../themes/createFontSize'
 import { TextColors } from '../../themes/createColor'
 import { Leadings } from '../../themes/createLeading'
 
-type TextProps = {
+export type TextProps = {
   size?: FontSizes
   weight?: CSSProperties['fontWeight']
   italic?: boolean


### PR DESCRIPTION
## Overview

Heading の実装を Text で置き換えました。
`line-height: 1` から `leading.TIGHT` に変わっています。デフォルト `leading.TIGHT` は `line-height: 1.25` と同等です（reg-suit の差分はすべてこれ）。

また `<fieldset />` 内の `<legend />` として使いたいこともあるので `HeadingTagTypes` に `legend` を追加しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `TextProps` が必要だったので `Text` から export
- `type` と styled-components で書いていたスタイリングを `Text` に置き換え