### PR TITLE
chore: deprecate placeholder attributes

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -5,12 +5,12 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { useId } from '../../hooks/useId'
 import { useClassNames } from './useClassNames'
 
-import { Input, Props as InputProps } from '../Input'
+import { Input } from '../Input'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { StatusLabel } from '../StatusLabel'
 import { FaExclamationCircleIcon } from '../Icon'
 
-type Props = Omit<InputProps, 'error'> & {
+type Props = Omit<React.ComponentProps<typeof Input>, 'error'> & {
   /** ラベル名 */
   label: ReactNode
   /** ラベルのタイプ */

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -23,7 +23,7 @@ type Props = Omit<
   /** 入力値がフォーマットされたときに発火するコールバック関数 */
   onFormatValue?: (value: string) => void
   /**
-   * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください
+   * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください。
    */
   placeholder?: string
 }

--- a/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -8,17 +8,24 @@ import React, {
   useState,
 } from 'react'
 
-import { Input, Props as InputProps } from '../Input'
+import { Input } from '../Input'
 import { formatCurrency } from './currencyInputHelper'
 import { useClassNames } from './useClassNames'
 
-type Props = Omit<InputProps, 'type' | 'value' | 'defaultValue'> & {
+type Props = Omit<
+  React.ComponentProps<typeof Input>,
+  'type' | 'value' | 'defaultValue' | 'placeholder'
+> & {
   /** 通貨の値 */
   value?: string
   /** デフォルトで表示する通貨の値 */
   defaultValue?: string
   /** 入力値がフォーマットされたときに発火するコールバック関数 */
   onFormatValue?: (value: string) => void
+  /**
+   * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください
+   */
+  placeholder?: string
 }
 
 export const CurrencyInput = forwardRef<HTMLInputElement, Props>(

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -28,7 +28,7 @@ type Props = {
   /** コンポーネント内の末尾に表示する内容 */
   suffix?: ReactNode
   /**
-   * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください
+   * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください。
    */
   placeholder?: string
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -14,7 +14,7 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { useClassNames } from './useClassNames'
 
-export type Props = {
+type Props = {
   /** input 要素の `type` 値 */
   type?: HTMLInputElement['type']
   /** フォームにエラーがあるかどうか */
@@ -27,9 +27,14 @@ export type Props = {
   prefix?: ReactNode
   /** コンポーネント内の末尾に表示する内容 */
   suffix?: ReactNode
-} & Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'>
+  /**
+   * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください
+   */
+  placeholder?: string
+}
+type ElementProps = Omit<InputHTMLAttributes<HTMLInputElement>, keyof Props>
 
-export const Input = forwardRef<HTMLInputElement, Props>(
+export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
   ({ onFocus, onBlur, autoFocus, prefix, suffix, className = '', width, ...props }, ref) => {
     const theme = useTheme()
     const innerRef = useRef<HTMLInputElement>(null)

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -20,7 +20,7 @@ type Props = {
   /** 行数の初期値。省略した場合は2 */
   rows?: number
   /**
-   * @deprecated placeholder属性は非推奨です。別途ヒント用要素の設置を検討してください
+   * @deprecated placeholder属性は非推奨です。別途ヒント用要素の設置を検討してください。
    */
   placeholder?: string
 }

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -19,6 +19,10 @@ type Props = {
   maxRows?: number
   /** 行数の初期値。省略した場合は2 */
   rows?: number
+  /**
+   * @deprecated placeholder属性は非推奨です。別途ヒント用要素の設置を検討してください
+   */
+  placeholder?: string
 }
 type ElementProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, keyof Props>
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- placeholder属性を非推奨にします
  - 基本的にテキストノードでヒントを表示、その領域がない場合はTooltipコンポーネントを使用することを促します

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
