### PR TITLE
feat: SearchInput に decorators 属性を追加

### DIFF
--- a/src/components/Input/SearchInput/SearchInput.stories.tsx
+++ b/src/components/Input/SearchInput/SearchInput.stories.tsx
@@ -8,11 +8,21 @@ import { SearchInput } from './SearchInput'
 
 export const Default: Story = () => (
   <Container>
-    <p>主に入力欄に対する説明をレイアウト上配置できない場合の利用を想定しています。</p>
-    <SearchInput
-      name="default"
-      tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
-    />
+    <div>
+      <p>主に入力欄に対する説明をレイアウト上配置できない場合の利用を想定しています。</p>
+      <SearchInput
+        name="default"
+        tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+      />
+    </div>
+    <div>
+      <p>アイコンの代替テキストを設定</p>
+      <SearchInput
+        name="default"
+        tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+        decorators={{ iconAlt: (txt) => `search.(${txt})` }}
+      />
+    </div>
   </Container>
 )
 Default.storyName = 'SearchInput'

--- a/src/components/Input/SearchInput/SearchInput.tsx
+++ b/src/components/Input/SearchInput/SearchInput.tsx
@@ -1,15 +1,27 @@
-import React, { ComponentProps, forwardRef } from 'react'
+import React, { ComponentProps, forwardRef, useMemo } from 'react'
 
+import { DecoratorsType } from '../../../types/props'
 import { FaSearchIcon } from '../../Icon'
 import { InputWithTooltip } from '../InputWithTooltip'
 
 type Props = Omit<ComponentProps<typeof InputWithTooltip>, 'tooltipMessage' | 'prefix'> & {
   /** 入力欄の説明を紐付けるツールチップに表示するメッセージ */
   tooltipMessage: React.ReactNode
+  decorators?: DecoratorsType<'iconAlt'>
 }
 
-export const SearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => (
-  <label>
-    <InputWithTooltip {...props} ref={ref} prefix={<FaSearchIcon alt="検索" color="TEXT_GREY" />} />
-  </label>
-))
+const ICON_ALT = '検索'
+
+export const SearchInput = forwardRef<HTMLInputElement, Props>(({ decorators, ...props }, ref) => {
+  const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
+
+  return (
+    <label>
+      <InputWithTooltip
+        {...props}
+        ref={ref}
+        prefix={<FaSearchIcon alt={iconAlt} color="TEXT_GREY" />}
+      />
+    </label>
+  )
+})


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- 固定だったアイコンの `検索` という文言を差し替えられるようにdecoratorsオプションを追加します

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
