### PR TITLE
fix: ライブラリの動作に必要ない jest-environment-jsdom を devDependencies に移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "SmartHR-UI Team",
   "dependencies": {
     "dayjs": "^1.11.2",
-    "jest-environment-jsdom": "^28.1.0",
     "lodash.merge": "^4.6.2",
     "lodash.range": "^3.2.0",
     "polished": "^4.2.2",
@@ -42,6 +41,7 @@
     "http-server": "^14.1.0",
     "husky": "^8.0.1",
     "jest": "^28.1.0",
+    "jest-environment-jsdom": "^28.1.0",
     "jest-styled-components": "^7.0.8",
     "lint-staged": "^12.4.1",
     "memory-fs": "^0.5.0",


### PR DESCRIPTION
## Related URL

- #2466

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

SmartHR UI v20 から v21 にあげたところ、テスト関連のライブラリまでインストールされるようになりました。

#2466 で `jest-environment-jsodom` を `dependencies` に追加したのが原因のようです。ライブラリを動かすためには必要のないパッケージなので、 `devDependencies` に配置するのが適切かと思いました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `jest-environment-jsdom` を `dependencies` から `devDependencies` に移動

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

N/A

<!--
Please attach a capture if it looks different.
-->
