### PR TITLE
feat: Select にサイズ小を追加

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import { Select } from './Select'
+import { Stack } from '../Layout'
 
 import readme from './README.md'
 
@@ -17,146 +18,115 @@ export default {
   },
 }
 
+const options = [
+  { label: '高齢任意加入被保険者', value: 'apple' },
+  { label: 'Orange', value: 'orange' },
+  { label: '評価業務担当者', value: 'banana' },
+  { label: '書類に記載する従業員・扶養家族', value: 'melon', disabled: true },
+]
+
 export const All: Story = () => (
   <List>
     <li>
-      <Text>default</Text>
-      <Select
-        options={[
-          { label: 'Apple', value: 'apple' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Banana', value: 'banana' },
-          { label: 'Melon', value: 'melon', disabled: true },
-        ]}
-      />
+      <Text>
+        <span>標準</span>
+        <Select options={options} />
+      </Text>
     </li>
     <li>
-      <Text>value</Text>
-      <Select
-        value="orange"
-        options={[
-          { label: 'Apple', value: 'apple' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Banana', value: 'banana' },
-        ]}
-      />
+      <Text>
+        <span>サイズ小</span>
+        <Select options={options} size="s" />
+      </Text>
     </li>
     <li>
-      <Text>error</Text>
-      <Select
-        error
-        options={[
-          { label: 'Apple', value: 'apple' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Banana', value: 'banana' },
-        ]}
-      />
+      <Text>
+        <span>value 指定</span>
+        <Select value="orange" options={options} />
+      </Text>
     </li>
     <li>
-      <Text>disabled</Text>
-      <Select
-        disabled
-        options={[
-          { label: 'Apple', value: 'apple' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Banana', value: 'banana' },
-        ]}
-      />
+      <Text>
+        <span>エラー状態</span>
+        <Select error options={options} />
+      </Text>
     </li>
     <li>
-      <Text>placeholder</Text>
-      <Select
-        value=""
-        options={[
-          { label: 'Select fruit', value: '' },
-          { label: 'Apple', value: 'apple' },
-          { label: 'Orange', value: 'orange' },
-          { label: 'Banana', value: 'banana' },
-        ]}
-      />
+      <Text>
+        <span>disabled 状態</span>
+        <Select disabled options={options} />
+      </Text>
     </li>
     <li>
-      <Text>optgroup</Text>
-      <Select
-        value="orange"
-        options={[
-          { label: 'Select fruit', value: '' },
-          { label: 'Apple', value: 'apple' },
-          {
-            label: 'citrus',
-            options: [
-              { label: 'Orange', value: 'orange' },
-              { label: 'Lemon', value: 'lemon' },
-              { label: 'Grapefruit', value: 'grapefruit' },
-            ],
-          },
-          { label: 'Banana', value: 'banana' },
-          {
-            label: 'Fruit vegetables',
-            disabled: true,
-            options: [
-              { label: 'Strawberry', value: 'strawberry' },
-              { label: 'Melon', value: 'melon' },
-              { label: 'Water melon', value: 'water melon' },
-            ],
-          },
-        ]}
-      />
+      <Text>
+        <span>選択肢グループ要素の使用</span>
+        <Select
+          value="orange"
+          options={[
+            { label: 'Select fruit', value: '' },
+            { label: 'Apple', value: 'apple' },
+            {
+              label: 'citrus',
+              options: [
+                { label: 'Orange', value: 'orange' },
+                { label: 'Lemon', value: 'lemon' },
+                { label: 'Grapefruit', value: 'grapefruit' },
+              ],
+            },
+            { label: 'Banana', value: 'banana' },
+            {
+              label: 'Fruit vegetables',
+              disabled: true,
+              options: [
+                { label: 'Strawberry', value: 'strawberry' },
+                { label: 'Melon', value: 'melon' },
+                { label: 'Water melon', value: 'water melon' },
+              ],
+            },
+          ]}
+        />
+      </Text>
     </li>
     <li>
-      <Text>width</Text>
-      <Select
-        width="100%"
-        options={[
-          { label: 'apple', value: 'apple' },
-          { label: 'orange', value: 'orange' },
-          { label: 'banana', value: 'banana' },
-        ]}
-      />
+      <Text>
+        <span>幅指定</span>
+        <Select width="100%" options={options} />
+      </Text>
     </li>
     <li>
-      <Text>hasBlank</Text>
-      <Select
-        hasBlank
-        options={[
-          { label: 'apple', value: 'apple' },
-          { label: 'orange', value: 'orange' },
-          { label: 'banana', value: 'banana' },
-        ]}
-      />
+      <Text>
+        <span>空の選択肢を表示</span>
+        <Select hasBlank options={options} />
+      </Text>
     </li>
     <li>
-      <Text>onChange</Text>
-      <Select
-        onChange={action('onChange!!')}
-        onChangeValue={action('onChangeValue')}
-        options={[
-          { label: 'apple', value: 'apple' },
-          { label: 'orange', value: 'orange' },
-          { label: 'banana', value: 'banana' },
-          {
-            label: 'Fruit vegetables',
-            options: [
-              { label: 'Strawberry', value: 'strawberry' },
-              { label: 'Melon', value: 'melon' },
-              { label: 'Water melon', value: 'water melon' },
-            ],
-          },
-        ]}
-      />
+      <Text>
+        <span>onChange</span>
+        <Select
+          onChange={action('onChange!!')}
+          onChangeValue={action('onChangeValue')}
+          options={[
+            { label: 'apple', value: 'apple' },
+            { label: 'orange', value: 'orange' },
+            { label: 'banana', value: 'banana' },
+            {
+              label: 'Fruit vegetables',
+              options: [
+                { label: 'Strawberry', value: 'strawberry' },
+                { label: 'Melon', value: 'melon' },
+                { label: 'Water melon', value: 'water melon' },
+              ],
+            },
+          ]}
+        />
+      </Text>
     </li>
   </List>
 )
 All.storyName = 'all'
 
-const List = styled.ul`
-  padding: 0 24px;
+const List = styled(Stack).attrs({ as: 'ul' })`
   list-style: none;
-
-  & > li:not(:first-child) {
-    margin-top: 16px;
-  }
+  padding: 0 24px;
 `
-const Text = styled.p`
-  margin: 0 0 8px;
-`
+const Text = styled(Stack).attrs({ as: 'label', gap: 0.5 })``

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -65,11 +65,11 @@ export function Select<T extends string>({
     },
     [onChange, onChangeValue, options],
   )
-  const classNames = useClassNames(size)
+  const classNames = useClassNames()
 
   return (
     <Wrapper
-      className={`${className} ${classNames.wrapper} ${classNames.size}`}
+      className={`${className} ${classNames.wrapper} ${generateSizeClassName(size)}`}
       $width={widthStyle}
     >
       <SelectBox
@@ -113,6 +113,8 @@ export function Select<T extends string>({
     </Wrapper>
   )
 }
+
+const generateSizeClassName = (size: Props<string>['size']) => (size === 's' ? '--small' : '')
 
 const Wrapper = styled.div<{
   $width: string

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -29,7 +29,7 @@ type Props<T extends string> = {
   /** 空の選択肢のラベル */
   blankLabel?: string
   /** コンポーネントの大きさ */
-  size?: 's'
+  size?: 'default' | 's'
 }
 
 type ElementProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, keyof Props<string> | 'children'>
@@ -42,7 +42,7 @@ export function Select<T extends string>({
   width = '16.25em',
   hasBlank = false,
   blankLabel = '選択してください',
-  size,
+  size = 'default',
   className = '',
   disabled,
   ...props

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -136,9 +136,10 @@ const SelectBox = styled.select<{
     background-color: ${color.WHITE};
     padding-inline: ${spacingByChar(0.5)} ${spacingByChar(2)};
     font-size: ${fontSize.M};
-    leading: ${leading.NONE};
+    line-height: ${leading.NONE};
     color: ${color.TEXT_BLACK};
     width: 100%;
+
     /* padding に依る積み上げでは文字が見切れてしまうため */
     min-height: calc(${fontSize.M} + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
 
@@ -165,6 +166,7 @@ const SelectBox = styled.select<{
     .--small & {
       padding-inline: ${spacingByChar(0.5)};
       font-size: ${fontSize.S};
+
       /* padding に依る積み上げでは文字が見切れてしまうため */
       min-height: calc(${fontSize.S} + ${spacingByChar(0.5)} * 2 + ${border.lineWidth} * 2);
     }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -28,9 +28,11 @@ type Props<T extends string> = {
   hasBlank?: boolean
   /** 空の選択肢のラベル */
   blankLabel?: string
+  /** コンポーネントの大きさ */
+  size?: 's'
 }
 
-type ElementProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'children'>
+type ElementProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, keyof Props<string> | 'children'>
 
 export function Select<T extends string>({
   options,
@@ -40,6 +42,7 @@ export function Select<T extends string>({
   width = '16.25em',
   hasBlank = false,
   blankLabel = '選択してください',
+  size,
   className = '',
   disabled,
   ...props
@@ -62,10 +65,13 @@ export function Select<T extends string>({
     },
     [onChange, onChangeValue, options],
   )
-  const classNames = useClassNames()
+  const classNames = useClassNames(size)
 
   return (
-    <Wrapper className={`${className} ${classNames.wrapper}`} $width={widthStyle} themes={theme}>
+    <Wrapper
+      className={`${className} ${classNames.wrapper} ${classNames.size}`}
+      $width={widthStyle}
+    >
       <SelectBox
         onChange={handleChange}
         aria-invalid={error || undefined}
@@ -110,80 +116,83 @@ export function Select<T extends string>({
 
 const Wrapper = styled.div<{
   $width: string
-  themes: Theme
-}>(({ $width, themes: { border, spacingByChar } }) => {
-  return css`
-    display: flex;
-    box-sizing: border-box;
+}>`
+  ${({ $width }) => css`
     position: relative;
+    box-sizing: border-box;
     width: ${$width};
-    min-height: calc(1rem + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
-  `
-})
+  `}
+`
 const SelectBox = styled.select<{
   error?: boolean
   themes: Theme
 }>`
-  ${({ error, themes }) => {
-    const { border, color, fontSize, radius, shadow, spacingByChar } = themes
+  ${({ error, themes: { border, color, fontSize, leading, radius, shadow, spacingByChar } }) => css`
+    appearance: none;
+    cursor: pointer;
+    outline: none;
+    border-radius: ${radius.m};
+    border: ${border.shorthand};
+    background-color: ${color.WHITE};
+    padding-inline: ${spacingByChar(0.5)} ${spacingByChar(2)};
+    font-size: ${fontSize.M};
+    leading: ${leading.NONE};
+    color: ${color.TEXT_BLACK};
+    width: 100%;
+    /* padding に依る積み上げでは文字が見切れてしまうため */
+    min-height: calc(${fontSize.M} + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
 
-    return css`
-      appearance: none;
-      cursor: pointer;
-      outline: none;
-      border-radius: ${radius.m};
-      border: ${border.shorthand};
-      background-color: ${color.WHITE};
-      padding-right: ${spacingByChar(2)};
-      padding-left: ${spacingByChar(0.5)};
-      font-size: ${fontSize.M};
-      color: ${color.TEXT_BLACK};
-      width: 100%;
+    ${error &&
+    css`
+      border-color: ${color.DANGER};
+    `}
 
-      ${error &&
-      css`
-        border-color: ${color.DANGER};
-      `}
+    &:hover {
+      background-color: ${color.hoverColor(color.WHITE)};
+    }
 
-      &:hover {
-        background-color: ${color.hoverColor(color.WHITE)};
-      }
+    &:focus-visible {
+      ${shadow.focusIndicatorStyles}
+    }
 
-      &:focus-visible {
-        ${shadow.focusIndicatorStyles}
-      }
+    &:disabled {
+      pointer-events: none;
+      opacity: 1;
+      background-color: ${color.COLUMN};
+      color: ${color.TEXT_DISABLED};
+    }
 
-      &:disabled {
-        pointer-events: none;
-        opacity: 1;
-        background-color: ${color.COLUMN};
-        color: ${color.TEXT_DISABLED};
-      }
-    `
-  }}
+    .--small & {
+      padding-inline: ${spacingByChar(0.5)};
+      font-size: ${fontSize.S};
+      /* padding に依る積み上げでは文字が見切れてしまうため */
+      min-height: calc(${fontSize.S} + ${spacingByChar(0.5)} * 2 + ${border.lineWidth} * 2);
+    }
+  `}
 `
 const IconWrap = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color, spacingByChar } = themes
+  ${({ themes: { color, fontSize, spacingByChar } }) => css`
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    right: ${spacingByChar(0.75)};
+    bottom: 0;
+    display: inline-flex;
+    align-items: center;
+    color: ${color.TEXT_GREY};
 
-    return css`
-      pointer-events: none;
-      position: absolute;
-      top: 0;
-      right: ${spacingByChar(0.75)};
-      bottom: 0;
-      display: inline-flex;
-      align-items: center;
-      color: ${color.TEXT_GREY};
+    ${SelectBox}:disabled + & {
+      color: ${color.TEXT_DISABLED};
+    }
+    ${SelectBox}:focus-visible + & {
+      color: ${color.TEXT_BLACK};
+    }
 
-      ${SelectBox}:disabled + & {
-        color: ${color.TEXT_DISABLED};
-      }
-      ${SelectBox}:focus-visible + & {
-        color: ${color.TEXT_BLACK};
-      }
-    `
-  }}
+    .--small & {
+      right: ${spacingByChar(0.5)};
+      font-size: ${fontSize.S};
+    }
+  `}
 `
 const BlankOptgroup = styled.optgroup`
   display: none;

--- a/src/components/Select/useClassNames.ts
+++ b/src/components/Select/useClassNames.ts
@@ -1,15 +1,14 @@
-import { ComponentProps, VFC, useMemo } from 'react'
+import { VFC, useMemo } from 'react'
 
 import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
 import { Select } from './Select'
 
-export const useClassNames = (size?: ComponentProps<typeof Select>['size']) => {
+export const useClassNames = () => {
   const generate = useClassNameGenerator((Select as VFC).displayName || 'Select')
   return useMemo(
     () => ({
       wrapper: generate(),
-      size: size === 's' ? '--small' : '',
     }),
-    [generate, size],
+    [generate],
   )
 }

--- a/src/components/Select/useClassNames.ts
+++ b/src/components/Select/useClassNames.ts
@@ -1,9 +1,9 @@
-import { VFC, useMemo } from 'react'
+import { ComponentProps, VFC, useMemo } from 'react'
 
 import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
 import { Select } from './Select'
 
-export const useClassNames = (size?: 's') => {
+export const useClassNames = (size?: ComponentProps<typeof Select>['size']) => {
   const generate = useClassNameGenerator((Select as VFC).displayName || 'Select')
   return useMemo(
     () => ({

--- a/src/components/Select/useClassNames.ts
+++ b/src/components/Select/useClassNames.ts
@@ -3,12 +3,13 @@ import { VFC, useMemo } from 'react'
 import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
 import { Select } from './Select'
 
-export function useClassNames() {
+export const useClassNames = (size?: 's') => {
   const generate = useClassNameGenerator((Select as VFC).displayName || 'Select')
   return useMemo(
     () => ({
       wrapper: generate(),
+      size: size === 's' ? '--small' : '',
     }),
-    [generate],
+    [generate, size],
   )
 }


### PR DESCRIPTION
## Overview

複数のプロダクトで独自実装を始めていたので作成。

select 要素に size 要素があるが、SmartHR UI では機能していないため潰す選択を取りました。
small など別のプロパティも検討しましたが、Button[size=s] などと合わせるためでもあります。

Select[size=s] は Button[size=s] と高さが揃います。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `size === 's'` の時、class に `--small` を足す
- `--small` の時のスタイルを追加
- styled-components の記述と不要なスタイリングを見直し
- Story を更新

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
