### PR TITLE
fix: CheckBox と RadioButton で static className があたってしまうのを修正

### DIFF
--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -70,11 +70,13 @@ const Box = styled.span<{ themes: Theme }>`
       box-sizing: border-box;
       pointer-events: none;
 
+      /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input:checked + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
       }
 
+      /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input[disabled] + && {
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -70,12 +70,12 @@ const Box = styled.span<{ themes: Theme }>`
       box-sizing: border-box;
       pointer-events: none;
 
-      input:checked + & {
+      input:checked + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
       }
 
-      input[disabled] + & {
+      input[disabled] + && {
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};
       }

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -60,6 +60,7 @@ const Box = styled.span<{ themes: Theme }>`
       background-color: ${color.WHITE};
       box-sizing: border-box;
 
+      /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input:checked + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
@@ -78,6 +79,7 @@ const Box = styled.span<{ themes: Theme }>`
         }
       }
 
+      /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input[disabled] + && {
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -60,7 +60,7 @@ const Box = styled.span<{ themes: Theme }>`
       background-color: ${color.WHITE};
       box-sizing: border-box;
 
-      input:checked + & {
+      input:checked + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
 
@@ -78,7 +78,7 @@ const Box = styled.span<{ themes: Theme }>`
         }
       }
 
-      input[disabled] + & {
+      input[disabled] + && {
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};
         cursor: not-allowed;


### PR DESCRIPTION
## Overview

CheckBox と RadioButton の一部スタイルが dynamic className ではなく static className があたってしまっていたので応急処置。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`&` を `&&` に変更（なぜか dynamic className）になってくれる。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->