### PR TITLE
chore: delete markdown type

### DIFF
--- a/src/types/markdown/markdown.d.ts
+++ b/src/types/markdown/markdown.d.ts
@@ -1,4 +1,0 @@
-declare module '*.md' {
-  const value: string
-  export default value
-}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://github.com/kufu/smarthr-ui/pull/2707

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

I use it as a reference for the implementation of the UI library. Thank you.
UIライブラリを実装する際に参考にさせていただいております。ありがとうございます。

In this time, I deleted the type because I thought it is forgotten to delete in the above pull request.
上記PRで型を削除し忘れているのかなと思い、軽微なPRを出しました。

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

I deleted the markdown type.
マークダウンの型定義を削除しました。

I executed `yarn lint`, `yarn build` and `yarn test` in local and confirmed that there were no errors.
lintとbuildとtestをlocalで打って問題ないことを確認しました。

## Capture

<!--
Please attach a capture if it looks different.
-->

none.
なし。

## Question
If you don't use this [template](https://github.com/kufu/smarthr-ui/blob/master/CONTRIBUTING.md#template), I will also remove this from CONTRIBUTING.md. Should I do?
テンプレートを使っていないのであればあわせて削除しますが、いかがでしょうか？