### PR TITLE
fix: Tooltip を div から span に変更

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -149,7 +149,7 @@ export const Tooltip: VFC<Props & ElementProps> = ({
   )
 }
 
-const Wrapper = styled.div<{ isIcon?: boolean; themes: Theme }>`
+const Wrapper = styled.span<{ isIcon?: boolean; themes: Theme }>`
   ${({ isIcon, themes: { shadow } }) => css`
     display: inline-block;
     max-width: 100%;


### PR DESCRIPTION
Tooltip の利用用途として、HTML の構文上 div だと困ることが多いため span としたい。
https://smarthr.atlassian.net/browse/SHRUI-623