### PR TITLE
fix: DefinitionListItem の破線を折返しがあっても下端で揃える

### DIFF
--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -23,14 +23,21 @@ export const DefinitionListItem: FC<DefinitionListItemProps & ElementProps> = ({
   const { definitionListItem } = useClassNames()
 
   return (
-    <Stack gap={0.25} className={`${className} ${definitionListItem.wrapper}`}>
+    <Wrapper themes={theme} className={`${className} ${definitionListItem.wrapper}`}>
       <Term className={definitionListItem.term}>{term}</Term>
       <Description themes={theme} className={definitionListItem.description}>
         {description}
       </Description>
-    </Stack>
+    </Wrapper>
   )
 }
+
+const Wrapper = styled(Stack).attrs({ gap: 0.25 })<{ themes: Theme }>`
+  ${({ themes: { border } }) => css`
+    border-bottom: ${border.shorthand};
+    border-bottom-style: dotted;
+  `}
+`
 
 const Term = styled(Text).attrs({
   forwardedAs: 'dt',
@@ -46,11 +53,9 @@ const Description = styled(Text).attrs({
   color: 'TEXT_BLACK',
   leading: 'NORMAL',
 })<{ themes: Theme }>`
-  ${({ themes: { border, leading, space } }) => css`
+  ${({ themes: { leading, space } }) => css`
     margin-inline-start: initial;
     padding-bottom: ${space(0.25)};
-    border-bottom: ${border.shorthand};
-    border-bottom-style: dotted;
     min-height: ${leading.NORMAL}em;
   `}
 `


### PR DESCRIPTION
dd に対してあてていた破線を、dt + dd の親 div にあてました。
一方の dd に改行があった場合も破線が揃う仕様になります。

改行を許さない場合は nowrap を使います。

https://deploy-preview-2758--smarthr-ui.netlify.app/?path=/story/definitionlist--all