### PR TITLE
chore: 要素のデフォルト属性を渡せるようにする (SHRUI-510)

### DIFF
--- a/src/components/Dropdown/DropdownContent.tsx
+++ b/src/components/Dropdown/DropdownContent.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 
 import { DropdownContext } from './Dropdown'
-import { DropdownContentInner } from './DropdownContentInner'
+import { DropdownContentInner, ElementProps as InnerElementProps } from './DropdownContentInner'
 import { useClassNames } from './useClassNames'
 
 export const DropdownContentContext = React.createContext<{
@@ -29,11 +29,14 @@ type Props = {
   children?: React.ReactNode
 }
 
-export const DropdownContent: React.VFC<Props> = ({
+type ElementProps = Omit<InnerElementProps, keyof Props>
+
+export const DropdownContent: React.VFC<Props & ElementProps> = ({
   controllable = false,
   scrollable = true,
   className = '',
   children,
+  ...props
 }) => {
   const { DropdownContentRoot, triggerRect, onClickCloser } = useContext(DropdownContext)
   const classNames = useClassNames()
@@ -42,6 +45,7 @@ export const DropdownContent: React.VFC<Props> = ({
     <DropdownContentRoot>
       <DropdownContentContext.Provider value={{ onClickCloser, controllable, scrollable }}>
         <DropdownContentInner
+          {...props}
           triggerRect={triggerRect}
           scrollable={scrollable}
           className={`${className} ${classNames.content}`}

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { VFC, createContext, useLayoutEffect, useRef, useState } from 'react'
+import React, { HTMLAttributes, VFC, createContext, useLayoutEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -15,6 +15,8 @@ type Props = {
   controllable: boolean
 }
 
+export type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+
 type DropdownContentInnerContextType = {
   maxHeight: string
 }
@@ -23,12 +25,13 @@ export const DropdownContentInnerContext = createContext<DropdownContentInnerCon
   maxHeight: '',
 })
 
-export const DropdownContentInner: VFC<Props> = ({
+export const DropdownContentInner: VFC<Props & ElementProps> = ({
   triggerRect,
   scrollable,
   children,
   className,
   controllable,
+  ...props
 }) => {
   const theme = useTheme()
   const [isActive, setIsActive] = useState(false)
@@ -72,6 +75,7 @@ export const DropdownContentInner: VFC<Props> = ({
 
   return (
     <Wrapper
+      {...props}
       ref={wrapperRef}
       contentBox={contentBox}
       className={`${className} ${isActive ? 'active' : ''}`}

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -5,6 +5,7 @@ import { useId } from '../../hooks/useId'
 import { StatusLabel } from '../StatusLabel'
 import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
+import { useClassNames } from './useClassNames'
 
 type innerMarginType = 'XXS' | 'XS' | 'S'
 type Props = {
@@ -50,16 +51,17 @@ export const FormGroup: VFC<Props & ElementProps> = ({
   const disabledClass = disabled ? 'disabled' : ''
   const managedLabelId = useId(labelId)
   const isRoleGroup = props.role === 'group'
+  const classNames = useClassNames()
 
   return (
     <Wrapper
       {...props}
-      className={`${className} ${disabledClass}`}
+      className={`${className} ${disabledClass} ${classNames.wrapper}`}
       themes={theme}
       aria-labelledby={isRoleGroup ? managedLabelId : undefined}
     >
-      <TitleWrapper>
-        <label htmlFor={htmlFor} id={managedLabelId}>
+      <TitleWrapper className={classNames.title}>
+        <label htmlFor={htmlFor} id={managedLabelId} className={classNames.label}>
           <Title tag="span" type={titleType} themes={theme} className={disabledClass}>
             {title}
           </Title>
@@ -73,12 +75,16 @@ export const FormGroup: VFC<Props & ElementProps> = ({
         )}
       </TitleWrapper>
 
-      {helpMessage && <HelpMessage themes={theme}>{helpMessage}</HelpMessage>}
+      {helpMessage && (
+        <HelpMessage themes={theme} className={classNames.helpMessage}>
+          {helpMessage}
+        </HelpMessage>
+      )}
 
       {errorMessages &&
         (typeof errorMessages === 'string' ? [errorMessages] : errorMessages).map(
           (message, index) => (
-            <ErrorMessage themes={theme} key={index}>
+            <ErrorMessage themes={theme} key={index} className={classNames.errorMessage}>
               <ErrorIcon
                 color={disabled ? theme.color.TEXT_DISABLED : theme.color.DANGER}
                 themes={theme}
@@ -87,7 +93,7 @@ export const FormGroup: VFC<Props & ElementProps> = ({
             </ErrorMessage>
           ),
         )}
-      <Body themes={theme} margin={innerMargin}>
+      <Body themes={theme} margin={innerMargin} className={classNames.body}>
         {children}
       </Body>
     </Wrapper>

--- a/src/components/FormGroup/useClassNames.ts
+++ b/src/components/FormGroup/useClassNames.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react'
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+
+import { FormGroup } from './'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator(FormGroup.displayName || 'FormGroup')
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+      title: generate('title'),
+      label: generate('label'),
+      helpMessage: generate('helpMessage'),
+      errorMessage: generate('errorMessage'),
+      body: generate('body'),
+    }),
+    [generate],
+  )
+}

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, VFC, useRef, useState } from 'react'
+import React, { InputHTMLAttributes, VFC, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Button } from '../Button'
@@ -22,7 +22,7 @@ export type Props = {
   /** ファイルリストを表示するかどうか */
   hasFileList?: boolean
 }
-type ElementProps = Omit<ComponentProps<'input'>, keyof Props>
+type ElementProps = Omit<InputHTMLAttributes<HTMLInputElement>, keyof Props>
 
 export const InputFile: VFC<Props & ElementProps> = ({
   className = '',

--- a/src/components/SideNav/SideNav.tsx
+++ b/src/components/SideNav/SideNav.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, VFC } from 'react'
+import React, { ComponentProps, HTMLAttributes, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -17,13 +17,20 @@ type Props = {
   /** コンポーネントに適用するクラス名 */
   className?: string
 }
+type ElementProps = Omit<HTMLAttributes<HTMLUListElement>, keyof Props>
 
-export const SideNav: VFC<Props> = ({ items, size = 'default', onClick, className = '' }) => {
+export const SideNav: VFC<Props & ElementProps> = ({
+  items,
+  size = 'default',
+  onClick,
+  className = '',
+  ...props
+}) => {
   const theme = useTheme()
   const classNames = useClassNames()
 
   return (
-    <Wrapper themes={theme} className={`${className} ${classNames.wrapper}`}>
+    <Wrapper {...props} themes={theme} className={`${className} ${classNames.wrapper}`}>
       {items.map((item) => (
         <SideNavItem
           id={item.id}


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-510
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
各コンポーネントのうち、wrapper の要素のデフォルト属性を渡せないものについて、渡せるように変更します。
また、エスケープハッチが付いていないコンポーネントにエスケープハッチを付与します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- デフォルト属性を渡せるようにする
  - Dropdown
  - InputFile
  - SideNav
- エスケープハッチ追加
  - FormGroup
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
