### PR TITLE
fix: Icon with Text の複数行表示を修正

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -100,12 +100,6 @@ export const WithText: Story = () => (
     </Text>
     <Text as="p" size="XL">
       <FaInfoCircleIcon text="文字サイズは親要素から継承されます。" />
-      <Text size="S">
-        <FaBullhornIcon
-          text="そのため一文の中で別の文字サイズを使いたければ Text コンポーネントを入れ子にしてください。"
-          right
-        />
-      </Text>
     </Text>
   </Stack>
 )

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -399,39 +399,59 @@ const createIcon = (SvgIcon: IconType) => {
     const classNames = useClassNames()
 
     const existsText = !!text
-    const Wrapper = existsText ? WithIcon : React.Fragment
-    const wrapperProps = existsText ? { gap: iconGap, right, className: classNames.withText } : {}
+    const svgIcon = (
+      <SvgIcon
+        {...props}
+        color={replacedColor}
+        className={`${className} ${classNames.wrapper}`}
+        role={role}
+        aria-hidden={isAriaHidden || alt !== undefined || undefined}
+        focusable={focusable}
+      />
+    )
+
+    if (existsText) {
+      return (
+        <WithIcon gap={iconGap} right={right} className={classNames.withText}>
+          {alt && <VisuallyHiddenText>{alt}</VisuallyHiddenText>}
+          {right && text}
+          {svgIcon}
+          {!right && text}
+        </WithIcon>
+      )
+    }
 
     return (
-      <Wrapper {...wrapperProps}>
+      <>
         {alt && <VisuallyHiddenText>{alt}</VisuallyHiddenText>}
-        <SvgIcon
-          {...props}
-          color={replacedColor}
-          className={`${className} ${classNames.wrapper}`}
-          role={role}
-          aria-hidden={isAriaHidden || alt !== undefined || undefined}
-          focusable={focusable}
-        />
-        {text}
-      </Wrapper>
+        {svgIcon}
+      </>
     )
   }
+
   return Icon
 }
 
-const WithIcon = styled.span<{ right?: boolean; gap?: CharRelativeSize | AbstractSize }>`
+const WithIcon = styled.span<{
+  right: ComponentProps['right']
+  gap: ComponentProps['iconGap']
+}>`
   ${({ right, gap }) => css`
-    display: inline-flex;
-    ${right && `flex-direction: row-reverse;`}
-    align-items: baseline;
-    ${gap && `column-gap: ${useSpacing(gap)};`}
+    ${!right &&
+    css`
+      display: inline-flex;
+      align-items: baseline;
+      ${gap && `column-gap: ${useSpacing(gap)};`}
+    `}
 
     .smarthr-ui-Icon {
-      align-self: center;
+      flex-shrink: 0;
+      transform: translateY(0.125em);
+      ${right && gap && `margin-inline-start: ${useSpacing(gap)};`}
     }
   `}
 `
+
 const VisuallyHiddenText = styled.span`
   ${VISUALLY_HIDDEN_STYLE}
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-625

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Icon with Text で複数行になる場合にアイコンが縦位置中央に揃ってしまっていたため、1行目の先頭に揃えました。

また、アイコンを右側に寄せる場合は flexbox ではなく inline のまま扱うようにしました。

Story で動きの確認もお願いします。
https://deploy-preview-2859--smarthr-ui.netlify.app/?path=/story/icon--with-text