### PR TITLE
feat: DropDownButtonのchildrenの型に `null | boolean` を追加する   SHRUI-586

### DIFF
--- a/src/components/Dropdown/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/Dropdown/DropdownButton/DropdownButton.stories.tsx
@@ -5,6 +5,8 @@ import { DropdownButton } from './DropdownButton'
 import { AnchorButton, Button } from '../../Button'
 import { Cluster } from '../../Layout'
 
+const flag = false
+
 export const Default: Story = () => (
   <Cluster align="center">
     <DropdownButton>
@@ -12,6 +14,7 @@ export const Default: Story = () => (
       <Button disabled>評価を確定</Button>
       <Button>ヒントメッセージの設定</Button>
       <AnchorButton href="#h2-2">ログアウト</AnchorButton>
+      {flag && <Button>非表示になるテキスト</Button>}
     </DropdownButton>
     <DropdownButton disabled>
       <Button>評価を開始</Button>

--- a/src/components/Dropdown/DropdownButton/DropdownButton.tsx
+++ b/src/components/Dropdown/DropdownButton/DropdownButton.tsx
@@ -14,6 +14,8 @@ type Actions = ActionItem | ActionItem[]
 type ActionItem =
   | ReactElement<ComponentProps<typeof Button>>
   | ReactElement<ComponentProps<typeof AnchorButton>>
+  | null
+  | boolean
 type Props = {
   /** 引き金となるボタンラベル。デフォルトは “その他の操作” */
   label?: string
@@ -64,9 +66,9 @@ export const DropdownButton: VFC<Props & ElementProps> = ({
       </DropdownTrigger>
       <DropdownContent>
         <ActionList themes={themes} className={classNames.panel}>
-          {React.Children.map(children, (item, i) => (
-            <li key={i}>{actionItem(item)}</li>
-          ))}
+          {React.Children.map(children, (item, i) =>
+            item && typeof item !== 'boolean' ? <li key={i}>{actionItem(item)}</li> : null,
+          )}
         </ActionList>
       </DropdownContent>
     </Dropdown>

--- a/src/components/Dropdown/DropdownButton/DropdownButton.tsx
+++ b/src/components/Dropdown/DropdownButton/DropdownButton.tsx
@@ -67,6 +67,7 @@ export const DropdownButton: VFC<Props & ElementProps> = ({
       <DropdownContent>
         <ActionList themes={themes} className={classNames.panel}>
           {React.Children.map(children, (item, i) =>
+            // MEMO: {flag && <Button/>}のような書き方に対応させるためbooleanの判定を入れています
             item && typeof item !== 'boolean' ? <li key={i}>{actionItem(item)}</li> : null,
           )}
         </ActionList>


### PR DESCRIPTION
## Related URL

[SHRUI-586](https://smarthr.atlassian.net/browse/SHRUI-586)

## Overview

DropDownButtonのchildrenはReactElementだけが許可されているため、条件分岐でnullを返したい場合などは使用することができません。
`null | boolean` を追加して、「条件によってボタンを表示しない」などの選択肢を取れるようにしたいです。

## What I did

`type ActionItem` に `null | boolean` を追加しました。

## Capture
