### PR TITLE
fix: ダイアログが `portalParent` 指定時に動かなくなっていた問題の修正

### DIFF
--- a/e2e/components/Dialog/Dialog.PortalParent.test.ts
+++ b/e2e/components/Dialog/Dialog.PortalParent.test.ts
@@ -1,0 +1,26 @@
+import { Selector } from 'testcafe'
+
+fixture('Dialog (Portal Parent)')
+  .page(
+    'http://localhost:6006/iframe.html?args=&id=dialog（ダイアログ）-dialog--body以外の-portal-parent&viewMode=story',
+  )
+  .beforeEach(async (t) => {
+    await t.maximizeWindow()
+  })
+
+test('body 以外を親にしたダイアログが開閉できること', async (t) => {
+  const trigger = Selector('[data-test=dialog-trigger]')
+  const content = Selector('[data-test=dialog-content]')
+  const closer = Selector('[data-test=dialog-closer]')
+
+  await t
+    .click(trigger)
+    .expect(content.visible)
+    .ok()
+    .click(closer)
+    .expect(content.exists)
+    .notOk()
+    // ダイアログを閉じた後、トリガがフォーカスされることを確認
+    .expect(trigger.focused)
+    .ok()
+})

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -730,7 +730,6 @@ export const Body以外のPortalParent: Story = () => {
           onClick={() => onClickOpen('actiion')}
           aria-haspopup="dialog"
           aria-controls="portal-action"
-          data-test="dialog-trigger"
         >
           ActionDialog を開く
         </Button>
@@ -738,7 +737,6 @@ export const Body以外のPortalParent: Story = () => {
           onClick={() => onClickOpen('message')}
           aria-haspopup="dialog"
           aria-controls="portal-message"
-          data-test="dialog-trigger"
         >
           MessageDialog を開く
         </Button>
@@ -780,7 +778,6 @@ export const Body以外のPortalParent: Story = () => {
         }}
         onClickClose={onClickClose}
         id="portal-action"
-        data-test="dialog-content"
         portalParent={portalParentRef}
       >
         <Content>
@@ -794,7 +791,6 @@ export const Body以外のPortalParent: Story = () => {
         onClickClose={onClickClose}
         onClickOverlay={onClickClose}
         id="portal-message"
-        data-test="dialog-content"
         portalParent={portalParentRef}
       />
       <ModelessDialog

--- a/src/components/Dialog/useDialogPortal.ts
+++ b/src/components/Dialog/useDialogPortal.ts
@@ -1,4 +1,4 @@
-import { ReactNode, RefObject, useCallback, useEffect, useRef } from 'react'
+import { ReactNode, RefObject, useCallback, useLayoutEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
 export function useDialogPortal(parent?: HTMLElement | RefObject<HTMLElement>) {
@@ -6,7 +6,7 @@ export function useDialogPortal(parent?: HTMLElement | RefObject<HTMLElement>) {
     typeof document === 'undefined' ? null : (document.createElement('div') as HTMLDivElement),
   ).current
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!portalContainer) {
       return
     }

--- a/src/components/Dialog/useDialogPortal.ts
+++ b/src/components/Dialog/useDialogPortal.ts
@@ -1,14 +1,12 @@
-import { ReactNode, RefObject, useCallback, useLayoutEffect, useRef } from 'react'
+import { ReactNode, RefObject, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
 export function useDialogPortal(parent?: HTMLElement | RefObject<HTMLElement>) {
   const portalContainer = useRef<HTMLDivElement | null>(
-    parent ?? typeof document === 'undefined'
-      ? null
-      : (document.createElement('div') as HTMLDivElement),
+    typeof document === 'undefined' ? null : (document.createElement('div') as HTMLDivElement),
   ).current
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!portalContainer) {
       return
     }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`Dialog` コンポーネントが `portalParent` を指定したときに動かなくなっていた問題に対応します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- 要素の生成方法が間違っていたのを修正
- e2e テストを追加

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
