### PR TITLE
fix: Button[variant=secondary] の disabled に背景色を追加

### DIFF
--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -168,7 +168,7 @@ function variantStyles(variant: Variant, theme: Theme) {
         `,
         disabled: css`
           border-color: ${color.disableColor(color.BORDER)};
-          background-color: ${color.disableColor(color.WHITE)};
+          background-color: ${color.hoverColor(color.WHITE)};
           color: ${color.TEXT_DISABLED};
         `,
       }

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -55,7 +55,7 @@ export const All: Story = () => {
       </li>
       <li>
         <Txt>disabled</Txt>
-        <Input disabled={true} />
+        <Input disabled={true} defaultValue="これは disabled なテキスト" />
       </li>
       <li>
         <Txt>error</Txt>


### PR DESCRIPTION
`Button[variant=secondary]` の背景色が `disabledColor(WHITE)` となり、WHITE のままになっていた。
以前はベタ書きで別の色が当たっていたらしい。
`Input[disabled]` の背景色と合わせて `hoverColor(WHITE)` を適用した。