### PR TITLE
fix: ButtonWrapper に渡していた loading を Transient Props に変更

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,7 +48,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         className={`${className} ${classNames.wrapper}`}
         buttonRef={ref}
         disabled={disabledOnLoading}
-        loading={loading}
+        $loading={loading}
       >
         <ButtonInner prefix={actualPrefix} suffix={actualSuffix}>
           {actualChildren}

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -16,7 +16,7 @@ type BaseProps = {
   square: boolean
   wide: boolean
   variant: Variant
-  loading?: boolean
+  $loading?: boolean
   className: string
   children: ReactNode
 }
@@ -33,7 +33,7 @@ type Props =
   | (ButtonProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonProps>)
   | (AnchorProps & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof AnchorProps>)
 
-type StyleProps = Pick<Props, 'wide' | 'variant' | 'loading'> & { themes: Theme }
+type StyleProps = Pick<Props, 'wide' | 'variant' | '$loading'> & { themes: Theme }
 
 export function ButtonWrapper({ size, square, className, ...props }: Props) {
   const theme = useTheme()
@@ -48,14 +48,14 @@ export function ButtonWrapper({ size, square, className, ...props }: Props) {
   )
 }
 
-const baseStyles = css<StyleProps>(({ wide, loading, themes }) => {
+const baseStyles = css<StyleProps>(({ wide, $loading, themes }) => {
   const { border, fontSize, leading, radius, shadow, spacingByChar } = themes
 
   return css`
     box-sizing: border-box;
     cursor: pointer;
     display: inline-flex;
-    ${loading && `flex-direction: row-reverse;`}
+    ${$loading && `flex-direction: row-reverse;`}
     justify-content: center;
     align-items: center;
     gap: ${spacingByChar(0.5)};


### PR DESCRIPTION
## 概要

Next.js 環境で以下の Warning が発生していた。

```
Warning: Received `false` for a non-boolean attribute `loading`.

If you want to write it to the DOM, pass a string instead: loading="false" or loading={value.toString()}.

If you used to conditionally omit it with loading={condition && value}, pass loading={condition ? value : undefined} instead.
```

原因は定かではないが、button 要素に対して `loading` を流し込んだときに `loading` は boolean ではない、と怒られていると考え Transient Props を用いて修正した。

https://smarthr.atlassian.net/browse/SHRUI-639

## 参考

- https://styled-components.com/docs/faqs#transient-props-since-51
- [HTMLImageElement.loading - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/HTMLImageElement/loading)
  - img 要素には loading 属性が存在する