### PR TITLE
feat!: DefinitionList の description に空文字を許容させる｜SHRUI-601

### DIFF
--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -6,6 +6,7 @@ import { Heading } from '../Heading'
 import { Base } from '../Base'
 import { DefinitionList } from './DefinitionList'
 import { FaExclamationCircleIcon } from '../Icon'
+import { Text } from '../Text'
 
 export default {
   title: 'DefinitionList',
@@ -19,7 +20,7 @@ const DefinitionListItems = [
   },
   {
     term: 'term 2',
-    description: 'description 2',
+    description: '-',
   },
   {
     term: 'term 3',
@@ -31,7 +32,6 @@ const DefinitionListItems = [
   },
   {
     term: 'term 5',
-    description: 'description 5',
   },
 ]
 
@@ -39,7 +39,7 @@ const Item = () => {
   const themes = useTheme()
   return (
     <Term>
-      <span>term 2</span>
+      <span>term 7</span>
       <Alert>
         <FaExclamationCircleIcon size={11} color={themes.color.DANGER} />
         <AlertText themes={themes}>error occurred</AlertText>
@@ -49,13 +49,26 @@ const Item = () => {
 }
 
 const customizedItems = [
+  ...DefinitionListItems,
   {
-    term: 'term 1',
-    description: 'description 1',
+    term: 'term 6',
+    description: 'description 6',
   },
   {
     term: <Item />,
-    description: 'description 2',
+    description: 'description 7',
+  },
+  {
+    term: '折り返されたくない要素は nowrap',
+    description: <Text whiteSpace="nowrap">so-much-longer-email-address@example.com</Text>,
+  },
+  {
+    term: '標準は折返し',
+    description: 'so-much-longer-email-address@example.com',
+  },
+  {
+    term: 'term 9',
+    description: 'description 9',
   },
 ]
 
@@ -79,7 +92,7 @@ export const All: Story = () => {
 
       <Title type="sectionTitle">customized</Title>
       <Content>
-        <DefinitionList items={customizedItems} />
+        <DefinitionList items={customizedItems} layout="double" />
       </Content>
     </Wrapper>
   )

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -58,7 +58,7 @@ const Wrapper = styled(Cluster).attrs({ as: 'dl', gap: 1.5 })`
 `
 
 const Item = styled(DefinitionListItem)<{ themes: Theme; layout: LayoutType }>`
-  ${({ layout, theme: { space } }) => {
+  ${({ layout, themes: { space } }) => {
     const $columns = column(layout)
     return css`
       flex-basis: calc((100% - (${space(1.5)} * ${$columns - 1})) / ${$columns});

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -1,10 +1,11 @@
-import React, { HTMLAttributes, VFC } from 'react'
+import React, { FC, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
 import { DefinitionListItem, DefinitionListItemProps } from './DefinitionListItem'
+import { Cluster } from '../Layout'
 
 type LayoutType = 'single' | 'double' | 'triple'
 type Props = {
@@ -17,7 +18,7 @@ type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDListElement>, keyof Props>
 
-export const DefinitionList: VFC<Props & ElementProps> = ({
+export const DefinitionList: FC<Props & ElementProps> = ({
   items,
   layout = 'single',
   className = '',
@@ -26,7 +27,7 @@ export const DefinitionList: VFC<Props & ElementProps> = ({
   const classNames = useClassNames()
 
   return (
-    <Wrapper className={`${className} ${classNames.definitionList.wrapper}`} layout={layout}>
+    <Wrapper className={`${className} ${classNames.definitionList.wrapper}`}>
       {items.map(({ term, description, className: itemClassName }, index) => (
         <Item
           term={term}
@@ -41,81 +42,27 @@ export const DefinitionList: VFC<Props & ElementProps> = ({
   )
 }
 
-const Wrapper = styled.dl<{ layout: LayoutType }>`
-  ${({ layout }) => {
-    const baseStyle = css`
-      padding: 0;
-      margin: 0;
-    `
+const column = (layout: LayoutType) => {
+  switch (layout) {
+    case 'single':
+      return 1
+    case 'double':
+      return 2
+    case 'triple':
+      return 3
+  }
+}
 
-    const flexStyle = css`
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      align-content: flex-start;
-      flex-wrap: wrap;
-    `
-
-    switch (layout) {
-      case 'double':
-        return css`
-          ${baseStyle}
-          ${flexStyle}
-        `
-      case 'triple':
-        return css`
-          ${baseStyle}
-          ${flexStyle}
-          &::after {
-            content: '';
-            display: block;
-            flex-basis: calc(33.3333% - 12px);
-          }
-        `
-      default:
-        return css`
-          ${baseStyle}
-          display: block;
-        `
-    }
-  }}
+const Wrapper = styled(Cluster).attrs({ as: 'dl', gap: 1.5 })`
+  margin-block: initial;
 `
+
 const Item = styled(DefinitionListItem)<{ themes: Theme; layout: LayoutType }>`
-  ${({ themes: { spacingByChar }, layout }) => {
-    const basicStyle = css`
-      margin-bottom: ${spacingByChar(1.5)};
+  ${({ layout, theme: { space } }) => {
+    const $columns = column(layout)
+    return css`
+      flex-basis: calc((100% - (${space(1.5)} * ${$columns - 1})) / ${$columns});
+      flex-shrink: 1;
     `
-
-    switch (layout) {
-      case 'double':
-        return css`
-          ${basicStyle}
-          flex-basis: calc(50% - 12px);
-
-          &:last-child,
-          &:nth-last-child(2) {
-            margin-bottom: 0;
-          }
-        `
-      case 'triple':
-        return css`
-          ${basicStyle}
-          flex-basis: calc(33.3333% - 12px);
-
-          &:last-child,
-          &:nth-last-child(2),
-          &:nth-last-child(3) {
-            margin-bottom: 0;
-          }
-        `
-      default:
-        return css`
-          ${basicStyle}
-
-          &:last-child {
-            margin-bottom: 0;
-          }
-        `
-    }
   }}
 `

--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -1,62 +1,56 @@
-import React, { HTMLAttributes, ReactNode, VFC } from 'react'
+import React, { FC, HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
-import { Heading, Props as HeadingProps } from '../Heading'
+import { Text } from '../Text'
+import { Stack } from '../Layout'
 
 export type DefinitionListItemProps = {
   term: ReactNode
-  description: ReactNode
-  termTag?: HeadingProps['tag']
+  description?: ReactNode
   className?: string
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof DefinitionListItemProps>
 
-export const DefinitionListItem: VFC<DefinitionListItemProps & ElementProps> = ({
+export const DefinitionListItem: FC<DefinitionListItemProps & ElementProps> = ({
   term,
   description,
-  termTag = 'span',
   className = '',
 }) => {
   const theme = useTheme()
   const { definitionListItem } = useClassNames()
 
   return (
-    <Wrapper className={`${className} ${definitionListItem.wrapper}`} themes={theme}>
-      <dt className={definitionListItem.term}>
-        <Heading tag={termTag} type="subSubBlockTitle">
-          {term}
-        </Heading>
-      </dt>
-      <Content themes={theme} className={definitionListItem.description}>
+    <Stack gap={0.25} className={`${className} ${definitionListItem.wrapper}`}>
+      <Term className={definitionListItem.term}>{term}</Term>
+      <Description themes={theme} className={definitionListItem.description}>
         {description}
-      </Content>
-    </Wrapper>
+      </Description>
+    </Stack>
   )
 }
 
-const Wrapper = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color, spacingByChar } = themes
+const Term = styled(Text).attrs({
+  forwardedAs: 'dt',
+  size: 'S',
+  weight: 'bold',
+  color: 'TEXT_GREY',
+  leading: 'TIGHT',
+})``
 
-    return css`
-      padding-bottom: ${spacingByChar(0.25)};
-      border-bottom: 1px dotted ${color.BORDER};
-    `
-  }}
-`
-const Content = styled.dd<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { spacingByChar, fontSize, color } = themes
-
-    return css`
-      margin: ${spacingByChar(0.25)} 0 0;
-      padding: 0;
-      color: ${color.TEXT_BLACK};
-      font-size: ${fontSize.M};
-      line-height: 1.5;
-    `
-  }}
+const Description = styled(Text).attrs({
+  forwardedAs: 'dd',
+  size: 'M',
+  color: 'TEXT_BLACK',
+  leading: 'NORMAL',
+})<{ themes: Theme }>`
+  ${({ themes: { border, leading, space } }) => css`
+    margin-inline-start: initial;
+    padding-bottom: ${space(0.25)};
+    border-bottom: ${border.shorthand};
+    border-bottom-style: dotted;
+    min-height: ${leading.NORMAL}em;
+  `}
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-601

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

![image](https://user-images.githubusercontent.com/19403400/186280764-2a944362-de66-48ff-9a6c-16a9087e300e.png)

- DefinitionListItems の description は存在しない場合もあるため optional にしました
- DefinitionListItem の termTag は invalid な HTML なため削除しました
- description は空文字の場合も見た目が崩れないようにしました
- 全体的にスタイリングを見直しました
  - reg-suit の差分が出ていますが、変更後のスタイルが正です
- コンテンツは標準で折り返されるため、折り返されたくない場合の対処方法を Story に追記しました
  - resolve #2597