### PR TITLE
fix: FilterDropdown 内のイベントがバブリングしないように制御

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -98,7 +98,12 @@ export const FilterDropdown: VFC<Props> = ({
       </DropdownTrigger>
       {hasStatusText && isFiltered ? <StatusText themes={themes}>{status}</StatusText> : null}
       <DropdownContent controllable>
-        <DropdownScrollArea>
+        <DropdownScrollArea
+          onClick={
+            // FIXME: 暫定対応。コンボボックスを内包した時、ドロップダウンポータルの親子判定できずに外側クリック判定になりドロップダウンが閉じてしまっている
+            (e) => e.stopPropagation()
+          }
+        >
           <ContentLayout>{children}</ContentLayout>
         </DropdownScrollArea>
         <BottomLayout themes={themes}>


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-634

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FilterDropdown 内に ComboBox がある場合など、内部のクリックイベントが Dropdown の外側まで伝搬しないように対処しました。
根本原因はポータルにあるため別途調査が必要そうです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
