### PR TITLE
fix: 特定の条件下で Loader コンポーネント使用時にスクロールバーが出現してしまう不具合を修正

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -71,6 +71,7 @@ export const Loader: VFC<Props & ElementProps> = ({
 
 const Wrapper = styled.div`
   display: inline-block;
+  overflow: hidden;
 `
 
 const VisuallyHidden = styled.span`


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

現状の Loader コンポーネントは、特定の条件下でスクロールバーが出現してしまいます。

👇 他の要素にホバーしたときに一瞬だけスクロールバーが表示されてしまっている様子

https://user-images.githubusercontent.com/14817308/214229233-8c6423d0-e30e-4c80-a4b9-9dd3a97383b6.mov




<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Loader コンポーネントのスタイルに `overflow: hidden;` を追記

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

👇 今回の修正でスクロールバーが出現しなくなっている様子

https://user-images.githubusercontent.com/14817308/214229751-e4486212-868e-4e07-ad97-503379503d6f.mov



<!--
Please attach a capture if it looks different.
-->
