### PR TITLE
fix: Select の width を初期値 auto に変更｜SHRUI-577

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -80,7 +80,7 @@ export const All: Story = () => (
         />
       </Text>
     </li>
-    <li>
+    <li style={{ alignSelf: 'stretch' }}>
       <Text>
         <span>幅指定</span>
         <Select width="100%" options={options} />
@@ -118,7 +118,7 @@ export const All: Story = () => (
 )
 All.storyName = 'all'
 
-const List = styled(Stack).attrs({ as: 'ul' })`
+const List = styled(Stack).attrs({ as: 'ul', align: 'flex-start' })`
   list-style: none;
   padding: 0 24px;
 `

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -39,7 +39,7 @@ export function Select<T extends string>({
   onChange,
   onChangeValue,
   error = false,
-  width = '16.25em',
+  width = 'auto',
   hasBlank = false,
   blankLabel = '選択してください',
   size = 'default',


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-577

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Select の width に初期値 16.25em（260px）が指定されていたが、デザイン意図ではなくデザインデータをそのまま実装に落とし込んだだけだったため、あるべき姿に修正しました。

input や select などの要素幅のデフォルトは auto なため、合わせて auto としました。