### PR TITLE
feat: Icon の alt属性を ReactNode に変更する

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -361,7 +361,7 @@ type ElementProps = Omit<React.SVGAttributes<SVGAElement>, keyof IconProps>
 
 export interface ComponentProps extends IconProps, ElementProps {
   /**アイコンの説明テキスト*/
-  alt?: string
+  alt?: React.ReactNode
   /** アイコンと並べるテキスト */
   text?: React.ReactNode
   /** アイコンと並べるテキストとの溝 */


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- Iconコンポーネントのalt属性をReactNodeに変更します
  - これにより、alt属性に対して翻訳用コンポーネントなどを設定することが可能になります

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
