### PR TITLE
fix: InputWithTooltip で width に比率を渡しても適用されるようにする

### DIFF
--- a/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
+++ b/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, forwardRef } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Tooltip as shrTooltip } from '../../Tooltip'
 import { Input } from '../Input'
@@ -10,14 +10,25 @@ type Props = ComponentProps<typeof Input> & {
 }
 
 export const InputWithTooltip = forwardRef<HTMLInputElement, Props>(
-  ({ tooltipMessage, ...props }, ref) => (
-    <Tooltip message={tooltipMessage} tabIndex={-1} ariaDescribedbyTarget="inner">
-      <Input {...props} ref={ref} />
-    </Tooltip>
-  ),
+  ({ tooltipMessage, width, ...props }, ref) => {
+    const widthStyle = typeof width === 'number' ? `${width}px` : width
+    return (
+      <Tooltip
+        width={widthStyle}
+        message={tooltipMessage}
+        tabIndex={-1}
+        ariaDescribedbyTarget="inner"
+      >
+        <Input {...props} width={widthStyle} ref={ref} />
+      </Tooltip>
+    )
+  },
 )
 
-const Tooltip = styled(shrTooltip)`
-  /* Input のフォーカスリングを表示するため */
-  overflow: revert;
-`
+const Tooltip = styled(shrTooltip)<{ width?: string }>(
+  ({ width }) => css`
+    /* Input のフォーカスリングを表示するため */
+    overflow: revert;
+    ${width && `width: ${width};`}
+  `,
+)


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-648

## Overview

- SearchInput で width に`100%`などの比率を適用する場合に正しく親コンポーネントの幅を評価できない問題を修正しました

## What I did

- width を定義した場合に InputWithTooltip の Tooltip コンポーネントおよびその子コンポーネントとなる Input コンポーネントのそれぞれに width を適用するようにしました

## Capture

<!--
Please attach a capture if it looks different.
-->
