### PR TITLE
feat: Icon に可視テキストを渡せるようにする

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -3,10 +3,12 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import * as Icons from './Icon'
+import { Stack } from '../Layout'
+import { Text } from '../Text'
 import readme from './README.md'
 
 const icons: Array<React.ComponentType<Icons.ComponentProps>> = Object.values(Icons)
-const { FaAddressBookIcon } = Icons
+const { FaAddressBookIcon, FaBullhornIcon, FaInfoCircleIcon } = Icons
 
 export default {
   title: 'Icon',
@@ -91,6 +93,27 @@ export const Color: Story = () => (
     <FaAddressBookIcon size={40} color="WARNING" />
     <FaAddressBookIcon size={40} color="DANGER" />
   </List>
+)
+
+export const WithText: Story = () => (
+  <Stack align="flex-start">
+    <FaAddressBookIcon text="連絡帳" />
+    <FaAddressBookIcon text="連絡帳（逆位置）" right />
+    <Text as="p">
+      文中にも
+      <FaBullhornIcon text="アイコン付きテキスト" />
+      を使えます。
+    </Text>
+    <Text as="p" size="XL">
+      <FaInfoCircleIcon text="文字サイズは親要素から継承されます。" />
+      <Text size="S">
+        <FaBullhornIcon
+          text="そのため一文の中で別の文字サイズを使いたければ Text コンポーネントを入れ子にしてください。"
+          right
+        />
+      </Text>
+    </Text>
+  </Stack>
 )
 
 const IconList = styled.dl`

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import styled, { css } from 'styled-components'
 import {
   FaAddressBook,
   FaAddressCard,
@@ -308,10 +309,11 @@ import {
 } from 'react-icons/fa'
 import type { IconBaseProps, IconType } from 'react-icons'
 import Warning from './WarningIcon'
-import styled from 'styled-components'
 import { VISUALLY_HIDDEN_STYLE } from '../../constants'
 import { useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
+import { AbstractSize, CharRelativeSize } from '../../themes/createSpacing'
+import { useSpacing } from '../../hooks/useSpacing'
 
 /**
  * literal union type に補完を効かせるためのハック
@@ -357,6 +359,12 @@ export interface ComponentProps extends IconProps, ElementProps {
    * （表示はされないが、 DOM 上に存在することで意味を明示可能）
    */
   visuallyHiddenText?: string
+  /** アイコンと並べるテキスト */
+  text?: string
+  /** アイコンと並べるテキストとの溝 */
+  iconGap?: CharRelativeSize | AbstractSize
+  /** `true` のとき、アイコンを右側に表示する */
+  right?: boolean
   /**
    * コンポーネントに適用するクラス名
    */
@@ -371,6 +379,9 @@ const createIcon = (SvgIcon: IconType) => {
     visuallyHiddenText,
     'aria-hidden': ariaHidden,
     focusable = false,
+    text,
+    iconGap = 0.25,
+    right = false,
     ...props
   }) => {
     const hasLabelByAria =
@@ -388,8 +399,12 @@ const createIcon = (SvgIcon: IconType) => {
 
     const classNames = useClassNames()
 
+    const existsText = !!text
+    const Wrapper = existsText ? WithIcon : React.Fragment
+    const wrapperProps = existsText ? { gap: iconGap, right, className: classNames.withText } : {}
+
     return (
-      <>
+      <Wrapper {...wrapperProps}>
         {visuallyHiddenText && <VisuallyHiddenText>{visuallyHiddenText}</VisuallyHiddenText>}
         <SvgIcon
           color={replacedColor}
@@ -399,12 +414,25 @@ const createIcon = (SvgIcon: IconType) => {
           focusable={focusable}
           {...props}
         />
-      </>
+        {text}
+      </Wrapper>
     )
   }
   return Icon
 }
 
+const WithIcon = styled.span<{ right?: boolean; gap?: CharRelativeSize | AbstractSize }>`
+  ${({ right, gap }) => css`
+    display: inline-flex;
+    ${right && `flex-direction: row-reverse;`}
+    align-items: baseline;
+    ${gap && `column-gap: ${useSpacing(gap)};`}
+
+    .smarthr-ui-Icon {
+      align-self: center;
+    }
+  `}
+`
 const VisuallyHiddenText = styled.span`
   ${VISUALLY_HIDDEN_STYLE}
 `

--- a/src/components/Icon/useClassNames.ts
+++ b/src/components/Icon/useClassNames.ts
@@ -7,6 +7,7 @@ export function useClassNames() {
   return useMemo(
     () => ({
       wrapper: generate(),
+      withText: generate('withText'),
     }),
     [generate],
   )


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-567
- https://github.com/kufu/smarthr-ui/pull/2657

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`<Text />` の拡張ではなく、`<Icon />` を拡張して可視テキストを渡せるようにしました。
アイコンとテキストを並べたいが、折り返されたくないときに利用します。