### PR TITLE
refactor!: DropdownMenuButton の labelのデフォルト値を削除

### DIFF
--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -27,12 +27,12 @@ const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'childr
 
 export const Default: Story = () => (
   <Cluster align="center">
-    <Template />
-    <Template disabled />
-    <Template onlyIconTrigger />
+    <Template label="デフォルト" />
+    <Template disabled label="無効化" />
+    <Template onlyIconTrigger label="アイコンのみ" />
     <Template triggerSize="s" label="操作" />
     <Template triggerSize="s" label={<span>操作</span>} disabled />
-    <Template triggerSize="s" onlyIconTrigger />
+    <Template triggerSize="s" onlyIconTrigger label="操作" />
   </Cluster>
 )
 Default.storyName = 'DropdownMenuButton'

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -27,9 +27,9 @@ const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'childr
 
 export const Default: Story = () => (
   <Cluster align="center">
-    <Template label="デフォルト" />
-    <Template disabled label="無効化" />
-    <Template onlyIconTrigger label="アイコンのみ" />
+    <Template label="その他の操作" />
+    <Template disabled label="その他の操作" />
+    <Template onlyIconTrigger label="その他の操作" />
     <Template triggerSize="s" label="操作" />
     <Template triggerSize="s" label={<span>操作</span>} disabled />
     <Template triggerSize="s" onlyIconTrigger label="操作" />

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -18,8 +18,8 @@ type ActionItem =
   | null
   | boolean
 type Props = {
-  /** 引き金となるボタンラベル。デフォルトは “その他の操作” */
-  label?: ReactNode
+  /** 引き金となるボタンラベル */
+  label: ReactNode
   /** 操作群 */
   children: Actions
   /** 引き金となるボタンの大きさ */
@@ -32,7 +32,7 @@ type Props = {
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>
 
 export const DropdownMenuButton: VFC<Props & ElementProps> = ({
-  label = 'その他の操作',
+  label,
   children,
   triggerSize,
   onlyIconTrigger = false,


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- 多くの場合で `その他操作` という文言で問題ないが、例えばアイコンのみ表示するかつ、他操作がない場合、意図しない代替テキストが設定される可能性がる
- 上記場合、設定されている代替テキストに、表示上気づく手段が無い
- そのため、どんなテキストを設定するのか？を明確に利用者に選択してもらうよう、label属性を必須にし、デフォルト値を削除する

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
