### PR TITLE
feat: spacingByChar の alias として space を追加｜SHRUI-568

### DIFF
--- a/src/themes/__tests__/createTheme.ts
+++ b/src/themes/__tests__/createTheme.ts
@@ -545,4 +545,9 @@ describe('createTheme', () => {
     expect(actual.radius.s).toBe('dummy_s')
     expect(actual.radius.m).toBe('dummy_radius_m')
   })
+
+  it('returns theme "space" is the same as "spacingByChar"', () => {
+    const { space, spacingByChar } = createTheme()
+    expect(space).toEqual(spacingByChar)
+  })
 })

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -93,7 +93,7 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     shadow: createShadow(theme.shadow),
     zIndex: createZIndex(theme.zIndex),
   }
-  return created
+  return { ...created, space: created.spacingByChar }
 }
 
 function getPaletteProperty(theme: ThemeProperty): PaletteProperty {

--- a/src/themes/createTheme.ts
+++ b/src/themes/createTheme.ts
@@ -61,6 +61,7 @@ export interface CreatedTheme {
   leading: CreatedLeading
   spacing: CreatedSpacingTheme
   spacingByChar: CreatedSpacingByCharTheme
+  space: CreatedSpacingByCharTheme
   breakpoint: CreatedBreakpointTheme
   /**
    * @deprecated The frame property will be deprecated, please use border or radius property instead
@@ -73,17 +74,19 @@ export interface CreatedTheme {
   zIndex: CreatedZindexTheme
 }
 
-export const createTheme = (theme: ThemeProperty = {}) => {
+export const createTheme = (theme: ThemeProperty = {}): CreatedTheme => {
   const paletteProperty = getPaletteProperty(theme)
   const colorProperty = getColorProperty(theme)
   const baseSize = getSpacingProperty(theme).baseSize
-  const created: CreatedTheme = {
+  const spacingByChar = createSpacingByChar(baseSize)
+  return {
     palette: createPalette(paletteProperty),
     color: createColor(colorProperty),
     size: createSize(getSizeProperty(theme)),
     fontSize: createFontSize(getFontSizeProperty(theme)),
     spacing: createSpacing(baseSize),
-    spacingByChar: createSpacingByChar(baseSize),
+    spacingByChar,
+    space: spacingByChar,
     leading: createLeading(getLeadingProperty(theme)),
     breakpoint: createBreakpoint(getBreakpointProperty(theme)),
     frame: createFrame(getFrameProperty(theme), paletteProperty),
@@ -93,7 +96,6 @@ export const createTheme = (theme: ThemeProperty = {}) => {
     shadow: createShadow(theme.shadow),
     zIndex: createZIndex(theme.zIndex),
   }
-  return { ...created, space: created.spacingByChar }
 }
 
 function getPaletteProperty(theme: ThemeProperty): PaletteProperty {


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-568

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- 新フォントサイズを利用している場合 `spacing` では余白の表現が足りない
- `spacingByChar` の利用を推奨しているが、頻繁に使う値の割に長く可読性が悪い
- `theme.space()` の形で使えるように alias を追加
