### PR TITLE
fix!: FloatAreaにfixed propsを追加 | SHRUI-574

### DIFF
--- a/src/components/FloatArea/FloatArea.stories.tsx
+++ b/src/components/FloatArea/FloatArea.stories.tsx
@@ -4,6 +4,9 @@ import * as React from 'react'
 import { FloatArea } from './FloatArea'
 import { Button } from '../Button'
 import { FaExclamationCircleIcon } from '../Icon'
+import { Heading } from '../Heading'
+import { Stack } from '../Layout'
+import { Base } from '../Base'
 
 export default {
   title: 'FloatArea',
@@ -11,15 +14,38 @@ export default {
 }
 
 export const All: Story = () => (
-  <FloatArea
-    primaryButton={<Button variant="primary">Submit</Button>}
-    secondaryButton={<Button>Cancel</Button>}
-    tertiaryButton={<Button>preview</Button>}
-    errorIcon={<FaExclamationCircleIcon color="DANGER" />}
-    errorText="This is the error text."
-    width="80%"
-    top={32}
-  />
+  <>
+    <Heading>書類に記載する扶養家族</Heading>
+    <FloatArea
+      primaryButton={<Button variant="primary">Submit</Button>}
+      secondaryButton={<Button>Cancel</Button>}
+      tertiaryButton={<Button>preview</Button>}
+      errorIcon={<FaExclamationCircleIcon color="DANGER" />}
+      errorText="これはfixedのFloatAreaです。"
+      top={36}
+      width="80%"
+      fixed
+    />
+    <Stack>
+      {[...Array(15)].map((_, index) => (
+        <>
+          {index === 13 && (
+            <FloatArea
+              primaryButton={<Button variant="primary">Submit</Button>}
+              secondaryButton={<Button>Cancel</Button>}
+              tertiaryButton={<Button>preview</Button>}
+              errorIcon={<FaExclamationCircleIcon color="DANGER" />}
+              errorText="これはstickyのFloatAreaです。"
+              bottom={24}
+            />
+          )}
+          <Base key={index}>
+            <p>複数の従業員項目を掛け合わせて（クロス集計）分析できる「レポート」を作成します。</p>
+          </Base>
+        </>
+      ))}
+    </Stack>
+  </>
 )
 All.storyName = 'all'
 
@@ -29,7 +55,6 @@ export const WithoutTertiary: Story = () => (
     secondaryButton={<Button>Cancel</Button>}
     errorIcon={<FaExclamationCircleIcon color="DANGER" />}
     errorText="This is the error text."
-    width="80%"
     bottom="24px"
   />
 )

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -56,7 +56,7 @@ export const FloatArea: VFC<Props & ElementProps> = ({
   errorIcon,
   fixed = false,
   className = '',
-  width = '80%',
+  width,
   ...props
 }) => {
   const theme = useTheme()
@@ -91,7 +91,7 @@ export const FloatArea: VFC<Props & ElementProps> = ({
   )
 }
 
-const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string; fixed: boolean }>`
+const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width?: string; fixed: boolean }>`
   ${({ themes: { spacingByChar }, top, bottom, $width, fixed, zIndex = 500 }) =>
     css`
       position: ${fixed ? 'fixed' : 'sticky'};
@@ -104,7 +104,10 @@ const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string;
         bottom: ${typeof bottom === 'number' ? `${bottom}px` : bottom};
       `}
       z-index: ${zIndex};
-      width: ${$width};
+      ${$width &&
+      css`
+        width: ${$width};
+      `}
       padding: ${spacingByChar(1)};
     `}
 `

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -35,6 +35,8 @@ type Props = StyleProps & {
    * エラーメッセージのアイコン（`FaExclamationCircleIcon` を指定）
    */
   errorIcon?: FunctionComponentElement<ComponentProps<typeof FaExclamationCircleIcon>>
+  /** 上下の位置を固定するかどうか */
+  fixed?: boolean
   /** コンポーネントの幅 */
   width?: string
   /** コンポーネントに適用するクラス名 */
@@ -52,6 +54,7 @@ export const FloatArea: VFC<Props & ElementProps> = ({
   tertiaryButton,
   errorText,
   errorIcon,
+  fixed = false,
   className = '',
   width = '80%',
   ...props
@@ -60,7 +63,13 @@ export const FloatArea: VFC<Props & ElementProps> = ({
   const classNames = useClassNames()
 
   return (
-    <Base themes={theme} className={`${className} ${classNames.wrapper}`} $width={width} {...props}>
+    <Base
+      themes={theme}
+      className={`${className} ${classNames.wrapper}`}
+      $width={width}
+      fixed={fixed}
+      {...props}
+    >
       <Cluster gap={1}>
         {tertiaryButton && tertiaryButton}
         <RightSide>
@@ -82,10 +91,10 @@ export const FloatArea: VFC<Props & ElementProps> = ({
   )
 }
 
-const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string }>`
-  ${({ themes: { spacingByChar }, top, bottom, $width, zIndex = 500 }) =>
+const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width: string; fixed: boolean }>`
+  ${({ themes: { spacingByChar }, top, bottom, $width, fixed, zIndex = 500 }) =>
     css`
-      position: fixed;
+      position: ${fixed ? 'fixed' : 'sticky'};
       ${exist(top) &&
       css`
         top: ${typeof top === 'number' ? `${top}px` : top};


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-574

## Overview

- FloatAreaのpositionのデフォルト値を`fixed`から`sticky`に変更
- fixedのpropsを用意した
- widthのデフォルト値(`80%`)を廃止
  - stickyで利用しにくいため