### PR TITLE
fix: `InformationPanel` の props と要素のデフォルト属性が重複しないように修正

### DIFF
--- a/src/components/InformationPanel/InformationPanel.stories.tsx
+++ b/src/components/InformationPanel/InformationPanel.stories.tsx
@@ -21,7 +21,7 @@ export const All: Story = () => (
       借り換え直前の残高3,000万円、借り換え後の借入額2,900万円の場合→借り換え後の借入額が少ないので「借り換え後の借入額の方が少ない・同じ」を選択
     </InformationPanel>
     <InformationPanel
-      title="賃金支払対象期間"
+      title={<span>賃金支払対象期間</span>}
       titleTag="h4"
       type="success"
       openButtonLabel="開く"

--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -41,7 +41,7 @@ type Props = {
   onClickTrigger?: (active: boolean) => void
 }
 
-export const InformationPanel: VFC<Props & BaseElementProps> = ({
+export const InformationPanel: VFC<Props & Omit<BaseElementProps, keyof Props>> = ({
   title,
   titleTag = 'h3',
   type,


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状 `InformationPanel` において、`title` props に JSX を渡そうとするとエラーになる問題を解消します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Props` と `BaseElementProps` の交差型によって意図しない型になってしまっているため、適切に Omit するように修正
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
