### PR TITLE
chore: return dependency version @types/jest to ^28.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@swc/core": "^1.2.208",
     "@swc/jest": "^0.2.21",
     "@testing-library/react-hooks": "^8.0.1",
-    "@types/jest": "^28.1.4",
+    "@types/jest": "^28.1.3",
     "@types/lodash.merge": "^4.6.7",
     "@types/lodash.range": "^3.2.7",
     "@types/node": "^14.18.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,10 +4400,10 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/jest@^28.1.4":
-  version "28.1.4"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.4.tgz#a11ee6c8fd0b52c19c9c18138b78bbcc201dad5a"
-  integrity sha512-telv6G5N7zRJiLcI3Rs3o+ipZ28EnE+7EvF0pSrt2pZOMnAVI/f+6/LucDxOvcBcTeTL3JMF744BbVQAVBUQRA==
+"@types/jest@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.3.tgz#52f3f3e50ce59191ff5fbb1084896cc0cf30c9ce"
+  integrity sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==
   dependencies:
     jest-matcher-utils "^28.0.0"
     pretty-format "^28.0.0"


### PR DESCRIPTION
Reverts kufu/smarthr-ui#2633

e2e が落ちるようになったので一旦 revert します。

エラーログ
```
$ testcafe chrome e2e/**/*.test.ts --host localhost --skip-js-errors
ERROR Cannot prepare tests due to the following error:
Error: TypeScript compilation failed.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (416, 62): ']' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (416, 65): ';' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (416, 70): ';' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (416, 94): ';' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (416, 95): Declaration or statement expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (420, 50): ']' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (420, 53): ';' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (420, 58): ';' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (420, 101): ';' expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (420, 102): Declaration or statement expected.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (420, 109): Declaration or statement expected.
error Command failed with exit code 1.
D:/a/smarthr-ui/smarthr-ui/node_modules/@types/jest/index.d.ts (1379, 1): Declaration or statement expected.
```

原因はこれっぽい。
https://github.com/DevExpress/testcafe/issues/6328