### PR TITLE
fix: コンボボックスの部分的レンダリングが効かなくなっているのを修正

### DIFF
--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -236,11 +236,14 @@ export function useListBox<T>({
     [isDisplayingPartial],
   )
   useEffect(() => {
-    // IntersectionObserver を設定
-    if (!bottomIntersectionRef.current) {
-      return
-    }
-    scrollObserver.observe(bottomIntersectionRef.current)
+    // bottomIntersection のレンダリングを待つ
+    setTimeout(() => {
+      // IntersectionObserver を設定
+      if (!bottomIntersectionRef.current) {
+        return
+      }
+      scrollObserver.observe(bottomIntersectionRef.current)
+    })
     return () => scrollObserver.disconnect()
   }, [scrollObserver])
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
現状、コンボボックスのリストボックスにおける、アイテム数が多い場合の部分的レンダリングが動かなくなっているのを修正します。

原因は、useEffect 外の document の参照を廃した（#2539）ことで、該当箇所のレンダリングが遅れて IntersectionObserver の登録がうまく行かなくなっているためだと思われます。

### 確認方法
コンボボックスの両ストーリーの下の方にある「アイテムが多い時」のコンボボックスで、スクロールにより100個目以上のアイテムが表示できること

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- IntersectionObserver の登録タイミングを遅らせる
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
