### PR TITLE
feat: RightFixedNote に decoratorsオプションを追加

### DIFF
--- a/src/components/RightFixedNote/RightFixedNote.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.tsx
@@ -1,8 +1,10 @@
-import React, { FormHTMLAttributes, VFC, useCallback } from 'react'
+import React, { FormHTMLAttributes, ReactNode, VFC, useCallback, useMemo } from 'react'
+import innerText from 'react-innertext'
 import styled, { css } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { DecoratorsType } from '../../types/props'
 import { Button } from '../Button'
 import { Heading } from '../Heading'
 import { Textarea } from '../Textarea'
@@ -12,30 +14,37 @@ import { useClassNames } from './useClassNames'
 
 type Props = {
   /** コンポーネントのタイトル */
-  title: string
+  title: ReactNode
   /** 表示するアイテムの配列 */
   items?: ItemProps[]
   /** submit ボタンのラベル */
+  /**
+   * @deprecated submitLabel属性は非推奨です。decorators属性を利用してください。
+   */
   submitLabel?: string
   /** コンポーネントの幅 */
   width?: number
   /** textarea のラベル */
-  textareaLabel?: string
+  textareaLabel?: ReactNode
   /** edit ボタンを押下したときに発火するコールバック関数 */
   onClickEdit: OnClickEdit
   /** submit ボタンを押下したときに発火するコールバック関数 */
   onSubmit: (e: React.FormEvent<HTMLFormElement>, text: string) => void
   /** コンポーネントに適用するクラス名 */
   className?: string
+  /** コンポーネント内の文言を変更するための関数を設定 */
+  decorators?: DecoratorsType<'submitLabel'>
 }
 type ElementProps = Omit<FormHTMLAttributes<HTMLFormElement>, keyof Props>
 
 const TEXT_AREA_NAME = 'admin_memo_new_text'
+const SUBMIT_LABEL = '送信'
 
 export const RightFixedNote: VFC<Props & ElementProps> = ({
   title,
   items,
-  submitLabel = '送信',
+  submitLabel,
+  decorators,
   width = 270,
   textareaLabel,
   onClickEdit,
@@ -44,6 +53,14 @@ export const RightFixedNote: VFC<Props & ElementProps> = ({
   ...props
 }) => {
   const theme = useTheme()
+
+  const actualSubmitLabel = useMemo(() => {
+    if (submitLabel) {
+      return submitLabel
+    }
+
+    return decorators?.submitLabel?.(SUBMIT_LABEL) || SUBMIT_LABEL
+  }, [])
 
   const handleSubmit = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
@@ -88,12 +105,12 @@ export const RightFixedNote: VFC<Props & ElementProps> = ({
         id={textareaId}
         name={TEXT_AREA_NAME}
         themes={theme}
-        aria-label={textareaLabel ? textareaLabel : title}
+        aria-label={innerText(textareaLabel || title)}
         className={classNames.textarea}
       />
 
       <SubmitButton type="submit" className={classNames.submitButton}>
-        {submitLabel}
+        {actualSubmitLabel}
       </SubmitButton>
     </Wrapper>
   )

--- a/src/components/RightFixedNote/RightFixedNoteItem.tsx
+++ b/src/components/RightFixedNote/RightFixedNoteItem.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from 'react'
+import React, { ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -12,11 +12,11 @@ export type ItemProps = {
   /** アイテムを特定するための識別子 */
   id: string
   /** 表示するテキスト */
-  text: string
+  text: ReactNode
   /** このアイテムが追加された日付 */
-  date?: string
+  date?: ReactNode
   /** このアイテムの著者 */
-  author?: string
+  author?: ReactNode
   /** edit ボタンの aria-label */
   editLabel?: string
   /** このコンポーネントに適用するクラス名 */


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- コンポーネント内で固定で持つ文言を変更する手段をdecoratorsに統一します
- decorators以外の手段は後ほど削除予定です

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
