### PR TITLE
fix: window.document に対する typeof の比較を修正

### DIFF
--- a/src/components/Dialog/useDialogPortal.ts
+++ b/src/components/Dialog/useDialogPortal.ts
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 
 export function useDialogPortal(parent?: HTMLElement | RefObject<HTMLElement>) {
   const portalContainer = useRef<HTMLDivElement | null>(
-    parent ?? typeof document === undefined
+    parent ?? typeof document === 'undefined'
       ? null
       : (document.createElement('div') as HTMLDivElement),
   ).current

--- a/src/hooks/usePortal.tsx
+++ b/src/hooks/usePortal.tsx
@@ -22,7 +22,7 @@ let portalSeq = 0
 
 export function usePortal() {
   const portalRoot = useRef<HTMLDivElement | null>(
-    typeof document === undefined ? null : (document.createElement('div') as HTMLDivElement),
+    typeof document === 'undefined' ? null : (document.createElement('div') as HTMLDivElement),
   ).current
   const currentSeq = useMemo(() => ++portalSeq, [])
   const parent = useContext(ParentContext)


### PR DESCRIPTION
## Related URL
#2936 
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`document` に対する typeof の比較方法が間違っていたので修正します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- typeof の比較対象を文字列に修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
