### PR TITLE
fix: bottomFixedArea/TertiaryLinkのtextにReactNodeを渡せるよう修正

### DIFF
--- a/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
+++ b/src/components/BottomFixedArea/BottomFixedArea.stories.tsx
@@ -22,7 +22,11 @@ export const _BottomFixedArea: Story = () => {
         { text: 'Tertiary_1', icon: FaTrashIcon, onClick: action('click_1') },
         { text: 'Tertiary_2', icon: FaTrashIcon, onClick: action('click_2') },
         { text: 'Tertiary_3', icon: FaTrashIcon, onClick: action('click_3') },
-        { text: 'Tertiary_4', icon: FaTrashIcon, onClick: action('click_4') },
+        {
+          text: <span>Tertiary_4</span>,
+          icon: FaTrashIcon,
+          onClick: action('click_4'),
+        },
       ]}
     />
   )

--- a/src/components/BottomFixedArea/TertiaryLink.tsx
+++ b/src/components/BottomFixedArea/TertiaryLink.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, VFC } from 'react'
+import React, { HTMLAttributes, ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -9,7 +9,7 @@ import { useClassNames } from './useClassNames'
 type ElementProps = Omit<HTMLAttributes<HTMLButtonElement>, keyof Props>
 
 type Props = {
-  text: string
+  text: ReactNode
   icon?: React.ComponentType<IconProps>
   type?: 'button' | 'reset'
   onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void


### PR DESCRIPTION
## Related URL
- https://smarthr.atlassian.net/browse/SHRUI-650

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
 - (okeで利用されていた)BottomFixedArea内でTertiaryLink利用時に多言語対応のためReactNodeを渡せるようにする
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- ボタンテキストにReactNodeを渡せるように修正。
- StoryBoardのBottomFixedArea内TertiaryLink利用箇所の４番目の文言をspanでラップ

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
