### PR TITLE
feat: Loader の alt, text オプションを ReactNode に変更

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, VFC } from 'react'
+import React, { HTMLAttributes, ReactNode, VFC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { VISUALLY_HIDDEN_STYLE } from '../../constants'
@@ -23,9 +23,9 @@ type Props = {
   /** ローダーの大きさ */
   size?: 's' | 'm'
   /** 代替テキスト */
-  alt?: string
+  alt?: ReactNode
   /** 表示するメッセージ */
-  text?: string
+  text?: ReactNode
   /** コンポーネントの色調 */
   type?: 'primary' | 'light'
 }
@@ -34,7 +34,7 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 export const Loader: VFC<Props & ElementProps> = ({
   size = 'm',
   alt = '処理中',
-  text = '',
+  text,
   type = 'primary',
   className = '',
   ...props
@@ -58,13 +58,13 @@ export const Loader: VFC<Props & ElementProps> = ({
             </Cog>
           </Line>
         ))}
+        <VisuallyHidden>{alt}</VisuallyHidden>
       </Spinner>
       {text && (
         <Text className={type} themes={theme}>
           {text}
         </Text>
       )}
-      <VisuallyHidden>{alt}</VisuallyHidden>
     </Wrapper>
   )
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- Loader コンポーネントの alt, text を ReactNodeに変更し、翻訳用コンポーネントなどを差し込めるようにする

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
