### PR TITLE
fix!: ヘッダーの tenants props の型を変更

### DIFF
--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -15,7 +15,7 @@ export default {
 export const all: Story = () => (
   <Stack gap={0.25}>
     <Header />
-    <Header tenants="株式会社SmartHR">
+    <Header tenants={[{ id: 'test', name: '株式会社SmartHR' }]}>
       <HeaderLink href="https://support.smarthr.jp/" prefix={<FaQuestionCircleIcon />}>
         ヘルプ
       </HeaderLink>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -20,8 +20,8 @@ type Props = {
   logo?: ReactElement
   /** ロゴリンク */
   logoHref?: string
-  /** テナント */
-  tenants?: string | Tenant[]
+  /** テナント一覧 */
+  tenants?: Tenant[]
   /** 現在のテナント ID */
   currentTenantId?: string
   /** テナントが選択された時に発火するコールバック関数 */
@@ -45,16 +45,16 @@ export const Header: React.VFC<Props & ElementProps> = ({
   const theme = useTheme()
   const classNames = useClassNames()
   const currentTenantName = useMemo(() => {
-    if (Array.isArray(tenants)) {
+    if (tenants) {
       const current = tenants.find(({ id }) => id === currentTenantId)
       return current ? current.name : tenants[0].name
     }
 
-    return tenants
+    return undefined
   }, [currentTenantId, tenants])
   const tenantInfo = useMemo(
     () =>
-      Array.isArray(tenants) ? (
+      tenants && tenants.length > 1 ? (
         <HeaderDropdownButton label={currentTenantName}>
           {tenants.map(({ id, name }) => (
             <Button key={id} onClick={() => onTenantSelect && onTenantSelect(id)}>


### PR DESCRIPTION
## Related URL

🍐 

## Overview

現状 Header の tenants props の型が `Tenant[] | string` になっていて、マルチテナントの場合は Tenant 型の配列、シングルテナントの場合はテナント名を文字列で渡す形になっている。
Header コンポーネントを使う側でシングルテナントかマルチテナントかを判断して値を整形して Header に渡す必要があり、手間がかかる。
使う側ではシングルテナントかマルチテナントかを意識せず、同じ形で props を渡せるようにしたい。

## What I did

tenants props の型を `Tenant[]` だけにした。
シングルテナントの場合は tenants に length が1つの配列を渡す形になる。
プロダクト側では基本的に tenants という配列を持っているのでそれをそのまま渡す形で良いはず。

## Capture

🍐 
