### PR TITLE
feat: DropdownButton に disabled な理由を渡せるようにする

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,6 +7,9 @@ import { useClassNames } from './useClassNames'
 import { ButtonWrapper } from './ButtonWrapper'
 import { ButtonInner } from './ButtonInner'
 import { Loader as shrLoader } from '../Loader'
+import { Cluster } from '../Layout'
+import { Tooltip } from '../Tooltip'
+import { FaInfoCircleIcon } from '../Icon'
 
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
 
@@ -21,6 +24,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
       wide = false,
       variant = 'secondary',
       disabled,
+      disabledDetail,
       className = '',
       children,
       loading = false,
@@ -37,7 +41,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
     const disabledOnLoading = loading || disabled
     const actualChildren = loading && square ? loader : children
 
-    return (
+    const button = (
       <ButtonWrapper
         {...props}
         type={type}
@@ -55,6 +59,21 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         </ButtonInner>
       </ButtonWrapper>
     )
+
+    if (disabled && disabledDetail) {
+      const DisabledDetailIcon = disabledDetail.icon || FaInfoCircleIcon
+
+      return (
+        <DisabledDetailWrapper themes={theme} className={classNames.disabledWrapper}>
+          {button}
+          <Tooltip message={disabledDetail.message} triggerType="icon">
+            <DisabledDetailIcon />
+          </Tooltip>
+        </DisabledDetailWrapper>
+      )
+    }
+
+    return button
   },
 )
 // BottomFixedArea での判定に用いるために displayName を明示的に設定する
@@ -75,6 +94,24 @@ const Loader = styled(shrLoader)<{ variant: Variant; themes: Theme }>`
       border-color: ${variant === 'secondary'
         ? color.TEXT_DISABLED
         : color.disableColor(color.TEXT_WHITE)};
+    }
+  `}
+`
+
+const DisabledDetailWrapper = styled(Cluster).attrs({
+  inline: true,
+  align: 'center',
+})<{ themes: Theme }>`
+  ${({ themes: { color, space } }) => css`
+    > .smarthr-ui-Tooltip {
+      overflow-y: unset;
+
+      .smarthr-ui-Icon {
+        /* Tooltip との距離を変えずに反応範囲を広げるために negative space を使う */
+        margin: ${space(-0.25)};
+        padding: ${space(0.25)};
+        color: ${color.TEXT_GREY};
+      }
     }
   `}
 `

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -12,6 +12,13 @@ export type BaseProps = {
    */
   className?: string
   /**
+   * 無効な理由
+   */
+  disabledDetail?: {
+    icon?: React.FunctionComponent
+    message: React.ReactNode
+  }
+  /**
    * ボタン内の先頭に表示する内容。
    * 通常は、アイコンを表示するために用いる。
    */

--- a/src/components/Button/useClassNames.ts
+++ b/src/components/Button/useClassNames.ts
@@ -40,6 +40,7 @@ export const useClassNames = () => {
     () => ({
       button: {
         wrapper: generateButotn(),
+        disabledWrapper: generateButotn('disabledWrapper'),
       },
       anchorButton: {
         wrapper: generateAnchorButotn(),

--- a/src/components/Dropdown/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/Dropdown/DropdownButton/DropdownButton.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ComponentProps } from 'react'
 import { Story } from '@storybook/react'
 
 import { DropdownButton } from './DropdownButton'
@@ -7,45 +7,31 @@ import { Cluster } from '../../Layout'
 
 const flag = false
 
+const Template: React.FC<Omit<ComponentProps<typeof DropdownButton>, 'children'>> = (props) => (
+  <DropdownButton {...props}>
+    <Button>評価を開始</Button>
+    <Button
+      disabled
+      disabledDetail={{
+        message: '評価を開始していないため、評価を確定できません。',
+      }}
+    >
+      評価を確定
+    </Button>
+    <Button>ヒントメッセージの設定</Button>
+    <AnchorButton href="#h2-2">ログアウト</AnchorButton>
+    {flag && <Button>非表示になるテキスト</Button>}
+  </DropdownButton>
+)
+
 export const Default: Story = () => (
   <Cluster align="center">
-    <DropdownButton>
-      <Button>評価を開始</Button>
-      <Button disabled>評価を確定</Button>
-      <Button>ヒントメッセージの設定</Button>
-      <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-      {flag && <Button>非表示になるテキスト</Button>}
-    </DropdownButton>
-    <DropdownButton disabled>
-      <Button>評価を開始</Button>
-      <Button disabled>評価を確定</Button>
-      <Button>ヒントメッセージの設定</Button>
-      <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    </DropdownButton>
-    <DropdownButton onlyIconTrigger>
-      <Button>評価を開始</Button>
-      <Button disabled>評価を確定</Button>
-      <Button>ヒントメッセージの設定</Button>
-      <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    </DropdownButton>
-    <DropdownButton triggerSize="s" label="操作">
-      <Button>評価を開始</Button>
-      <Button disabled>評価を確定</Button>
-      <Button>ヒントメッセージの設定</Button>
-      <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    </DropdownButton>
-    <DropdownButton triggerSize="s" label={<span>操作</span>} disabled>
-      <Button>評価を開始</Button>
-      <Button disabled>評価を確定</Button>
-      <Button>ヒントメッセージの設定</Button>
-      <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    </DropdownButton>
-    <DropdownButton triggerSize="s" onlyIconTrigger>
-      <Button>評価を開始</Button>
-      <Button disabled>評価を確定</Button>
-      <Button>ヒントメッセージの設定</Button>
-      <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    </DropdownButton>
+    <Template />
+    <Template disabled />
+    <Template onlyIconTrigger />
+    <Template triggerSize="s" label="操作" />
+    <Template triggerSize="s" label={<span>操作</span>} disabled />
+    <Template triggerSize="s" onlyIconTrigger />
   </Cluster>
 )
 Default.storyName = 'DropdownButton'

--- a/src/components/Dropdown/DropdownButton/DropdownButton.tsx
+++ b/src/components/Dropdown/DropdownButton/DropdownButton.tsx
@@ -87,18 +87,28 @@ const TriggerButton = styled(Button)`
   }
 `
 const ActionList = styled(Stack).attrs({ as: 'ul', gap: 0 })<{ themes: Theme }>`
