### PR TITLE
fix: Header, AppLauncher の props で入れられる値を広げる

### DIFF
--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -12,7 +12,7 @@ import { TextLink } from '../../TextLink'
 import { useClassNames } from './useClassNames'
 
 type Category = {
-  type?: 'base'
+  type?: string
   heading: string
   items: Array<{
     label: string
@@ -22,7 +22,7 @@ type Category = {
 }
 type Props = {
   apps: Category[]
-  urlToShowAll?: string
+  urlToShowAll?: string | null
 }
 
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -45,7 +45,7 @@ export const Header: React.VFC<Props & ElementProps> = ({
   const theme = useTheme()
   const classNames = useClassNames()
   const currentTenantName = useMemo(() => {
-    if (tenants) {
+    if (tenants && tenants.length >= 1) {
       const current = tenants.find(({ id }) => id === currentTenantId)
       return current ? current.name : tenants[0].name
     }


### PR DESCRIPTION
## Related URL

🍐 

## Overview

以下の3点の問題に対応したい。

- Header の tenants props に空の配列が渡されたときランタイムエラーが起きてしまう
- AppLauncher の urlToShowAll に `string | undefined` の他に null も許容したい
- AppLauncher の apps の type に `base` 以外の文字列も渡せるようにしたい

下の2点はランチャー API のレスポンスに合わせてそうしたい感じです。

## What I did

- Header の tenants props に空の配列が渡されたときランタイムエラーが起きてしまう
  - 👉 tenants.length が1以上のときにしか currentTenant を取得しないようにした
- AppLauncher の urlToShowAll に `string | undefined` の他に null も許容したい
  - 👉 null 追加した
- AppLauncher の apps の type に `base` 以外の文字列も渡せるようにしたい
  - 👉 type を string にした

## Capture

🍐 
