### PR TITLE
feat: Text にアイコンを渡せるようにする

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Story } from '@storybook/react'
 import { Text } from './Text'
+import { FaBullhornIcon, FaInfoCircleIcon } from '../Icon'
 
 import readme from './README.md'
 
@@ -40,6 +41,19 @@ export const Default: Story = () => (
         Valid
       </Text>
       な HTML になるよう注意してください。
+    </Text>
+    <Text as="h2" size="XL" leading="TIGHT">
+      &lt;With Icon&gt;
+    </Text>
+    <Text as="p">
+      任意で<Text prefixIcon={<FaBullhornIcon />}>アイコン</Text>を入れられます。
+    </Text>
+    <Text as="p" prefixIcon={<FaInfoCircleIcon />} suffixIcon={<FaInfoCircleIcon />} size="XL">
+      これは
+      <Text prefixIcon={<FaBullhornIcon size="3em" color="TEXT_GREY" />} iconGap={0.5}>
+        テスト
+      </Text>
+      です。真似しないでください。
     </Text>
   </>
 )

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -16,7 +16,7 @@ export type TextProps = {
   /** 斜体にするかどうかの真偽値（font-style: italic） */
   italic?: boolean
   /** 色。初期値は inherit（color、） */
-  color?: TextColors
+  color?: TextColors | 'inherit'
   /** 行送りの抽象値（line-height） */
   leading?: Leadings
   /** ホワイトスペース（white-space） */
@@ -93,7 +93,7 @@ const Wrapper = styled.span<
     size,
     weight = 'normal',
     italic,
-    color,
+    color = 'inherit',
     leading = 'NORMAL',
     whiteSpace,
     emphasis,
@@ -108,7 +108,7 @@ const Wrapper = styled.span<
       line-height: ${shrLeading[leading]};
       font-weight: ${emphasis ? 'bold' : weight};
       ${italic && `font-style: italic;`}
-      color: ${color ? shrColor[color] : 'inherit'};
+      color: ${color === 'inherit' ? color : shrColor[color]};
 
       ${existsIcon &&
       css`

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,43 +1,94 @@
-import React, { CSSProperties, HTMLAttributes } from 'react'
+import React, { CSSProperties, ComponentType, HTMLAttributes, ReactComponentElement } from 'react'
 import styled, { css } from 'styled-components'
 import { useTheme } from '../../hooks/useTheme'
 import { FontSizes } from '../../themes/createFontSize'
 import { TextColors } from '../../themes/createColor'
 import { Leadings } from '../../themes/createLeading'
+import { ComponentProps as IconProps } from '../Icon'
+import { AbstractSize, CharRelativeSize } from '../../themes/createSpacing'
+import { useSpacing } from '../../hooks/useSpacing'
 
 export type TextProps = {
+  /** フォントサイズの抽象値（font-size） */
   size?: FontSizes
+  /** フォントウェイト（font-weight） */
   weight?: CSSProperties['fontWeight']
+  /** 斜体にするかどうかの真偽値（font-style: italic） */
   italic?: boolean
+  /** 色。初期値は inherit（color、） */
   color?: TextColors | 'inherit'
+  /** 行送りの抽象値（line-height） */
   leading?: Leadings
+  /** ホワイトスペース（white-space） */
   whiteSpace?: CSSProperties['whiteSpace']
+  /** 強調するかどうかの真偽値。指定すると em 要素になる */
   emphasis?: boolean
+  /** テキストコンポーネントの HTML タグ名。初期値は span */
+  as?: string | ComponentType<any> | undefined
 }
-type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof TextProps>
+type WithIconProps = {
+  /** テキストの前につけるアイコン */
+  prefixIcon?: ReactComponentElement<ComponentType<IconProps>>
+  /** テキストの後ろにつけるアイコン */
+  suffixIcon?: ReactComponentElement<ComponentType<IconProps>>
+  /** テキストとアイコンの間隔 */
+  iconGap?: CharRelativeSize | AbstractSize
+}
+type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof TextProps | keyof WithIconProps>
 
 export type Props = TextProps &
+  WithIconProps &
   ElementProps & {
-    as?: string | React.ComponentType<any> | undefined
     children: React.ReactNode
   }
 
-/**
- * @param [size] フォントサイズの抽象値（font-size）
- * @param [weight] フォントウェイト（font-weight）
- * @param [italic] 斜体にするかどうかの真偽値（font-style: italic）
- * @param [color] 色。初期値は inherit（color、）
- * @param [leading] 行送りの抽象値（line-height）
- * @param [whiteSpace] ホワイトスペース（white-space）
- * @param [emphasis] 強調するかどうかの真偽値。指定すると em 要素になる
- * @param [as] テキストコンポーネントの HTML タグ名。初期値は span
- * @param [children]
- */
-export const Text: React.VFC<Props> = ({ as = 'span', ...props }) => {
-  return <Wrapper as={props.emphasis ? 'em' : as} {...props} />
-}
+/* https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements */
+const BlockLevelElement = [
+  'blockquote',
+  'details',
+  'dialog',
+  'dd',
+  'div',
+  'dl',
+  'dt',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1 , h2 , h3 , h4 , h5 , h6',
+  'header',
+  'hgroup',
+  'hr',
+  'li',
+  'main',
+  'nav',
+  'ol',
+  'p',
+  'pre',
+  'section',
+  'table',
+  'ul',
+] as const
+type BlockLevelElementType = typeof BlockLevelElement[number]
 
-const Wrapper = styled.span<TextProps>(
+export const Text: React.VFC<Props> = ({
+  as = 'span',
+  prefixIcon,
+  suffixIcon,
+  children,
+  ...props
+}) => (
+  <Wrapper {...props} as={props.emphasis ? 'em' : as} existsIcon={prefixIcon || suffixIcon}>
+    {prefixIcon && React.cloneElement(prefixIcon, { className: '--prefix' })}
+    {children}
+    {suffixIcon && React.cloneElement(suffixIcon, { className: '--suffix' })}
+  </Wrapper>
+)
+
+const Wrapper = styled.span<
+  TextProps & { existsIcon?: boolean; iconGap?: CharRelativeSize | AbstractSize }
+>(
   ({
     size = 'M',
     weight = 'normal',
@@ -46,6 +97,9 @@ const Wrapper = styled.span<TextProps>(
     leading = 'NORMAL',
     whiteSpace,
     emphasis,
+    as,
+    existsIcon = false,
+    iconGap = 0.25,
   }) => {
     const { color: shrColor, fontSize, leading: shrLeading } = useTheme()
     return css`
@@ -55,6 +109,22 @@ const Wrapper = styled.span<TextProps>(
       font-weight: ${emphasis ? 'bold' : weight};
       ${italic && `font-style: italic;`}
       color: ${color === 'inherit' ? color : shrColor[color]};
+
+      ${existsIcon &&
+      css`
+        /* ブロックレベル要素以外はインライン要素として振る舞ってほしい */
+        display: ${typeof as === 'string' && BlockLevelElement.includes(as as BlockLevelElementType)
+          ? 'flex'
+          : 'inline-flex'};
+        align-items: center;
+
+        > .--prefix {
+          margin-inline-end: ${useSpacing(iconGap)};
+        }
+        > .--suffix {
+          margin-inline-start: ${useSpacing(iconGap)};
+        }
+      `}
     `
   },
 )

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -90,7 +90,7 @@ const Wrapper = styled.span<
   TextProps & { existsIcon?: boolean; iconGap?: CharRelativeSize | AbstractSize }
 >(
   ({
-    size = 'M',
+    size,
     weight = 'normal',
     italic,
     color = 'inherit',
@@ -104,7 +104,7 @@ const Wrapper = styled.span<
     const { color: shrColor, fontSize, leading: shrLeading } = useTheme()
     return css`
       ${whiteSpace && `white-space: ${whiteSpace};`}
-      font-size: ${fontSize[size]};
+      font-size: ${size ? fontSize[size] : 'inherit'};
       line-height: ${shrLeading[leading]};
       font-weight: ${emphasis ? 'bold' : weight};
       ${italic && `font-style: italic;`}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -16,7 +16,7 @@ export type TextProps = {
   /** 斜体にするかどうかの真偽値（font-style: italic） */
   italic?: boolean
   /** 色。初期値は inherit（color、） */
-  color?: TextColors | 'inherit'
+  color?: TextColors
   /** 行送りの抽象値（line-height） */
   leading?: Leadings
   /** ホワイトスペース（white-space） */
@@ -93,7 +93,7 @@ const Wrapper = styled.span<
     size,
     weight = 'normal',
     italic,
-    color = 'inherit',
+    color,
     leading = 'NORMAL',
     whiteSpace,
     emphasis,
@@ -108,7 +108,7 @@ const Wrapper = styled.span<
       line-height: ${shrLeading[leading]};
       font-weight: ${emphasis ? 'bold' : weight};
       ${italic && `font-style: italic;`}
-      color: ${color === 'inherit' ? color : shrColor[color]};
+      color: ${color ? shrColor[color] : 'inherit'};
 
       ${existsIcon &&
       css`

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -90,7 +90,7 @@ const Wrapper = styled.span<
   TextProps & { existsIcon?: boolean; iconGap?: CharRelativeSize | AbstractSize }
 >(
   ({
-    size,
+    size = 'M',
     weight = 'normal',
     italic,
     color = 'inherit',
@@ -104,7 +104,7 @@ const Wrapper = styled.span<
     const { color: shrColor, fontSize, leading: shrLeading } = useTheme()
     return css`
       ${whiteSpace && `white-space: ${whiteSpace};`}
-      font-size: ${size ? fontSize[size] : 'inherit'};
+      font-size: ${fontSize[size]};
       line-height: ${shrLeading[leading]};
       font-weight: ${emphasis ? 'bold' : weight};
       ${italic && `font-style: italic;`}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-567

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`<TextWithIcon />` を新しく作るのは悪手に思えたので、`<Text />` を拡張しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Text に prefixIcon と suffixIcon を渡せるようにする
- テキストとアイコンの間隔を iconGap で管理できるようにする
- ~~Text の size をデフォルト `inherit` とする~~ revert しました

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
