### PR TITLE
fix: ComboBoxのstyle調整 & inputにfocusしたままdropdownが閉じた状態でcaret downをクリックしてもdropdownが開かない問題を修正

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -409,7 +409,7 @@ export function MultiComboBox<T>({
           )}
         </InputArea>
 
-        <Suffix themes={theme}>
+        <Suffix themes={theme} disabled={disabled}>
           <FaCaretDownIcon color={caretIconColor} />
         </Suffix>
 
@@ -513,8 +513,8 @@ const Placeholder = styled.p<{ themes: Theme }>`
     `
   }}
 `
-const Suffix = styled.div<{ themes: Theme }>`
-  ${({ themes: { color, spacingByChar } }) =>
+const Suffix = styled.div<{ themes: Theme; disabled: boolean }>`
+  ${({ themes: { color, spacingByChar }, disabled }) =>
     css`
       position: relative;
       display: flex;
@@ -523,7 +523,7 @@ const Suffix = styled.div<{ themes: Theme }>`
       padding: ${spacingByChar(0.5)};
       padding-left: calc(${spacingByChar(0.5)} + 1px);
       box-sizing: border-box;
-      cursor: pointer;
+      cursor: ${disabled ? 'not-allowed' : 'pointer'};
 
       &::before {
         content: '';

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -514,26 +514,29 @@ const Placeholder = styled.p<{ themes: Theme }>`
   }}
 `
 const Suffix = styled.div<{ themes: Theme; disabled: boolean }>`
-  ${({ themes: { color, spacingByChar }, disabled }) =>
-    css`
+  ${({ themes: { color, spacingByChar }, disabled }) => {
+    const space = spacingByChar(0.5)
+
+    return css`
       position: relative;
       display: flex;
       justify-content: center;
       align-items: center;
-      padding: ${spacingByChar(0.5)};
-      padding-left: calc(${spacingByChar(0.5)} + 1px);
+      padding: ${space};
+      padding-left: calc(${space} + 1px);
       box-sizing: border-box;
       cursor: ${disabled ? 'not-allowed' : 'pointer'};
 
       &::before {
         content: '';
         position: absolute;
-        top: ${spacingByChar(0.5)};
+        top: ${space};
         left: 0;
         display: block;
         width: 1px;
         background-color: ${color.BORDER};
-        height: calc(100% - ${spacingByChar(0.5)} * 2);
+        height: calc(100% - ${space} * 2);
       }
-    `}
+    `
+  }}
 `

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -514,14 +514,26 @@ const Placeholder = styled.p<{ themes: Theme }>`
   }}
 `
 const Suffix = styled.div<{ themes: Theme }>`
-  ${({ themes: { spacingByChar, border } }) =>
+  ${({ themes: { color, spacingByChar } }) =>
     css`
+      position: relative;
       display: flex;
       justify-content: center;
       align-items: center;
-      margin: ${spacingByChar(0.5)} 0;
-      padding: 0 ${spacingByChar(0.5)};
-      border-left: ${border.shorthand};
+      padding: ${spacingByChar(0.5)};
+      padding-left: calc(${spacingByChar(0.5)} + 1px);
       box-sizing: border-box;
+      cursor: pointer;
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: ${spacingByChar(0.5)};
+        left: 0;
+        display: block;
+        width: 1px;
+        background-color: ${color.BORDER};
+        height: calc(100% - ${spacingByChar(0.5)} * 2);
+      }
     `}
 `

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -359,7 +359,7 @@ export function SingleComboBox<T>({
                   }
                 />
               </ClearButton>
-              <CaretDownLayout themes={theme}>
+              <CaretDownLayout themes={theme} onClick={onClickInput}>
                 <CaretDownWrapper themes={theme}>
                   <FaCaretDownIcon color={caretIconColor} />
                 </CaretDownWrapper>

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -397,13 +397,15 @@ const StyledInput = styled(Input)`
 `
 const CaretDownLayout = styled.span<{ themes: Theme }>(({ themes }) => {
   const { spacingByChar } = themes
+  const space = spacingByChar(0.5)
+
   return css`
     height: 100%;
     box-sizing: border-box;
-    padding: ${spacingByChar(0.5)} 0;
+    padding: ${space};
+    padding-left: 0;
+    margin-right: -${space};
     cursor: pointer;
-    margin-right: -${spacingByChar(0.5)};
-    padding-right: ${spacingByChar(0.5)};
   `
 })
 const CaretDownWrapper = styled.span<{ themes: Theme }>(({ themes }) => {

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -401,6 +401,9 @@ const CaretDownLayout = styled.span<{ themes: Theme }>(({ themes }) => {
     height: 100%;
     box-sizing: border-box;
     padding: ${spacingByChar(0.5)} 0;
+    cursor: pointer;
+    margin-right: -${spacingByChar(0.5)};
+    padding-right: ${spacingByChar(0.5)};
   `
 })
 const CaretDownWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
@@ -415,6 +418,7 @@ const CaretDownWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
     border-left: ${border.shorthand};
   `
 })
+
 const ClearButton = styled(UnstyledButton)<{ themes: Theme }>`
   ${({ themes }) => {
     const { shadow, spacingByChar } = themes


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- Comboboxの調整を行います
  - caret down にマウスオーバーしてもしてもマウスカーソルがinput用のままだったため、クリック用に調整
  - inputにfocusした状態でdropdownを閉じさせる操作を行ったあと、caret down をクリックしてもdropdownが開かない問題を修正
    - 再現手順: 適当に選択肢を選んだあと、inputにfocusされたままの状態でcaret downをクリックする

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
