### PR TITLE
fix: 色の型を変数から生成する

### DIFF
--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -1,37 +1,6 @@
 import { merge } from '../libs/lodash'
 import { darken, rgba, transparentize } from 'polished'
 
-// Allow deviations from the JavaScript naming convention to match SmartHR design guidelines
-type Palette = {
-  TEXT_BLACK: string
-  TEXT_WHITE: string
-  TEXT_GREY: string
-  TEXT_DISABLED: string
-  TEXT_LINK: string
-  WHITE: string
-  BORDER: string
-  ACTION_BACKGROUND: string
-  BACKGROUND: string
-  COLUMN: string
-  OVER_BACKGROUND: string
-  HEAD: string
-  BASE_GREY: string
-  MAIN: string
-  DANGER: string
-  WARNING: string
-  SCRIM: string
-  OVERLAY: string
-  BRAND: string
-  OUTLINE: string
-}
-
-export type ColorProperty = Partial<Palette>
-
-export type CreatedColorTheme = Palette & {
-  hoverColor: (value: string, darkenAmount?: 0.05 | 0.15) => string
-  disableColor: (value: string) => string
-}
-
 export type TextColors = 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
 
 const BLACK = '#030302' // hwb(56, 17, 1)
@@ -82,7 +51,14 @@ const semanticTokens = {
   BRAND: primitiveTokens.SMARTHR_BLUE,
 }
 
-export const defaultColor = { ...semanticTokens, ...greyScale, ...transparencyScale }
+export const defaultColor = { ...semanticTokens, ...greyScale }
+
+type Palette = typeof defaultColor
+export type ColorProperty = Partial<Palette>
+export type CreatedColorTheme = Palette & {
+  hoverColor: (value: string, darkenAmount?: 0.05 | 0.15) => string
+  disableColor: (value: string) => string
+}
 
 export const createColor = (userColor: ColorProperty = {}) => {
   const created: CreatedColorTheme = merge(


### PR DESCRIPTION
https://github.com/kufu/smarthr-ui/pull/2447 で灰色のデザイントークンを足したが、型情報に追加が漏れていた。

- theme として展開する色のオブジェクトから型定義を生成するように変更
- theme から TRANSPARENCY_n を参照できなくて良いので削除