### PR TITLE
fix: combobox default-item optionのバグを修正する

### DIFF
--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -11,7 +11,7 @@ import React, {
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { useOuterClick } from '../../hooks/useOuterClick'
+import { useClick } from '../../hooks/useClick'
 import { useSingleComboBoxClassNames } from './useClassNames'
 
 import { Input } from '../Input'
@@ -261,14 +261,6 @@ export function SingleComboBox<T>({
     },
     [isComposing, isExpanded, setIsExpanded, unfocus, handleListBoxKeyDown],
   )
-  const onBlurInput = useCallback(() => {
-    // HINT: useOuterClickよりあとに発火させたいためsetTimeoutでキューに積む
-    setTimeout(() => {
-      if (!selectedItem && defaultItem) {
-        onSelect && onSelect(defaultItem)
-      }
-    }, 10)
-  }, [selectedItem, defaultItem, onSelect])
 
   const caretIconColor = useMemo(() => {
     if (isFocused) return theme.color.TEXT_BLACK
@@ -276,8 +268,13 @@ export function SingleComboBox<T>({
     return theme.color.TEXT_GREY
   }, [disabled, isFocused, theme])
 
-  useOuterClick(
+  useClick(
     [outerRef, listBoxRef, clearButtonRef],
+    useCallback(() => {
+      if (!isFocused && onSelect && !selectedItem && defaultItem) {
+        onSelect(defaultItem)
+      }
+    }, [isFocused, selectedItem, onSelect, defaultItem]),
     useCallback(() => {
       unfocus()
     }, [unfocus]),
@@ -351,7 +348,6 @@ export function SingleComboBox<T>({
           onCompositionStart={onCompositionStart}
           onCompositionEnd={onCompositionEnd}
           onKeyDown={onKeyDownInput}
-          onBlur={onBlurInput}
           ref={inputRef}
           autoComplete="off"
           aria-activedescendant={activeOption?.id}

--- a/src/hooks/useClick.ts
+++ b/src/hooks/useClick.ts
@@ -1,0 +1,34 @@
+import { RefObject, useCallback, useEffect } from 'react'
+
+export function useClick(
+  innerRefs: Array<RefObject<HTMLElement>>,
+  innerCallback: (e: MouseEvent) => void,
+  outerCallback: (e: MouseEvent) => void,
+) {
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      if (innerRefs.some((target) => isEventIncludedParent(e, target.current))) {
+        innerCallback(e)
+        return
+      }
+      outerCallback(e)
+    },
+    // spread innerRefs to compare deps one by one
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [...innerRefs, innerCallback, outerCallback],
+  )
+
+  useEffect(() => {
+    window.addEventListener('click', handleClick)
+
+    return () => {
+      window.removeEventListener('click', handleClick)
+    }
+  }, [handleClick])
+}
+
+function isEventIncludedParent(e: MouseEvent, parent: Element | null): boolean {
+  const path = e.composedPath()
+  if (path.length === 0 || !parent) return false
+  return path.includes(parent)
+}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- SingleComboboxの defaultItem オプションが特定の操作時、バグってしまうため、調整した
  - 再現手順
    - comboboxにfocusする
    - deleteキーなどでinputをclearする
    - defaultItemに指定している以外の選択肢を選ぶ
    - defaultItemが選ばれてしまう

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