-  ${({ themes: { spacingByChar } }) => css`
+  ${({ themes: { space } }) => css`
     list-style: none;
     margin-block: 0;
-    padding-block: ${spacingByChar(0.5)};
+    padding-block: ${space(0.5)};
     padding-inline-start: 0;
 
     .smarthr-ui-Button,
     .smarthr-ui-AnchorButton {
       justify-content: flex-start;
 
-      padding-block: ${spacingByChar(0.5)};
+      padding-block: ${space(0.5)};
       font-weight: normal;
+    }
+
+    .smarthr-ui-Button-disabledWrapper {
+      /* unset した Button の右 padding 分 */
+      padding-inline-end: ${space(1)};
+
+      > [disabled] {
+        padding-inline-end: unset;
+        width: unset;
+      }
     }
   `}
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-603

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DropdownButton の children に Button[disabled] がある時、利用者は disabled な理由を知る術がない。
Button[disabled] の外で disabled な理由を伝えたいため、Button に disabled な理由（disabledDetail）を渡せるようにした。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- [Button に disabled な理由を渡せるようにする](https://github.com/kufu/smarthr-ui/commit/12205138aac6119d4056ebc03d184f42f42b9426)
- [DropdownButton 内の disabled な Button スタイリングを調整](https://github.com/kufu/smarthr-ui/commit/d502d5bcb61d5002ec136c40f754db4909aea196)
- [Story を修正](https://github.com/kufu/smarthr-ui/commit/5dd4b978ac9b46c3dd7cd94541b806d78600950e)

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
![image](https://user-images.githubusercontent.com/19403400/201557520-d3d6e6d5-bd4a-4cae-aefc-8ae77b039e55.png)
