### PR TITLE
fix: AppNavi においてカスタムタグ判定を最初に行うように変更

### DIFF
--- a/src/components/AppNavi/AppNavi.tsx
+++ b/src/components/AppNavi/AppNavi.tsx
@@ -51,6 +51,23 @@ export const AppNavi: VFC<Props & ElementProps> = ({
         <Buttons themes={theme} className={classNames.buttons}>
           {buttons.map((button, i) => {
             const isUnclickable = button.current && isCurrentUnclickable
+            if ('tag' in button) {
+              const { tag, icon, current, children: buttonChildren, ...buttonProps } = button
+              return (
+                <li key={i} className={classNames.listItem}>
+                  <AppNaviCustomTag
+                    {...buttonProps}
+                    tag={tag}
+                    icon={icon}
+                    current={current}
+                    isUnclickable={isUnclickable}
+                  >
+                    {buttonChildren}
+                  </AppNaviCustomTag>
+                </li>
+              )
+            }
+
             if ('href' in button) {
               return (
                 <li key={i} className={classNames.listItem}>
@@ -78,23 +95,6 @@ export const AppNavi: VFC<Props & ElementProps> = ({
                   >
                     {button.children}
                   </AppNaviDropdown>
-                </li>
-              )
-            }
-
-            if ('tag' in button) {
-              const { tag, icon, current, children: buttonChildren, ...buttonProps } = button
-              return (
-                <li key={i} className={classNames.listItem}>
-                  <AppNaviCustomTag
-                    {...buttonProps}
-                    tag={tag}
-                    icon={icon}
-                    current={current}
-                    isUnclickable={isUnclickable}
-                  >
-                    {buttonChildren}
-                  </AppNaviCustomTag>
                 </li>
               )
             }


### PR DESCRIPTION
## Overview

`AppNavi` に対して、

```tsx
<AppNavi
  buttons={[
    { children: 'ボタン' },
    { children: 'アンカー', href: '/' },
    { children: 'カスタム', tag: Link, href: '/' },
  ]}
/>
```

のようにボタンを設定した場合、３つ目のボタンがカスタムタグではなくアンカーとして扱われてしまう問題に対応します。

### 原因

`AppNavi` 内のボタン判定がアンカー → ドロップダウン → カスタムタグ → ボタン の順で行われているため、カスタムタグのデータに `href` のフィールドが含まれていると先にアンカーとして判定されてしまうため。

## What I did

- カスタムタグの判定を最初に行うようにした。
  - `tag` フィールドは他のボタンの型には含まれていないので問題にはならないはず

