### PR TITLE
fix: InputFile のフォーカススタイルをクラス名で行わないように修正

### DIFF
--- a/src/components/InputFile/InputFile.stories.tsx
+++ b/src/components/InputFile/InputFile.stories.tsx
@@ -15,23 +15,23 @@ export const All: Story = () => {
     <List>
       <dt>Default</dt>
       <dd>
-        <InputFile label="Choose File" onChange={action('onChange')} multiple />
+        <InputFile label="ファイルを選択" onChange={action('onChange')} multiple />
       </dd>
       <dt>Size S</dt>
       <dd>
-        <InputFile label="Choose File" onChange={action('onChange')} size="s" multiple />
+        <InputFile label="ファイルを選択" onChange={action('onChange')} size="s" multiple />
       </dd>
       <dt>Disabled file list</dt>
       <dd>
-        <InputFile label="Choose File" onChange={action('onChange')} hasFileList={false} />
+        <InputFile label="ファイルを選択" onChange={action('onChange')} hasFileList={false} />
       </dd>
       <dt>Disabled input</dt>
       <dd>
-        <InputFile label="Choose File" disabled />
+        <InputFile label="ファイルを選択" disabled />
       </dd>
       <dt>エラー</dt>
       <dd>
-        <InputFile label="Choose File" error />
+        <InputFile label="ファイルを選択" error />
       </dd>
     </List>
   )

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -161,7 +161,7 @@ const InputWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
       padding: ${spacingByChar(0.5)};
       font-size: ${fontSize.S};
     }
-    &.focus {
+    &:focus-within {
       ${shadow.focusIndicatorStyles}
     }
     &.disabled {


### PR DESCRIPTION
フォーカススタイリングを State とクラス名で管理していたため、コンポーネントが予期せぬタイミングで disabled になった場合にフォーカススタイルが残ってしまっていた。

:focus-within を利用し、フォーカスしているかどうかの判定は UA に任せることにした。
クラス名の付け替えを利用しているプロダクトもありそうなので、削除せず残しました。