### PR TITLE
feat: SingleComboBox の onClear の引数に event を渡せるようにした

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -215,6 +215,25 @@ export const Single: Story = () => {
           onSelect={action('onSelect')}
         />
       </dd>
+      <dt>クリアボタンクリック時のデフォルトの挙動を無効化</dt>
+      <dd>
+        <SingleComboBox
+          items={items}
+          selectedItem={selectedItem}
+          width={400}
+          dropdownHelpMessage="入力でフィルタリングできます。"
+          onSelect={handleSelectItem}
+          onClearClick={(e) => {
+            e.preventDefault()
+            handleClear()
+          }}
+          onChangeSelected={(item) => {
+            action('onChangeSelected')(item)
+            setSelectedItem(item)
+          }}
+          data-test="single-combobox-default"
+        />
+      </dd>
       <dt>デフォルトの選択肢あり</dt>
       <dd>
         <SingleWithDefaultItem />

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -1,6 +1,7 @@
 import React, {
   ChangeEvent,
   HTMLAttributes,
+  MouseEvent,
   ReactNode,
   useCallback,
   useLayoutEffect,
@@ -99,7 +100,7 @@ type Props<T> = {
   /**
    * 選択されているアイテムがクリアされた時に発火するコールバック関数
    */
-  onClear?: () => void
+  onClear?: (e: MouseEvent | ChangeEvent<HTMLInputElement>) => void
   /**
    * 選択されているアイテムのリストが変わった時に発火するコールバック関数
    */
@@ -202,9 +203,9 @@ export function SingleComboBox<T>({
     }
   }, [selectedItem, defaultItem, onSelect])
   const onClickClear = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent) => {
       e.stopPropagation()
-      onClear && onClear()
+      onClear && onClear(e)
       onChangeSelected && onChangeSelected(null)
 
       inputRef.current?.focus()
@@ -214,7 +215,7 @@ export function SingleComboBox<T>({
     [setIsFocused, setIsExpanded, onClear, onChangeSelected],
   )
   const onClickInput = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent) => {
       if (disabled) {
         e.stopPropagation()
         return
@@ -240,7 +241,7 @@ export function SingleComboBox<T>({
       setInputValue(value)
 
       if (value === '') {
-        onClear && onClear()
+        onClear && onClear(e)
         onChangeSelected && onChangeSelected(null)
       }
     },

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -100,7 +100,12 @@ type Props<T> = {
   /**
    * 選択されているアイテムがクリアされた時に発火するコールバック関数
    */
-  onClear?: (e: MouseEvent | ChangeEvent<HTMLInputElement>) => void
+  onClear?: () => void
+  /**
+   * 選択されているアイテムがクリアされた時に発火するコールバック関数
+   * 指定している場合、クリア時にonClickを実行せずにonClearClickのみ実行する
+   */
+  onClearClick?: (e: MouseEvent) => void
   /**
    * 選択されているアイテムのリストが変わった時に発火するコールバック関数
    */
@@ -138,6 +143,7 @@ export function SingleComboBox<T>({
   onAdd,
   onSelect,
   onClear,
+  onClearClick,
   onChangeSelected,
   decorator,
   ...props
@@ -205,14 +211,15 @@ export function SingleComboBox<T>({
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
-      onClear && onClear(e)
+      onClearClick && onClearClick(e)
+      !onClearClick && onClear && onClear()
       onChangeSelected && onChangeSelected(null)
 
       inputRef.current?.focus()
       setIsFocused(true)
       setIsExpanded(true)
     },
-    [setIsFocused, setIsExpanded, onClear, onChangeSelected],
+    [setIsFocused, setIsExpanded, onClear, onClearClick, onChangeSelected],
   )
   const onClickInput = useCallback(
     (e: MouseEvent) => {
@@ -241,7 +248,7 @@ export function SingleComboBox<T>({
       setInputValue(value)
 
       if (value === '') {
-        onClear && onClear(e)
+        onClear && onClear()
         onChangeSelected && onChangeSelected(null)
       }
     },

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -211,15 +211,27 @@ export function SingleComboBox<T>({
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
-      onClearClick && onClearClick(e)
-      !onClearClick && onClear && onClear()
-      onChangeSelected && onChangeSelected(null)
 
-      inputRef.current?.focus()
-      setIsFocused(true)
-      setIsExpanded(true)
+      let isExecutedPreventDefault = false
+
+      onClearClick &&
+        onClearClick({
+          ...e,
+          preventDefault: () => {
+            e.preventDefault()
+            isExecutedPreventDefault = true
+          },
+        })
+
+      if (!isExecutedPreventDefault) {
+        onClear && onClear()
+        onChangeSelected && onChangeSelected(null)
+        inputRef.current?.focus()
+        setIsFocused(true)
+        setIsExpanded(true)
+      }
     },
-    [setIsFocused, setIsExpanded, onClear, onClearClick, onChangeSelected],
+    [onClearClick, onClear, onChangeSelected],
   )
   const onClickInput = useCallback(
     (e: MouseEvent) => {


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-646
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- SingleComboBox の onClear の引数に event を渡せるようにした
  - コンポーネントの利用側で event オブジェクトを利用したいケースがあったので
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- SingleComboBox の onClear の型定義を修正
- onClearを呼び出している箇所で event オブジェクトを渡すようにした
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
