### PR TITLE
fix: Button の無効理由が見きれないように Tooltip の位置を自動に変更

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -67,7 +67,12 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
       return (
         <DisabledDetailWrapper themes={theme} className={classNames.disabledWrapper}>
           {button}
-          <Tooltip message={disabledDetail.message} triggerType="icon">
+          <Tooltip
+            message={disabledDetail.message}
+            triggerType="icon"
+            horizontal="auto"
+            vertical="auto"
+          >
             <DisabledDetailIcon />
           </Tooltip>
         </DisabledDetailWrapper>

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -26,7 +26,7 @@ const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'childr
 )
 
 export const Default: Story = () => (
-  <Cluster align="center">
+  <Cluster align="center" justify="flex-end">
     <Template label="その他の操作" />
     <Template disabled label="その他の操作" />
     <Template onlyIconTrigger label="その他の操作" />


### PR DESCRIPTION
`DropdownMenuButton` で `Button[disableDetail]` を使った時、`Tooltip` が見切れてしまう問題があった。
`Button[disableDetail]` の `Tooltip` を自動位置決めに変えることで対応した。

- `Button[disableDetail]` の `Tooltip[horizontal / vertical]` に `auto` を指定
- DropdownMenuButton は右端に配置されることが多いので、Story を修正

https://deploy-preview-3092--smarthr-ui.netlify.app/?path=/story/buttons%EF%BC%88%E3%83%9C%E3%82%BF%E3%83%B3%EF%BC%89-dropdown--dropdown-menu-button