### PR TITLE
feat: 入力系コンポーネントに ref を渡せるよう修正

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,12 @@
-import React, { VFC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import styled, { css } from 'styled-components'
 import dayjs from 'dayjs'
 
@@ -52,265 +60,275 @@ type InputAttributes = Omit<React.InputHTMLAttributes<HTMLInputElement>, OmitInp
 
 export const DEFAULT_FROM = new Date(1900, 0, 1)
 
-export const DatePicker: VFC<Props & InputAttributes> = ({
-  value,
-  name,
-  from = DEFAULT_FROM,
-  to,
-  disabled,
-  error,
-  className = '',
-  parseInput,
-  formatDate,
-  showAlternative,
-  onChangeDate,
-  ...inputAttrs
-}) => {
-  const stringToDate = useCallback(
-    (str?: string | null) => {
-      if (!str) {
-        return null
-      }
-      return parseInput ? parseInput(str) : parseJpnDateString(str)
+export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
+  (
+    {
+      value,
+      name,
+      from = DEFAULT_FROM,
+      to,
+      disabled,
+      error,
+      className = '',
+      parseInput,
+      formatDate,
+      showAlternative,
+      onChangeDate,
+      ...inputAttrs
     },
-    [parseInput],
-  )
+    ref,
+  ) => {
+    const stringToDate = useCallback(
+      (str?: string | null) => {
+        if (!str) {
+          return null
+        }
+        return parseInput ? parseInput(str) : parseJpnDateString(str)
+      },
+      [parseInput],
+    )
 
-  const dateToString = useCallback(
-    (d: Date | null) => {
-      if (formatDate) {
-        return formatDate(d)
-      }
-      if (!d) {
-        return ''
-      }
-      return dayjs(d).format('YYYY/MM/DD')
-    },
-    [formatDate],
-  )
+    const dateToString = useCallback(
+      (d: Date | null) => {
+        if (formatDate) {
+          return formatDate(d)
+        }
+        if (!d) {
+          return ''
+        }
+        return dayjs(d).format('YYYY/MM/DD')
+      },
+      [formatDate],
+    )
 
-  const dateToAlternativeFormat = useCallback(
-    (d: Date | null) => {
-      if (!d || !showAlternative) {
-        return null
-      }
-      return showAlternative(d)
-    },
-    [showAlternative],
-  )
+    const dateToAlternativeFormat = useCallback(
+      (d: Date | null) => {
+        if (!d || !showAlternative) {
+          return null
+        }
+        return showAlternative(d)
+      },
+      [showAlternative],
+    )
 
-  const themes = useTheme()
-  const [selectedDate, setSelectedDate] = useState<Date | null>(stringToDate(value))
-  const inputRef = useRef<HTMLInputElement>(null)
-  const inputWrapperRef = useRef<HTMLDivElement>(null)
-  const calendarPortalRef = useRef<HTMLDivElement>(null)
-  const [inputRect, setInputRect] = useState<DOMRect | null>(null)
-  const [isInputFocused, setIsInputFocused] = useState(false)
-  const [isCalendarShown, setIsCalendarShown] = useState(false)
-  const [alternativeFormat, setAlternativeFormat] = useState<null | string>(null)
-  const calenderId = useId()
+    const themes = useTheme()
+    const [selectedDate, setSelectedDate] = useState<Date | null>(stringToDate(value))
+    const inputRef = useRef<HTMLInputElement>(null)
+    const inputWrapperRef = useRef<HTMLDivElement>(null)
+    const calendarPortalRef = useRef<HTMLDivElement>(null)
+    const [inputRect, setInputRect] = useState<DOMRect | null>(null)
+    const [isInputFocused, setIsInputFocused] = useState(false)
+    const [isCalendarShown, setIsCalendarShown] = useState(false)
+    const [alternativeFormat, setAlternativeFormat] = useState<null | string>(null)
+    const calenderId = useId()
 
-  const updateDate = useCallback(
-    (newDate: Date | null) => {
-      if (
-        !inputRef.current ||
-        newDate === selectedDate ||
-        (newDate && selectedDate && newDate.getTime() === selectedDate.getTime())
-      ) {
-        // Do not update date if the new date is same with the old one.
-        return
-      }
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current,
+    )
 
-      const isValid = !newDate || dayjs(newDate).isValid()
-      const nextDate = isValid ? newDate : null
-      const errors: string[] = []
-
-      if (!isValid) {
-        errors.push('INVALID_DATE')
-      }
-
-      inputRef.current.value = dateToString(nextDate)
-      setAlternativeFormat(dateToAlternativeFormat(nextDate))
-      setSelectedDate(nextDate)
-      onChangeDate && onChangeDate(nextDate, inputRef.current.value, { errors })
-    },
-    [selectedDate, dateToString, dateToAlternativeFormat, onChangeDate],
-  )
-
-  const switchCalendarVisibility = useCallback((isVisible: boolean) => {
-    if (!isVisible) {
-      setIsCalendarShown(false)
-      return
-    }
-    if (!inputWrapperRef.current) {
-      return
-    }
-    setIsCalendarShown(true)
-    setInputRect(inputWrapperRef.current.getBoundingClientRect())
-  }, [])
-
-  useEffect(() => {
-    if (value === undefined || !inputRef.current) {
-      return
-    }
-    /**
-     * Do not format the given value in the following cases
-     * - while input element is focused.
-     * - if the given value is not date formattable.
-     */
-    if (!isInputFocused) {
-      const newDate = stringToDate(value)
-      if (newDate && dayjs(newDate).isValid()) {
-        inputRef.current.value = dateToString(newDate)
-        setAlternativeFormat(dateToAlternativeFormat(newDate))
-        setSelectedDate(newDate)
-        return
-      }
-      setSelectedDate(null)
-    }
-    inputRef.current.value = value || ''
-  }, [value, isInputFocused, dateToString, dateToAlternativeFormat, stringToDate])
-
-  useOuterClick(
-    [inputWrapperRef, calendarPortalRef],
-    useCallback(() => {
-      switchCalendarVisibility(false)
-    }, [switchCalendarVisibility]),
-  )
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || !inputRef.current || !calendarPortalRef.current) {
-        return
-      }
-      const calendarButtons = calendarPortalRef.current.querySelectorAll('button')
-      if (calendarButtons.length === 0) {
-        return
-      }
-      const firstCalendarButton = calendarButtons[0]
-      const lastCalendarButton = calendarButtons[calendarButtons.length - 1]
-      if (isInputFocused) {
-        if (e.shiftKey) {
-          // move focus from Input to previous elements of DatePicker
-          switchCalendarVisibility(false)
+    const updateDate = useCallback(
+      (newDate: Date | null) => {
+        if (
+          !inputRef.current ||
+          newDate === selectedDate ||
+          (newDate && selectedDate && newDate.getTime() === selectedDate.getTime())
+        ) {
+          // Do not update date if the new date is same with the old one.
           return
         }
-        // move focus from Input to Calendar
-        e.preventDefault()
-        firstCalendarButton.focus()
+
+        const isValid = !newDate || dayjs(newDate).isValid()
+        const nextDate = isValid ? newDate : null
+        const errors: string[] = []
+
+        if (!isValid) {
+          errors.push('INVALID_DATE')
+        }
+
+        inputRef.current.value = dateToString(nextDate)
+        setAlternativeFormat(dateToAlternativeFormat(nextDate))
+        setSelectedDate(nextDate)
+        onChangeDate && onChangeDate(nextDate, inputRef.current.value, { errors })
+      },
+      [selectedDate, dateToString, dateToAlternativeFormat, onChangeDate],
+    )
+
+    const switchCalendarVisibility = useCallback((isVisible: boolean) => {
+      if (!isVisible) {
+        setIsCalendarShown(false)
         return
       }
-      const currentFocused = Array.from(calendarButtons).find((button) => button === e.target)
-      if (e.shiftKey && currentFocused === firstCalendarButton) {
-        // move focus from Calendar to Input
-        inputRef.current.focus()
-        e.preventDefault()
-      } else if (!e.shiftKey && currentFocused === lastCalendarButton) {
-        // move focus from Calendar to next elements of DatePicker
-        inputRef.current.focus()
-        switchCalendarVisibility(false)
+      if (!inputWrapperRef.current) {
+        return
       }
-    },
-    [isInputFocused, switchCalendarVisibility],
-  )
-  useGlobalKeyDown(handleKeyDown)
+      setIsCalendarShown(true)
+      setInputRect(inputWrapperRef.current.getBoundingClientRect())
+    }, [])
 
-  const caretIconColor = useMemo(() => {
-    if (isInputFocused || isCalendarShown) return themes.color.TEXT_BLACK
-    if (disabled) return themes.color.TEXT_DISABLED
-    return themes.color.TEXT_GREY
-  }, [isCalendarShown, isInputFocused, disabled, themes])
-
-  const classNames = useClassNames()
-
-  return (
-    <Container
-      className={`${className} ${classNames.wrapper}`}
-      onClick={() => {
-        if (!disabled && !isCalendarShown) {
-          switchCalendarVisibility(true)
+    useEffect(() => {
+      if (value === undefined || !inputRef.current) {
+        return
+      }
+      /**
+       * Do not format the given value in the following cases
+       * - while input element is focused.
+       * - if the given value is not date formattable.
+       */
+      if (!isInputFocused) {
+        const newDate = stringToDate(value)
+        if (newDate && dayjs(newDate).isValid()) {
+          inputRef.current.value = dateToString(newDate)
+          setAlternativeFormat(dateToAlternativeFormat(newDate))
+          setSelectedDate(newDate)
+          return
         }
-      }}
-      onKeyDown={(e) => {
-        if ((e.key === 'Escape' || e.key === 'Esc') && isCalendarShown) {
-          e.stopPropagation()
-          requestAnimationFrame(() => {
-            // delay hiding calendar because calendar will be displayed when input is focused
+        setSelectedDate(null)
+      }
+      inputRef.current.value = value || ''
+    }, [value, isInputFocused, dateToString, dateToAlternativeFormat, stringToDate])
+
+    useOuterClick(
+      [inputWrapperRef, calendarPortalRef],
+      useCallback(() => {
+        switchCalendarVisibility(false)
+      }, [switchCalendarVisibility]),
+    )
+
+    const handleKeyDown = useCallback(
+      (e: KeyboardEvent) => {
+        if (e.key !== 'Tab' || !inputRef.current || !calendarPortalRef.current) {
+          return
+        }
+        const calendarButtons = calendarPortalRef.current.querySelectorAll('button')
+        if (calendarButtons.length === 0) {
+          return
+        }
+        const firstCalendarButton = calendarButtons[0]
+        const lastCalendarButton = calendarButtons[calendarButtons.length - 1]
+        if (isInputFocused) {
+          if (e.shiftKey) {
+            // move focus from Input to previous elements of DatePicker
             switchCalendarVisibility(false)
-          })
-          inputRef.current && inputRef.current.focus()
-        }
-      }}
-    >
-      <div ref={inputWrapperRef}>
-        <StyledInput
-          {...inputAttrs}
-          type="text"
-          name={name}
-          onChange={() => {
-            if (isCalendarShown) {
-              switchCalendarVisibility(false)
-            }
-          }}
-          onKeyPress={(e) => {
-            if (e.key === 'Enter') {
-              switchCalendarVisibility(!isCalendarShown)
-            }
-          }}
-          onFocus={() => {
-            setIsInputFocused(true)
-            switchCalendarVisibility(true)
-          }}
-          onBlur={(e) => {
-            setIsInputFocused(false)
-            const inputString = e.target.value
-            if (inputString === '') {
-              updateDate(null)
-              return
-            }
-            const newDate = parseInput ? parseInput(inputString) : parseJpnDateString(inputString)
-            updateDate(newDate)
-          }}
-          suffix={
-            <InputSuffixLayout themes={themes}>
-              <InputSuffixWrapper themes={themes}>
-                {showAlternative && (
-                  <InputSuffixText themes={themes}>{alternativeFormat}</InputSuffixText>
-                )}
-                <FaCalendarAltIcon color={caretIconColor} />
-              </InputSuffixWrapper>
-            </InputSuffixLayout>
+            return
           }
-          disabled={disabled}
-          error={error}
-          ref={inputRef}
-          className={classNames.inputContainer}
-          aria-expanded={isCalendarShown}
-          aria-controls={calenderId}
-          aria-haspopup={true}
-        />
-      </div>
-      {isCalendarShown && inputRect && (
-        <Portal inputRect={inputRect} ref={calendarPortalRef}>
-          <Calendar
-            id={calenderId}
-            value={selectedDate || undefined}
-            from={from}
-            to={to}
-            onSelectDate={(_, selected) => {
-              updateDate(selected)
-              requestAnimationFrame(() => {
-                // delay hiding calendar because calendar will be displayed when input is focused
+          // move focus from Input to Calendar
+          e.preventDefault()
+          firstCalendarButton.focus()
+          return
+        }
+        const currentFocused = Array.from(calendarButtons).find((button) => button === e.target)
+        if (e.shiftKey && currentFocused === firstCalendarButton) {
+          // move focus from Calendar to Input
+          inputRef.current.focus()
+          e.preventDefault()
+        } else if (!e.shiftKey && currentFocused === lastCalendarButton) {
+          // move focus from Calendar to next elements of DatePicker
+          inputRef.current.focus()
+          switchCalendarVisibility(false)
+        }
+      },
+      [isInputFocused, switchCalendarVisibility],
+    )
+    useGlobalKeyDown(handleKeyDown)
+
+    const caretIconColor = useMemo(() => {
+      if (isInputFocused || isCalendarShown) return themes.color.TEXT_BLACK
+      if (disabled) return themes.color.TEXT_DISABLED
+      return themes.color.TEXT_GREY
+    }, [isCalendarShown, isInputFocused, disabled, themes])
+
+    const classNames = useClassNames()
+
+    return (
+      <Container
+        className={`${className} ${classNames.wrapper}`}
+        onClick={() => {
+          if (!disabled && !isCalendarShown) {
+            switchCalendarVisibility(true)
+          }
+        }}
+        onKeyDown={(e) => {
+          if ((e.key === 'Escape' || e.key === 'Esc') && isCalendarShown) {
+            e.stopPropagation()
+            requestAnimationFrame(() => {
+              // delay hiding calendar because calendar will be displayed when input is focused
+              switchCalendarVisibility(false)
+            })
+            inputRef.current && inputRef.current.focus()
+          }
+        }}
+      >
+        <div ref={inputWrapperRef}>
+          <StyledInput
+            {...inputAttrs}
+            type="text"
+            name={name}
+            onChange={() => {
+              if (isCalendarShown) {
                 switchCalendarVisibility(false)
-              })
-              inputRef.current && inputRef.current.focus()
+              }
             }}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') {
+                switchCalendarVisibility(!isCalendarShown)
+              }
+            }}
+            onFocus={() => {
+              setIsInputFocused(true)
+              switchCalendarVisibility(true)
+            }}
+            onBlur={(e) => {
+              setIsInputFocused(false)
+              const inputString = e.target.value
+              if (inputString === '') {
+                updateDate(null)
+                return
+              }
+              const newDate = parseInput ? parseInput(inputString) : parseJpnDateString(inputString)
+              updateDate(newDate)
+            }}
+            suffix={
+              <InputSuffixLayout themes={themes}>
+                <InputSuffixWrapper themes={themes}>
+                  {showAlternative && (
+                    <InputSuffixText themes={themes}>{alternativeFormat}</InputSuffixText>
+                  )}
+                  <FaCalendarAltIcon color={caretIconColor} />
+                </InputSuffixWrapper>
+              </InputSuffixLayout>
+            }
+            disabled={disabled}
+            error={error}
+            ref={inputRef}
+            className={classNames.inputContainer}
+            aria-expanded={isCalendarShown}
+            aria-controls={calenderId}
+            aria-haspopup={true}
           />
-        </Portal>
-      )}
-    </Container>
-  )
-}
+        </div>
+        {isCalendarShown && inputRect && (
+          <Portal inputRect={inputRect} ref={calendarPortalRef}>
+            <Calendar
+              id={calenderId}
+              value={selectedDate || undefined}
+              from={from}
+              to={to}
+              onSelectDate={(_, selected) => {
+                updateDate(selected)
+                requestAnimationFrame(() => {
+                  // delay hiding calendar because calendar will be displayed when input is focused
+                  switchCalendarVisibility(false)
+                })
+                inputRef.current && inputRef.current.focus()
+              }}
+            />
+          </Portal>
+        )}
+      </Container>
+    )
+  },
+)
 
 const Container = styled.div`
   display: inline-block;

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -1,8 +1,9 @@
 import React, {
   InputHTMLAttributes,
   ReactNode,
-  VFC,
+  forwardRef,
   useCallback,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -38,116 +39,125 @@ type ElementProps = Omit<InputHTMLAttributes<HTMLInputElement>, keyof Props>
 
 const DESTROY_BUTTON_TEXT = '削除'
 
-export const InputFile: VFC<Props & ElementProps> = ({
-  className = '',
-  size = 'default',
-  label,
-  hasFileList = true,
-  onChange,
-  disabled = false,
-  error,
-  decorator = {},
-  ...props
-}) => {
-  const theme = useTheme()
-  const [files, setFiles] = useState<File[]>([])
-  const { destroy: destroyDecorator } = decorator
-
-  // Safari において、input.files への直接代入時に onChange が発火することを防ぐためのフラグ
-  const isUpdatingFilesDirectly = useRef(false)
-
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  const destroyButtonText = useMemo(
-    () => (destroyDecorator ? destroyDecorator(DESTROY_BUTTON_TEXT) : DESTROY_BUTTON_TEXT),
-    [destroyDecorator],
-  )
-  const inputWrapperClassName = useMemo(
-    () => `${size === 's' ? 'small' : ''} ${disabled ? 'disabled' : ''} ${error ? 'error' : ''}`,
-    [disabled, error, size],
-  )
-
-  const classNames = useClassNames()
-
-  const updateFiles = useCallback(
-    (newFiles: File[]) => {
-      onChange && onChange(newFiles)
-      setFiles(newFiles)
+export const InputFile = forwardRef<HTMLInputElement, Props & ElementProps>(
+  (
+    {
+      className = '',
+      size = 'default',
+      label,
+      hasFileList = true,
+      onChange,
+      disabled = false,
+      error,
+      decorator = {},
+      ...props
     },
-    [setFiles, onChange],
-  )
+    ref,
+  ) => {
+    const theme = useTheme()
+    const [files, setFiles] = useState<File[]>([])
+    const { destroy: destroyDecorator } = decorator
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (isUpdatingFilesDirectly.current) {
-        return
-      }
-      const newFiles = Array.from(e.target.files ?? [])
-      updateFiles(newFiles)
-    },
-    [isUpdatingFilesDirectly, updateFiles],
-  )
+    // Safari において、input.files への直接代入時に onChange が発火することを防ぐためのフラグ
+    const isUpdatingFilesDirectly = useRef(false)
 
-  const handleDelete = useCallback(
-    (index: number) => {
-      if (!inputRef.current) {
-        return
-      }
-      const newFiles = files.filter((_, i) => index !== i)
-      updateFiles(newFiles)
+    const inputRef = useRef<HTMLInputElement>(null)
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current,
+    )
 
-      const buff = new DataTransfer()
-      newFiles.forEach((file) => {
-        buff.items.add(file)
-      })
-      isUpdatingFilesDirectly.current = true
-      inputRef.current.files = buff.files
-      isUpdatingFilesDirectly.current = false
-    },
-    [files, isUpdatingFilesDirectly, inputRef, updateFiles],
-  )
+    const destroyButtonText = useMemo(
+      () => (destroyDecorator ? destroyDecorator(DESTROY_BUTTON_TEXT) : DESTROY_BUTTON_TEXT),
+      [destroyDecorator],
+    )
+    const inputWrapperClassName = useMemo(
+      () => `${size === 's' ? 'small' : ''} ${disabled ? 'disabled' : ''} ${error ? 'error' : ''}`,
+      [disabled, error, size],
+    )
 
-  return (
-    <Wrapper className={`${className} ${classNames.wrapper}`}>
-      {!disabled && hasFileList && files.length > 0 && (
-        <FileList themes={theme} className={classNames.fileList}>
-          {files.map((file, index) => {
-            return (
-              <li key={`${file.name}-${index}`}>
-                <span className={classNames.fileName}>{file.name}</span>
-                <span>
-                  <Button
-                    variant="text"
-                    prefix={<FaTrashAltIcon />}
-                    onClick={() => handleDelete(index)}
-                    className={classNames.deleteButton}
-                  >
-                    {destroyButtonText}
-                  </Button>
-                </span>
-              </li>
-            )
-          })}
-        </FileList>
-      )}
-      <InputWrapper className={inputWrapperClassName} themes={theme}>
-        <input
-          {...props}
-          type="file"
-          onChange={handleChange}
-          disabled={disabled}
-          className={classNames.input}
-          ref={inputRef}
-          aria-invalid={error || undefined}
-        />
-        <Prefix themes={theme}>
-          <FaFolderOpenIcon />
-        </Prefix>
-        {label}
-      </InputWrapper>
-    </Wrapper>
-  )
-}
+    const classNames = useClassNames()
+
+    const updateFiles = useCallback(
+      (newFiles: File[]) => {
+        onChange && onChange(newFiles)
+        setFiles(newFiles)
+      },
+      [setFiles, onChange],
+    )
+
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (isUpdatingFilesDirectly.current) {
+          return
+        }
+        const newFiles = Array.from(e.target.files ?? [])
+        updateFiles(newFiles)
+      },
+      [isUpdatingFilesDirectly, updateFiles],
+    )
+
+    const handleDelete = useCallback(
+      (index: number) => {
+        if (!inputRef.current) {
+          return
+        }
+        const newFiles = files.filter((_, i) => index !== i)
+        updateFiles(newFiles)
+
+        const buff = new DataTransfer()
+        newFiles.forEach((file) => {
+          buff.items.add(file)
+        })
+        isUpdatingFilesDirectly.current = true
+        inputRef.current.files = buff.files
+        isUpdatingFilesDirectly.current = false
+      },
+      [files, isUpdatingFilesDirectly, inputRef, updateFiles],
+    )
+
+    return (
+      <Wrapper className={`${className} ${classNames.wrapper}`}>
+        {!disabled && hasFileList && files.length > 0 && (
+          <FileList themes={theme} className={classNames.fileList}>
+            {files.map((file, index) => {
+              return (
+                <li key={`${file.name}-${index}`}>
+                  <span className={classNames.fileName}>{file.name}</span>
+                  <span>
+                    <Button
+                      variant="text"
+                      prefix={<FaTrashAltIcon />}
+                      onClick={() => handleDelete(index)}
+                      className={classNames.deleteButton}
+                    >
+                      {destroyButtonText}
+                    </Button>
+                  </span>
+                </li>
+              )
+            })}
+          </FileList>
+        )}
+        <InputWrapper className={inputWrapperClassName} themes={theme}>
+          <input
+            {...props}
+            type="file"
+            onChange={handleChange}
+            disabled={disabled}
+            className={classNames.input}
+            ref={inputRef}
+            aria-invalid={error || undefined}
+          />
+          <Prefix themes={theme}>
+            <FaFolderOpenIcon />
+          </Prefix>
+          {label}
+        </InputWrapper>
+      </Wrapper>
+    )
+  },
+)
 
 const Wrapper = styled.div`
   display: block;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, SelectHTMLAttributes, useCallback } from 'react'
