### PR TITLE
chore: コンボボックスの IntersectionObserver の紐付け方法を修正

### DIFF
--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -165,10 +165,8 @@ export function useListBox<T>({
   const theme = useTheme()
   const { createPortal } = usePortal()
   const listBoxId = useId()
-  const bottomIntersectionRef = useRef<HTMLDivElement>(null)
-  const partialOptions = usePartialRendering({
+  const { items: partialOptions, renderIntersection } = usePartialRendering({
     items: options,
-    bottomIntersectionRef,
     minLength: useMemo(
       () => (activeOption === null ? 0 : options.indexOf(activeOption)) + 1,
       [activeOption, options],
@@ -230,7 +228,7 @@ export function useListBox<T>({
             )
           })
         )}
-        <div ref={bottomIntersectionRef} />
+        {renderIntersection()}
       </Container>,
     )
   }, [
@@ -247,6 +245,7 @@ export function useListBox<T>({
     listBoxRect,
     options.length,
     partialOptions,
+    renderIntersection,
     theme,
   ])
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
コンボボックスにおいて、`IntersectionObserver` の登録の方法に起因して不要な `setTimeout` が存在していたため、`IntersectionObserver` の紐付け方法を変更します。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `IntersectionObserver` を張る要素を `usePartialRendering` 内で 管理するように変更
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
