### PR TITLE
feat: アプリランチャーの urlToShowAll props を optional にする

### DIFF
--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -28,7 +28,7 @@ type Category = {
 }
 type Props = {
   apps: Category[]
-  urlToShowAll: string
+  urlToShowAll?: string
 }
 
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>
@@ -91,11 +91,14 @@ export const AppLauncher: React.FC<Props & ElementProps> = ({ apps, urlToShowAll
               </Cluster>
             </Stack>
           </DropdownScrollArea>
-          <Footer themes={theme} className={classNames.footer}>
-            <TextLink href={urlToShowAll} style={{ width: 'fit-content' }}>
-              すべて見る
-            </TextLink>
-          </Footer>
+
+          {urlToShowAll && (
+            <Footer themes={theme} className={classNames.footer}>
+              <TextLink href={urlToShowAll} style={{ width: 'fit-content' }}>
+                すべて見る
+              </TextLink>
+            </Footer>
+          )}
         </Wrapper>
       </DropdownContent>
     </Dropdown>


### PR DESCRIPTION
## Related URL

なし

## Overview

アプリランチャーの「すべて見る」のリンク先が、現状用意できるページがないので、一旦これを出さない選択肢をとれるようにしたい。

## What I did

urlToShowAll を渡さなかった場合に「すべて見る」を含むランチャーのフッター部分を表示しないようにした

## Capture

### urlToShowAll がある場合

<img width="816" alt="image" src="https://user-images.githubusercontent.com/11153463/206593126-e24b88aa-38ba-41bd-9e8f-96027e297bce.png">

### urlToShowAll がない場合

<img width="813" alt="image" src="https://user-images.githubusercontent.com/11153463/206593088-458eba08-a8d3-4b3c-9391-66be2e383430.png">
