### PR TITLE
feat: Base に背景色を指定するための color を追加

### DIFF
--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -53,19 +53,19 @@ export const BaseStory: Story = () => {
             <Base>初期値</Base>
           </li>
           <li>
-            <Base color="BACKGROUND">color: BACKGROUND</Base>
+            <Base bgColor="BACKGROUND">bgColor: BACKGROUND</Base>
           </li>
           <li>
-            <Base color="BASE_GREY">color: BASE_GREY</Base>
+            <Base bgColor="BASE_GREY">bgColor: BASE_GREY</Base>
           </li>
           <li>
-            <Base color="OVER_BACKGROUND">color: OVER_BACKGROUND</Base>
+            <Base bgColor="OVER_BACKGROUND">bgColor: OVER_BACKGROUND</Base>
           </li>
           <li>
-            <Base color="HEAD">color: HEAD</Base>
+            <Base bgColor="HEAD">bgColor: HEAD</Base>
           </li>
           <li>
-            <Base color="ACTION_BACKGROUND">color: ACTION_BACKGROUND</Base>
+            <Base bgColor="ACTION_BACKGROUND">bgColor: ACTION_BACKGROUND</Base>
           </li>
         </List>
       </dd>

--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -37,6 +37,30 @@ export const BaseStory: Story = () => {
           </li>
         </List>
       </dd>
+      <dt>color</dt>
+      <dd>
+        <p>styled-components で wrap することなく背景色を変えられます。</p>
+        <List>
+          <li>
+            <Base>初期値</Base>
+          </li>
+          <li>
+            <Base color="BACKGROUND">color: BACKGROUND</Base>
+          </li>
+          <li>
+            <Base color="BASE_GREY">color: BASE_GREY</Base>
+          </li>
+          <li>
+            <Base color="OVER_BACKGROUND">color: OVER_BACKGROUND</Base>
+          </li>
+          <li>
+            <Base color="HEAD">color: HEAD</Base>
+          </li>
+          <li>
+            <Base color="ACTION_BACKGROUND">color: ACTION_BACKGROUND</Base>
+          </li>
+        </List>
+      </dd>
       <dt>radius</dt>
       <dd>
         <List>

--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -1,8 +1,9 @@
 import { Story } from '@storybook/react'
-import * as React from 'react'
-import styled from 'styled-components'
+import React from 'react'
+import styled, { css } from 'styled-components'
 
 import { useTheme } from '../../hooks/useTheme'
+import { Stack } from '../Layout'
 import { Text } from '../Text'
 
 import { Base, LayerKeys, layerMap } from './Base'
@@ -11,6 +12,10 @@ import { DialogBase } from './DialogBase'
 export default {
   title: 'Data Display（データ表示）/Base',
   component: Base,
+  parameters: {
+    layout: 'fullscreen',
+    withTheming: true,
+  },
 }
 
 export const BaseStory: Story = () => {
@@ -18,7 +23,9 @@ export const BaseStory: Story = () => {
 
   return (
     <DescriptionList>
-      <dt>padding</dt>
+      <Text as="dt" weight="bold">
+        padding
+      </Text>
       <dd>
         <List>
           <li>
@@ -37,9 +44,10 @@ export const BaseStory: Story = () => {
           </li>
         </List>
       </dd>
-      <dt>color</dt>
+      <Text as="dt" weight="bold">
+        color
+      </Text>
       <dd>
-        <p>styled-components で wrap することなく背景色を変えられます。</p>
         <List>
           <li>
             <Base>初期値</Base>
@@ -61,7 +69,9 @@ export const BaseStory: Story = () => {
           </li>
         </List>
       </dd>
-      <dt>radius</dt>
+      <Text as="dt" weight="bold">
+        radius
+      </Text>
       <dd>
         <List>
           <li>
@@ -76,15 +86,18 @@ export const BaseStory: Story = () => {
           </li>
         </List>
       </dd>
-      <dt>box-shadow</dt>
+      <Text as="dt" weight="bold">
+        box-shadow
+      </Text>
       <dd>
         <List>
           {Object.keys(layerMap).map((layer, index) => (
             <li key={`${layer}-${index}`}>
               <Base layer={Number(layer) as LayerKeys}>
                 <Text>
-                  If layer props is specified as <Bold>{layer}</Bold>, box-shadow becomes
-                  <Bold> {themes.shadow[layerMap[Number(layer) as LayerKeys]]}</Bold>.
+                  If layer props is specified as <Text weight="bold">{layer}</Text>, box-shadow
+                  becomes
+                  <Text weight="bold"> {themes.shadow[layerMap[Number(layer) as LayerKeys]]}</Text>.
                 </Text>
               </Base>
             </li>
@@ -101,14 +114,16 @@ export const DialogBaseStory: Story = () => (
     <li>
       <DialogBase radius="s">
         <Text>
-          If radius props is specified as <Bold>s</Bold>, border-radius becomes <Bold>6px</Bold>.
+          If radius props is specified as <Text weight="bold">s</Text>, border-radius becomes{' '}
+          <Text weight="bold">6px</Text>.
         </Text>
       </DialogBase>
     </li>
     <li>
       <DialogBase radius="m">
         <Text>
-          If radius props is specified as <Bold>m</Bold>, border-radius becomes <Bold>8px</Bold>.
+          If radius props is specified as <Text weight="bold">m</Text>, border-radius becomes{' '}
+          <Text weight="bold">8px</Text>.
         </Text>
       </DialogBase>
     </li>
@@ -116,22 +131,11 @@ export const DialogBaseStory: Story = () => (
 )
 DialogBaseStory.storyName = 'DialogBase（非推奨）'
 
-const DescriptionList = styled.dl`
-  padding: 24px;
-  background-color: #eee;
+const DescriptionList = styled(Stack).attrs({ as: 'dl', gap: 1.5 })`
+  ${({ theme: { color, space } }) => css`
+    background-color: ${color.BACKGROUND};
+    padding: ${space(1.5)};
+  `}
 `
 
-const List = styled.ul`
-  margin: 0;
-  padding: 24px;
-  background-color: #eee;
-  list-style: none;
-
-  & > li:not(:first-child) {
-    margin-top: 24px;
-  }
-`
-
-const Bold = styled.span`
-  font-weight: bold;
-`
+const List = styled(Stack).attrs({ as: 'ul', gap: 0.75 })``

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -13,7 +13,7 @@ type Props = {
   /** 境界とコンテンツの間の余白 */
   padding?: Gap | SeparatePadding
   /** 背景色 */
-  color?: GreyScaleColors | 'inherit'
+  bgColor?: GreyScaleColors | 'inherit'
   /** 角丸のサイズ */
   radius?: 's' | 'm'
   /** レイヤの重なり方向の高さ（影の付き方に影響する） */
@@ -52,7 +52,7 @@ const separatePadding = (padding: Props['padding']) => {
 }
 
 export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
-  ({ padding, color, radius = 'm', layer = 1, className = '', ...props }, ref) => {
+  ({ padding, bgColor, radius = 'm', layer = 1, className = '', ...props }, ref) => {
     const themes = useTheme()
     const classNames = useClassNames()
 
@@ -72,7 +72,7 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
         className={`${className} ${classNames.base.wrapper}`}
         themes={themes}
         $padding={$padding}
-        $color={color}
+        $bgColor={bgColor}
         $radius={$radius}
         $layer={layerMap[layer]}
         ref={ref}
@@ -84,14 +84,18 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
 const Wrapper = styled.div<{
   themes: Theme
   $padding: { block?: Gap; inline?: Gap }
-  $color?: Props['color']
+  $bgColor?: Props['bgColor']
   $radius: string
   $layer: (typeof layerMap)[LayerKeys]
 }>`
-  ${({ themes: { color, shadow }, $padding, $color, $radius, $layer }) => css`
+  ${({ themes: { color, shadow }, $padding, $bgColor, $radius, $layer }) => css`
     box-shadow: ${shadow[$layer]};
     border-radius: ${$radius};
-    background-color: ${$color ? ($color === 'inherit' ? $color : color[$color]) : color.WHITE};
+    background-color: ${$bgColor
+      ? $bgColor === 'inherit'
+        ? $bgColor
+        : color[$bgColor]
+      : color.WHITE};
     ${$padding.block && `padding-block: ${useSpacing($padding.block)};`}
     ${$padding.inline && `padding-inline: ${useSpacing($padding.inline)};`}
   `}

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { GreyScaleColors } from '../../themes/createColor'
 import { Gap } from '../Layout'
 
 import { useClassNames } from './useClassNames'
@@ -11,6 +12,8 @@ type Props = {
   children: ReactNode
   /** 境界とコンテンツの間の余白 */
   padding?: Gap | SeparatePadding
+  /** 背景色 */
+  color?: GreyScaleColors | 'inherit'
   /** 角丸のサイズ */
   radius?: 's' | 'm'
   /** レイヤの重なり方向の高さ（影の付き方に影響する） */
@@ -49,7 +52,7 @@ const separatePadding = (padding: Props['padding']) => {
 }
 
 export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
-  ({ padding, radius = 'm', layer = 1, className = '', ...props }, ref) => {
+  ({ padding, color, radius = 'm', layer = 1, className = '', ...props }, ref) => {
     const themes = useTheme()
     const classNames = useClassNames()
 
@@ -69,6 +72,7 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
         className={`${className} ${classNames.base.wrapper}`}
         themes={themes}
         $padding={$padding}
+        $color={color}
         $radius={$radius}
         $layer={layerMap[layer]}
         ref={ref}
@@ -80,13 +84,14 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
 const Wrapper = styled.div<{
   themes: Theme
   $padding: { block?: Gap; inline?: Gap }
+  $color?: Props['color']
   $radius: string
   $layer: (typeof layerMap)[LayerKeys]
 }>`
-  ${({ themes: { color, shadow }, $padding, $radius, $layer }) => css`
+  ${({ themes: { color, shadow }, $padding, $color, $radius, $layer }) => css`
     box-shadow: ${shadow[$layer]};
     border-radius: ${$radius};
-    background-color: ${color.WHITE};
+    background-color: ${$color ? ($color === 'inherit' ? $color : color[$color]) : color.WHITE};
     ${$padding.block && `padding-block: ${useSpacing($padding.block)};`}
     ${$padding.inline && `padding-inline: ${useSpacing($padding.inline)};`}
   `}

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -3,6 +3,15 @@ import { darken, rgba, transparentize } from 'polished'
 import { merge } from '../libs/lodash'
 
 export type TextColors = 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
+export type GreyScaleColors =
+  | keyof typeof greyScale
+  | 'BACKGROUND'
+  | 'COLUMN'
+  | 'BASE_GREY'
+  | 'OVER_BACKGROUND'
+  | 'HEAD'
+  | 'BORDER'
+  | 'ACTION_BACKGROUND'
 
 const BLACK = '#030302' // hwb(56, 17, 1)
 const greyScale = {


### PR DESCRIPTION
Base に背景色を付けたいことが多いが、毎度 styled-components で wrap していて不便だった。
- 灰色以外の色を指定することは基本的にないため、グレースケールに絞っている
- セマンティクストークン名でもプリミティブトークン名でもどちらでも指定できる
- 初期値は WHITE