### PR TITLE
test: ReactDOM.reander を createRoot に切り替え

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -58,7 +58,9 @@ module.exports = {
   // globalTeardown: null,
 
   // A set of global variables that need to be available in all test environments
-  // globals: {},
+  globals: {
+    IS_REACT_ACT_ENVIRONMENT: true,
+  },
 
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [

--- a/src/components/Base/__test__/index.test.tsx
+++ b/src/components/Base/__test__/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
 
 import { Base } from '../Base'
 
@@ -14,12 +15,13 @@ describe('Base', () => {
   })
   it('should render given children', () => {
     const hello = 'hello'
-    ReactDOM.render(
-      <Base>
-        <p>{hello}</p>
-      </Base>,
-      container,
-    )
+    act(() => {
+      createRoot(container).render(
+        <Base>
+          <p>{hello}</p>
+        </Base>,
+      )
+    })
 
     expect(document.querySelectorAll('p')).toHaveLength(1)
     expect(document.querySelector('p')!.textContent).toBe(hello)

--- a/src/components/FlashMessage/FlashMessage.test.tsx
+++ b/src/components/FlashMessage/FlashMessage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
 import { FlashMessage } from './FlashMessage'
 
 describe('FlashMessage', () => {
@@ -12,27 +13,29 @@ describe('FlashMessage', () => {
     document.body.removeChild(container)
   })
   it('should render if prop visible is true', () => {
-    ReactDOM.render(
-      <FlashMessage type="success" text="flash!!" onClose={jest.fn()} visible={true} />,
-      container,
-    )
+    act(() => {
+      createRoot(container).render(
+        <FlashMessage type="success" text="flash!!" onClose={jest.fn()} visible={true} />,
+      )
+    })
     expect(container.textContent).toEqual(expect.stringContaining('flash!!'))
   })
   it('should not render if prop visible is false', () => {
-    ReactDOM.render(
-      <FlashMessage type="success" text="flash!!" onClose={jest.fn()} visible={false} />,
-      container,
-    )
+    act(() => {
+      createRoot(container).render(
+        <FlashMessage type="success" text="flash!!" onClose={jest.fn()} visible={false} />,
+      )
+    })
     expect(container.textContent).toEqual(expect.not.stringContaining('flash!!'))
   })
 
   it('should call onClose on click close button', () => {
     const spy = jest.fn()
-    ReactDOM.render(
-      <FlashMessage type="success" text="flash!!" onClose={spy} visible={true} />,
-      container,
-    )
-
+    act(() => {
+      createRoot(container).render(
+        <FlashMessage type="success" text="flash!!" onClose={spy} visible={true} />,
+      )
+    })
     document.querySelector<HTMLButtonElement>('button.close')!.click()
 
     expect(spy).toHaveBeenCalled()

--- a/src/components/StatusLabel/StatusLabel.test.tsx
+++ b/src/components/StatusLabel/StatusLabel.test.tsx
@@ -1,6 +1,7 @@
 import { create } from 'react-test-renderer'
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
 
 import { StatusLabel } from './StatusLabel'
 
@@ -19,7 +20,9 @@ describe('StatusLabel', () => {
     expect(testRenderer.toJSON()).toMatchSnapshot()
   })
   it('should render given children', () => {
-    ReactDOM.render(<StatusLabel type="success">{hello}</StatusLabel>, container)
+    act(() => {
+      createRoot(container).render(<StatusLabel type="success">{hello}</StatusLabel>)
+    })
     expect(container.textContent).toBe(hello)
   })
   it('should have given type', () => {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
React 18 以降は `ReactDOM.reander()` は `createRoot()` への置き換えが推奨されるため、テストで使っている部分を置き換えます。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `ReactDOM.reander()` を `createRoot` に置き換え
  - `act()` を使うためにテスト環境のフラグを有効化（[参考](https://ja.reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#configuring-your-testing-environment)）
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
