### PR TITLE
feat: 一部の入力系コンポーネントに ref を渡せるよう修正

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -14,33 +14,35 @@ type Props = {
   children?: ReactNode
 } & CheckBoxInputProps
 
-export const CheckBox: FC<Props> = ({ lineHeight = 1.5, className = '', children, ...props }) => {
-  const theme = useTheme()
-  const classNames = useClassNames()
-  const checkBoxId = useId(props.id)
+export const CheckBox = forwardRef<HTMLInputElement, Props>(
+  ({ lineHeight = 1.5, className = '', children, ...props }, ref) => {
+    const theme = useTheme()
+    const classNames = useClassNames()
+    const checkBoxId = useId(props.id)
 
-  if (!children)
+    if (!children)
+      return (
+        <Wrapper className={`${className} ${classNames.wrapper}`}>
+          <CheckBoxInput {...props} ref={ref} />
+        </Wrapper>
+      )
+
     return (
       <Wrapper className={`${className} ${classNames.wrapper}`}>
-        <CheckBoxInput {...props} />
+        <CheckBoxInput {...props} ref={ref} id={checkBoxId} />
+
+        <Label
+          className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
+          htmlFor={checkBoxId}
+          $lineHeight={lineHeight}
+          themes={theme}
+        >
+          {children}
+        </Label>
       </Wrapper>
     )
-
-  return (
-    <Wrapper className={`${className} ${classNames.wrapper}`}>
-      <CheckBoxInput {...props} id={checkBoxId} />
-
-      <Label
-        className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
-        htmlFor={checkBoxId}
-        $lineHeight={lineHeight}
-        themes={theme}
-      >
-        {children}
-      </Label>
-    </Wrapper>
-  )
-}
+  },
+)
 
 // Use flex-start to support multi-line text.
 const Wrapper = styled.div`

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -1,4 +1,4 @@
-import React, { VFC, useCallback } from 'react'
+import React, { forwardRef, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 import { transparentize } from 'polished'
 
@@ -12,35 +12,38 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
   mixed?: boolean
 }
 
-export const CheckBoxInput: VFC<Props> = ({ mixed = false, onChange, ...props }) => {
-  const theme = useTheme()
-  const { checked, disabled } = props
-  const boxClassName = `${checked ? 'active' : ''} ${disabled ? 'disabled' : ''}`
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (onChange) onChange(e)
-    },
-    [onChange],
-  )
-  const classNames = useClassNames()
+export const CheckBoxInput = forwardRef<HTMLInputElement, Props>(
+  ({ mixed = false, onChange, ...props }, ref) => {
+    const theme = useTheme()
+    const { checked, disabled } = props
+    const boxClassName = `${checked ? 'active' : ''} ${disabled ? 'disabled' : ''}`
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (onChange) onChange(e)
+      },
+      [onChange],
+    )
+    const classNames = useClassNames()
 
-  return (
-    <Wrapper themes={theme}>
-      <Input
-        {...props}
-        {...(mixed && { 'aria-checked': 'mixed' })}
-        type="checkbox"
-        onChange={handleChange}
-        className={classNames.checkBox}
-        themes={theme}
-      />
-      <Box className={boxClassName} themes={theme} />
-      <IconWrap themes={theme}>
-        {mixed ? <FaMinusIcon color="TEXT_WHITE" /> : <FaCheckIcon color="TEXT_WHITE" />}
-      </IconWrap>
-    </Wrapper>
-  )
-}
+    return (
+      <Wrapper themes={theme}>
+        <Input
+          {...props}
+          {...(mixed && { 'aria-checked': 'mixed' })}
+          type="checkbox"
+          onChange={handleChange}
+          className={classNames.checkBox}
+          themes={theme}
+          ref={ref}
+        />
+        <Box className={boxClassName} themes={theme} />
+        <IconWrap themes={theme}>
+          {mixed ? <FaMinusIcon color="TEXT_WHITE" /> : <FaCheckIcon color="TEXT_WHITE" />}
+        </IconWrap>
+      </Wrapper>
+    )
+  },
+)
 
 const Wrapper = styled.span<{ themes: Theme }>`
   ${({ themes }) => {

--- a/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
+++ b/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react'
+import React, { ComponentProps, forwardRef } from 'react'
 import styled from 'styled-components'
 
 import { Input } from '../Input'
@@ -9,13 +9,13 @@ type Props = ComponentProps<typeof Input> & {
   tooltipMessage: React.ReactNode
 }
 
-export const InputWithTooltip: React.FC<Props> = ({ tooltipMessage, ...props }) => {
-  return (
+export const InputWithTooltip = forwardRef<HTMLInputElement, Props>(
+  ({ tooltipMessage, ...props }, ref) => (
     <Tooltip message={tooltipMessage} tabIndex={-1} ariaDescribedbyTarget="inner">
-      <Input {...props} />
+      <Input {...props} ref={ref} />
     </Tooltip>
-  )
-}
+  ),
+)
 
 const Tooltip = styled(shrTooltip)`
   /* Input のフォーカスリングを表示するため */

--- a/src/components/Input/SearchInput/SearchInput.tsx
+++ b/src/components/Input/SearchInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 import { ComponentProps } from 'react'
 import { InputWithTooltip } from '../InputWithTooltip'
@@ -9,8 +9,8 @@ type Props = Omit<ComponentProps<typeof InputWithTooltip>, 'tooltipMessage' | 'p
   tooltipMessage: React.ReactNode
 }
 
-export const SearchInput: React.FC<Props> = ({ ...props }) => (
+export const SearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => (
   <label>
-    <InputWithTooltip {...props} prefix={<FaSearchIcon alt="検索" color="TEXT_GREY" />} />
+    <InputWithTooltip {...props} ref={ref} prefix={<FaSearchIcon alt="検索" color="TEXT_GREY" />} />
   </label>
-)
+))

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { ReactNode, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -14,41 +14,38 @@ type Props = {
   children?: ReactNode
 } & RadioButtonInputProps
 
-export const RadioButton: FC<Props> = ({
-  lineHeight = 1.5,
-  children,
-  className = '',
-  ...props
-}) => {
-  const theme = useTheme()
-  const classNames = useClassNames()
-  const radioButtonId = useId(props.id)
+export const RadioButton = forwardRef<HTMLInputElement, Props>(
+  ({ lineHeight = 1.5, children, className = '', ...props }, ref) => {
+    const theme = useTheme()
+    const classNames = useClassNames()
+    const radioButtonId = useId(props.id)
 
-  if (!children) {
+    if (!children) {
+      return (
+        <Wrapper className={`${className} ${classNames.wrapper}`} themes={theme}>
+          <RadioButtonInput {...props} ref={ref} className={classNames.radioButton} />
+        </Wrapper>
+      )
+    }
+
     return (
       <Wrapper className={`${className} ${classNames.wrapper}`} themes={theme}>
-        <RadioButtonInput {...props} className={classNames.radioButton} />
+        <ButtonLayout $height={`${lineHeight}em`}>
+          <RadioButtonInput {...props} ref={ref} id={radioButtonId} />
+        </ButtonLayout>
+
+        <Label
+          htmlFor={radioButtonId}
+          className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
+          $lineHeight={lineHeight}
+          themes={theme}
+        >
+          {children}
+        </Label>
       </Wrapper>
     )
-  }
-
-  return (
-    <Wrapper className={`${className} ${classNames.wrapper}`} themes={theme}>
-      <ButtonLayout $height={`${lineHeight}em`}>
-        <RadioButtonInput {...props} id={radioButtonId} />
-      </ButtonLayout>
-
-      <Label
-        htmlFor={radioButtonId}
-        className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
-        $lineHeight={lineHeight}
-        themes={theme}
-      >
-        {children}
-      </Label>
-    </Wrapper>
-  )
-}
+  },
+)
 
 const Wrapper = styled.div<{ themes: Theme }>`
   ${({ themes: { fontSize } }) => css`

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, InputHTMLAttributes, VFC, useCallback } from 'react'
+import React, { ChangeEvent, InputHTMLAttributes, forwardRef, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 import { transparentize } from 'polished'
 
@@ -7,31 +7,34 @@ import { useClassNames } from './useClassNames'
 
 export type Props = InputHTMLAttributes<HTMLInputElement>
 
-export const RadioButtonInput: VFC<Props> = ({ onChange, ...props }) => {
-  const theme = useTheme()
-  const { checked, disabled } = props
-  const boxClassName = `${checked ? 'active' : ''} ${disabled ? 'disabled' : ''}`
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      if (onChange) onChange(e)
-    },
-    [onChange],
-  )
-  const classNames = useClassNames()
+export const RadioButtonInput = forwardRef<HTMLInputElement, Props>(
+  ({ onChange, ...props }, ref) => {
+    const theme = useTheme()
+    const { checked, disabled } = props
+    const boxClassName = `${checked ? 'active' : ''} ${disabled ? 'disabled' : ''}`
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        if (onChange) onChange(e)
+      },
+      [onChange],
+    )
+    const classNames = useClassNames()
 
-  return (
-    <Wrapper themes={theme}>
-      <Input
-        {...props}
-        type="radio"
-        onChange={handleChange}
-        className={classNames.radioButton}
-        themes={theme}
-      />
-      <Box className={boxClassName} themes={theme} />
-    </Wrapper>
-  )
-}
+    return (
+      <Wrapper themes={theme}>
+        <Input
+          {...props}
+          type="radio"
+          onChange={handleChange}
+          className={classNames.radioButton}
+          themes={theme}
+          ref={ref}
+        />
+        <Box className={boxClassName} themes={theme} />
+      </Wrapper>
+    )
+  },
+)
 
 const Wrapper = styled.span<{ themes: Theme }>`
   ${({ themes }) => {


### PR DESCRIPTION
## Overview

react-hook-form など ref の公開を必要とする外部ライブラリに対応したい。
下記コンポーネントを forwardRef で置き換えた。

- SearchInput（内部で TooltipWithMessage）
- CheckBox（内部で CheckBoxInput）
- RadioButton（内部で RadioButtonInput）

また、以下コンポーネントは内部で ref を利用していたため別途対応予定。

- ComboBox
- DatePicker
- Textarea

以下コンポーネントは generics を含む場合の forwardRef の書き方がわからなかったため別途対応予定。

- Select