### PR TITLE
feat: CheckBoxにエラーのステータスを追加する

### DIFF
--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -34,6 +34,12 @@ export const All: Story = () => {
           </li>
 
           <li>
+            <CheckBox error onChange={handleChange}>
+              CheckBox / error
+            </CheckBox>
+          </li>
+
+          <li>
             <CheckBox disabled onChange={handleChange}>
               CheckBox / disabled
             </CheckBox>
@@ -56,6 +62,10 @@ export const All: Story = () => {
           </li>
 
           <li>
+            <CheckBox error onChange={handleChange} />
+          </li>
+
+          <li>
             <CheckBox disabled onChange={handleChange} />
           </li>
 
@@ -72,6 +82,12 @@ export const All: Story = () => {
           <li>
             <CheckBox name="3" checked={checkedName.includes('3')} mixed onChange={handleChange}>
               CheckBox / mixed
+            </CheckBox>
+          </li>
+
+          <li>
+            <CheckBox mixed error onChange={handleChange}>
+              CheckBox / mixed / error
             </CheckBox>
           </li>
 

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -10,6 +10,8 @@ import { useClassNames } from './useClassNames'
 export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
   /** `true` のとき、チェック状態を `mixed` にする */
   mixed?: boolean
+  /** チェックボックスにエラーがあるかどうか */
+  error?: boolean
 }
 
 export const CheckBoxInput = forwardRef<HTMLInputElement, Props>(
@@ -36,7 +38,7 @@ export const CheckBoxInput = forwardRef<HTMLInputElement, Props>(
           themes={theme}
           ref={ref}
         />
-        <Box className={boxClassName} themes={theme} />
+        <Box className={boxClassName} themes={theme} error={props.error} />
         <IconWrap themes={theme}>
           {mixed ? <FaMinusIcon color="TEXT_WHITE" /> : <FaCheckIcon color="TEXT_WHITE" />}
         </IconWrap>
@@ -60,8 +62,8 @@ const Wrapper = styled.span<{ themes: Theme }>`
     `
   }}
 `
-const Box = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
+const Box = styled.span<{ themes: Theme; error?: boolean }>`
+  ${({ themes, error }) => {
     const { border, color } = themes
     return css`
       position: absolute;
@@ -84,6 +86,11 @@ const Box = styled.span<{ themes: Theme }>`
         background-color: ${color.BORDER};
         border-color: ${color.BORDER};
       }
+
+      ${error &&
+      css`
+        border-color: ${color.DANGER};
+      `}
     `
   }}
 `

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -37,6 +37,7 @@ export const CheckBoxInput = forwardRef<HTMLInputElement, Props>(
           className={classNames.checkBox}
           themes={theme}
           ref={ref}
+          aria-invalid={props.error || undefined}
         />
         <Box className={boxClassName} themes={theme} error={props.error} />
         <IconWrap themes={theme}>


### PR DESCRIPTION
## Related URL
特に無し
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`CheckBox`にエラーのステータスを追加したいです。
ユースケースとしては同意を求めるチェックボックスにチェックを入れずにSubmitした場合などを想定しています。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `CheckBoxInput.tsx`に`error`propsを追加
- `error`が`true`の場合にチェックボックスの外枠が赤くなるようCSSを追加
- Storybookにエラー状態のチェックボックスを追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
![image](https://user-images.githubusercontent.com/60545096/207012372-c43d8b78-9023-4803-bf2b-ce2d3cee85fd.png)

<!--
Please attach a capture if it looks different.
-->
