### PR TITLE
feat: グラフ色を追加

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,3 +14,16 @@ export const VISUALLY_HIDDEN_STYLE = css`
   overflow: hidden;
 `
 export const FONT_FAMILY = 'system-ui, sans-serif'
+export const CHART_COLORS = [
+  'rgb(0, 196, 204)',
+  'rgb(255, 205, 0)',
+  'rgb(255, 145, 0)',
+  'rgb(230, 85, 55)',
+  'rgb(45, 75, 155)',
+  'rgb(45, 125, 240)',
+  'rgb(105, 215, 255)',
+  'rgb(75, 180, 125)',
+  'rgb(5, 135, 140)',
+  'rgb(0, 90, 100)',
+]
+export const OTHER_CHART_COLOR = 'rgb(235, 235, 235)'

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export { defaultSpacing } from './themes/createSpacing'
 export { defaultBreakpoint } from './themes/createBreakpoint'
 
 // constants
-export { FONT_FAMILY, VISUALLY_HIDDEN_STYLE } from './constants'
+export { FONT_FAMILY, VISUALLY_HIDDEN_STYLE, CHART_COLORS, OTHER_CHART_COLOR } from './constants'
 
 // utils
 export { SequencePrefixIdProvider } from './hooks/useId'


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-642
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

![グラフ色10色とその他1色](https://user-images.githubusercontent.com/19403400/211736639-9549734d-e2ba-450b-815e-7dc55c7ad8d6.png)

グラフに使用している色がプロダクト間で揺れていたため SmartHR UI で提供し統一を図ります。
その他のグラフ色を使ってるプロダクトはまだありませんが、合わせて追加しています。


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
