### PR TITLE
fix: `Select` 内部のテキスト上端が見きれないように修正 (SHRUI-569)

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -111,15 +111,13 @@ export function Select<T extends string>({
 const Wrapper = styled.div<{
   $width: string
   themes: Theme
-}>(({ $width, theme: { border, radius, spacingByChar } }) => {
+}>(({ $width, theme: { border, spacingByChar } }) => {
   return css`
     display: flex;
     box-sizing: border-box;
     position: relative;
     width: ${$width};
     min-height: calc(1rem + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
-    border: ${border.shorthand};
-    border-radius: ${radius.m};
   `
 })
 const SelectBox = styled.select<{
@@ -127,14 +125,14 @@ const SelectBox = styled.select<{
   themes: Theme
 }>`
   ${({ error, themes }) => {
-    const { color, fontSize, radius, shadow, spacingByChar } = themes
+    const { border, color, fontSize, radius, shadow, spacingByChar } = themes
 
     return css`
       appearance: none;
       cursor: pointer;
       outline: none;
       border-radius: ${radius.m};
-      border: none;
+      border: ${border.shorthand};
       background-color: ${color.WHITE};
       padding-right: ${spacingByChar(2)};
       padding-left: ${spacingByChar(0.5)};

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -65,7 +65,7 @@ export function Select<T extends string>({
   const classNames = useClassNames()
 
   return (
-    <Wrapper className={`${className} ${classNames.wrapper}`} $width={widthStyle}>
+    <Wrapper className={`${className} ${classNames.wrapper}`} $width={widthStyle} themes={theme}>
       <SelectBox
         onChange={handleChange}
         aria-invalid={error || undefined}
@@ -108,11 +108,18 @@ export function Select<T extends string>({
   )
 }
 
-const Wrapper = styled.div<{ $width: string }>(({ $width }) => {
+const Wrapper = styled.div<{
+  $width: string
+  themes: Theme
+}>(({ $width, theme: { border, radius, spacingByChar } }) => {
   return css`
+    display: flex;
     box-sizing: border-box;
     position: relative;
     width: ${$width};
+    min-height: calc(1rem + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
+    border: ${border.shorthand};
+    border-radius: ${radius.m};
   `
 })
 const SelectBox = styled.select<{
@@ -120,21 +127,19 @@ const SelectBox = styled.select<{
   themes: Theme
 }>`
   ${({ error, themes }) => {
-    const { border, color, fontSize, leading, radius, shadow, spacingByChar } = themes
+    const { color, fontSize, radius, shadow, spacingByChar } = themes
 
     return css`
       appearance: none;
       cursor: pointer;
       outline: none;
       border-radius: ${radius.m};
-      border: ${border.shorthand};
+      border: none;
       background-color: ${color.WHITE};
-      padding: ${spacingByChar(0.75)};
       padding-right: ${spacingByChar(2)};
       padding-left: ${spacingByChar(0.5)};
       font-size: ${fontSize.M};
       color: ${color.TEXT_BLACK};
-      line-height: ${leading.NONE};
       width: 100%;
 
       ${error &&


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-569
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`Select` コンポーネント内部のテキストの上端（特に半濁点）が見切れてしまうのを修正します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- select 要素に対する padding 指定だと内部テキストが見切れてしまうため、wrapper 側でコンポーネントの高さを制御するように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/270422/172762845-7aee602f-5a90-42c1-816c-0c0683730771.png) | ![image](https://user-images.githubusercontent.com/270422/172762802-3f80e6a3-1d69-429e-9126-7fbcce5017b5.png) |
<!--
Please attach a capture if it looks different.
-->
