### PR TITLE
feat: Dialog タイトルのデフォルトを h2 に統一｜SHRUI-572

### DIFF
--- a/src/components/Dialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog.tsx
@@ -13,6 +13,7 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
   children,
   title,
   subtitle,
+  titleTag,
   closeText,
   actionText,
   actionTheme,
@@ -54,6 +55,7 @@ export const ActionDialog: React.VFC<Props & ElementProps> = ({
         title={title}
         titleId={titleId}
         subtitle={subtitle}
+        titleTag={titleTag}
         closeText={closeText}
         actionText={actionText}
         actionTheme={actionTheme}

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -10,6 +10,7 @@ import { FaCheckCircleIcon, FaExclamationCircleIcon } from '../Icon'
 import { Text } from '../Text'
 import { Loader } from '../Loader'
 import { useClassNames } from './useClassNames'
+import { HeadingTagTypes } from '../Heading'
 
 export type BaseProps = {
   /**
@@ -24,6 +25,10 @@ export type BaseProps = {
    * ダイアログのサブタイトル
    */
   subtitle?: ReactNode
+  /**
+   * ダイアログタイトルの HTML タグ
+   */
+  titleTag?: HeadingTagTypes
   /**
    * 閉じるボタンのラベル
    */
@@ -71,6 +76,7 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   title,
   titleId,
   subtitle,
+  titleTag = 'h2',
   closeText = 'キャンセル',
   actionText,
   actionTheme = 'primary',
@@ -91,13 +97,19 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
 
   return (
     <>
-      <TitleArea gap={0.25} themes={theme} ref={titleRef} className={classNames.titleArea}>
+      <TitleArea
+        gap={0.25}
+        themes={theme}
+        ref={titleRef}
+        className={classNames.titleArea}
+        as={titleTag}
+      >
         {subtitle && (
-          <Text as="p" size="S" leading="TIGHT" color="TEXT_GREY" className={classNames.subtitle}>
+          <Text size="S" leading="TIGHT" color="TEXT_GREY" className={classNames.subtitle}>
             {subtitle}
           </Text>
         )}
-        <Text id={titleId} as="p" size="L" leading="TIGHT" className={classNames.title}>
+        <Text id={titleId} size="L" leading="TIGHT" className={classNames.title}>
           {title}
         </Text>
       </TitleArea>
@@ -139,8 +151,9 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
   )
 }
 
-const TitleArea = styled(Stack)<{ themes: Theme }>(
+const TitleArea = styled(Stack)<{ themes: Theme; as: HeadingTagTypes }>(
   ({ themes: { border, spacing } }) => css`
+    margin-block: unset;
     border-bottom: ${border.shorthand};
     padding: ${spacing.XS} ${spacing.S};
   `,

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -809,10 +809,11 @@ export const Body以外のPortalParent: Story = () => {
   )
 }
 
-const Title = styled.p<{ themes: Theme }>`
+const Title = styled.h2<{ themes: Theme }>`
   padding: 16px 24px;
   margin: 0;
   font-size: ${({ themes }) => themes.fontSize.L};
+  font-weight: normal;
   line-height: 1;
   border-bottom: ${({ themes }) => themes.border.shorthand};
 `
@@ -848,7 +849,7 @@ const TriggerList = styled.ul`
     margin: 8px;
   }
 `
-const ModelessHeading = styled.h3`
+const ModelessHeading = styled.h2`
   font-size: 1em;
   margin: 0;
   font-weight: normal;

--- a/src/components/Dialog/MessageDialog.tsx
+++ b/src/components/Dialog/MessageDialog.tsx
@@ -15,6 +15,7 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 export const MessageDialog: React.VFC<Props & ElementProps> = ({
   title,
   subtitle,
+  titleTag,
   description,
   closeText,
   onClickClose,

--- a/src/components/Dialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialogContentInner.tsx
@@ -8,6 +8,7 @@ import { useOffsetHeight } from './dialogHelper'
 import { Stack } from '../Layout'
 import { Button } from '../Button'
 import { Text } from '../Text'
+import { HeadingTagTypes } from '../Heading'
 
 export type BaseProps = {
   /**
@@ -18,6 +19,10 @@ export type BaseProps = {
    * ダイアログのサブタイトル
    */
   subtitle?: React.ReactNode
+  /**
+   * ダイアログタイトルの HTML タグ
+   */
+  titleTag?: HeadingTagTypes
   /**
    * ダイアログの説明
    */
@@ -36,6 +41,7 @@ export type MessageDialogContentInnerProps = BaseProps & {
 export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
   title,
   subtitle,
+  titleTag = 'h2',
   titleId,
   description,
   closeText = '閉じる',
@@ -47,13 +53,19 @@ export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
 
   return (
     <>
-      <TitleArea gap={0.25} themes={theme} ref={titleRef} className={classNames.titleArea}>
+      <TitleArea
+        gap={0.25}
+        themes={theme}
+        ref={titleRef}
+        className={classNames.titleArea}
+        as={titleTag}
+      >
         {subtitle && (
-          <Text as="p" size="S" leading="TIGHT" color="TEXT_GREY" className={classNames.subtitle}>
+          <Text size="S" leading="TIGHT" color="TEXT_GREY" className={classNames.subtitle}>
             {subtitle}
           </Text>
         )}
-        <Text as="p" id={titleId} size="L" leading="TIGHT" className={classNames.title}>
+        <Text id={titleId} size="L" leading="TIGHT" className={classNames.title}>
           {title}
         </Text>
       </TitleArea>
@@ -69,8 +81,9 @@ export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
   )
 }
 
-const TitleArea = styled(Stack)<{ themes: Theme }>(
+const TitleArea = styled(Stack)<{ themes: Theme; as: HeadingTagTypes }>(
   ({ themes: { border, spacing } }) => css`
+    margin-block: unset;
     border-bottom: ${border.shorthand};
     padding: ${spacing.XS} ${spacing.S};
   `,


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-572

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

より適切なマークアップをするため、ダイアログタイトルのデフォルトを p から h2 に変えます。
ダイアログを呼び出すドキュメントに h1 があるはずなので、ダイアログは h2 以降になると考えています。

参考： [Modal Dialog Example | APG | WAI | W3C](https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/dialog.html)

また、デフォルトは h2 ですが、利用者が適宜指定できるようにしています。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- ActionDialog の title / subtitle 領域をまとめて h2 で囲みました
- MessageDialog の title / subtitle 領域をまとめて h2 で囲みました
- Dialog および ModelessDialog の Story を修正しました

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
