### PR TITLE
fix: Dropdown系コンポーネント内で SingleComboBoxの選択肢をclickすると Dropdownが閉じてしまうバグを修正する

### DIFF
--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -152,14 +152,6 @@ export function SingleComboBox<T>({
   const [isComposing, setIsComposing] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
 
-  // HINT: Dropdown系コンポーネント内でComboBoxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-  // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-  const closeDropdown = useCallback(() => {
-    requestAnimationFrame(() => {
-      setIsExpanded(false)
-    })
-  }, [setIsExpanded])
-
   const { options } = useOptions({
     items,
     selected: selectedItem,
@@ -182,10 +174,14 @@ export function SingleComboBox<T>({
       (selected: ComboBoxItem<T>) => {
         onSelect && onSelect(selected)
         onChangeSelected && onChangeSelected(selected)
-        closeDropdown()
+        // HINT: Dropdown系コンポーネント内でComboBoxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
+        // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        requestAnimationFrame(() => {
+          setIsExpanded(false)
+        })
         setIsEditing(false)
       },
-      [onChangeSelected, onSelect, closeDropdown],
+      [onChangeSelected, onSelect],
     ),
     isExpanded,
     isLoading,
@@ -201,14 +197,14 @@ export function SingleComboBox<T>({
   }, [isFocused])
   const unfocus = useCallback(() => {
     setIsFocused(false)
-    closeDropdown()
+    setIsExpanded(false)
     setIsEditing(false)
 
     if (!selectedItem && defaultItem) {
       setInputValue(defaultItem.label)
       onSelect && onSelect(defaultItem)
     }
-  }, [selectedItem, defaultItem, onSelect, closeDropdown])
+  }, [selectedItem, defaultItem, onSelect])
   const onClickClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -269,7 +265,7 @@ export function SingleComboBox<T>({
       if (['Escape', 'Exc'].includes(e.key)) {
         if (isExpanded) {
           e.stopPropagation()
-          closeDropdown()
+          setIsExpanded(false)
         }
       } else if (e.key === 'Tab') {
         unfocus()
@@ -284,7 +280,7 @@ export function SingleComboBox<T>({
       }
       handleListBoxKeyDown(e)
     },
-    [isComposing, isExpanded, setIsExpanded, closeDropdown, unfocus, handleListBoxKeyDown],
+    [isComposing, isExpanded, setIsExpanded, unfocus, handleListBoxKeyDown],
   )
 
   const caretIconColor = useMemo(() => {

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -152,6 +152,14 @@ export function SingleComboBox<T>({
   const [isComposing, setIsComposing] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
 
+  // HINT: Dropdown系コンポーネント内でComboBoxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
+  // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+  const closeDropdown = useCallback(() => {
+    requestAnimationFrame(() => {
+      setIsExpanded(false)
+    })
+  }, [setIsExpanded])
+
   const { options } = useOptions({
     items,
     selected: selectedItem,
@@ -174,7 +182,7 @@ export function SingleComboBox<T>({
       (selected: ComboBoxItem<T>) => {
         onSelect && onSelect(selected)
         onChangeSelected && onChangeSelected(selected)
-        setIsExpanded(false)
+        closeDropdown()
         setIsEditing(false)
       },
       [onChangeSelected, onSelect],
@@ -193,7 +201,7 @@ export function SingleComboBox<T>({
   }, [isFocused])
   const unfocus = useCallback(() => {
     setIsFocused(false)
-    setIsExpanded(false)
+    closeDropdown()
     setIsEditing(false)
 
     if (!selectedItem && defaultItem) {
@@ -261,7 +269,7 @@ export function SingleComboBox<T>({
       if (['Escape', 'Exc'].includes(e.key)) {
         if (isExpanded) {
           e.stopPropagation()
-          setIsExpanded(false)
+          closeDropdown()
         }
       } else if (e.key === 'Tab') {
         unfocus()

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -185,7 +185,7 @@ export function SingleComboBox<T>({
         closeDropdown()
         setIsEditing(false)
       },
-      [onChangeSelected, onSelect],
+      [onChangeSelected, onSelect, closeDropdown],
     ),
     isExpanded,
     isLoading,
@@ -208,7 +208,7 @@ export function SingleComboBox<T>({
       setInputValue(defaultItem.label)
       onSelect && onSelect(defaultItem)
     }
-  }, [selectedItem, defaultItem, onSelect])
+  }, [selectedItem, defaultItem, onSelect, closeDropdown])
   const onClickClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -284,7 +284,7 @@ export function SingleComboBox<T>({
       }
       handleListBoxKeyDown(e)
     },
-    [isComposing, isExpanded, setIsExpanded, unfocus, handleListBoxKeyDown],
+    [isComposing, isExpanded, setIsExpanded, closeDropdown, unfocus, handleListBoxKeyDown],
   )
 
   const caretIconColor = useMemo(() => {

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -3,7 +3,7 @@ import { Story } from '@storybook/react'
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
-import { SingleComboBox } from '../../ComboBox'
+import { MultiComboBox, SingleComboBox } from '../../ComboBox'
 import { Input } from '../../Input'
 import { RadioButton } from '../../RadioButton'
 
@@ -63,6 +63,7 @@ export const Default: Story = () => {
             </Description>
             <Text>Children content is scrollable.</Text>
             <PartSingleComboBox />
+            <PartMultiComboBox />
           </FilterDropdown>
         </dd>
         <dt>Filtered</dt>
@@ -193,13 +194,88 @@ const PartSingleComboBox: React.VFC = () => {
   }, [])
 
   return (
-    <SingleComboBox
-      items={items}
-      selectedItem={selectedItem}
-      defaultItem={items[0]}
-      width={400}
-      onSelect={handleSelectItem}
-      onClear={handleClear}
-    />
+    <div>
+      <SingleComboBox
+        items={items}
+        selectedItem={selectedItem}
+        defaultItem={items[0]}
+        width={400}
+        onSelect={handleSelectItem}
+        onClear={handleClear}
+      />
+    </div>
+  )
+}
+const PartMultiComboBox: React.VFC = () => {
+  const [items, _setItems] = useState([
+    {
+      label: 'option 1',
+      value: 'value-1',
+      data: {
+        name: 'test',
+        age: 23,
+      },
+    },
+    {
+      label: 'option 2',
+      value: 'value-2',
+      data: {
+        name: 'test 2',
+        age: 34,
+      },
+    },
+    {
+      label: 'option 3',
+      value: 'value-3',
+      disabled: true,
+    },
+    {
+      label: 'option 4',
+      value: 'value-4',
+    },
+    {
+      label: 'option 5',
+      value: 'value-5',
+    },
+    {
+      label:
+        'アイテムのラベルが長い場合（ダミーテキストダミーテキストダミーテキストダミーテキスト）',
+      value: 'value-6',
+    },
+  ])
+  const [selectedItems, setSelectedItems] = useState<Item[]>([])
+
+  const handleSelectItem = useCallback(
+    (item: Item) => {
+      action('onSelect')(item)
+      setSelectedItems([...selectedItems, item])
+    },
+    [selectedItems],
+  )
+  const handleDelete = useCallback(
+    (deleted: Item) => {
+      action('onDelete')()
+      setSelectedItems(selectedItems.filter((item) => item.value !== deleted.value))
+    },
+    [selectedItems],
+  )
+
+  return (
+    <div>
+      <MultiComboBox
+        items={items}
+        selectedItems={selectedItems}
+        width={400}
+        dropdownHelpMessage="入力でフィルタリングできます。"
+        onDelete={handleDelete}
+        onSelect={handleSelectItem}
+        onChangeSelected={(selected) => {
+          action('onChangeSelected')(selected)
+          setSelectedItems(selected)
+        }}
+        onFocus={action('onFocus')}
+        onBlur={action('onBlur')}
+      />
+    </div>
   )
 }

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -1,7 +1,9 @@
+import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
-import * as React from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 
+import { SingleComboBox } from '../../ComboBox'
 import { Input } from '../../Input'
 import { RadioButton } from '../../RadioButton'
 
@@ -60,6 +62,7 @@ export const Default: Story = () => {
               ↓<br />↓
             </Description>
             <Text>Children content is scrollable.</Text>
+            <PartSingleComboBox />
           </FilterDropdown>
         </dd>
         <dt>Filtered</dt>
@@ -139,3 +142,64 @@ const Description = styled.p`
 const RadioButtonList = styled.ul`
   list-style: none;
 `
+
+type Item = { label: string; value: string }
+const PartSingleComboBox: React.VFC = () => {
+  const [items, _setItems] = useState([
+    {
+      label: 'option 1',
+      value: 'value-1',
+      data: {
+        name: 'test',
+        age: 23,
+      },
+    },
+    {
+      label: 'option 2',
+      value: 'value-2',
+      data: {
+        name: 'test 2',
+        age: 34,
+      },
+    },
+    {
+      label: 'option 3',
+      value: 'value-3',
+      disabled: true,
+    },
+    {
+      label: 'option 4',
+      value: 'value-4',
+    },
+    {
+      label: 'option 5',
+      value: 'value-5',
+    },
+    {
+      label:
+        'アイテムのラベルが長い場合（ダミーテキストダミーテキストダミーテキストダミーテキスト）',
+      value: 'value-6',
+    },
+  ])
+  const [selectedItem, setSelectedItem] = useState<Item | null>(null)
+
+  const handleSelectItem = useCallback((item: Item) => {
+    action('onSelect')(item)
+    setSelectedItem(item)
+  }, [])
+  const handleClear = useCallback(() => {
+    action('onClear')()
+    setSelectedItem(null)
+  }, [])
+
+  return (
+    <SingleComboBox
+      items={items}
+      selectedItem={selectedItem}
+      defaultItem={items[0]}
+      width={400}
+      onSelect={handleSelectItem}
+      onClear={handleClear}
+    />
+  )
+}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- 選択肢クリック時の動作を遅延させることでdropdownが閉じないように修正した

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- 分かりづらいバグであり、smarthr-ui同士の組み合わせで発生する問題なのでsmarthr-uiで解決すると良さそうだったので。

## Capture

<!--
Please attach a capture if it looks different.
-->
