### PR TITLE
fix: ボタンコンポーネントに ref を渡せるように修正

### DIFF
--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -1,4 +1,4 @@
-import React, { AnchorHTMLAttributes, VFC } from 'react'
+import React, { AnchorHTMLAttributes, forwardRef, useImperativeHandle, useRef } from 'react'
 
 import { BaseProps } from './types'
 import { useClassNames } from './useClassNames'
@@ -7,32 +7,43 @@ import { ButtonInner } from './ButtonInner'
 
 type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
 
-export const AnchorButton: VFC<BaseProps & ElementProps> = ({
-  size = 'default',
-  square = false,
-  prefix,
-  suffix,
-  wide = false,
-  variant = 'secondary',
-  className = '',
-  children,
-  ...props
-}) => {
-  const classNames = useClassNames().anchorButton
+export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementProps>(
+  (
+    {
+      size = 'default',
+      square = false,
+      prefix,
+      suffix,
+      wide = false,
+      variant = 'secondary',
+      className = '',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const anchorRef = useRef<HTMLAnchorElement>(null)
+    useImperativeHandle<HTMLAnchorElement | null, HTMLAnchorElement | null>(
+      ref,
+      () => anchorRef.current,
+    )
+    const classNames = useClassNames().anchorButton
 
-  return (
-    <ButtonWrapper
-      {...props}
-      size={size}
-      square={square}
-      wide={wide}
-      variant={variant}
-      className={`${className} ${classNames.wrapper}`}
-      isAnchor
-    >
-      <ButtonInner prefix={prefix} suffix={suffix}>
-        {children}
-      </ButtonInner>
-    </ButtonWrapper>
-  )
-}
+    return (
+      <ButtonWrapper
+        {...props}
+        size={size}
+        square={square}
+        wide={wide}
+        variant={variant}
+        className={`${className} ${classNames.wrapper}`}
+        isAnchor
+        anchorRef={anchorRef}
+      >
+        <ButtonInner prefix={prefix} suffix={suffix}>
+          {children}
+        </ButtonInner>
+      </ButtonWrapper>
+    )
+  },
+)

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, VFC } from 'react'
+import React, { ButtonHTMLAttributes, forwardRef, useImperativeHandle, useRef } from 'react'
 
 import { BaseProps } from './types'
 import { useClassNames } from './useClassNames'
@@ -7,31 +7,42 @@ import { ButtonInner } from './ButtonInner'
 
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
 
-export const Button: VFC<BaseProps & ElementProps> = ({
-  size = 'default',
-  square = false,
-  prefix,
-  suffix,
-  wide = false,
-  variant = 'secondary',
-  className = '',
-  children,
-  ...props
-}) => {
-  const classNames = useClassNames().button
+export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
+  (
+    {
+      size = 'default',
+      square = false,
+      prefix,
+      suffix,
+      wide = false,
+      variant = 'secondary',
+      className = '',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const buttonRef = useRef<HTMLButtonElement>(null)
+    useImperativeHandle<HTMLButtonElement | null, HTMLButtonElement | null>(
+      ref,
+      () => buttonRef.current,
+    )
+    const classNames = useClassNames().button
 
-  return (
-    <ButtonWrapper
-      {...props}
-      size={size}
-      square={square}
-      wide={wide}
-      variant={variant}
-      className={`${className} ${classNames.wrapper}`}
-    >
-      <ButtonInner prefix={prefix} suffix={suffix}>
-        {children}
-      </ButtonInner>
-    </ButtonWrapper>
-  )
-}
+    return (
+      <ButtonWrapper
+        {...props}
+        size={size}
+        square={square}
+        wide={wide}
+        variant={variant}
+        className={`${className} ${classNames.wrapper}`}
+        buttonRef={buttonRef}
+      >
+        <ButtonInner prefix={prefix} suffix={suffix}>
+          {children}
+        </ButtonInner>
+      </ButtonWrapper>
+    )
+  },
+)

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -1,32 +1,40 @@
-import React, { ReactNode, useMemo } from 'react'
+import React, { ReactNode, RefObject, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Variant } from './types'
 
-type Props = {
+type BaseProps = {
   size: 'default' | 's'
   square: boolean
   wide: boolean
   variant: Variant
   className: string
   children: ReactNode
-  isAnchor?: boolean
 }
+
+type Props =
+  | (BaseProps & {
+      isAnchor?: never
+      buttonRef?: RefObject<HTMLButtonElement>
+    })
+  | (BaseProps & {
+      isAnchor: true
+      anchorRef?: RefObject<HTMLAnchorElement>
+    })
 type StyleProps = Pick<Props, 'wide' | 'variant'> & { themes: Theme }
 
-export function ButtonWrapper<T extends Props>({ size, square, className, isAnchor, ...props }: T) {
+export function ButtonWrapper({ size, square, className, ...props }: Props) {
   const theme = useTheme()
   const buttonClassName = useMemo(
     () => `${size} ${className} ${square ? 'square' : ''}`,
     [className, size, square],
   )
-
-  return isAnchor ? (
-    <Anchor {...props} className={buttonClassName} themes={theme} />
+  return props.isAnchor ? (
+    <Anchor {...props} className={buttonClassName} ref={props.anchorRef} themes={theme} />
   ) : (
-    <Button {...props} className={buttonClassName} themes={theme} />
+    <Button {...props} className={buttonClassName} ref={props.buttonRef} themes={theme} />
   )
 }
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Button`, `AnchorButton` に `ref` を渡せるように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Button`, `AnchorButton` を `forwardRef()` で wrap
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
