### PR TITLE
refactor: story で useTheme を使わないようにする

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -1,9 +1,7 @@
 import { Story } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
-import React, { VFC, useState } from 'react'
+import React, { FC, useState } from 'react'
 import styled, { css } from 'styled-components'
-
-import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Base } from '../Base'
 import { Button } from '../Button'
@@ -21,6 +19,9 @@ export default {
     AccordionPanelItem,
     AccordionPanelContent,
     AccordionPanelTrigger,
+  },
+  parameters: {
+    withTheming: true,
   },
 }
 
@@ -56,7 +57,7 @@ const content = () => {
   )
 }
 
-const AccordionPanelController: VFC<{ theme: Theme }> = ({ theme }) => {
+const AccordionPanelController: FC = () => {
   const [expandedId, setExpandedId] = useState('')
 
   const Buttons = styled.div`
@@ -87,7 +88,7 @@ const AccordionPanelController: VFC<{ theme: Theme }> = ({ theme }) => {
             <AccordionPanelItem key={i} name={`accordion-panel-${i}`}>
               <AccordionPanelTrigger>AccordionPanelItem {i}</AccordionPanelTrigger>
               <AccordionPanelContent>
-                <Content themes={theme}>{content()}</Content>
+                <Content>{content()}</Content>
               </AccordionPanelContent>
             </AccordionPanelItem>
           ))}
@@ -98,19 +99,17 @@ const AccordionPanelController: VFC<{ theme: Theme }> = ({ theme }) => {
 }
 
 export const AccordionStyle: Story = () => {
-  const theme = useTheme()
-
   return (
     <Wrapper>
       <Base>
         <AccordionPanel>
-          <BorderList themes={theme}>
+          <BorderList>
             {arr.map((_, i) => (
               <li key={i}>
                 <AccordionPanelItem name={`left-icon-${i}`}>
                   <AccordionPanelTrigger>Left Icon (default) {i}</AccordionPanelTrigger>
                   <AccordionPanelContent>
-                    <Content themes={theme}>{content()}</Content>
+                    <Content>{content()}</Content>
                   </AccordionPanelContent>
                 </AccordionPanelItem>
               </li>
@@ -120,13 +119,13 @@ export const AccordionStyle: Story = () => {
       </Base>
       <Base>
         <AccordionPanel iconPosition="right">
-          <BorderList themes={theme}>
+          <BorderList>
             {arr.map((_, i) => (
               <li key={i}>
                 <AccordionPanelItem name={`right-icon-${i}`}>
                   <AccordionPanelTrigger>Right Icon {i}</AccordionPanelTrigger>
                   <AccordionPanelContent>
-                    <Content themes={theme}>{content()}</Content>
+                    <Content>{content()}</Content>
                   </AccordionPanelContent>
                 </AccordionPanelItem>
               </li>
@@ -136,13 +135,13 @@ export const AccordionStyle: Story = () => {
       </Base>
       <Base>
         <AccordionPanel displayIcon={false}>
-          <BorderList themes={theme}>
+          <BorderList>
             {arr.map((_, i) => (
               <li key={i}>
                 <AccordionPanelItem name={`no-icon-${i}`}>
                   <AccordionPanelTrigger>No Icon {i}</AccordionPanelTrigger>
                   <AccordionPanelContent>
-                    <Content themes={theme}>{content()}</Content>
+                    <Content>{content()}</Content>
                   </AccordionPanelContent>
                 </AccordionPanelItem>
               </li>
@@ -156,8 +155,6 @@ export const AccordionStyle: Story = () => {
 AccordionStyle.storyName = 'Accordion style'
 
 export const ExpandedOptions: Story = () => {
-  const theme = useTheme()
-
   return (
     <Wrapper>
       <Base>
@@ -166,7 +163,7 @@ export const ExpandedOptions: Story = () => {
             <AccordionPanelItem key={i} name={`expandable-multiply-${i}`}>
               <AccordionPanelTrigger>Expandable Multiply {i}</AccordionPanelTrigger>
               <AccordionPanelContent>
-                <Content themes={theme}>{content()}</Content>
+                <Content>{content()}</Content>
               </AccordionPanelContent>
             </AccordionPanelItem>
           ))}
@@ -178,7 +175,7 @@ export const ExpandedOptions: Story = () => {
             <AccordionPanelItem key={i} name={`default-expanded-${i}`}>
               <AccordionPanelTrigger>Default Expanded {i}</AccordionPanelTrigger>
               <AccordionPanelContent>
-                <Content themes={theme}>{content()}</Content>
+                <Content>{content()}</Content>
               </AccordionPanelContent>
             </AccordionPanelItem>
           ))}
@@ -190,8 +187,6 @@ export const ExpandedOptions: Story = () => {
 ExpandedOptions.storyName = 'Expanded options'
 
 export const Callback: Story = () => {
-  const theme = useTheme()
-
   return (
     <Wrapper>
       <Base>
@@ -200,7 +195,7 @@ export const Callback: Story = () => {
             <AccordionPanelItem key={i} name={`expandable-multiply-${i}`}>
               <AccordionPanelTrigger>Expandable Multiply {i}</AccordionPanelTrigger>
               <AccordionPanelContent>
-                <Content themes={theme}>{content()}</Content>
+                <Content>{content()}</Content>
               </AccordionPanelContent>
             </AccordionPanelItem>
           ))}
@@ -211,8 +206,7 @@ export const Callback: Story = () => {
 }
 
 export const ChangeDefaultExpanded: Story = () => {
-  const theme = useTheme()
-  return <AccordionPanelController theme={theme} />
+  return <AccordionPanelController />
 }
 ChangeDefaultExpanded.storyName = 'Change defaultExpanded'
 
@@ -223,8 +217,8 @@ const Wrapper = styled.div`
     margin-top: 24px;
   }
 `
-const BorderList = styled.ul<{ themes: Theme }>(
-  ({ themes: { color } }) => css`
+const BorderList = styled.ul(
+  ({ theme: { color } }) => css`
     margin: 0;
     padding: 0;
     list-style: none;
@@ -234,8 +228,8 @@ const BorderList = styled.ul<{ themes: Theme }>(
     }
   `,
 )
-const Content = styled.div<{ themes: Theme }>(
-  ({ themes: { color } }) => css`
+const Content = styled.div(
+  ({ theme: { color } }) => css`
     background-color: ${color.BACKGROUND};
     padding: 16px;
   `,

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -1,18 +1,20 @@
 import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
-import React, { ReactNode, VFC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { FaBirthdayCakeIcon, FaChartPieIcon, FaCogIcon, FaFileIcon, FaUserAltIcon } from '../Icon/'
 import { AppNavi } from './AppNavi'
-import { Theme, useTheme } from '../../hooks/useTheme'
 
 export default {
   title: 'AppNavi',
   component: AppNavi,
+  parameters: {
+    withTheming: true,
+  },
 }
 
-const Link: VFC<{ to: string; children: ReactNode; disabled?: boolean; className?: string }> = ({
+const Link: FC<{ to: string; children: ReactNode; disabled?: boolean; className?: string }> = ({
   to,
   children,
   disabled = false,
@@ -24,11 +26,9 @@ const Link: VFC<{ to: string; children: ReactNode; disabled?: boolean; className
   </a>
 )
 
-const List: VFC = () => {
-  const theme = useTheme()
-
+const List: FC = () => {
   return (
-    <ListWrapper themes={theme}>
+    <ListWrapper>
       <li>
         <button onClick={action('clicked item 1')}>ドロップダウンアイテム1</button>
       </li>
@@ -77,10 +77,8 @@ const buttons = [
 const withoutIconButtons = buttons.map(({ icon, ...button }) => button)
 
 export const WithChildren: Story = () => {
-  const theme = useTheme()
-
   return (
-    <Wrapper themes={theme}>
+    <Wrapper>
       <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret>
         <Child>Some child components</Child>
       </AppNavi>
@@ -90,10 +88,8 @@ export const WithChildren: Story = () => {
 WithChildren.storyName = 'with children'
 
 export const WithoutChildren: Story = () => {
-  const theme = useTheme()
-
   return (
-    <Wrapper themes={theme}>
+    <Wrapper>
       <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret />
     </Wrapper>
   )
@@ -101,11 +97,10 @@ export const WithoutChildren: Story = () => {
 WithoutChildren.storyName = 'without children'
 
 export const UnclickableCurrent: Story = () => {
-  const theme = useTheme()
   const items = buttons.map(({ current, ...button }) => button)
 
   return (
-    <Wrapper themes={theme}>
+    <Wrapper>
       {items.map((_, currentIndex) => (
         <InnerWrapper key={currentIndex}>
           <AppNavi
@@ -127,10 +122,8 @@ export const UnclickableCurrent: Story = () => {
 UnclickableCurrent.storyName = 'unclickable current'
 
 export const NoIconAndCaret: Story = () => {
-  const theme = useTheme()
-
   return (
-    <Wrapper themes={theme}>
+    <Wrapper>
       <AppNavi label="機能名" buttons={buttons} />
     </Wrapper>
   )
@@ -138,10 +131,8 @@ export const NoIconAndCaret: Story = () => {
 NoIconAndCaret.storyName = 'アイコンありドロップダウン示唆なし'
 
 export const ContainerScrollX: Story = () => {
-  const theme = useTheme()
-
   return (
-    <OverflowWrapper themes={theme}>
+    <OverflowWrapper>
       <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret>
         <Child>Some child components</Child>
       </AppNavi>
@@ -150,9 +141,9 @@ export const ContainerScrollX: Story = () => {
 }
 ContainerScrollX.storyName = '横スクロールさせる場合'
 
-const Wrapper = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color } = themes
+const Wrapper = styled.div`
+  ${({ theme }) => {
+    const { color } = theme
 
     return css`
       padding: 32px 0;
@@ -170,27 +161,23 @@ const InnerWrapper = styled.div`
   margin-bottom: 40px;
 `
 
-const ListWrapper = styled.ul<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color } = themes
+const ListWrapper = styled.ul(
+  ({ theme: { color } }) => css`
+    margin: 0;
+    padding: 8px 0;
+    list-style: none;
 
-    return css`
-      margin: 0;
-      padding: 8px 0;
-      list-style: none;
+    & > li > button {
+      line-height: 40px;
+      width: 100%;
+      padding: 0 20px;
+      border: none;
+      background-color: ${color.WHITE};
+      color: ${color.TEXT_BLACK};
 
-      & > li > button {
-        line-height: 40px;
-        width: 100%;
-        padding: 0 20px;
-        border: none;
-        background-color: ${color.WHITE};
-        color: ${color.TEXT_BLACK};
-
-        &:hover {
-          background-color: ${color.hoverColor(color.WHITE)};
-        }
+      &:hover {
+        background-color: ${color.hoverColor(color.WHITE)};
       }
-    `
-  }}
-`
+    }
+  `,
+)

--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -1,7 +1,7 @@
 import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
-import { Theme, useTheme } from '../../hooks/useTheme'
+import { useTheme } from '../../hooks/useTheme'
 import { Heading } from '../Heading'
 import { Base } from '../Base'
 import { DefinitionList } from './DefinitionList'
@@ -11,6 +11,9 @@ import { Text } from '../Text'
 export default {
   title: 'DefinitionList',
   component: DefinitionList,
+  parameters: {
+    withTheming: true,
+  },
 }
 
 const DefinitionListItems = [
@@ -42,7 +45,7 @@ const Item = () => {
       <span>term 7</span>
       <Alert>
         <FaExclamationCircleIcon size={11} color={themes.color.DANGER} />
-        <AlertText themes={themes}>error occurred</AlertText>
+        <AlertText>error occurred</AlertText>
       </Alert>
     </Term>
   )
@@ -118,8 +121,8 @@ const Alert = styled.span`
   align-items: center;
   margin-left: 8px;
 `
-const AlertText = styled.span<{ themes: Theme }>`
+const AlertText = styled.span`
   margin-left: 4px;
-  color: ${({ themes }) => themes.color.TEXT_BLACK};
-  font-size: ${({ themes }) => themes.fontSize.S};
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+  font-size: ${({ theme }) => theme.fontSize.S};
 `

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -15,7 +15,6 @@ import {
   MessageDialogContent,
   ModelessDialog,
 } from '.'
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { Button } from '../Button'
 import { Input } from '../Input'
 import { RadioButton } from '../RadioButton'
@@ -44,6 +43,7 @@ export default {
         type: 'code',
       },
     },
+    withTheming: true,
   },
 }
 
@@ -54,7 +54,6 @@ export const Default: Story = () => {
   const onClickClose = () => setOpended(null)
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
   const inputRef = useRef<HTMLInputElement>(null)
-  const themes = useTheme()
 
   return (
     <TriggerList>
@@ -75,7 +74,7 @@ export const Default: Story = () => {
           ariaLabel="Dialog"
           data-test="dialog-content"
         >
-          <Title themes={themes}>Dialog</Title>
+          <Title>Dialog</Title>
           <Description>
             The value of isOpen must be managed by you, but you can customize content freely.
           </Description>
@@ -104,7 +103,7 @@ export const Default: Story = () => {
               </RadioButton>
             </li>
           </RadioList>
-          <Footer themes={themes}>
+          <Footer>
             <Button onClick={onClickClose} data-test="dialog-closer">
               close
             </Button>
@@ -128,11 +127,11 @@ export const Default: Story = () => {
           id="dialog-focus"
           ariaLabel="特定の要素をフォーカスするダイアログ"
         >
-          <Title themes={themes}>特定の要素をフォーカスするダイアログ</Title>
+          <Title>特定の要素をフォーカスするダイアログ</Title>
           <Content>
             <Input ref={inputRef} data-test="input-focus-target" />
           </Content>
-          <Footer themes={themes}>
+          <Footer>
             <Button onClick={onClickClose} data-test="dialog-closer">
               close
             </Button>
@@ -709,7 +708,6 @@ export const Body以外のPortalParent: Story = () => {
   const onClickOpen = (type: 'deault' | 'actiion' | 'message' | 'modeless') => setIsOpen(type)
   const onClickClose = () => setIsOpen(undefined)
   const portalParentRef = useRef<HTMLDivElement>(null)
-  const themes = useTheme()
 
   return (
     <div ref={portalParentRef}>
@@ -756,11 +754,11 @@ export const Body以外のPortalParent: Story = () => {
         data-test="dialog-content"
         portalParent={portalParentRef}
       >
-        <Title themes={themes}>Dialog</Title>
+        <Title>Dialog</Title>
         <Content>
           <p>Dialog を近接要素に生成しています。</p>
         </Content>
-        <Footer themes={themes}>
+        <Footer>
           <Button onClick={onClickClose} data-test="dialog-closer">
             閉じる
           </Button>
@@ -809,13 +807,13 @@ export const Body以外のPortalParent: Story = () => {
   )
 }
 
-const Title = styled.h2<{ themes: Theme }>`
+const Title = styled.h2`
   padding: 16px 24px;
   margin: 0;
-  font-size: ${({ themes }) => themes.fontSize.L};
+  font-size: ${({ theme }) => theme.fontSize.L};
   font-weight: normal;
   line-height: 1;
-  border-bottom: ${({ themes }) => themes.border.shorthand};
+  border-bottom: ${({ theme }) => theme.border.shorthand};
 `
 const Description = styled.p`
   margin: 16px 24px;
@@ -830,11 +828,11 @@ const RadioList = styled.ul`
   padding: 0;
   list-style: none;
 `
-const Footer = styled.div<{ themes: Theme }>`
+const Footer = styled.div`
   display: flex;
   justify-content: flex-end;
   padding: 16px 24px;
-  border-top: ${({ themes }) => themes.border.shorthand};
+  border-top: ${({ theme }) => theme.border.shorthand};
 
   & > *:not(:first-child) {
     margin-left: 16px;

--- a/src/components/Downloader/Downloader.stories.tsx
+++ b/src/components/Downloader/Downloader.stories.tsx
@@ -1,21 +1,21 @@
 import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaExternalLinkAltIcon } from '../Icon'
 
 export default {
   title: '[TBD] Downloader',
+  parameters: {
+    withTheming: true,
+  },
 }
 
 export const All: Story = () => {
-  const themes = useTheme()
   return (
-    <Wrapper themes={themes}>
+    <Wrapper>
       <Title>To Be Developed</Title>
       <Description>This component will develop in the near future.</Description>
       <Link
-        themes={themes}
         href="https://smarthr.invisionapp.com/share/ADUDJ8BW74C#/386514188_downloaders"
         target="_blank"
       >
@@ -27,13 +27,13 @@ export const All: Story = () => {
 }
 All.storyName = 'all'
 
-const Wrapper = styled.div<{ themes: Theme }>`
+const Wrapper = styled.div`
   box-sizing: border-box;
   padding: 24px;
   border-radius: 6px;
   box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
-  color: ${({ themes }) => themes.color.TEXT_BLACK};
-  font-size: ${({ themes }) => themes.fontSize.M};
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+  font-size: ${({ theme }) => theme.fontSize.M};
   text-align: center;
   line-height: 1;
   position: absolute;
@@ -53,8 +53,8 @@ const Description = styled.div`
   margin-bottom: 16px;
 `
 
-const Link = styled.a<{ themes: Theme }>`
-  color: ${({ themes }) => themes.color.TEXT_LINK};
+const Link = styled.a`
+  color: ${({ theme }) => theme.color.TEXT_LINK};
 `
 const LinkText = styled.span`
   vertical-align: middle;

--- a/src/components/DropZone/DropZone.stories.tsx
+++ b/src/components/DropZone/DropZone.stories.tsx
@@ -4,18 +4,18 @@ import * as React from 'react'
 import styled, { css } from 'styled-components'
 
 import { DropZone } from './DropZone'
-import { Theme, useTheme } from '../../hooks/useTheme'
 
 export default {
   title: 'DropZone',
   component: DropZone,
+  parameters: {
+    withTheming: true,
+  },
 }
 
 const onSelectFiles = action('onSelectFiles')
 
 export const All: Story = () => {
-  const theme = useTheme()
-
   return (
     <Group>
       <li>
@@ -26,7 +26,7 @@ export const All: Story = () => {
       <li>
         <Text>With children</Text>
         <DropZone onSelectFiles={onSelectFiles}>
-          <DropZoneText theme={theme}>
+          <DropZoneText>
             <span>ここにドラッグ&ドロップ</span>
             <span>または</span>
           </DropZoneText>
@@ -36,7 +36,7 @@ export const All: Story = () => {
       <li>
         <Text>Button accepting only image files</Text>
         <DropZone onSelectFiles={onSelectFiles} accept="image/*">
-          <DropZoneText theme={theme}>
+          <DropZoneText>
             <span>ここにドラッグ&ドロップ</span>
             <span>または</span>
           </DropZoneText>
@@ -64,10 +64,9 @@ const Text = styled.p`
   margin: 0 0 16px;
 `
 
-const DropZoneText = styled.p<{ theme: Theme }>`
-  ${({ theme }) => {
-    const { palette } = theme
-    return css`
+const DropZoneText = styled.p(
+  ({ theme: { palette } }) =>
+    css`
       margin: 0;
       span {
         display: block;
@@ -76,6 +75,5 @@ const DropZoneText = styled.p<{ theme: Theme }>`
         line-height: 1;
         color: ${palette.TEXT_GREY};
       }
-    `
-  }}
-`
+    `,
+)

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -3,8 +3,6 @@ import { action } from '@storybook/addon-actions'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
-import { Theme, useTheme } from '../../hooks/useTheme'
-
 import { Dropdown } from './Dropdown'
 import { DropdownTrigger } from './DropdownTrigger'
 import { DropdownContent } from './DropdownContent'
@@ -33,12 +31,14 @@ export default {
     DropdownCloser,
     DropdownScrollArea,
   },
+  parameters: {
+    withTheming: true,
+  },
 }
 
 const ListMenu = () => {
-  const themes = useTheme()
   return (
-    <ActionList as="ul" themes={themes}>
+    <ActionList as="ul">
       <li>
         <Button id="dropdown-list-item-1" onClick={action('clicked 編集')}>
           編集
@@ -63,7 +63,6 @@ const ControllableDropdown = () => {
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
   const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.currentTarget.value)
   const [isDialogOpen, setIsDialogOpen] = React.useState(false)
-  const themes = useTheme()
 
   return (
     <>
@@ -111,7 +110,7 @@ const ControllableDropdown = () => {
                 </DropdownCloser>
               </Stack>
             </ControllableBoxMain>
-            <ControllableBoxBottom themes={themes}>
+            <ControllableBoxBottom>
               <Cluster justify="flex-end">
                 <DropdownCloser>
                   <Button>Close only</Button>
@@ -144,9 +143,8 @@ const ControllableDropdown = () => {
 }
 
 const Template: Story = () => {
-  const themes = useTheme()
   return (
-    <Wrapper themes={themes}>
+    <Wrapper>
       <Legends>
         <li>
           <Box>
@@ -255,8 +253,8 @@ RegOpenDropdown.play = async ({ canvasElement }) => {
   userEvent.click(buttons[0])
 }
 
-const ActionList = styled(Stack).attrs({ gap: 0 })<{ themes: Theme }>(
-  ({ themes: { spacingByChar } }) => css`
+const ActionList = styled(Stack).attrs({ gap: 0 })(
+  ({ theme: { spacingByChar } }) => css`
     list-style: none;
     margin-block: 0;
     padding-block: ${spacingByChar(0.5)};
@@ -272,9 +270,9 @@ const ActionList = styled(Stack).attrs({ gap: 0 })<{ themes: Theme }>(
   `,
 )
 const TriggerButton = styled(Button).attrs({ suffix: <FaCaretDownIcon /> })``
-const Wrapper = styled.div<{ themes: Theme }>`
+const Wrapper = styled.div`
   padding: 24px;
-  color: ${({ themes }) => themes.color.TEXT_BLACK};
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
 `
 const Legends = styled.ul`
   margin: 0;
@@ -291,8 +289,8 @@ const Box = styled.div`
 const ControllableBoxMain = styled(Stack)`
   padding: 24px;
 `
-const ControllableBoxBottom = styled.div<{ themes: Theme }>`
-  border-top: ${({ themes }) => themes.border.shorthand};
+const ControllableBoxBottom = styled.div`
+  border-top: ${({ theme }) => theme.border.shorthand};
   padding: 16px 24px;
 `
 const RightAlign = styled.div`

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -2,8 +2,6 @@ import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
-import { Theme, useTheme } from '../../../hooks/useTheme'
-
 import { FilterDropdown } from './FilterDropdown'
 import { RadioButton } from '../../RadioButton'
 import { Input } from '../../Input'
@@ -13,14 +11,13 @@ export const Default: Story = () => {
   const [text, setText] = React.useState('')
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)
   const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => setText(e.currentTarget.value)
-  const themes = useTheme()
   const [isFiltered, setIsFiltered] = React.useState(false)
   const [isFiltered2, setIsFiltered2] = React.useState(true)
   const [isFiltered3, setIsFiltered3] = React.useState(true)
   const [isFiltered4, setIsFiltered4] = React.useState(true)
 
   return (
-    <Wrapper themes={themes}>
+    <Wrapper>
       <List>
         <dt>nonFiltered</dt>
         <dd>
@@ -33,7 +30,7 @@ export const Default: Story = () => {
             }}
             isFiltered={isFiltered}
           >
-            <Text themes={themes}>
+            <Text>
               `FilterDropdown` provide specific interface to be able to filter data.
               <br />
               You can control inputs for filtering conditions as children components.
@@ -61,7 +58,7 @@ export const Default: Story = () => {
             <Description>
               ↓<br />↓
             </Description>
-            <Text themes={themes}>Children content is scrollable.</Text>
+            <Text>Children content is scrollable.</Text>
           </FilterDropdown>
         </dd>
         <dt>Filtered</dt>
@@ -71,9 +68,7 @@ export const Default: Story = () => {
             onApply={() => setIsFiltered2(true)}
             onReset={() => setIsFiltered2(false)}
           >
-            <Text themes={themes}>
-              You can change border color of the trigger button by setting `isFiltered`.
-            </Text>
+            <Text>You can change border color of the trigger button by setting `isFiltered`.</Text>
           </FilterDropdown>
         </dd>
         <dt>Filtered has status text</dt>
@@ -84,7 +79,7 @@ export const Default: Story = () => {
             onReset={() => setIsFiltered3(false)}
             hasStatusText
           >
-            <Text themes={themes}>
+            <Text>
               You can change border text and color of the trigger button by setting `isFiltered`.
             </Text>
           </FilterDropdown>
@@ -104,7 +99,7 @@ export const Default: Story = () => {
               resetButton: (txt) => <span data-wovn-enable="true">{txt}</span>,
             }}
           >
-            <Text themes={themes}>
+            <Text>
               You can change border text and color of the trigger button by setting `isFiltered`.
             </Text>
           </FilterDropdown>
@@ -114,10 +109,11 @@ export const Default: Story = () => {
   )
 }
 Default.storyName = 'FilterDropdown'
+Default.parameters = { withTheming: true }
 
-const Wrapper = styled.div<{ themes: Theme }>`
+const Wrapper = styled.div`
   padding: 24px;
-  color: ${({ themes }) => themes.color.TEXT_BLACK};
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
 `
 const List = styled.dl`
   margin: 0;
@@ -131,9 +127,9 @@ const List = styled.dl`
     margin: 0;
   }
 `
-const Text = styled.p<{ themes: Theme }>`
+const Text = styled.p`
   margin: 0;
-  color: ${({ themes }) => themes.color.TEXT_BLACK};
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
 `
 const Description = styled.p`
   margin: 0;

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
-import { Theme, useTheme } from '../../hooks/useTheme'
+import { useTheme } from '../../hooks/useTheme'
 
 import { FaExclamationCircleIcon } from '../Icon'
 import { FieldSet } from './FieldSet'
@@ -10,6 +10,9 @@ import { FieldSet } from './FieldSet'
 export default {
   title: 'FieldSet',
   component: FieldSet,
+  parameters: {
+    withTheming: true,
+  },
 }
 
 export const All: Story = () => {
@@ -63,14 +66,14 @@ export const All: Story = () => {
           labelSuffix={
             <Suffix>
               <FaExclamationCircleIcon size={12} color={themes.color.TEXT_GREY} />
-              <SuffixText themes={themes}>suffix text</SuffixText>
+              <SuffixText>suffix text</SuffixText>
             </Suffix>
           }
         />
       </li>
       <li>
         <FieldSet label="custom field">
-          <CustomTag themes={themes}>It is a field where tags can be freely inserted.</CustomTag>
+          <CustomTag>It is a field where tags can be freely inserted.</CustomTag>
         </FieldSet>
       </li>
       <li>
@@ -90,12 +93,12 @@ export const All: Story = () => {
           labelSuffix={
             <Suffix>
               <FaExclamationCircleIcon size={12} color={themes.color.TEXT_GREY} />
-              <SuffixText themes={themes}>suffix text</SuffixText>
+              <SuffixText>suffix text</SuffixText>
             </Suffix>
           }
           required
         >
-          <CustomTag themes={themes}>It is a field where tags can be freely inserted.</CustomTag>
+          <CustomTag>It is a field where tags can be freely inserted.</CustomTag>
         </FieldSet>
       </li>
     </List>
@@ -119,16 +122,14 @@ const Suffix = styled.div`
     margin-right: 4px;
   }
 `
-const SuffixText = styled.p<{ themes: Theme }>`
+const SuffixText = styled.p`
   margin: 0;
-  font-size: ${({ themes }) => themes.fontSize.S};
+  font-size: ${({ theme }) => theme.fontSize.S};
 `
-const CustomTag = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    return css`
-      padding: 10px;
-      border: 1px solid ${themes.color.BORDER};
-      border-radius: 5px;
-    `
-  }}
-`
+const CustomTag = styled.div(
+  ({ theme }) => css`
+    padding: 10px;
+    border: 1px solid ${theme.color.BORDER};
+    border-radius: 5px;
+  `,
+)

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -2,14 +2,15 @@ import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 
-import { Theme, useTheme } from '../../hooks/useTheme'
-
 import { FormGroup } from './FormGroup'
 import { Input } from '../Input'
 
 export default {
   title: 'FormGroup',
   component: FormGroup,
+  parameters: {
+    withTheming: true,
+  },
 }
 
 type SampleChildrenProps = {
@@ -55,17 +56,15 @@ const SampleStatusLabelProps = [
 ]
 
 export const All: Story = () => {
-  const theme = useTheme()
-
   return (
     <Wrapper>
-      <Title themes={theme}>default</Title>
+      <Title>default</Title>
       <Body>
         <FormGroup title="Title" titleType="blockTitle" role="group">
           <SampleChildren id1="id_1-1" id2="id_1-2" />
         </FormGroup>
       </Body>
-      <Title themes={theme}>with status label</Title>
+      <Title>with status label</Title>
       <Body>
         <FormGroup
           title="Title"
@@ -76,7 +75,7 @@ export const All: Story = () => {
           <SampleChildren id1="id_2-1" id2="id_2-2" />
         </FormGroup>
       </Body>
-      <Title themes={theme}>with help message</Title>
+      <Title>with help message</Title>
       <Body>
         <FormGroup
           title="Title"
@@ -87,7 +86,7 @@ export const All: Story = () => {
           <SampleChildren id1="id_3-1" id2="id_3-2" />
         </FormGroup>
       </Body>
-      <Title themes={theme}>with error messages</Title>
+      <Title>with error messages</Title>
       <Body>
         <FormGroup
           title="Title"
@@ -99,7 +98,7 @@ export const All: Story = () => {
           <SampleChildren id1="id_4-1" id2="id_4-2" />
         </FormGroup>
       </Body>
-      <Title themes={theme}>with all options</Title>
+      <Title>with all options</Title>
       <Body>
         <FormGroup
           title="Title"
@@ -112,7 +111,7 @@ export const All: Story = () => {
           <SampleChildren id1="id_5-1" id2="id_5-2" />
         </FormGroup>
       </Body>
-      <Title themes={theme}>disabled</Title>
+      <Title>disabled</Title>
       <Body>
         <FormGroup
           title="Title"
@@ -137,15 +136,15 @@ const Wrapper = styled.dl`
   margin: 0;
 `
 
-const Title = styled.dt<{ themes: Theme }>`
-  ${({ themes }) => css`
+const Title = styled.dt(
+  ({ theme }) => css`
     display: block;
     padding: 0;
     margin: 0 0 16px;
-    color: ${themes.color.TEXT_GREY};
+    color: ${theme.color.TEXT_GREY};
     font-style: italic;
-  `}
-`
+  `,
+)
 
 const Body = styled.dd`
   display: block;

--- a/src/components/Layout/Cluster/Cluster.stories.tsx
+++ b/src/components/Layout/Cluster/Cluster.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Story } from '@storybook/react'
 
-import { Theme, useTheme } from '../../../hooks/useTheme'
 import { Cluster } from '.'
 import { Stack } from '../Stack'
 import { Heading as shrHeading } from '../../Heading'
@@ -12,11 +11,8 @@ import { Base } from '../../Base'
 import { RadioButton } from '../../RadioButton'
 
 export const ClusterStory: Story = () => {
-  const themes = useTheme()
-  const { spacing } = themes
-
   return (
-    <Stack gap="L" style={{ padding: spacing.L }}>
+    <StyledStack gap="L">
       <Stack as="figure" gap="X3S">
         <figcaption>幅を狭めて収まり切らなくなると折返します。</figcaption>
         <Cluster>
@@ -50,7 +46,7 @@ export const ClusterStory: Story = () => {
       </Stack>
       <Stack as="figure" gap="X3S">
         <figcaption>垂直方向と水平方向で異なった余白を設定できます。</figcaption>
-        <StyledBase themes={themes}>
+        <StyledBase>
           <Cluster gap={{ row: 'X3S', column: 'XS' }}>
             <RadioButton name="部署" defaultChecked={true}>
               申請者に戻す
@@ -85,17 +81,24 @@ export const ClusterStory: Story = () => {
           </Cluster>
         </Cluster>
       </Stack>
-    </Stack>
+    </StyledStack>
   )
 }
+ClusterStory.parameters = { withTheming: true }
 
 const Heading = styled(shrHeading)`
   margin-top: 0;
   margin-bottom: 0;
 `
 
-const StyledBase = styled(Base)<{ themes: Theme }>(({ themes }) => {
-  const { color, spacing } = themes
+const StyledStack = styled(Stack)(
+  ({ theme }) => css`
+    padding: ${theme.spacing.L};
+  `,
+)
+
+const StyledBase = styled(Base)(({ theme }) => {
+  const { color, spacing } = theme
 
   return css`
     width: 50%;
@@ -104,10 +107,8 @@ const StyledBase = styled(Base)<{ themes: Theme }>(({ themes }) => {
   `
 })
 
-const ColorBox = styled.div(() => {
-  const { color, radius } = useTheme()
-
-  return css`
+const ColorBox = styled.div(
+  ({ theme: { radius, color } }) => css`
     display: flex;
     align-items: center;
     justify-content: center;
@@ -116,5 +117,5 @@ const ColorBox = styled.div(() => {
     color: ${color.TEXT_WHITE};
     width: 80px;
     height: 80px;
-  `
-})
+  `,
+)

--- a/src/components/Layout/LineUp/LineUp.stories.tsx
+++ b/src/components/Layout/LineUp/LineUp.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { Story } from '@storybook/react'
 
-import { useTheme } from '../../../hooks/useTheme'
 import { Stack } from '../Stack'
 import { LineUp } from '.'
 
@@ -83,11 +82,10 @@ export const LineUpStory: Story = () => (
     </figure>
   </Stack>
 )
+LineUpStory.parameters = { withTheming: true }
 
-const ColorBox = styled.div(() => {
-  const { color } = useTheme()
-
-  return css`
+const ColorBox = styled.div(
+  ({ theme: { color } }) => css`
     display: flex;
     align-items: center;
     justify-content: center;
@@ -95,14 +93,13 @@ const ColorBox = styled.div(() => {
     color: ${color.TEXT_WHITE};
     width: 80px;
     height: 80px;
-  `
-})
+  `,
+)
 
-const Link = styled.a(() => {
-  const { color } = useTheme()
-  return css`
+const Link = styled.a(
+  ({ theme: { color } }) => css`
     color: ${color.TEXT_LINK};
     text-decoration: underline;
     text-underline-position: under;
-  `
-})
+  `,
+)

--- a/src/components/Layout/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Story } from '@storybook/react'
 
-import { useTheme } from '../../../hooks/useTheme'
 import { Sidebar } from './Sidebar'
 
 import styled, { css } from 'styled-components'
@@ -55,9 +54,11 @@ export const SidebarStory: Story = () => {
     </div>
   )
 }
+SidebarStory.parameters = {
+  withTheming: true,
+}
 
-const Main = styled.main(() => {
-  const theme = useTheme()
+const Main = styled.main(({ theme }) => {
   const { color, spacing } = theme
 
   return css`
@@ -67,8 +68,7 @@ const Main = styled.main(() => {
   `
 })
 
-const Side = styled.aside(() => {
-  const theme = useTheme()
+const Side = styled.aside(({ theme }) => {
   const { color, spacing } = theme
 
   return css`
@@ -80,8 +80,7 @@ const Side = styled.aside(() => {
   `
 })
 
-const Code = styled.code(() => {
-  const theme = useTheme()
+const Code = styled.code(({ theme }) => {
   const { color, radius, spacing } = theme
 
   return css`

--- a/src/components/Layout/Stack/Stack.stories.tsx
+++ b/src/components/Layout/Stack/Stack.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { Story } from '@storybook/react'
 
-import { useTheme } from '../../../hooks/useTheme'
 import { Stack } from '.'
 import { Base as shrBase } from '../../Base'
 import { Heading } from '../../Heading'
@@ -46,6 +45,7 @@ export const StackStory: Story = () => (
     </SideAreaStack>
   </LineUp>
 )
+StackStory.parameters = { withTheming: true }
 
 const SideAreaStack = styled(Stack)`
   flex: 1;
@@ -54,19 +54,17 @@ const Content = styled.div`
   flex: 3;
   min-height: 30vw;
 `
-const Base = styled(shrBase)(() => {
-  const { spacingByChar } = useTheme()
-  return css`
+const Base = styled(shrBase)(
+  ({ theme: { spacingByChar } }) => css`
     padding: ${spacingByChar(1.5)};
-  `
-})
-const InnerBase = styled(shrBase)(() => {
-  const { color, spacingByChar } = useTheme()
-  return css`
+  `,
+)
+const InnerBase = styled(shrBase)(
+  ({ theme: { color, spacingByChar } }) => css`
     background-color: ${color.OVER_BACKGROUND};
     padding: ${spacingByChar(1)};
-  `
-})
+  `,
+)
 const P = styled.p`
   margin-top: 0;
   margin-bottom: 0;

--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -1,4 +1,3 @@
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
@@ -11,8 +10,6 @@ export default {
 }
 
 export const All: Story = () => {
-  const theme = useTheme()
-
   return (
     <>
       <Wrapper>
@@ -33,7 +30,7 @@ export const All: Story = () => {
         </List>
       </Wrapper>
 
-      <GrayWrapper themes={theme}>
+      <GrayWrapper>
         <Text>Light</Text>
         <List>
           <dt>Default</dt>
@@ -54,24 +51,21 @@ export const All: Story = () => {
   )
 }
 All.storyName = 'all'
+All.parameters = { withTheming: true }
 
 const Wrapper = styled.div`
   padding: 24px;
 `
-const GrayWrapper = styled(Wrapper)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color } = themes
+const GrayWrapper = styled(Wrapper)(
+  ({ theme: { color } }) => css`
+    background-color: ${color.SCRIM};
 
-    return css`
-      background-color: ${color.SCRIM};
-
-      p,
-      dt {
-        color: #fff;
-      }
-    `
-  }}
-`
+    p,
+    dt {
+      color: #fff;
+    }
+  `,
+)
 
 const Text = styled.p`
   margin: 0 0 16px;

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Story } from '@storybook/react'
 import styled, { css } from 'styled-components'
-import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { Base } from '../Base'
 import { MessageScreen } from './MessageScreen'
@@ -13,10 +12,12 @@ import { Input } from '../Input'
 export default {
   title: 'MessageScreen',
   component: MessageScreen,
+  parameters: {
+    withTheming: true,
+  },
 }
 
 export const Full: Story = () => {
-  const themes = useTheme()
   return (
     <MessageScreen
       title="SmartHR は現在メンテナンス中です"
@@ -28,7 +29,7 @@ export const Full: Story = () => {
         },
       ]}
     >
-      <Description themes={themes}>
+      <Description>
         いつも SmartHR をご利用いただきありがとうございます。
         <br />
         ただいまメンテナンスのため、一時サービスを停止しております。
@@ -92,14 +93,13 @@ export const WithoutTitle: Story = () => {
 WithoutTitle.storyName = 'without title'
 
 export const WithoutLinks: Story = () => {
-  const themes = useTheme()
   return (
     <MessageScreen
       title={
         <>
           株式会社 TEST INC
           <br />
-          <Headline themes={themes}>専用ログイン画面</Headline>
+          <Headline>専用ログイン画面</Headline>
         </>
       }
     >
@@ -154,14 +154,15 @@ WithoutChildren.storyName = 'without children'
 export const WithoutAllOptionalProps: Story = () => <MessageScreen />
 WithoutAllOptionalProps.storyName = 'without all optional props'
 
-const Description = styled.div<{ themes: Theme }>`
-  ${({ themes }) => css`
-    color: ${themes.color.TEXT_BLACK};
-    font-size: ${themes.fontSize.M};
+const Description = styled.div(
+  ({ theme }) => css`
+    color: ${theme.color.TEXT_BLACK};
+    font-size: ${theme.fontSize.M};
     line-height: 21px;
     text-align: center;
-  `}
-`
+  `,
+)
+
 const BoxWrapper = styled.div`
   margin-bottom: 16px;
 `
@@ -188,13 +189,13 @@ const Bottom = styled.div`
     margin-bottom: 24px;
   }
 `
-const Headline = styled.span<{ themes: Theme }>`
-  ${({ themes }) => css`
+const Headline = styled.span(
+  ({ theme }) => css`
     display: inline-block;
     width: 100%;
     margin-top: 16px;
-    color: ${themes.color.TEXT_BLACK};
-    font-size: ${themes.fontSize.L};
+    color: ${theme.color.TEXT_BLACK};
+    font-size: ${theme.fontSize.L};
     text-align: center;
-  `}
-`
+  `,
+)

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,21 +1,21 @@
 import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaExternalLinkAltIcon } from '../Icon'
 
 export default {
   title: '[TBD] ProgressBar',
+  parameters: {
+    withTheming: true,
+  },
 }
 
 export const All: Story = () => {
-  const themes = useTheme()
   return (
-    <Wrapper themes={themes}>
+    <Wrapper>
       <Title>To Be Developed</Title>
       <Description>This component will develop in the near future.</Description>
       <Link
-        themes={themes}
         href="https://smarthr.invisionapp.com/share/ADUDJ8BW74C#/391861064_progress_Bar"
         target="_blank"
       >
@@ -27,12 +27,12 @@ export const All: Story = () => {
 }
 All.storyName = 'all'
 
-const Wrapper = styled.div<{ themes: Theme }>`
+const Wrapper = styled.div`
   box-sizing: border-box;
   padding: 24px;
   border-radius: 6px;
   box-shadow: rgba(51, 51, 51, 0.3) 1px 1px 4px 0;
-  color: ${({ themes }) => themes.color.TEXT_BLACK};
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
   text-align: center;
   line-height: 1;
   position: absolute;
@@ -52,8 +52,8 @@ const Description = styled.div`
   margin-bottom: 16px;
 `
 
-const Link = styled.a<{ themes: Theme }>`
-  color: ${({ themes }) => themes.color.TEXT_LINK};
+const Link = styled.a`
+  color: ${({ theme }) => theme.color.TEXT_LINK};
 `
 const LinkText = styled.span`
   vertical-align: middle;


### PR DESCRIPTION
## Related URL

- https://github.com/kufu/smarthr-ui/pull/2793#discussion_r1000118459

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

上記リンク先のレビュー指摘を反映させたい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Story の実装時に `useTheme` それぞれで使うのではなく `parameters: { withTheming: true }` を指定し、`ThemeProvider` から渡される `theme` 値を使うように変更しました。

`.stories.tsx` 以外のファイルには手を入れていないのと、reg-suit にも差分は出ていないので問題なさそうなことは確認済み。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