+import React, {
+  ChangeEvent,
+  ForwardedRef,
+  SelectHTMLAttributes,
+  forwardRef,
+  useCallback,
+} from 'react'
 import styled, { css } from 'styled-components'
 
 import { isMobileSafari } from '../../libs/ua'
@@ -34,85 +40,91 @@ type Props<T extends string> = {
 
 type ElementProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, keyof Props<string> | 'children'>
 
-export function Select<T extends string>({
-  options,
-  onChange,
-  onChangeValue,
-  error = false,
-  width = 'auto',
-  hasBlank = false,
-  blankLabel = '選択してください',
-  size = 'default',
-  className = '',
-  disabled,
-  ...props
-}: Props<T> & ElementProps) {
-  const theme = useTheme()
-  const widthStyle = typeof width === 'number' ? `${width}px` : width
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLSelectElement>) => {
-      if (onChange) onChange(e)
-      if (onChangeValue) {
-        const flattenOptions = options.reduce(
-          (pre, cur) => pre.concat('value' in cur ? cur : cur.options),
-          [] as Array<Option<T>>,
-        )
-        const selectedOption = flattenOptions.find((option) => option.value === e.target.value)
-        if (selectedOption) {
-          onChangeValue(selectedOption.value)
-        }
-      }
-    },
-    [onChange, onChangeValue, options],
-  )
-  const classNames = useClassNames()
-
-  return (
-    <Wrapper
-      className={`${className} ${classNames.wrapper} ${generateSizeClassName(size)}`}
-      $width={widthStyle}
-    >
-      <SelectBox
-        {...props}
-        onChange={handleChange}
-        aria-invalid={error || undefined}
-        themes={theme}
-        error={error}
-        disabled={disabled}
-      >
-        {hasBlank && <option value="">{blankLabel}</option>}
-        {options.map((option) => {
-          if ('value' in option) {
-            return (
-              <option {...option} key={option.value}>
-                {option.label}
-              </option>
-            )
-          }
-
-          const { options: groupedOptions, ...optgroup } = option
-
-          return (
-            <optgroup {...optgroup} key={optgroup.label}>
-              {groupedOptions.map((groupedOption) => (
-                <option {...groupedOption} key={groupedOption.value}>
-                  {groupedOption.label}
-                </option>
-              ))}
-            </optgroup>
+export const Select = forwardRef(
+  <T extends string>(
+    {
+      options,
+      onChange,
+      onChangeValue,
+      error = false,
+      width = 'auto',
+      hasBlank = false,
+      blankLabel = '選択してください',
+      size = 'default',
+      className = '',
+      disabled,
+      ...props
+    }: Props<T> & ElementProps,
+    ref: ForwardedRef<HTMLSelectElement>,
+  ) => {
+    const theme = useTheme()
+    const widthStyle = typeof width === 'number' ? `${width}px` : width
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLSelectElement>) => {
+        if (onChange) onChange(e)
+        if (onChangeValue) {
+          const flattenOptions = options.reduce(
+            (pre, cur) => pre.concat('value' in cur ? cur : cur.options),
+            [] as Array<Option<T>>,
           )
-        })}
-        {
-          // Support for not omitting labels in Mobile Safari
-          isMobileSafari && <BlankOptgroup />
+          const selectedOption = flattenOptions.find((option) => option.value === e.target.value)
+          if (selectedOption) {
+            onChangeValue(selectedOption.value)
+          }
         }
-      </SelectBox>
-      <IconWrap themes={theme}>
-        <FaSortIcon />
-      </IconWrap>
-    </Wrapper>
-  )
-}
+      },
+      [onChange, onChangeValue, options],
+    )
+    const classNames = useClassNames()
+
+    return (
+      <Wrapper
+        className={`${className} ${classNames.wrapper} ${generateSizeClassName(size)}`}
+        $width={widthStyle}
+      >
+        <SelectBox
+          {...props}
+          onChange={handleChange}
+          aria-invalid={error || undefined}
+          themes={theme}
+          error={error}
+          disabled={disabled}
+          ref={ref}
+        >
+          {hasBlank && <option value="">{blankLabel}</option>}
+          {options.map((option) => {
+            if ('value' in option) {
+              return (
+                <option {...option} key={option.value}>
+                  {option.label}
+                </option>
+              )
+            }
+
+            const { options: groupedOptions, ...optgroup } = option
+
+            return (
+              <optgroup {...optgroup} key={optgroup.label}>
+                {groupedOptions.map((groupedOption) => (
+                  <option {...groupedOption} key={groupedOption.value}>
+                    {groupedOption.label}
+                  </option>
+                ))}
+              </optgroup>
+            )
+          })}
+          {
+            // Support for not omitting labels in Mobile Safari
+            isMobileSafari && <BlankOptgroup />
+          }
+        </SelectBox>
+        <IconWrap themes={theme}>
+          <FaSortIcon />
+        </IconWrap>
+      </Wrapper>
+    )
+  },
+)
 
 const generateSizeClassName = (size: Props<string>['size']) => (size === 's' ? '--small' : '')
 

