### PR TITLE
feat: Textarea が自動で広がるように機能追加

### DIFF
--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { Textarea } from './Textarea'
 
 import readme from './README.md'
+import { Stack } from '../Layout'
 
 export default {
   title: 'Textarea',
@@ -23,28 +24,46 @@ export const All: Story = () => {
   return (
     <List>
       <li>
-        <Txt>normal</Txt>
-        <Textarea />
+        <Label>
+          標準
+          <Textarea />
+        </Label>
       </li>
       <li>
-        <Txt>width</Txt>
-        <Textarea width="100%" />
+        <Label>
+          入力欄を自動で広げる（初期： 3行、最大： 10行）
+          <Textarea cols={35} rows={3} maxRows={10} autoGrowable />
+        </Label>
       </li>
       <li>
-        <Txt>disabled</Txt>
-        <Textarea disabled={true} />
+        <Label>
+          幅指定
+          <Textarea width="100%" />
+        </Label>
       </li>
       <li>
-        <Txt>error</Txt>
-        <Textarea error={true} />
+        <Label>
+          disabled
+          <Textarea disabled={true} />
+        </Label>
       </li>
       <li>
-        <Txt>maxLength (defaultValue)</Txt>
-        <Textarea maxLength={140} defaultValue="message👌" />
+        <Label>
+          エラー時
+          <Textarea error={true} />
+        </Label>
       </li>
       <li>
-        <Txt>maxLength (value)</Txt>
-        <Textarea maxLength={140} value={value} onChange={onChangeValue} />
+        <Label>
+          最大文字数 (defaultValue)
+          <Textarea maxLength={140} defaultValue="message👌" />
+        </Label>
+      </li>
+      <li>
+        <Label>
+          最大文字数 (value)
+          <Textarea maxLength={140} value={value} onChange={onChangeValue} />
+        </Label>
       </li>
     </List>
   )
@@ -52,14 +71,8 @@ export const All: Story = () => {
 
 All.storyName = 'all'
 
-const List = styled.ul`
+const List = styled(Stack).attrs({ as: 'ul', gap: 1.5 })`
   padding: 0 24px;
   list-style: none;
-
-  & > li:not(:first-child) {
-    margin-top: 16px;
-  }
 `
-const Txt = styled.p`
-  margin: 0 0 8px;
-`
+const Label = styled(Stack).attrs({ as: 'label', gap: 0.25, align: 'flex-start' })``

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -32,7 +32,7 @@ export const All: Story = () => {
       <li>
         <Label>
           入力欄を自動で広げる（初期： 3行、最大： 10行）
-          <Textarea cols={35} rows={3} maxRows={10} autoGrowable />
+          <Textarea cols={35} rows={3} maxRows={10} autoResize />
         </Label>
       </li>
       <li>

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -14,7 +14,7 @@ type Props = {
   /** 自動でフォーカスされるかどうか */
   autoFocus?: boolean
   /** 自動で広がるかどうか */
-  autoGrowable?: boolean
+  autoResize?: boolean
   /** 最大行数。超えるとスクロールする。初期値は無限 */
   maxRows?: number
   /** 行数の初期値。省略した場合は2 */
@@ -40,7 +40,7 @@ export const Textarea: VFC<Props & ElementProps> = ({
   maxLength,
   width,
   className = '',
-  autoGrowable = false,
+  autoResize = false,
   maxRows = Infinity,
   rows = 2,
   onInput,
@@ -64,7 +64,7 @@ export const Textarea: VFC<Props & ElementProps> = ({
   }, [])
   const handleInput = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      if (!autoGrowable) {
+      if (!autoResize) {
         return onInput && onInput(e)
       }
 
@@ -86,7 +86,7 @@ export const Textarea: VFC<Props & ElementProps> = ({
       setInterimRows(currentRows < maxRows ? currentRows : maxRows)
       onInput && onInput(e)
     },
-    [autoGrowable, maxRows, onInput, rows, theme.leading.NORMAL],
+    [autoResize, maxRows, onInput, rows, theme.leading.NORMAL],
   )
 
   const classNames = useClassNames()


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Textarea がコンテンツの量に依って、縦方向に自動的に広がると良さそうだったので機能を加えました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- autoGrowable を追加
- autoGrowable がある場合は rows や maxRows に依って高さを動的に変える
  - rows の初期値は 2（HTML 仕様に則る
  - maxRows の初期値は Infinity
- アクセシビリティ観点でも問題がないことを確認
  - rows を直接編集しているが HTML の仕様的に特に問題はない
  - macOS の VoiceOver で確認したが問題なし
  - アクセシビリティエキスパートによるレビューも問題なし

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
