### PR TITLE
fix: `Button` コンポーネントをデフォルトで `type=button` にする

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -10,6 +10,7 @@ type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProp
 export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
   (
     {
+      type = 'button',
       size = 'default',
       square = false,
       prefix,
@@ -32,6 +33,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
     return (
       <ButtonWrapper
         {...props}
+        type={type}
         size={size}
         square={square}
         wide={wide}

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -1,4 +1,10 @@
-import React, { ReactNode, RefObject, useMemo } from 'react'
+import React, {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactNode,
+  RefObject,
+  useMemo,
+} from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -14,15 +20,18 @@ type BaseProps = {
   children: ReactNode
 }
 
+type ButtonProps = BaseProps & {
+  isAnchor?: never
+  buttonRef?: RefObject<HTMLButtonElement>
+}
+type AnchorProps = BaseProps & {
+  isAnchor: true
+  anchorRef?: RefObject<HTMLAnchorElement>
+}
 type Props =
-  | (BaseProps & {
-      isAnchor?: never
-      buttonRef?: RefObject<HTMLButtonElement>
-    })
-  | (BaseProps & {
-      isAnchor: true
-      anchorRef?: RefObject<HTMLAnchorElement>
-    })
+  | (ButtonProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonProps>)
+  | (AnchorProps & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof AnchorProps>)
+
 type StyleProps = Pick<Props, 'wide' | 'variant'> & { themes: Theme }
 
 export function ButtonWrapper({ size, square, className, ...props }: Props) {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Button` コンポーネント追加時に、`type` のデフォルトが `button` になっていなかったのを修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Button` の `type` のデフォルト値を `button` に修正
- 適切な型に修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
