### PR TITLE
chore: react-innertextをdependenciesに移動 | SHRUI-628

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "polished": "^4.2.2",
     "react-draggable": "^4.4.5",
     "react-icons": "^4.4.0",
+    "react-innertext": "^1.1.5",
     "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
@@ -61,7 +62,6 @@
     "puppeteer": "^18.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-innertext": "^1.1.5",
     "react-test-renderer": "^18.2.0",
     "reg-keygen-git-hash-plugin": "^0.12.1",
     "reg-notify-github-plugin": "^0.12.1",


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-628
https://kufuinc.slack.com/archives/CGC58MW01/p1665539082777099

## Overview

- `react-innertext`がdevDependenciesに定義されていたことでSmartHR-UIを利用するプロダクト側で当該ライブラリが不足することによるエラーで正常にビルドできない状態になっていたためこれを修正したい

## What I did

- `react-innertext`をdevDependenciesからdependenciesに移動

## Capture

<!--
Please attach a capture if it looks different.
-->
