### PR TITLE
feat: BaseColumn を追加

### DIFF
--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -76,7 +76,9 @@ BaseStory.storyName = 'Base'
 
 export const BaseColumnStory: Story = () => (
   <Stack as="ul">
-    <p>padding / bgColor で余白と背景色を変えることもできます</p>
+    <li>
+      <p>padding / bgColor で余白と背景色を変えることもできます</p>
+    </li>
     <li>
       <BaseColumn>初期状態。padding は1文字分。背景は COLUMN。</BaseColumn>
     </li>

--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -3,9 +3,11 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 import { useTheme } from '../../hooks/useTheme'
+import { Stack } from '../Layout'
 import { Text } from '../Text'
 
 import { Base, LayerKeys, layerMap } from './Base'
+import { BaseColumn } from './BaseColumn'
 import { DialogBase } from './DialogBase'
 
 export default {
@@ -71,6 +73,21 @@ export const BaseStory: Story = () => {
   )
 }
 BaseStory.storyName = 'Base'
+
+export const BaseColumnStory: Story = () => (
+  <Stack as="ul">
+    <p>padding / bgColor で余白と背景色を変えることもできます</p>
+    <li>
+      <BaseColumn>初期状態。padding は1文字分。背景は COLUMN。</BaseColumn>
+    </li>
+    <li>
+      <BaseColumn padding={1.5} bgColor="ACTION_BACKGROUND">
+        padding を1.5文字分に、背景を ACTION_BACKGROUND に変更。
+      </BaseColumn>
+    </li>
+  </Stack>
+)
+BaseColumnStory.storyName = 'BaseColumn'
 
 export const DialogBaseStory: Story = () => (
   <List>

--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -1,9 +1,8 @@
 import { Story } from '@storybook/react'
-import React from 'react'
-import styled, { css } from 'styled-components'
+import * as React from 'react'
+import styled from 'styled-components'
 
 import { useTheme } from '../../hooks/useTheme'
-import { Stack } from '../Layout'
 import { Text } from '../Text'
 
 import { Base, LayerKeys, layerMap } from './Base'
@@ -12,10 +11,6 @@ import { DialogBase } from './DialogBase'
 export default {
   title: 'Data Display（データ表示）/Base',
   component: Base,
-  parameters: {
-    layout: 'fullscreen',
-    withTheming: true,
-  },
 }
 
 export const BaseStory: Story = () => {
@@ -23,9 +18,7 @@ export const BaseStory: Story = () => {
 
   return (
     <DescriptionList>
-      <Text as="dt" weight="bold">
-        padding
-      </Text>
+      <dt>padding</dt>
       <dd>
         <List>
           <li>
@@ -44,34 +37,7 @@ export const BaseStory: Story = () => {
           </li>
         </List>
       </dd>
-      <Text as="dt" weight="bold">
-        color
-      </Text>
-      <dd>
-        <List>
-          <li>
-            <Base>初期値</Base>
-          </li>
-          <li>
-            <Base bgColor="BACKGROUND">bgColor: BACKGROUND</Base>
-          </li>
-          <li>
-            <Base bgColor="BASE_GREY">bgColor: BASE_GREY</Base>
-          </li>
-          <li>
-            <Base bgColor="OVER_BACKGROUND">bgColor: OVER_BACKGROUND</Base>
-          </li>
-          <li>
-            <Base bgColor="HEAD">bgColor: HEAD</Base>
-          </li>
-          <li>
-            <Base bgColor="ACTION_BACKGROUND">bgColor: ACTION_BACKGROUND</Base>
-          </li>
-        </List>
-      </dd>
-      <Text as="dt" weight="bold">
-        radius
-      </Text>
+      <dt>radius</dt>
       <dd>
         <List>
           <li>
@@ -86,18 +52,15 @@ export const BaseStory: Story = () => {
           </li>
         </List>
       </dd>
-      <Text as="dt" weight="bold">
-        box-shadow
-      </Text>
+      <dt>box-shadow</dt>
       <dd>
         <List>
           {Object.keys(layerMap).map((layer, index) => (
             <li key={`${layer}-${index}`}>
               <Base layer={Number(layer) as LayerKeys}>
                 <Text>
-                  If layer props is specified as <Text weight="bold">{layer}</Text>, box-shadow
-                  becomes
-                  <Text weight="bold"> {themes.shadow[layerMap[Number(layer) as LayerKeys]]}</Text>.
+                  If layer props is specified as <Bold>{layer}</Bold>, box-shadow becomes
+                  <Bold> {themes.shadow[layerMap[Number(layer) as LayerKeys]]}</Bold>.
                 </Text>
               </Base>
             </li>
@@ -114,16 +77,14 @@ export const DialogBaseStory: Story = () => (
     <li>
       <DialogBase radius="s">
         <Text>
-          If radius props is specified as <Text weight="bold">s</Text>, border-radius becomes{' '}
-          <Text weight="bold">6px</Text>.
+          If radius props is specified as <Bold>s</Bold>, border-radius becomes <Bold>6px</Bold>.
         </Text>
       </DialogBase>
     </li>
     <li>
       <DialogBase radius="m">
         <Text>
-          If radius props is specified as <Text weight="bold">m</Text>, border-radius becomes{' '}
-          <Text weight="bold">8px</Text>.
+          If radius props is specified as <Bold>m</Bold>, border-radius becomes <Bold>8px</Bold>.
         </Text>
       </DialogBase>
     </li>
@@ -131,11 +92,22 @@ export const DialogBaseStory: Story = () => (
 )
 DialogBaseStory.storyName = 'DialogBase（非推奨）'
 
-const DescriptionList = styled(Stack).attrs({ as: 'dl', gap: 1.5 })`
-  ${({ theme: { color, space } }) => css`
-    background-color: ${color.BACKGROUND};
-    padding: ${space(1.5)};
-  `}
+const DescriptionList = styled.dl`
+  padding: 24px;
+  background-color: #eee;
 `
 
-const List = styled(Stack).attrs({ as: 'ul', gap: 0.75 })``
+const List = styled.ul`
+  margin: 0;
+  padding: 24px;
+  background-color: #eee;
+  list-style: none;
+
+  & > li:not(:first-child) {
+    margin-top: 24px;
+  }
+`
+
+const Bold = styled.span`
+  font-weight: bold;
+`

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -3,7 +3,6 @@ import styled, { css } from 'styled-components'
 
 import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { GreyScaleColors } from '../../themes/createColor'
 import { Gap } from '../Layout'
 
 import { useClassNames } from './useClassNames'
@@ -12,8 +11,6 @@ type Props = {
   children: ReactNode
   /** 境界とコンテンツの間の余白 */
   padding?: Gap | SeparatePadding
-  /** 背景色 */
-  bgColor?: GreyScaleColors | 'inherit'
   /** 角丸のサイズ */
   radius?: 's' | 'm'
   /** レイヤの重なり方向の高さ（影の付き方に影響する） */
@@ -52,7 +49,7 @@ const separatePadding = (padding: Props['padding']) => {
 }
 
 export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
-  ({ padding, bgColor, radius = 'm', layer = 1, className = '', ...props }, ref) => {
+  ({ padding, radius = 'm', layer = 1, className = '', ...props }, ref) => {
     const themes = useTheme()
     const classNames = useClassNames()
 
@@ -72,7 +69,6 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
         className={`${className} ${classNames.base.wrapper}`}
         themes={themes}
         $padding={$padding}
-        $bgColor={bgColor}
         $radius={$radius}
         $layer={layerMap[layer]}
         ref={ref}
@@ -84,18 +80,13 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
 const Wrapper = styled.div<{
   themes: Theme
   $padding: { block?: Gap; inline?: Gap }
-  $bgColor?: Props['bgColor']
   $radius: string
   $layer: (typeof layerMap)[LayerKeys]
 }>`
-  ${({ themes: { color, shadow }, $padding, $bgColor, $radius, $layer }) => css`
+  ${({ themes: { color, shadow }, $padding, $radius, $layer }) => css`
     box-shadow: ${shadow[$layer]};
     border-radius: ${$radius};
-    background-color: ${$bgColor
-      ? $bgColor === 'inherit'
-        ? $bgColor
-        : color[$bgColor]
-      : color.WHITE};
+    background-color: ${color.WHITE};
     ${$padding.block && `padding-block: ${useSpacing($padding.block)};`}
     ${$padding.inline && `padding-inline: ${useSpacing($padding.inline)};`}
   `}

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactNode, forwardRef, useMemo } from 'react'
+import React, { HTMLAttributes, PropsWithChildren, forwardRef, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useSpacing } from '../../hooks/useSpacing'
@@ -7,15 +7,14 @@ import { Gap } from '../Layout'
 
 import { useClassNames } from './useClassNames'
 
-type Props = {
-  children: ReactNode
+type Props = PropsWithChildren<{
   /** 境界とコンテンツの間の余白 */
   padding?: Gap | SeparatePadding
   /** 角丸のサイズ */
   radius?: 's' | 'm'
   /** レイヤの重なり方向の高さ（影の付き方に影響する） */
   layer?: LayerKeys
-}
+}>
 
 export type LayerKeys = keyof typeof layerMap
 

--- a/src/components/Base/BaseColumn.tsx
+++ b/src/components/Base/BaseColumn.tsx
@@ -1,0 +1,36 @@
+import React, { ComponentProps, HTMLAttributes } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+import { GreyScaleColors } from '../../themes/createColor'
+
+import { Base as shrBase } from './Base'
+
+type BaseProps = Omit<ComponentProps<typeof Base>, 'radius' | 'layer'>
+type Props = {
+  /** 背景色。初期値は COLUMN */
+  bgColor?: GreyScaleColors
+}
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof BaseProps | keyof Props>
+
+export const BaseColumn: React.FC<BaseProps & Props & ElementProps> = ({
+  padding = 1,
+  ...props
+}) => {
+  const themes = useTheme()
+  return <Base {...props} padding={padding} layer={0} themes={themes} />
+}
+
+const Base = styled(shrBase)<{
+  bgColor?: Props['bgColor']
+  themes: Theme
+}>`
+  ${({ bgColor = 'COLUMN', themes: { color } }) => css`
+    border-radius: unset;
+
+    ${bgColor &&
+    css`
+      background-color: ${color[bgColor]};
+    `}
+  `}
+`

--- a/src/components/Base/index.ts
+++ b/src/components/Base/index.ts
@@ -1,3 +1,4 @@
 export { Base } from './Base'
 export type { ElementProps as BaseElementProps } from './Base'
 export { DialogBase } from './DialogBase'
+export { BaseColumn } from './BaseColumn'

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export {
   TextButtonAnchor,
 } from './components/Button'
 export { StatusLabel } from './components/StatusLabel'
-export { Base, DialogBase } from './components/Base'
+export { Base, BaseColumn, DialogBase } from './components/Base'
 export * from './components/Icon'
 export { SmartHRLogo } from './components/SmartHRLogo'
 export {

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -3,15 +3,6 @@ import { darken, rgba, transparentize } from 'polished'
 import { merge } from '../libs/lodash'
 
 export type TextColors = 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
-export type GreyScaleColors =
-  | keyof typeof greyScale
-  | 'BACKGROUND'
-  | 'COLUMN'
-  | 'BASE_GREY'
-  | 'OVER_BACKGROUND'
-  | 'HEAD'
-  | 'BORDER'
-  | 'ACTION_BACKGROUND'
 
 const BLACK = '#030302' // hwb(56, 17, 1)
 const greyScale = {

--- a/src/themes/createColor.ts
+++ b/src/themes/createColor.ts
@@ -3,6 +3,15 @@ import { darken, rgba, transparentize } from 'polished'
 import { merge } from '../libs/lodash'
 
 export type TextColors = 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
+export type GreyScaleColors =
+  | keyof typeof greyScale
+  | 'BACKGROUND'
+  | 'COLUMN'
+  | 'BASE_GREY'
+  | 'OVER_BACKGROUND'
+  | 'HEAD'
+  | 'BORDER'
+  | 'ACTION_BACKGROUND'
 
 const BLACK = '#030302' // hwb(56, 17, 1)
 const greyScale = {


### PR DESCRIPTION
プロダクトデザイナーで検討したところ `Base` ではなく `BaseColumn` として実装しようとなったので Base に色を載せるのは revert して `BaseColumn` を追加します。

revert コミット付きなので、以下コミットを見てもらえると良さそうです。
- ef910c2765e070ed4afc74d0eec006b4a7c149c6
- b611db69e969f77c536022d908ba3add3ceb0bdc

Reverts kufu/smarthr-ui#3081