### PR TITLE
fix: `ModelessDialog` を画面上部の境界外にドラッグ&ドロップできないようにする

### DIFF
--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -1,4 +1,5 @@
 import React, {
+  ComponentProps,
   MouseEvent,
   ReactNode,
   RefObject,
@@ -105,6 +106,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     x: 0,
     y: 0,
   })
+  const [bounds, setBounds] = useState<ComponentProps<typeof Draggable>['bounds']>()
   const theme = useTheme()
 
   useEffect(() => {
@@ -184,6 +186,20 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     [isOpen],
   )
 
+  useEffect(() => {
+    if (!isOpen || !isReady) return
+
+    if (centering.top) {
+      setBounds({ top: centering.top * -1 })
+      return
+    }
+
+    if (wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect()
+      setBounds({ top: rect.top * -1 })
+    }
+  }, [isOpen, isReady, centering.top])
+
   const labelId = useId()
   const classNames = useClassNames().modelessDialog
 
@@ -201,6 +217,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
           })
         }}
         position={position}
+        bounds={bounds}
       >
         <Layout
           {...props}

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -106,7 +106,8 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     x: 0,
     y: 0,
   })
-  const [bounds, setBounds] = useState<ComponentProps<typeof Draggable>['bounds']>()
+  const [draggableBounds, setDraggableBounds] =
+    useState<ComponentProps<typeof Draggable>['bounds']>()
   const theme = useTheme()
 
   useEffect(() => {
@@ -190,13 +191,13 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     if (!isOpen || !isReady) return
 
     if (centering.top) {
-      setBounds({ top: centering.top * -1 })
+      setDraggableBounds({ top: centering.top * -1 })
       return
     }
 
     if (wrapperRef.current) {
       const rect = wrapperRef.current.getBoundingClientRect()
-      setBounds({ top: rect.top * -1 })
+      setDraggableBounds({ top: rect.top * -1 })
     }
   }, [isOpen, isReady, centering.top])
 
@@ -217,7 +218,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
           })
         }}
         position={position}
-        bounds={bounds}
+        bounds={draggableBounds}
       >
         <Layout
           {...props}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-584

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`ModelessDialog` を画面外にドラッグ&ドロップできてしまい、マウス操作でダイアログを閉じたり、ダイアログの位置を戻したりできなくなることがあるため修正したい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`react-draggable` の props に、`Draggable` の境界を指定する `bounds` props があるため、これを使用し、画面上部を超えてドラッグ&ドロップできないように調整しました。
https://github.com/react-grid-layout/react-draggable#draggable-props

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

https://user-images.githubusercontent.com/32166731/197096894-64a2e4a7-978f-4e6d-890c-213bcde50b44.mov




<!--
Please attach a capture if it looks different.
-->
