### PR TITLE
fix: React 18 以降であれば ID 生成に `React.useId` を使うように変更

### DIFF
--- a/e2e/components/ComboBox/MultiComboBox.test.ts
+++ b/e2e/components/ComboBox/MultiComboBox.test.ts
@@ -6,10 +6,12 @@ fixture('MultiComboBox')
     await t.maximizeWindow()
   })
 
+const elementWithId = Selector((id) => document.getElementById(id))
+
 test('アイテムの選択と選択解除ができること', async (t) => {
   const combobox = Selector('[data-test=multi-combobox-default]')
   const textbox = combobox.find('input[type=text]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-owns')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-owns'))
   const selectedItems = combobox.find('.smarthr-ui-MultiComboBox-selectedItem')
 
   await t
@@ -32,7 +34,7 @@ test('アイテムの選択と選択解除ができること', async (t) => {
 
 test('リストボックスが開閉できること', async (t) => {
   const combobox = Selector('[data-test=multi-combobox-default]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-owns')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-owns'))
 
   await t
     // コンボボックスをクリックするとリストボックスが表示されること
@@ -59,7 +61,7 @@ test('リストボックスが開閉できること', async (t) => {
 
 test('コンボボックスがフォーカスされていない時に選択解除ボタンを押下してもリストボックスが表示されないこと', async (t) => {
   const combobox = Selector('[data-test=multi-combobox-default]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-owns')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-owns'))
   const selectedItems = combobox.find('.smarthr-ui-MultiComboBox-selectedItem')
 
   await t
@@ -77,7 +79,7 @@ test('コンボボックスがフォーカスされていない時に選択解�
 test('新しいアイテムを追加できること', async (t) => {
   const combobox = Selector('[data-test=multi-combobox-creatable]')
   const textbox = combobox.find('input[type=text]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-owns')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-owns'))
   const addButton = listbox.find('.smarthr-ui-MultiComboBox-addButton')
   const selectedItems = combobox.find('.smarthr-ui-MultiComboBox-selectedItem')
 
@@ -100,9 +102,9 @@ test('新しいアイテムを追加できること', async (t) => {
 
 test('disabled なコンボボックスではアイテムの選択と選択解除ができないこと', async (t) => {
   const normal = Selector('[data-test=multi-combobox-default]')
-  const normalListbox = Selector(`#${await normal.getAttribute('aria-owns')}`)
+  const normalListbox = elementWithId(await normal.getAttribute('aria-owns'))
   const disabled = Selector('[data-test=multi-combobox-disabled]')
-  const disabledListbox = Selector(`#${await disabled.getAttribute('aria-owns')}`)
+  const disabledListbox = elementWithId(await disabled.getAttribute('aria-owns'))
   const disabledSelectedItems = disabled.find('.smarthr-ui-MultiComboBox-selectedItem')
 
   await t

--- a/e2e/components/ComboBox/SingleComboBox.test.ts
+++ b/e2e/components/ComboBox/SingleComboBox.test.ts
@@ -6,10 +6,12 @@ fixture('SingleComboBox')
     await t.maximizeWindow()
   })
 
+const elementWithId = Selector((id) => document.getElementById(id))
+
 test('アイテムの選択と選択解除ができること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
   const textbox = combobox.find('input[type=text]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-controls')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
   const clearButton = combobox.find('.smarthr-ui-SingleComboBox-clearButton')
 
   await t
@@ -32,7 +34,7 @@ test('アイテムの選択と選択解除ができること', async (t) => {
 
 test('リストボックスが開閉できること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-controls')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
 
   await t
     // コンボボックスをクリックするとリストボックスが表示されること
@@ -59,8 +61,7 @@ test('リストボックスが開閉できること', async (t) => {
 
 test('コンボボックスがフォーカスされていない時に選択解除ボタンを押下してもリストボックスが表示されないこと', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
-  const textbox = combobox.find('input[type=text]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-controls')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
   const clearButton = combobox.find('.smarthr-ui-SingleComboBox-clearButton')
 
   await t
@@ -78,7 +79,7 @@ test('コンボボックスがフォーカスされていない時に選択解�
 test('新しいアイテムを追加できること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-creatable]')
   const textbox = combobox.find('input[type=text]')
-  const listbox = Selector(`#${await combobox.getAttribute('aria-controls')}`)
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
   const addButton = listbox.find('.smarthr-ui-SingleComboBox-addButton')
   const clearButton = combobox.find('.smarthr-ui-SingleComboBox-clearButton')
 
@@ -103,9 +104,9 @@ test('新しいアイテムを追加できること', async (t) => {
 
 test('disabled なコンボボックスではアイテムの選択と選択解除ができないこと', async (t) => {
   const normal = Selector('[data-test=single-combobox-default]')
-  const normalListbox = Selector(`#${await normal.getAttribute('aria-controls')}`)
+  const normalListbox = elementWithId(await normal.getAttribute('aria-controls'))
   const disabled = Selector('[data-test=single-combobox-disabled]')
-  const disabledListbox = Selector(`#${await disabled.getAttribute('aria-controls')}`)
+  const disabledListbox = elementWithId(await disabled.getAttribute('aria-controls'))
 
   await t
     // disabled なコンボボックスをクリックしてもリストボックスは表示されないこと

--- a/e2e/components/DatePicker.test.ts
+++ b/e2e/components/DatePicker.test.ts
@@ -1,6 +1,8 @@
 import { Selector } from 'testcafe'
 const dayjs = require('dayjs')
 
+const elementWithId = Selector((id) => document.getElementById(id))
+
 fixture('DatePicker')
   .page('http://localhost:6006/iframe.html?id=datepicker--all&viewMode=story')
   .beforeEach(async (t) => {
@@ -13,7 +15,7 @@ test('カレンダーから日付が選択できること', async (t) => {
     .click(input)
     // コントロール下の Calendar コンポーネントで日付をクリック
     .click(
-      Selector(`#${await input.getAttribute('aria-controls')}`)
+      elementWithId(await input.getAttribute('aria-controls'))
         .find('.smarthr-ui-CalendarTable-dataCell')
         .withText('3')
         .find('button'),
@@ -22,7 +24,7 @@ test('カレンダーから日付が選択できること', async (t) => {
     .expect(input.value)
     .eql(dayjs().date(3).format('YYYY/MM/DD'))
     // 選択後はカレンダーが閉じる確認
-    .expect(Selector(`#${await input.getAttribute('aria-controls')}`).exists)
+    .expect(elementWithId(await input.getAttribute('aria-controls')).exists)
     .notOk()
 })
 
@@ -41,7 +43,7 @@ test('テキストボックスフォーカス後に Tab キーを押すとカレ
     .click(input)
     .pressKey('tab')
     .expect(
-      Selector(`#${await input.getAttribute('aria-controls')}`).find(
+      elementWithId(await input.getAttribute('aria-controls')).find(
         '.smarthr-ui-Calendar-selectingYear',
       ).focused,
     )
@@ -52,9 +54,9 @@ test('カレンダー展開後にカレンダー外をクリックするとカ�
   const input = Selector('[data-test=datepicker-1]')
   await t
     .click(input)
-    .expect(Selector(`#${await input.getAttribute('aria-controls')}`).exists)
+    .expect(elementWithId(await input.getAttribute('aria-controls')).exists)
     .ok()
     .click('body')
-    .expect(Selector(`#${await input.getAttribute('aria-controls')}`).exists)
+    .expect(elementWithId(await input.getAttribute('aria-controls')).exists)
     .notOk()
 })

--- a/src/hooks/useId.tsx
+++ b/src/hooks/useId.tsx
@@ -12,17 +12,17 @@ const defaultContext: IdContextValue = {
 
 const IdContext = createContext<IdContextValue>(defaultContext)
 
+function useId_OLD(defaultId?: string) {
+  const context = useContext(IdContext)
+  return useMemo(
+    () => defaultId || `id-${context.prefix}-${++context.current}`,
+    [defaultId, context],
+  )
+}
+
 export const useId =
   // React v18 以降は React.useId を使う
-  'useId' in React
-    ? React.useId
-    : (defaultId?: string) => {
-        const context = useContext(IdContext)
-        return useMemo(
-          () => defaultId || `id-${context.prefix}-${++context.current}`,
-          [defaultId, context],
-        )
-      }
+  'useId' in React ? React.useId : useId_OLD
 
 export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {
   const context = useContext(IdContext)

--- a/src/hooks/useId.tsx
+++ b/src/hooks/useId.tsx
@@ -12,21 +12,17 @@ const defaultContext: IdContextValue = {
 
 const IdContext = createContext<IdContextValue>(defaultContext)
 
-export function useId(defaultId?: string) {
-  // React バージョンによって使うフックを切り替えるためルールを抑止
-  /* eslint-disable react-hooks/rules-of-hooks */
-  if ('useId' in React) {
-    // React v18 以降は React.useId を使う
-    return defaultId || React.useId()
-  }
-
-  const context = useContext(IdContext)
-  return useMemo(
-    () => defaultId || `id-${context.prefix}-${++context.current}`,
-    [defaultId, context],
-  )
-  /* eslint-enable */
-}
+export const useId =
+  // React v18 以降は React.useId を使う
+  'useId' in React
+    ? React.useId
+    : (defaultId?: string) => {
+        const context = useContext(IdContext)
+        return useMemo(
+          () => defaultId || `id-${context.prefix}-${++context.current}`,
+          [defaultId, context],
+        )
+      }
 
 export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {
   const context = useContext(IdContext)

--- a/src/hooks/useId.tsx
+++ b/src/hooks/useId.tsx
@@ -13,11 +13,19 @@ const defaultContext: IdContextValue = {
 const IdContext = createContext<IdContextValue>(defaultContext)
 
 export function useId(defaultId?: string) {
+  // React バージョンによって使うフックを切り替えるためルールを抑止
+  /* eslint-disable react-hooks/rules-of-hooks */
+  if ('useId' in React) {
+    // React v18 以降は React.useId を使う
+    return defaultId || React.useId()
+  }
+
   const context = useContext(IdContext)
   return useMemo(
     () => defaultId || `id-${context.prefix}-${++context.current}`,
     [defaultId, context],
   )
+  /* eslint-enable */
 }
 
 export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
id 生成用のフックとして独自で実装を持っている `useId` は、React 18 以降の環境では適切に動作しないと思われるほか、Strict モード時の SSR においてサーバとクライアントの id がずれる問題があるため、可能であれば `React.useId` を使うように変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- React 18 以降なら `React.userId` を使うように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
