### PR TITLE
fix: FilterDropdownのvalueをvariantに変更

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -114,7 +114,7 @@ export const FilterDropdown: VFC<Props> = ({
               <Button onClick={() => onCancel?.()}>{cancelButton}</Button>
             </DropdownCloser>
             <DropdownCloser>
-              <Button value="primary" onClick={() => onApply()}>
+              <Button variant="primary" onClick={() => onApply()}>
                 {applyButton}
               </Button>
             </DropdownCloser>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- FilterDropdownのメインアクションボタンがSecondaryになっていた
- `value="primary"`となっていたので、おそらく指定が漏れている

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

-  `value="primary"`を`variant="primary"`に変更修正した

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

### Before

![image](https://user-images.githubusercontent.com/4032232/207485394-f9c5a3a0-8be3-4674-a167-164e5a821cc0.png)

### After

![CleanShot 2022-12-14 at 10 50 59](https://user-images.githubusercontent.com/4032232/207485369-a556927f-2703-4839-8750-52d4ccb5fc52.png)

<!--
Please attach a capture if it looks different.
-->
