### PR TITLE
feat: MultiComboBoxのドロップダウンリストの幅を指定可能にする

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -124,6 +124,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
+          dropdownHelpMessage="Disabled なコンボボックス"
           disabled
           onSelect={handleSelectItem}
           onClear={handleClear}
@@ -306,6 +307,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
+          dropdownHelpMessage="Disabled なコンボボックス"
           disabled
           onDelete={handleDelete}
           onSelect={handleSelectItem}

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -172,7 +172,7 @@ export const Single: Story = () => {
           selectedItem={selectedItem}
           width={400}
           dropdownWidth="auto"
-          dropdownHelpMessage="入力でフィルタリングできます。"
+          dropdownHelpMessage="入力でフィルタリングできます。（ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト）"
           onSelect={handleSelectItem}
           onClear={handleClear}
         />
@@ -397,7 +397,7 @@ export const Multi: Story = () => {
           selectedItems={selectedItems}
           width={400}
           dropdownWidth="auto"
-          dropdownHelpMessage="入力でフィルタリングできます。"
+          dropdownHelpMessage="入力でフィルタリングできます。（ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト）"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
         />

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -94,7 +94,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onSelect={handleSelectItem}
           onClear={handleClear}
           onChangeSelected={(item) => {
@@ -110,7 +110,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
-          dropdownHelpMessage="新しいアイテムを追加できます"
+          dropdownHelpMessage="新しいアイテムを追加できます。"
           creatable
           onSelect={handleSelectItem}
           onClear={handleClear}
@@ -124,7 +124,6 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
-          dropdownHelpMessage="Disabled なコンボボックス"
           disabled
           onSelect={handleSelectItem}
           onClear={handleClear}
@@ -137,7 +136,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           error
           onSelect={handleSelectItem}
           onClear={handleClear}
@@ -149,7 +148,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           isLoading
           onSelect={handleSelectItem}
           onClear={handleClear}
@@ -161,7 +160,7 @@ export const Single: Story = () => {
           items={items}
           selectedItem={selectedItem}
           width="100%"
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onSelect={handleSelectItem}
           onClear={handleClear}
         />
@@ -173,7 +172,7 @@ export const Single: Story = () => {
           selectedItem={selectedItem}
           width={400}
           dropdownWidth="auto"
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onSelect={handleSelectItem}
           onClear={handleClear}
         />
@@ -185,7 +184,7 @@ export const Single: Story = () => {
           selectedItem={selectedItem}
           width={400}
           dropdownWidth="200%"
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onSelect={handleSelectItem}
           onClear={handleClear}
         />
@@ -196,7 +195,7 @@ export const Single: Story = () => {
           items={manyItems}
           selectedItem={null}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onSelect={action('onSelect')}
         />
       </dd>
@@ -275,7 +274,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
           onChangeSelected={(selected) => {
@@ -293,7 +292,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="新しいアイテムを追加できます"
+          dropdownHelpMessage="新しいアイテムを追加できます。"
           creatable
           onDelete={handleDelete}
           onSelect={handleSelectItem}
@@ -307,7 +306,6 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="Disabled なコンボボックス"
           disabled
           onDelete={handleDelete}
           onSelect={handleSelectItem}
@@ -320,7 +318,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           error
           onDelete={handleDelete}
           onSelect={handleSelectItem}
@@ -332,7 +330,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
           selectedItemEllipsis
@@ -344,7 +342,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           isLoading
           onDelete={handleDelete}
           onSelect={handleSelectItem}
@@ -356,7 +354,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems.map((item) => ({ ...item, deletable: false }))}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
         />
@@ -367,7 +365,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
           onChangeSelected={(selected) => {
@@ -387,7 +385,7 @@ export const Multi: Story = () => {
           items={items}
           selectedItems={selectedItems}
           width="100%"
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
         />
@@ -399,7 +397,7 @@ export const Multi: Story = () => {
           selectedItems={selectedItems}
           width={400}
           dropdownWidth="auto"
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
         />
@@ -411,7 +409,7 @@ export const Multi: Story = () => {
           selectedItems={selectedItems}
           width={400}
           dropdownWidth="200%"
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
         />
@@ -422,7 +420,7 @@ export const Multi: Story = () => {
           items={manyItems}
           selectedItems={[]}
           width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
+          dropdownHelpMessage="入力でフィルタリングできます。"
           onSelect={action('onSelect')}
           data-test="multi-combobox-many"
         />

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -392,6 +392,30 @@ export const Multi: Story = () => {
           onSelect={handleSelectItem}
         />
       </dd>
+      <dt>ドロップダウンリストの幅をアイテムの幅に合わせる</dt>
+      <dd>
+        <MultiComboBox
+          items={items}
+          selectedItems={selectedItems}
+          width={400}
+          dropdownWidth="auto"
+          dropdownHelpMessage="入力でフィルタリングできます"
+          onDelete={handleDelete}
+          onSelect={handleSelectItem}
+        />
+      </dd>
+      <dt>ドロップダウンリストの幅を相対指定（Inputの200%幅）</dt>
+      <dd>
+        <MultiComboBox
+          items={items}
+          selectedItems={selectedItems}
+          width={400}
+          dropdownWidth="200%"
+          dropdownHelpMessage="入力でフィルタリングできます"
+          onDelete={handleDelete}
+          onSelect={handleSelectItem}
+        />
+      </dd>
       <dt>アイテム数が多い時</dt>
       <dd>
         <MultiComboBox

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -71,6 +71,10 @@ type Props<T> = {
    */
   width?: number | string
   /**
+   * ドロップダウンリストの `width` スタイルに適用する値
+   */
+  dropdownWidth?: number | string
+  /**
    * テキストボックスの `value` 属性の値。
    * `onChangeInput` と併せて設定することで、テキストボックスの挙動が制御可能になる。
    */
@@ -128,6 +132,7 @@ export function MultiComboBox<T>({
   isLoading,
   selectedItemEllipsis,
   width = 'auto',
+  dropdownWidth = '100%',
   inputValue: controlledInputValue,
   className = '',
   onChange,
@@ -195,6 +200,7 @@ export function MultiComboBox<T>({
   } = useListBox({
     options,
     dropdownHelpMessage,
+    dropdownWidth,
     onAdd,
     onSelect: handleSelect,
     isExpanded: isFocused,

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -340,13 +340,14 @@ const Container = styled.div<
 
 const HelpMessage = styled.p<{ themes: Theme }>`
   ${({ themes }) => {
-    const { color, fontSize, spacingByChar } = themes
+    const { border, fontSize, spacingByChar } = themes
 
     return css`
       margin: 0 ${spacingByChar(0.5)} ${spacingByChar(0.5)};
       padding: 0 ${spacingByChar(0.5)} ${spacingByChar(0.5)};
-      border-bottom: 1px dotted ${color.BORDER};
+      border-bottom: ${border.shorthand};
       font-size: ${fontSize.S};
+      white-space: initial;
     `
   }}
 `


### PR DESCRIPTION
## Related URL

- SingleComboBox編：https://github.com/kufu/smarthr-ui/pull/2920

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
SingleComboBoxに引き続き、MultiComboBoxのドロップダウンリストの幅を指定できるようにしました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- MultiComboBoxにdropdownWidth propsを追加
- ヘルプメッセージの区切り線をsolidに変更、長い場合に折り返されるようにした
- StoryのdropdownHelpMessageの文言を修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
<img width="754" alt="image" src="https://user-images.githubusercontent.com/64398878/203703165-ec2d5427-6d1d-495b-b479-1ae7a2f182a6.png">

<!--
Please attach a capture if it looks different.
-->
