### PR TITLE
feat: Button に処理中の状態を追加

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -56,9 +56,6 @@ export const _Button: Story = () => {
             <Button variant="primary" disabled square onClick={action('clicked')}>
               <FaPlusCircleIcon alt="プラスボタン" />
             </Button>
-            <Button variant="primary" loading={true} onClick={action('clicked')}>
-              ボタン
-            </Button>
           </Cluster>
         </Stack>
       </dd>
@@ -73,6 +70,9 @@ export const _Button: Story = () => {
             <Button variant="primary" disabled onClick={action('clicked')}>
               ボタン
             </Button>
+            <Button variant="primary" onClick={action('clicked')} loading>
+              ボタン
+            </Button>
           </Cluster>
           <Cluster>
             <Button variant="secondary" onClick={action('clicked')}>
@@ -81,12 +81,18 @@ export const _Button: Story = () => {
             <Button variant="secondary" disabled onClick={action('clicked')}>
               ボタン
             </Button>
+            <Button variant="secondary" onClick={action('clicked')} loading>
+              ボタン
+            </Button>
           </Cluster>
           <Cluster>
             <Button variant="danger" onClick={action('clicked')}>
               ボタン
             </Button>
             <Button variant="danger" disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant="danger" onClick={action('clicked')} loading>
               ボタン
             </Button>
           </Cluster>
@@ -121,6 +127,11 @@ export const _Button: Story = () => {
           </Cluster>
           <Cluster>
             <Button variant="primary" disabled size="s" onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
+          <Cluster>
+            <Button variant="primary" disabled size="s" onClick={action('clicked')} loading>
               ボタン
             </Button>
           </Cluster>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from '@storybook/react'
-import React from 'react'
+import React, { useState } from 'react'
 import { action } from '@storybook/addon-actions'
 import styled, { css } from 'styled-components'
 
@@ -60,6 +60,25 @@ export const _Button: Story = () => {
               <FaPlusCircleIcon alt="プラスボタン" />
             </Button>
           </Cluster>
+          <Cluster>
+            <Button variant="primary" loading onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant="primary" loading prefix={<FaPlusIcon />} onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button
+              variant="primary"
+              loading
+              suffix={<FaPlusSquareIcon />}
+              onClick={action('clicked')}
+            >
+              ボタン
+            </Button>
+            <Button variant="primary" loading square onClick={action('clicked')}>
+              <FaPlusCircleIcon alt="プラスボタン" />
+            </Button>
+          </Cluster>
         </Stack>
       </dd>
 
@@ -73,9 +92,6 @@ export const _Button: Story = () => {
             <Button variant="primary" disabled onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant="primary" onClick={action('clicked')} loading>
-              ボタン
-            </Button>
           </Cluster>
           <Cluster>
             <Button variant="secondary" onClick={action('clicked')}>
@@ -84,18 +100,12 @@ export const _Button: Story = () => {
             <Button variant="secondary" disabled onClick={action('clicked')}>
               ボタン
             </Button>
-            <Button variant="secondary" onClick={action('clicked')} loading>
-              ボタン
-            </Button>
           </Cluster>
           <Cluster>
             <Button variant="danger" onClick={action('clicked')}>
               ボタン
             </Button>
             <Button variant="danger" disabled onClick={action('clicked')}>
-              ボタン
-            </Button>
-            <Button variant="danger" onClick={action('clicked')} loading>
               ボタン
             </Button>
           </Cluster>
@@ -135,6 +145,9 @@ export const _Button: Story = () => {
           </Cluster>
           <Cluster>
             <Button variant="primary" disabled size="s" onClick={action('clicked')} loading>
+              ボタン
+            </Button>
+            <Button variant="primary" square disabled size="s" onClick={action('clicked')} loading>
               ボタン
             </Button>
           </Cluster>
@@ -338,6 +351,20 @@ _ButtonAnchorControl.argTypes = {
   children: { control: 'text', defaultValue: 'ボタン' },
   prefix: { control: 'text' },
   suffix: { control: 'text' },
+}
+
+export const WithLoading: Story = (args: ButtonProps) => {
+  const [loading, setLoading] = useState(false)
+  const handleClick = () => {
+    setLoading(true)
+    setTimeout(() => setLoading(false), 1000)
+  }
+
+  return (
+    <Button {...args} prefix={<FaPlusCircleIcon />} loading={loading} onClick={handleClick}>
+      読み込み
+    </Button>
+  )
 }
 
 const Wrapper = styled.div`

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -13,6 +13,9 @@ export default {
   subcomponents: {
     AnchorButton,
   },
+  parameters: {
+    withTheming: true,
+  },
 }
 
 type ButtonProps = React.ComponentProps<typeof Button>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -56,6 +56,9 @@ export const _Button: Story = () => {
             <Button variant="primary" disabled square onClick={action('clicked')}>
               <FaPlusCircleIcon alt="プラスボタン" />
             </Button>
+            <Button variant="primary" loading={true} onClick={action('clicked')}>
+              ボタン
+            </Button>
           </Cluster>
         </Stack>
       </dd>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,6 +4,7 @@ import { BaseProps } from './types'
 import { useClassNames } from './useClassNames'
 import { ButtonWrapper } from './ButtonWrapper'
 import { ButtonInner } from './ButtonInner'
+import { Loader } from '../Loader'
 
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
 
@@ -17,13 +18,18 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
       suffix,
       wide = false,
       variant = 'secondary',
+      disabled,
       className = '',
       children,
+      loading = false,
       ...props
     },
     ref,
   ) => {
     const classNames = useClassNames().button
+
+    const actualPrefix = loading ? <Loader size="s" type="light" /> : prefix
+    const disabledOnLoading = loading || disabled
 
     return (
       <ButtonWrapper
@@ -35,8 +41,9 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         variant={variant}
         className={`${className} ${classNames.wrapper}`}
         buttonRef={ref}
+        disabled={disabledOnLoading}
       >
-        <ButtonInner prefix={prefix} suffix={suffix}>
+        <ButtonInner prefix={actualPrefix} suffix={suffix}>
           {children}
         </ButtonInner>
       </ButtonWrapper>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -29,9 +29,11 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
   ) => {
     const classNames = useClassNames().button
 
+    const loader = <Loader size="s" type="light" variant={variant} />
     const actualPrefix = !loading && prefix
-    const actualSuffix = loading ? <Loader size="s" type="light" variant={variant} /> : suffix
+    const actualSuffix = loading && !square ? loader : suffix
     const disabledOnLoading = loading || disabled
+    const actualChildren = loading && square ? loader : children
 
     return (
       <ButtonWrapper
@@ -47,7 +49,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         loading={loading}
       >
         <ButtonInner prefix={actualPrefix} suffix={actualSuffix}>
-          {children}
+          {actualChildren}
         </ButtonInner>
       </ButtonWrapper>
     )
@@ -58,6 +60,8 @@ Button.displayName = 'Button'
 
 const Loader = styled(shrLoader)<{ variant: Variant }>`
   ${({ variant, theme: { color } }) => css`
+    vertical-align: bottom;
+
     &&& {
       .s {
         width: 1em;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,11 @@
 import React, { ButtonHTMLAttributes, forwardRef } from 'react'
+import styled, { css } from 'styled-components'
 
-import { BaseProps } from './types'
+import { BaseProps, Variant } from './types'
 import { useClassNames } from './useClassNames'
 import { ButtonWrapper } from './ButtonWrapper'
 import { ButtonInner } from './ButtonInner'
-import { Loader } from '../Loader'
+import { Loader as shrLoader } from '../Loader'
 
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
 
@@ -28,7 +29,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
   ) => {
     const classNames = useClassNames().button
 
-    const actualPrefix = loading ? <Loader size="s" type="light" /> : prefix
+    const actualPrefix = loading ? <Loader size="s" type="light" variant={variant} /> : prefix
     const disabledOnLoading = loading || disabled
 
     return (
@@ -52,3 +53,20 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
 )
 // BottomFixedArea での判定に用いるために displayName を明示的に設定する
 Button.displayName = 'Button'
+
+const Loader = styled(shrLoader)<{ variant: Variant }>`
+  ${({ variant, theme: { color } }) => css`
+    &&& {
+      .s {
+        width: 1em;
+        height: 1em;
+      }
+    }
+
+    .light {
+      border-color: ${color.disableColor(
+        variant === 'secondary' ? color.TEXT_BLACK : color.TEXT_WHITE,
+      )};
+    }
+  `}
+`

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -29,7 +29,8 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
   ) => {
     const classNames = useClassNames().button
 
-    const actualPrefix = loading ? <Loader size="s" type="light" variant={variant} /> : prefix
+    const actualPrefix = !loading && prefix
+    const actualSuffix = loading ? <Loader size="s" type="light" variant={variant} /> : suffix
     const disabledOnLoading = loading || disabled
 
     return (
@@ -43,8 +44,9 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         className={`${className} ${classNames.wrapper}`}
         buttonRef={ref}
         disabled={disabledOnLoading}
+        loading={loading}
       >
-        <ButtonInner prefix={actualPrefix} suffix={suffix}>
+        <ButtonInner prefix={actualPrefix} suffix={actualSuffix}>
           {children}
         </ButtonInner>
       </ButtonWrapper>
@@ -64,9 +66,9 @@ const Loader = styled(shrLoader)<{ variant: Variant }>`
     }
 
     .light {
-      border-color: ${color.disableColor(
-        variant === 'secondary' ? color.TEXT_BLACK : color.TEXT_WHITE,
-      )};
+      border-color: ${variant === 'secondary'
+        ? color.TEXT_DISABLED
+        : color.disableColor(color.TEXT_WHITE)};
     }
   `}
 `

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -16,7 +16,7 @@ type BaseProps = {
   square: boolean
   wide: boolean
   variant: Variant
-  loading: boolean
+  loading?: boolean
   className: string
   children: ReactNode
 }

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -16,6 +16,7 @@ type BaseProps = {
   square: boolean
   wide: boolean
   variant: Variant
+  loading: boolean
   className: string
   children: ReactNode
 }
@@ -32,7 +33,7 @@ type Props =
   | (ButtonProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonProps>)
   | (AnchorProps & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof AnchorProps>)
 
-type StyleProps = Pick<Props, 'wide' | 'variant'> & { themes: Theme }
+type StyleProps = Pick<Props, 'wide' | 'variant' | 'loading'> & { themes: Theme }
 
 export function ButtonWrapper({ size, square, className, ...props }: Props) {
   const theme = useTheme()
@@ -47,13 +48,14 @@ export function ButtonWrapper({ size, square, className, ...props }: Props) {
   )
 }
 
-const baseStyles = css<StyleProps>(({ wide, themes }) => {
+const baseStyles = css<StyleProps>(({ wide, loading, themes }) => {
   const { border, fontSize, leading, radius, shadow, spacingByChar } = themes
 
   return css`
     box-sizing: border-box;
     cursor: pointer;
     display: inline-flex;
+    ${loading && `flex-direction: row-reverse;`}
     justify-content: center;
     align-items: center;
     gap: ${spacingByChar(0.5)};

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -33,6 +33,10 @@ export type BaseProps = {
    * ボタンのスタイルの種類
    */
   variant?: Variant
+  /**
+   * 処理が走ってるかどうか
+   */
+  loading?: boolean
 }
 
 export type Variant = 'primary' | 'secondary' | 'danger' | 'skeleton' | 'text'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

処理中にボタン自体が処理の状態を表せるように変更

## What I did

- 処理中の状態を表すBooleanを追加
- 処理中の時は強制的にLoaderがsuffixに入るようにした
- 処理中の時はボタン自体がdisabledになるようにした
- themeの各スタイルに合うようにLoaderのスタイルを変更

## なぜやるのか？
- 基本的に使うのは通信処理が発生するActionDialog周り、SmartHR本体のサーバーが死んでるとかじゃない限り通信処理は成功するので、表示するメッセージはerrorのメッセージだけにしたい。
    - ダイアログがガクガクするのを極力減らしたい
    - ガクガクしたときにはエラーメッセージが出てるという認知に変えていきたい
## 使い方
- このButtonを使用するのは主にActionDialog
    - responseMessageがあるのでそれをそのまま使えば実装できそう
    - processingは要らない
    - successはメッセージの内容や状況によって必要
        - utsuwaの評価テンプレート作成時の「作成しました」等のFB時はsuccessは要らない
## 今後の動き方
1. プロデザにレビューしてもらう
2. そしてSmartHRUIチームからのレビュー

<!--
Please attach a capture if it looks different.
-->
