### PR TITLE
refactor: 不要になったresolutions指定の削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,9 +146,6 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "@types/react": "^18.0.9",
-    "@babel/helper-compilation-targets": "^7.18.2",
-    "@emotion/core": "^10.3.1",
-    "@emotion/styled-base": "^10.3.0",
-    "emotion-theming": "^10.3.0"
+    "@babel/helper-compilation-targets": "^7.18.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,7 +2165,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.20", "@emotion/core@^10.3.1":
+"@emotion/core@^10.0.20":
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.3.1.tgz#4021b6d8b33b3304d48b0bb478485e7d7421c69d"
   integrity sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==
@@ -2231,7 +2231,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
 
-"@emotion/styled-base@^10.0.27", "@emotion/styled-base@^10.3.0":
+"@emotion/styled-base@^10.0.27":
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.3.0.tgz#9aa2c946100f78b47316e4bc6048321afa6d4e36"
   integrity sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==
@@ -7926,7 +7926,7 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-emotion-theming@^10.0.19, emotion-theming@^10.3.0:
+emotion-theming@^10.0.19:
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.3.0.tgz#7f84d7099581d7ffe808aab5cd870e30843db72a"
   integrity sha512-mXiD2Oj7N9b6+h/dC6oLf9hwxbtKHQjoIqtodEyL8CpkN4F3V4IK/BT4D0C7zSs4BBFOu4UlPJbvvBLa88SGEA==


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-566

## Overview

Storybookがv6.5.x系にアップグレードされ、React v18対応のために指定していたemotionのバージョン固定が不要になったため除去します。

## What I did

- `package.json`の`resolutions`から以下のライブラリを除去
  - `"@emotion/core": "^10.3.1"`
  - `"@emotion/styled-base"`
  - `"emotion-theming"`

## Capture
