### PR TITLE
chore: renovate で yarn-deduplicate が自動実行されるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,6 @@ commands:
     steps:
       - run: yarn audit --groups dependencies
       - run: yarn lint
-      - run:
-          name: check deduplicated packages
-          command: |
-            # ここで落ちた場合は以下を実行して push してください
-            # npx yarn-deduplicate ; yarn install; git commit -m 'npx yarn-deduplicate ; yarn install' yarn.lock
-            git diff --exit-code --quiet origin/master..origin/${CIRCLE_BRANCH} yarn.lock || npx --yes yarn-deduplicate --fail
   run-npm-test:
     steps:
       - run: yarn test -w 1

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
-  "extends": [
-    "github>kufu/renovate-config"
-  ]
+  "extends": ["github>kufu/renovate-config"],
+  "npm": {
+    "postUpdateOptions": ["yarnDedupeHighest"]
+  }
 }


### PR DESCRIPTION
## Related URL

届出書類チームで実施されていた改善を取り込みました。

これまでは CircleCI で yarn-deduplicate が実行されつつ、手動で push する必要がありましたが、今後は renovate が自動的にやってくれるようになります。

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
