### PR TITLE
fix!: Center の天地中央揃えを verticalCentering に変更

### DIFF
--- a/src/components/Layout/Center/Center.stories.tsx
+++ b/src/components/Layout/Center/Center.stories.tsx
@@ -54,10 +54,10 @@ export const All: Story = () => {
 
       <Stack as="section">
         <Heading tag="h2" type="sectionTitle">
-          vAlign (with minHeight: 200px)
+          with Vertical Centering (with minHeight: 200px)
         </Heading>
         <DemoWrapper>
-          <Center vAlign minHeight="200px">
+          <Center verticalCentering minHeight="200px">
             <Button>水平垂直中央揃え</Button>
           </Center>
         </DemoWrapper>

--- a/src/components/Layout/Center/Center.tsx
+++ b/src/components/Layout/Center/Center.tsx
@@ -10,9 +10,9 @@ export const Center = styled.div<{
   maxWidth?: number | string
   /** 境界とコンテンツの間の余白 */
   padding?: Gap
-  /** true の場合は垂直中央揃えを有効化 */
-  vAlign?: boolean
-}>(({ minHeight, maxWidth, padding, vAlign = false }) => {
+  /** 天地中央揃えも有効化するかどうか */
+  verticalCentering?: boolean
+}>(({ minHeight, maxWidth, padding, verticalCentering = false }) => {
   return css`
     box-sizing: content-box;
     margin-left: auto;
@@ -24,6 +24,6 @@ export const Center = styled.div<{
     ${minHeight && `min-height: ${minHeight};`}
     ${maxWidth && `max-width: ${maxWidth};`}
     ${padding && `padding: ${useSpacing(padding)};`}
-    ${vAlign && 'justify-content: center;'}
+    ${verticalCentering && 'justify-content: center;'}
   `
 })


### PR DESCRIPTION
Center の天地中央揃えするかどうかの props が `vAlign` だったが、`align` や `vAlign` は `align-items` や `text-align` のような値が来ることを想起しそうなため、明確に絞った名前に変更しました。