### PR TITLE
fix: チャート色を30色に拡張

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import { shade, tint } from 'polished'
 import { css } from 'styled-components'
 
 export const VISUALLY_HIDDEN_STYLE = css`
@@ -14,7 +15,7 @@ export const VISUALLY_HIDDEN_STYLE = css`
   overflow: hidden;
 `
 export const FONT_FAMILY = 'system-ui, sans-serif'
-export const CHART_COLORS = [
+const BASE_CHART_COLORS = [
   'rgb(0, 196, 204)',
   'rgb(255, 205, 0)',
   'rgb(255, 145, 0)',
@@ -25,5 +26,12 @@ export const CHART_COLORS = [
   'rgb(75, 180, 125)',
   'rgb(5, 135, 140)',
   'rgb(0, 90, 100)',
+]
+/* 機械的に使うことを考えて、基本チャート色が10色、基本色より明るい10色、暗い10色
+ * lighten / darken よりも彩度は変わるが自然な色彩になるため tint / shade を使っている */
+export const CHART_COLORS = [
+  ...BASE_CHART_COLORS,
+  ...BASE_CHART_COLORS.map((color) => tint(0.4, color)),
+  ...BASE_CHART_COLORS.map((color) => shade(0.4, color)),
 ]
 export const OTHER_CHART_COLOR = 'rgb(235, 235, 235)'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

![SmartHR チャート色30色が並んでいる](https://user-images.githubusercontent.com/19403400/214725376-4e812eaa-7a53-444f-a31c-915107d14df6.png)

基本10色をプロダクト側で30色まで増やす想定でしたが、SmartHR UI 側で増やせば良いことに気がついたので拡張しました。

自然な色合いになるように `tint / shade` を使っています。機械的に増やした色のためコントラスト比などの担保はできません。プロダクト側でできるだけ色に頼らない使い方をする必要があります。

また、利用ライブラリの都合で、出力される色は、基本色が RGB 値で拡張値が HEX 値になっていますが特に問題ないと判断しました。