### PR TITLE
feat: MessageScreen の links[number]label を string から ReactNode に変更

### DIFF
--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -14,7 +14,7 @@ type Props = {
   /** コンテンツの下に表示されるアンカー要素のリスト */
   links?: Array<{
     /** アンカー要素のテキスト */
-    label: string
+    label: ReactNode
     /** アンカー要素の href */
     url: string
     /** アンカー要素の target。`_blank` を設定すると外部リンクアイコンが表示されます。*/
@@ -59,8 +59,8 @@ export const MessageScreen: VFC<Props & ElementProps> = ({
 
         {links && links.length && (
           <Links themes={theme} className={classNames.linkList}>
-            {links.map((link) => (
-              <li key={link.label}>
+            {links.map((link, index) => (
+              <li key={index}>
                 <TextLink
                   {...(link.target ? { target: link.target } : {})}
                   href={link.url}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- MessageScreen コンポーネントの links[number].label を string から ReactNode に変更します
- これにより、翻訳用のコンポーネントなどでラップすることが可能になります

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
