### PR TITLE
feat: add compressalt icon and expandalt icon

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -98,6 +98,7 @@ import {
   FaCommentSlash,
   FaComments,
   FaCompress,
+  FaCompressAlt,
   FaCopy,
   FaCreditCard,
   FaCube,
@@ -116,6 +117,7 @@ import {
   FaExclamationCircle,
   FaExclamationTriangle,
   FaExpand,
+  FaExpandAlt,
   FaExpandArrowsAlt,
   FaExternalLinkAlt,
   FaEye,
@@ -531,6 +533,7 @@ export const FaCommentDotsIcon = /*#__PURE__*/ createIcon(FaCommentDots)
 export const FaCommentSlashIcon = /*#__PURE__*/ createIcon(FaCommentSlash)
 export const FaCommentsIcon = /*#__PURE__*/ createIcon(FaComments)
 export const FaCompressIcon = /*#__PURE__*/ createIcon(FaCompress)
+export const FaCompressAltIcon = /*#__PURE__*/ createIcon(FaCompressAlt)
 export const FaCopyIcon = /*#__PURE__*/ createIcon(FaCopy)
 export const FaCreditCardIcon = /*#__PURE__*/ createIcon(FaCreditCard)
 export const FaCubeIcon = /*#__PURE__*/ createIcon(FaCube)
@@ -549,6 +552,7 @@ export const FaExclamationIcon = /*#__PURE__*/ createIcon(FaExclamation)
 export const FaExclamationCircleIcon = /*#__PURE__*/ createIcon(FaExclamationCircle)
 export const FaExclamationTriangleIcon = /*#__PURE__*/ createIcon(FaExclamationTriangle)
 export const FaExpandIcon = /*#__PURE__*/ createIcon(FaExpand)
+export const FaExpandAltIcon = /*#__PURE__*/ createIcon(FaExpandAlt)
 export const FaExpandArrowsAltIcon = /*#__PURE__*/ createIcon(FaExpandArrowsAlt)
 export const FaExternalLinkAltIcon = /*#__PURE__*/ createIcon(FaExternalLinkAlt)
 export const FaEyeIcon = /*#__PURE__*/ createIcon(FaEye)


### PR DESCRIPTION
## Overview

Icon に以下のアイコンを追加したい。

- FaCompressAlt
- FaExpandAlt

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Icon に以下のアイコンを追加。

- FaCompressAlt
- FaExpandAlt

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<img width="122" alt="image" src="https://user-images.githubusercontent.com/23610884/190078625-31b56c61-ef38-48e7-9e37-098ef3b76bff.png">

<img width="140" alt="image" src="https://user-images.githubusercontent.com/23610884/190078680-8f0d8cb7-2eb6-4812-9fa8-c742103b6cf2.png">


<!--
Please attach a capture if it looks different.
-->
