### PR TITLE
feat: buttonコンポーネントのvariantオプションにpseudoAnchorを追加

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -125,6 +125,14 @@ export const _Button: Story = () => {
               ボタン
             </Button>
           </Cluster>
+          <Cluster>
+            <Button variant="pseudoAnchor" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button variant="pseudoAnchor" disabled onClick={action('clicked')}>
+              ボタン
+            </Button>
+          </Cluster>
         </Stack>
       </dd>
 

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -223,5 +223,25 @@ function variantStyles(variant: Variant, theme: Theme) {
           color: ${color.TEXT_DISABLED};
         `,
       }
+    case 'pseudoAnchor':
+      return {
+        default: css`
+          background-color: transparent;
+          border-radius: 0;
+          color: ${color.TEXT_LINK};
+          font-weight: normal;
+          padding: 0;
+        `,
+        focus: css`
+          background-color: transparent;
+          color: ${color.hoverColor(color.TEXT_LINK)};
+          text-decoration: underline;
+        `,
+        disabled: css`
+          background-color: transparent;
+          color: ${color.TEXT_DISABLED};
+          text-decoration: none;
+        `,
+      }
   }
 }

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -46,4 +46,4 @@ export type BaseProps = {
   loading?: boolean
 }
 
-export type Variant = 'primary' | 'secondary' | 'danger' | 'skeleton' | 'text'
+export type Variant = 'primary' | 'secondary' | 'danger' | 'skeleton' | 'text' | 'pseudoAnchor'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- UIの関係上、 `見た目はリンクだがタグとしてはbutton` にしたい場合がある
- button variantオプションを拡張し、上記の見た目を提供したい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- Buttonのvariantに pseudoAnchor を追加
- pseudoAnchorの場合、リンクのように見えるstyleを適用するように修正

## Capture

<!--
Please attach a capture if it looks different.
-->
<img width="244" alt="スクリーンショット 2023-01-13 12 44 33" src="https://user-images.githubusercontent.com/773467/212232447-aafd952d-fdf7-4145-b688-b0e18716a384.png">
