### PR TITLE
fix: add line-height to AppLauncher

### DIFF
--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -115,8 +115,9 @@ const AppsButton = styled(Button)<{ themes: Theme }>`
   `}
 `
 const Wrapper = styled(Stack).attrs({ as: 'nav', gap: 1.5 })<{ themes: Theme }>`
-  ${({ themes: { space } }) => css`
+  ${({ themes: { space, leading } }) => css`
     padding: ${space(1.5)};
+    line-height: ${leading.NORMAL};
   `}
 `
 const Footer = styled(Stack)<{ themes: Theme }>`


### PR DESCRIPTION
## Related URL

🍐 

## Overview

AppLauncher のドロップダウンでスクロールが発生してしまうので修正したい

## What I did

line-height をつけることでスクロールが消えるので付与。
また、それによって行間が詰まっていたのも少し広くなりました。

## Capture

### Before

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/11153463/209610256-3c246f4d-9030-4d07-9f3e-8a9d2e3dfb82.png">

### After

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/11153463/209610276-e358a477-78e4-401f-846b-b94dcebafc1e.png">
