### PR TITLE
fix: ボタンの displayName を明示的に設定

### DIFF
--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -47,3 +47,5 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementPro
     )
   },
 )
+// BottomFixedArea での判定に用いるために displayName を明示的に設定する
+AnchorButton.displayName = 'AnchorButton'

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,3 +48,5 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
     )
   },
 )
+// BottomFixedArea での判定に用いるために displayName を明示的に設定する
+Button.displayName = 'Button'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`BottomFixedArea` の Props 判定に用いるボタンコンポーネントの `displayName` の設定が漏れていたので、設定します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `Button`, `AnchorButton` コンポーネントの `displayName` を明示的に設定
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
