### PR TITLE
docs: 意図せず DropdownButton の文字色が赤くなっていたので修正

### DIFF
--- a/src/components/Dropdown/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/Dropdown/DropdownButton/DropdownButton.stories.tsx
@@ -34,7 +34,7 @@ export const Default: Story = () => (
       <Button>ヒントメッセージの設定</Button>
       <AnchorButton href="#h2-2">ログアウト</AnchorButton>
     </DropdownButton>
-    <DropdownButton triggerSize="s" label={<span style={{ color: 'red' }}>操作</span>}>
+    <DropdownButton triggerSize="s" label={<span>操作</span>}>
       <Button>評価を開始</Button>
       <Button disabled>評価を確定</Button>
       <Button>ヒントメッセージの設定</Button>


### PR DESCRIPTION
`color: red` を指定しなくても ReactNode を渡せる確認はできるので消しました @hndrr 