### PR TITLE
fix: フッターの特定商取引法に基づく表記リンクを削除

### DIFF
--- a/src/components/MessageScreen/Footer.tsx
+++ b/src/components/MessageScreen/Footer.tsx
@@ -18,7 +18,6 @@ export const Footer: VFC<ElementProps> = ({ className = '', ...props }) => {
         <Item href="https://smarthr.jp/update/">お知らせ</Item>
         <Item href="https://smarthr.jp/terms/">利用規約</Item>
         <Item href="https://smarthr.co.jp/privacy/">プライバシーポリシー</Item>
-        <Item href="https://smarthr.jp/law/">特定商取引法に基づく表記</Item>
         <Item href="https://smarthr.co.jp">運営会社</Item>
         <Item href="https://developer.smarthr.jp">開発者向けAPI </Item>
       </List>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
SmartHR基本機能のフッター上から`特定商取引法に基づく表記`リンクが削除されたので、smarthr-uiをこれに追従させたい。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
フッターの`特定商取引法に基づく表記`リンクを削除しました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
