### PR TITLE
test: `TextArea` の入力欄の拡張を検証する Story の追加

### DIFF
--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -6,6 +6,7 @@ import { Textarea } from './Textarea'
 
 import readme from './README.md'
 import { Stack } from '../Layout'
+import { userEvent, within } from '@storybook/testing-library'
 
 export default {
   title: 'Textarea',
@@ -17,7 +18,7 @@ export default {
   },
 }
 
-export const All: Story = () => {
+const Template: Story = () => {
   const [value, setValue] = useState('message👌')
   const onChangeValue = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
     setValue(e.currentTarget.value)
@@ -69,7 +70,21 @@ export const All: Story = () => {
   )
 }
 
-All.storyName = 'all'
+export const All = Template.bind({})
+
+export const RegInput = Template.bind({})
+RegInput.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const notResizableTextarea = await canvas.findByLabelText('標準')
+  // デフォルトでは入力欄が広がらないことを確認する
+  await userEvent.type(notResizableTextarea, 'hoge\n'.repeat(3), { delay: 0.1 })
+
+  const resizableTextarea = await canvas.findByLabelText(
+    '入力欄を自動で広げる（初期： 3行、最大： 10行）',
+  )
+  // 11行入力し、入力欄が10行以上広がらないことを確認する
+  await userEvent.type(resizableTextarea, 'hoge\n'.repeat(11), { delay: 0.1 })
+}
 
 const List = styled(Stack).attrs({ as: 'ul', gap: 1.5 })`
   padding: 0 24px;


### PR DESCRIPTION
## Related URL

- https://github.com/kufu/smarthr-ui/pull/2598

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

上記 feat にて、 TextArea の入力欄を自動で拡張するためのオプション（`autoResize`）が追加されましたが、対応する VRT ができていなかったため、該当の Story を Play Function で実装しました。

`RegInput` story で以下の検証が出来るようにしています。

- `autoResize = false`で、TextArea が自動で拡張しないこと
- `autoResize = true`で、TextArea が自動で拡張すること

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
