### PR TITLE
fix: ヘルプページなどのURLを置き換え

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -15,7 +15,7 @@ export const all: Story = () => (
   <Stack gap={0.25}>
     <Header />
     <Header tenants="株式会社SmartHR">
-      <HeaderLink href="https://knowledge.smarthr.jp/" prefix={<FaQuestionCircleIcon />}>
+      <HeaderLink href="https://support.smarthr.jp/" prefix={<FaQuestionCircleIcon />}>
         ヘルプ
       </HeaderLink>
       <HeaderDropdownButton label="info@example.com">
@@ -33,7 +33,7 @@ export const all: Story = () => (
       <HeaderLink href="https://school.smarthr.jp/" prefix={<FaGraduationCapIcon />}>
         スクール
       </HeaderLink>
-      <HeaderLink href="https://knowledge.smarthr.jp/" prefix={<FaQuestionCircleIcon />}>
+      <HeaderLink href="https://support.smarthr.jp/" prefix={<FaQuestionCircleIcon />}>
         ヘルプ
       </HeaderLink>
       <HeaderLink href="https://support.smarthr.jp/">リリースノート</HeaderLink>

--- a/src/components/MessageScreen/Footer.tsx
+++ b/src/components/MessageScreen/Footer.tsx
@@ -12,11 +12,11 @@ export const Footer: VFC<ElementProps> = ({ className = '', ...props }) => {
   return (
     <Wrapper {...props} themes={theme} className={`${footer} ${className}`}>
       <List themes={theme}>
-        <Item href="https://smarthr.jp/help">ヘルプ</Item>
-        <Item href="https://smarthr.jp/info">お知らせ</Item>
-        <Item href="https://smarthr.jp/terms">利用規約</Item>
-        <Item href="https://smarthr.jp/policy">プライバシーポリシー</Item>
-        <Item href="https://smarthr.jp/law">特定商取引法に基づく表記</Item>
+        <Item href="https://support.smarthr.jp/">ヘルプ</Item>
+        <Item href="https://smarthr.jp/update/">お知らせ</Item>
+        <Item href="https://smarthr.jp/terms/">利用規約</Item>
+        <Item href="https://smarthr.co.jp/privacy/">プライバシーポリシー</Item>
+        <Item href="https://smarthr.jp/law/">特定商取引法に基づく表記</Item>
         <Item href="https://smarthr.co.jp">運営会社</Item>
         <Item href="https://developer.smarthr.jp">開発者向けAPI </Item>
       </List>


### PR DESCRIPTION
## Related URL

https://smarthr.jp/news/42544

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

SmartHRのヘルプセンターのURLが古いものだったので、最新のものに変更した。
合わせて、お知らせやプライバシーポリシーポリシーのURLも古いものだったので、最新のものに変更した。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- smarthr.jp/help が含まれるURLの置換
- knowledge.smarthr.jpが含まれるURLの置換
- `Footer.txs` 内の古いURLの置換

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

🍐 

<!--
Please attach a capture if it looks different.
-->
