### PR TITLE
fix: disabled な DropdownButton で onClick が発火してしまう問題を修正

### DIFF
--- a/src/components/Dropdown/DropdownTrigger.tsx
+++ b/src/components/Dropdown/DropdownTrigger.tsx
@@ -31,6 +31,16 @@ export const DropdownTrigger: React.VFC<Props> = ({ children, className = '' }) 
     <Wrapper
       ref={triggerElementRef}
       onClick={(e) => {
+        // 引き金となる要素が disabled な場合は発火させない
+        const includeDisabledTrigger = React.Children.map(
+          children,
+          (child) => React.isValidElement(child) && child.props.disabled,
+        )?.some((bool: boolean) => bool)
+
+        if (includeDisabledTrigger) {
+          return
+        }
+
         const rect = e.currentTarget.getBoundingClientRect()
         onClickTrigger({
           top: rect.top,


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-605

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DropdownTrigger の内包要素が disabled な時でも、クリックで DropdownContent が表示されてしまうバグを修正しました。