### PR TITLE
fix: ドロップダウンのフォーカス制御の修正

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -100,14 +100,11 @@ export const Dropdown: VFC<Props> = ({ children }) => {
           },
           onClickCloser: () => {
             setActive(false)
-            // wait to re-render
-            requestAnimationFrame(() => {
-              // return focus to the Trigger
-              const trigger = getFirstTabbable(triggerElementRef)
-              if (trigger) {
-                trigger.focus()
-              }
-            })
+            // return focus to the Trigger
+            const trigger = getFirstTabbable(triggerElementRef)
+            if (trigger) {
+              trigger.focus()
+            }
           },
           DropdownContentRoot,
           contentId,

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -68,7 +68,7 @@ export const DropdownContentInner: VFC<Props> = ({
     }
   }, [isActive])
 
-  useKeyboardNavigation(wrapperRef)
+  useKeyboardNavigation(wrapperRef, focusTargetRef)
 
   return (
     <Wrapper

--- a/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/src/components/Dropdown/useKeyboardNavigation.ts
@@ -4,7 +4,10 @@ import { tabbable } from '../../libs/tabbable'
 import { DropdownContext } from './Dropdown'
 import { getFirstTabbable } from './dropdownHelper'
 
-export function useKeyboardNavigation(wrapperRef: RefObject<HTMLDivElement>) {
+export function useKeyboardNavigation(
+  wrapperRef: RefObject<HTMLDivElement>,
+  dummyFocusRef: RefObject<HTMLElement>,
+) {
   const { triggerElementRef, rootTriggerRef, onClickCloser } = useContext(DropdownContext)
 
   const handleKeyDown = useCallback(
@@ -36,7 +39,10 @@ export function useKeyboardNavigation(wrapperRef: RefObject<HTMLDivElement>) {
           e.preventDefault()
           firstTabbable.focus()
           return
-        } else if (e.shiftKey && e.target === firstTabbable) {
+        } else if (
+          e.shiftKey &&
+          (e.target === firstTabbable || e.target === dummyFocusRef.current)
+        ) {
           // focus the Trigger
           e.preventDefault()
           trigger.focus()
@@ -71,7 +77,7 @@ export function useKeyboardNavigation(wrapperRef: RefObject<HTMLDivElement>) {
         }
       }
     },
-    [wrapperRef, triggerElementRef, rootTriggerRef, onClickCloser],
+    [wrapperRef, triggerElementRef, rootTriggerRef, dummyFocusRef, onClickCloser],
   )
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown)

--- a/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/src/components/Dropdown/useKeyboardNavigation.ts
@@ -64,6 +64,11 @@ export function useKeyboardNavigation(
           }
         }
 
+        if (e.target && e.target === dummyFocusRef.current) {
+          onClickCloser()
+          return
+        }
+
         if (wrapperRef.current) {
           const tabbablesInContent = tabbable(wrapperRef.current)
           tabbablesInContent.some((inner) => {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
ドロップダウンのフォーカス制御で確認されている以下の問題を解決します。
- ダイアログを開く処理とドロップダウンを閉じる処理を同時に行うと、ドロップダウンのトリガにフォーカスを戻す処理が勝ってフォーカスがダイアログ内に移動しない
- ドロップダウンを開いた直後ダミー要素がフォーカスされている状態で Shift + Tab を押下したとき、フォーカスがトリガに戻らない
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- ドロップダウンのトリガにフォーカスを戻す処理を `requestAnimationFrame` で遅らせていたのを削除
- フォーカス制御において、ダミー要素のフォーカス考慮を追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