--- a/src/components/Select/useClassNames.ts
+++ b/src/components/Select/useClassNames.ts
@@ -1,10 +1,10 @@
-import { VFC, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
 import { Select } from './Select'
 
 export const useClassNames = () => {
-  const generate = useClassNameGenerator((Select as VFC).displayName || 'Select')
+  const generate = useClassNameGenerator(Select.displayName || 'Select')
   return useMemo(
     () => ({
       wrapper: generate(),

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,4 +1,12 @@
-import React, { TextareaHTMLAttributes, VFC, useCallback, useEffect, useRef, useState } from 'react'
+import React, {
+  TextareaHTMLAttributes,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -39,87 +47,97 @@ const getStringLength = (value: string | number | readonly string[]) => {
   return formattedValue.length - (formattedValue.match(surrogatePairs) || []).length
 }
 
-export const Textarea: VFC<Props & ElementProps> = ({
-  autoFocus,
-  maxLength,
-  width,
-  className = '',
-  autoResize = false,
-  maxRows = Infinity,
-  rows = 2,
-  onInput,
-  ...props
-}) => {
-  const theme = useTheme()
-  const ref = useRef<HTMLTextAreaElement>(null)
-  const currentValue = props.defaultValue || props.value
-  const [interimRows, setInterimRows] = useState(rows)
-  const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
-  const textAreaWidth = typeof width === 'number' ? `${width}px` : width
-
-  useEffect(() => {
-    if (autoFocus && ref && ref.current) {
-      ref.current.focus()
-    }
-  }, [autoFocus])
-
-  const handleKeyup = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    setCount(getStringLength(event.currentTarget.value))
-  }, [])
-  const handleInput = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      if (!autoResize) {
-        return onInput && onInput(e)
-      }
-
-      const previousRows = e.target.rows
-      // 消したことを検知できないので必ず初期化
-      e.target.rows = rows
-
-      const currentRows = Math.floor(
-        e.target.scrollHeight / (defaultHtmlFontSize * theme.leading.NORMAL),
-      )
-
-      if (previousRows === currentRows) {
-        e.target.rows = currentRows
-      } else if (maxRows < currentRows) {
-        // 最大まで達したとき高さが潰れないように代入
-        e.target.rows = maxRows
-      }
-
-      setInterimRows(currentRows < maxRows ? currentRows : maxRows)
-      onInput && onInput(e)
+export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
+  (
+    {
+      autoFocus,
+      maxLength,
+      width,
+      className = '',
+      autoResize = false,
+      maxRows = Infinity,
+      rows = 2,
+      onInput,
+      ...props
     },
-    [autoResize, maxRows, onInput, rows, theme.leading.NORMAL],
-  )
+    ref,
+  ) => {
+    const theme = useTheme()
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
+    const currentValue = props.defaultValue || props.value
+    const [interimRows, setInterimRows] = useState(rows)
+    const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
+    const textAreaWidth = typeof width === 'number' ? `${width}px` : width
 
-  const classNames = useClassNames()
+    useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
+      ref,
+      () => textareaRef.current,
+    )
 
-  return (
-    <>
-      <StyledTextarea
-        {...props}
-        {...(maxLength ? { onKeyUp: handleKeyup } : {})}
-        textAreaWidth={textAreaWidth}
-        ref={ref}
-        themes={theme}
-        aria-invalid={props.error || undefined}
-        className={`${className} ${classNames.textarea}`}
-        rows={interimRows}
-        onInput={handleInput}
-      />
-      {maxLength && (
-        <Counter themes={theme} className={classNames.counter}>
-          あと
-          <span className={maxLength && maxLength - count <= 0 ? 'error' : ''}>
-            {maxLength - count}
-          </span>
-          文字
-        </Counter>
-      )}
-    </>
-  )
-}
+    useEffect(() => {
+      if (autoFocus && textareaRef && textareaRef.current) {
+        textareaRef.current.focus()
+      }
+    }, [autoFocus])
+
+    const handleKeyup = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      setCount(getStringLength(event.currentTarget.value))
+    }, [])
+    const handleInput = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        if (!autoResize) {
+          return onInput && onInput(e)
+        }
+
+        const previousRows = e.target.rows
+        // 消したことを検知できないので必ず初期化
+        e.target.rows = rows
+
+        const currentRows = Math.floor(
+          e.target.scrollHeight / (defaultHtmlFontSize * theme.leading.NORMAL),
+        )
+
+        if (previousRows === currentRows) {
+          e.target.rows = currentRows
+        } else if (maxRows < currentRows) {
+          // 最大まで達したとき高さが潰れないように代入
+          e.target.rows = maxRows
+        }
+
+        setInterimRows(currentRows < maxRows ? currentRows : maxRows)
+        onInput && onInput(e)
+      },
+      [autoResize, maxRows, onInput, rows, theme.leading.NORMAL],
+    )
+
+    const classNames = useClassNames()
+
+    return (
+      <>
+        <StyledTextarea
+          {...props}
+          {...(maxLength ? { onKeyUp: handleKeyup } : {})}
+          textAreaWidth={textAreaWidth}
+          ref={textareaRef}
+          themes={theme}
+          aria-invalid={props.error || undefined}
+          className={`${className} ${classNames.textarea}`}
+          rows={interimRows}
+          onInput={handleInput}
+        />
+        {maxLength && (
+          <Counter themes={theme} className={classNames.counter}>
+            あと
+            <span className={maxLength && maxLength - count <= 0 ? 'error' : ''}>
+              {maxLength - count}
+            </span>
+            文字
+          </Counter>
+        )}
+      </>
+    )
+  },
+)
 
 const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: string | number }>`
   ${({


### PR DESCRIPTION
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

#2929 で対応できなかったコンポーネントにも ref を渡せるように修正した。

diff は多いが、

```tsx
const Hoge: React.FC<Props> = (props) => {
  const innerRef = useRef<HTMLElement>(null)
  return <some-element ref={innerRef} />
}
```

となっているものを

```tsx
const Hoge = forwardRef<HTMLElement, Props>((props, ref) => {
  const innerRef = useRef<HTMLElement>(null)
  useImperativeHandle<HTMLElement | null, HTMLElement | null>(ref, () => innerRef.current)
  return <some-element ref={innerRef} />
})
```

としただけで、内部処理には一切手を加えていない。

## 対応したコンポーネント

- DatePicker
- DropZone
- InputFile
- Select
- Textarea