### PR TITLE
fix: Button と AnchorButton から不要な ref の詰め替えを消す

### DIFF
--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -1,4 +1,4 @@
-import React, { AnchorHTMLAttributes, forwardRef, useImperativeHandle, useRef } from 'react'
+import React, { AnchorHTMLAttributes, forwardRef } from 'react'
 
 import { BaseProps } from './types'
 import { useClassNames } from './useClassNames'
@@ -22,11 +22,6 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementPro
     },
     ref,
   ) => {
-    const anchorRef = useRef<HTMLAnchorElement>(null)
-    useImperativeHandle<HTMLAnchorElement | null, HTMLAnchorElement | null>(
-      ref,
-      () => anchorRef.current,
-    )
     const classNames = useClassNames().anchorButton
 
     return (
@@ -38,7 +33,7 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementPro
         variant={variant}
         className={`${className} ${classNames.wrapper}`}
         isAnchor
-        anchorRef={anchorRef}
+        anchorRef={ref}
       >
         <ButtonInner prefix={prefix} suffix={suffix}>
           {children}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, forwardRef, useImperativeHandle, useRef } from 'react'
+import React, { ButtonHTMLAttributes, forwardRef } from 'react'
 
 import { BaseProps } from './types'
 import { useClassNames } from './useClassNames'
@@ -23,11 +23,6 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
     },
     ref,
   ) => {
-    const buttonRef = useRef<HTMLButtonElement>(null)
-    useImperativeHandle<HTMLButtonElement | null, HTMLButtonElement | null>(
-      ref,
-      () => buttonRef.current,
-    )
     const classNames = useClassNames().button
 
     return (
@@ -39,7 +34,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         wide={wide}
         variant={variant}
         className={`${className} ${classNames.wrapper}`}
-        buttonRef={buttonRef}
+        buttonRef={ref}
       >
         <ButtonInner prefix={prefix} suffix={suffix}>
           {children}

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -1,6 +1,7 @@
 import React, {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
+  ForwardedRef,
   ReactNode,
   RefObject,
   useMemo,
@@ -22,11 +23,11 @@ type BaseProps = {
 
 type ButtonProps = BaseProps & {
   isAnchor?: never
-  buttonRef?: RefObject<HTMLButtonElement>
+  buttonRef?: ForwardedRef<HTMLButtonElement>
 }
 type AnchorProps = BaseProps & {
   isAnchor: true
-  anchorRef?: RefObject<HTMLAnchorElement>
+  anchorRef?: ForwardedRef<HTMLAnchorElement>
 }
 type Props =
   | (ButtonProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonProps>)

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -3,7 +3,6 @@ import React, {
   ButtonHTMLAttributes,
   ForwardedRef,
   ReactNode,
-  RefObject,
   useMemo,
 } from 'react'
 import styled, { css } from 'styled-components'


### PR DESCRIPTION
Button と AnchorButton から `useImperativeHandle` を利用した ref の詰め替えが不要そうなので消しました。