### PR TITLE
fix: InformationPanel のスタイリングを微調整

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -359,7 +359,7 @@ export interface ComponentProps extends IconProps, ElementProps {
   /**アイコンの説明テキスト*/
   alt?: string
   /** アイコンと並べるテキスト */
-  text?: string
+  text?: React.ReactNode
   /** アイコンと並べるテキストとの溝 */
   iconGap?: CharRelativeSize | AbstractSize
   /** `true` のとき、アイコンを右側に表示する */

--- a/src/components/InformationPanel/InformationPanel.stories.tsx
+++ b/src/components/InformationPanel/InformationPanel.stories.tsx
@@ -15,7 +15,7 @@ export const All: Story = () => (
       借り換え直前の残高3,000万円、借り換え後の借入額2,900万円の場合→借り換え後の借入額が少ないので「借り換え後の借入額の方が少ない・同じ」を選択
     </InformationPanel>
     <InformationPanel
-      title={<span>賃金支払対象期間</span>}
+      title={<span>SmartHRの項目一覧表をダウンロード</span>}
       titleTag="h4"
       type="success"
       openButtonLabel="開く"

--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -6,6 +6,7 @@ import { useId } from '../../hooks/useId'
 import { useClassNames } from './useClassNames'
 
 import { Base, BaseElementProps } from '../Base'
+import { Cluster, Stack } from '../Layout'
 import {
   FaCaretDownIcon,
   FaCaretUpIcon,
@@ -113,16 +114,13 @@ export const InformationPanel: VFC<Props & Omit<BaseElementProps, keyof Props>> 
       role="region"
       aria-labelledby={titleId}
     >
-      <Header themes={theme} togglable={togglable}>
-        <Title themes={theme} id={titleId} className={classNames.title}>
-          <StyledHeading type="blockTitle" tag={titleTag}>
-            <Icon color={iconColor} $theme={theme} />
-            {title}
-          </StyledHeading>
-        </Title>
-        {togglable && (
-          <div>
-            <Button
+      <Stack gap={1.25}>
+        <Header themes={theme} togglable={togglable}>
+          <Heading type="blockTitle" tag={titleTag} id={titleId} className={classNames.title}>
+            <Icon color={iconColor} text={title} iconGap={0.5} />
+          </Heading>
+          {togglable && (
+            <TogglableButton
               suffix={active ? <FaCaretUpIcon /> : <FaCaretDownIcon />}
               size="s"
               onClick={handleClickTrigger}
@@ -131,63 +129,53 @@ export const InformationPanel: VFC<Props & Omit<BaseElementProps, keyof Props>> 
               className={classNames.closeButton}
             >
               {active ? closeButtonLabel : openButtonLabel}
-            </Button>
-          </div>
-        )}
-      </Header>
-      <Content themes={theme} id={contentId} aria-hidden={!active} className={classNames.content}>
-        {children}
-      </Content>
+            </TogglableButton>
+          )}
+        </Header>
+        <Content themes={theme} id={contentId} aria-hidden={!active} className={classNames.content}>
+          {children}
+        </Content>
+      </Stack>
     </Wrapper>
   )
 }
 
-const Wrapper = styled(Base)<{ themes: Theme; role: string }>`
-  ${({ themes: { spacingByChar, shadow } }) => {
+const Wrapper = styled(Base)<{ themes: Theme }>`
+  ${({ themes: { spacingByChar, shadow } }) => css`
+    padding: ${spacingByChar(1.5)};
+    box-shadow: ${shadow.LAYER3};
+  `}
+`
+
+const Header = styled(Cluster).attrs({
+  align: 'center',
+  justify: 'space-between',
+})<{ themes: Theme; togglable: boolean }>`
+  ${({ themes: { border, fontSize, leading, space }, togglable }) => {
+    // (Button(1rem + padding-block + border) - Heading(1rem * 1.25) / 2)
+    const adjust = `calc((
+        (${fontSize.S} + ${space(1)} + ${border.lineWidth} * 2)
+        - (${fontSize.M} * ${leading.TIGHT})
+      ) / -2)
+    `
     return css`
-      padding: ${spacingByChar(1.5)};
-      box-shadow: ${shadow.LAYER3};
+      ${togglable &&
+      css`
+        &&& {
+          margin-block: ${adjust};
+        }
+      `}
     `
   }}
 `
 
-const Header = styled.div<{ themes: Theme; togglable: boolean }>(
-  ({ togglable }) => `
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  ${
-    togglable &&
-    // (Button(27px) - Heading(14px)) / 2 = 6.5px
-    `
-    margin-top: -6.5px;
-    margin-bottom: -6.5px;
-  `
-  }
-`,
-)
-
-const Title = styled.div<{ themes: Theme }>`
-  vertical-align: middle;
-  line-height: 1;
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      margin-right: ${spacingByChar(0.5)};
-    `
-  }}
+const TogglableButton = styled(Button)`
+  margin-inline-start: auto;
 `
 
-const createTitleIcon = (Icon: typeof FaCheckCircleIcon) => {
-  return styled(Icon)<{ $theme: Theme }>`
-    vertical-align: text-top;
-    ${({ $theme: { spacingByChar } }) => {
-      return css`
-        margin-right: ${spacingByChar(0.5)};
-      `
-    }}
-  `
-}
+const createTitleIcon = (Icon: typeof FaCheckCircleIcon) => styled(Icon)`
+  flex-shrink: 0;
+`
 const SuccessTitleIcon = createTitleIcon(FaCheckCircleIcon)
 const InfoTitleIcon = createTitleIcon(FaInfoCircleIcon)
 const WarningTitleIcon = createTitleIcon(WarningIcon)
@@ -195,17 +183,11 @@ const ErrorTitleIcon = createTitleIcon(FaExclamationCircleIcon)
 const SyncIcon = createTitleIcon(FaSyncAltIcon)
 
 const Content = styled.div<{ themes: Theme }>`
-  ${({ themes: { fontSize, spacingByChar } }) => {
-    return css`
-      margin-top: ${spacingByChar(1.5)};
-      font-size: ${fontSize.M};
-      &[aria-hidden='true'] {
-        display: none;
-      }
-    `
-  }}
-`
+  ${({ themes: { fontSize } }) => css`
+    font-size: ${fontSize.M};
 
-const StyledHeading = styled(Heading)`
-  display: inline;
+    &[aria-hidden='true'] {
+      display: none;
+    }
+  `}
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-626

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

InformationPanel の見出し縦位置のズレを直すついでに、スタイリングを見直しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Icon の text に ReactNode を渡せるよう修正
- InformationPanel の Story を幅の狭い画面用に修正
- 見出し部分を Icon with Text で書き換え
- px 固定値を算出 ほか

## 申し送り

#2818 の後にマージします