### PR TITLE
feat: DropZone を単一ファイル選択でも使えるようにする｜SHRUI-588

### DIFF
--- a/src/components/DropZone/DropZone.stories.tsx
+++ b/src/components/DropZone/DropZone.stories.tsx
@@ -48,6 +48,11 @@ export const All: Story = () => {
           </DropZoneText>
         </DropZone>
       </li>
+
+      <li>
+        <Text>単一ファイルは任意（デフォルト複数選択可）</Text>
+        <DropZone onSelectFiles={onSelectFiles} multiple={false} />
+      </li>
     </Group>
   )
 }

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -21,6 +21,8 @@ type DropZoneProps = {
    * <b>（ドラッグ&ドロップの挙動には影響しません）</b>
    */
   accept?: string
+  /** 複数ファイルを選択できるかどうか */
+  multiple?: boolean
   children?: React.ReactNode
 }
 
@@ -33,6 +35,7 @@ export const DropZone: React.VFC<DropZoneProps & ElementProps> = ({
   children,
   onSelectFiles,
   accept,
+  multiple = true,
 }) => {
   const theme = useTheme()
   const classNames = useClassNames()
@@ -84,7 +87,7 @@ export const DropZone: React.VFC<DropZoneProps & ElementProps> = ({
       <Button prefix={<FaFolderOpenIcon />} onClick={onClickButton}>
         ファイルを選択
       </Button>
-      <input ref={fileRef} type="file" multiple accept={accept} onChange={onChange} />
+      <input ref={fileRef} type="file" multiple={multiple} accept={accept} onChange={onChange} />
     </Wrapper>
   )
 }


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-588

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DropZone の `input[type=file]` が `multiple` 固定になっている。