### PR TITLE
feat!: Th に並び替え機能を追加

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components'
@@ -90,8 +91,12 @@ export const All: Story = () => (
                 <CheckBox name="tableAllCheckBox" checked={false} />
               </label>
             </Th>
-            <Th sort="ascending">Name</Th>
-            <Th sort="none">Calories</Th>
+            <Th sort="ascending" onClick={action('降順に並び替え')}>
+              Name
+            </Th>
+            <Th sort="none" onClick={action('昇順に並び替え')}>
+              Calories
+            </Th>
             <Th>Fat (g)</Th>
             <Th>Carbs (g)</Th>
             <Th>Protein (g)</Th>
@@ -122,6 +127,39 @@ export const All: Story = () => (
       </Table>
     </li>
     <li>
+      行頭で改行が発生する場合
+      <Table>
+        <thead>
+          <tr>
+            <Th>
+              <VisuallyHiddenText>行を選択</VisuallyHiddenText>
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label>
+                <VisuallyHiddenText>すべての行を選択</VisuallyHiddenText>
+                <CheckBox name="tableAllCheckBox" checked={false} />
+              </label>
+            </Th>
+            <Th sort="ascending" onClick={action('降順に並び替え')}>
+              Name
+            </Th>
+            <Th sort="none" onClick={action('昇順に並び替え')}>
+              Calories
+              <br />
+              (kcal)
+            </Th>
+            <Th>
+              Fat
+              <br />
+              (g)
+            </Th>
+            <Th>Carbs (g)</Th>
+            <Th>Protein (g)</Th>
+            <Th>Button</Th>
+          </tr>
+        </thead>
+      </Table>
+    </li>
+    <li>
       table fixed header
       <div style={{ overflow: 'clip' }}>
         <Table fixedHead>
@@ -137,6 +175,7 @@ export const All: Story = () => (
               </Th>
               <Th
                 sort="descending"
+                onClick={action('昇順に並び替え')}
                 decorators={{ sortDirectionLabel: (text, { sort }) => `${sort} (${text})` }}
               >
                 Name

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -137,11 +137,7 @@ export const All: Story = () => (
               </Th>
               <Th
                 sort="descending"
-                decorators={{
-                  descendingLabel: (text) => `descending(${text})`,
-                  ascendingLabel: (text) => `ascending(${text})`,
-                  noSortLabel: (text) => `ascending(${text})`,
-                }}
+                decorators={{ sortDirectionLabel: (text) => `sort direction (${text})` }}
               >
                 Name
               </Th>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,12 +1,10 @@
-import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import { Base as BaseComponent } from '../Base'
 import { Button } from '../Button'
 import { CheckBox as CheckBoxComponent } from '../CheckBox'
-import { FaArrowDownIcon } from '../Icon'
 import { Text } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
@@ -92,13 +90,8 @@ export const All: Story = () => (
                 <CheckBox name="tableAllCheckBox" checked={false} />
               </label>
             </Th>
-            <Th aria-sort="ascending" highlighted={true}>
-              <ClickableCellButton onClick={action('clicked')}>
-                <span style={{ lineHeight: '1.5' }}>Name</span>
-                <ArrowIcon alt="昇順" />
-              </ClickableCellButton>
-            </Th>
-            <Th>Calories</Th>
+            <Th sort="ascending">Name</Th>
+            <Th sort="none">Calories</Th>
             <Th>Fat (g)</Th>
             <Th>Carbs (g)</Th>
             <Th>Protein (g)</Th>
@@ -142,12 +135,7 @@ export const All: Story = () => (
                   <CheckBox name="tableAllCheckBox" checked={false} />
                 </label>
               </Th>
-              <Th aria-sort="ascending" highlighted={true}>
-                <ClickableCellButton onClick={action('clicked')}>
-                  <span style={{ lineHeight: '1.5' }}>Name</span>
-                  <ArrowIcon alt="昇順" />
-                </ClickableCellButton>
-              </Th>
+              <Th sort="descending">Name</Th>
               <Th>Calories</Th>
               <Th>Fat (g)</Th>
               <Th>Carbs (g)</Th>
@@ -292,27 +280,6 @@ const Ul = styled.ul`
 
 const CheckBox = styled(CheckBoxComponent)`
   vertical-align: middle;
-`
-
-const ClickableCellButton = styled.button`
-  appearance: none;
-  padding: 8px 16px;
-  border: 0;
-  box-sizing: border-box;
-  background-color: transparent;
-  width: calc(100% + 32px);
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin: -8px -16px;
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-`
-
-const ArrowIcon = styled(FaArrowDownIcon)`
-  transform: rotate(180deg);
 `
 
 const Base = styled(BaseComponent)`

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -135,7 +135,16 @@ export const All: Story = () => (
                   <CheckBox name="tableAllCheckBox" checked={false} />
                 </label>
               </Th>
-              <Th sort="descending">Name</Th>
+              <Th
+                sort="descending"
+                decorators={{
+                  descendingLabel: (text) => `descending(${text})`,
+                  ascendingLabel: (text) => `ascending(${text})`,
+                  noSortLabel: (text) => `ascending(${text})`,
+                }}
+              >
+                Name
+              </Th>
               <Th>Calories</Th>
               <Th>Fat (g)</Th>
               <Th>Carbs (g)</Th>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -91,7 +91,7 @@ export const All: Story = () => (
                 <CheckBox name="tableAllCheckBox" checked={false} />
               </label>
             </Th>
-            <Th sort="ascending" onSort={action('降順に並び替え')}>
+            <Th sort="asc" onSort={action('降順に並び替え')}>
               Name
             </Th>
             <Th sort="none" onSort={action('昇順に並び替え')}>
@@ -139,7 +139,7 @@ export const All: Story = () => (
                 <CheckBox name="tableAllCheckBox" checked={false} />
               </label>
             </Th>
-            <Th sort="ascending" onSort={action('降順に並び替え')}>
+            <Th sort="asc" onSort={action('降順に並び替え')}>
               Name
             </Th>
             <Th sort="none" onSort={action('昇順に並び替え')}>
@@ -174,7 +174,7 @@ export const All: Story = () => (
                 </label>
               </Th>
               <Th
-                sort="descending"
+                sort="desc"
                 onSort={action('昇順に並び替え')}
                 decorators={{ sortDirectionIconAlt: (text, { sort }) => `${sort} (${text})` }}
               >

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -137,7 +137,7 @@ export const All: Story = () => (
               </Th>
               <Th
                 sort="descending"
-                decorators={{ sortDirectionLabel: (text) => `sort direction (${text})` }}
+                decorators={{ sortDirectionLabel: (text, { sort }) => `${sort} (${text})` }}
               >
                 Name
               </Th>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -176,7 +176,7 @@ export const All: Story = () => (
               <Th
                 sort="descending"
                 onSort={action('昇順に並び替え')}
-                decorators={{ sortDirectionLabel: (text, { sort }) => `${sort} (${text})` }}
+                decorators={{ sortDirectionIconAlt: (text, { sort }) => `${sort} (${text})` }}
               >
                 Name
               </Th>

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -91,10 +91,10 @@ export const All: Story = () => (
                 <CheckBox name="tableAllCheckBox" checked={false} />
               </label>
             </Th>
-            <Th sort="ascending" onClick={action('降順に並び替え')}>
+            <Th sort="ascending" onSort={action('降順に並び替え')}>
               Name
             </Th>
-            <Th sort="none" onClick={action('昇順に並び替え')}>
+            <Th sort="none" onSort={action('昇順に並び替え')}>
               Calories
             </Th>
             <Th>Fat (g)</Th>
@@ -139,10 +139,10 @@ export const All: Story = () => (
                 <CheckBox name="tableAllCheckBox" checked={false} />
               </label>
             </Th>
-            <Th sort="ascending" onClick={action('降順に並び替え')}>
+            <Th sort="ascending" onSort={action('降順に並び替え')}>
               Name
             </Th>
-            <Th sort="none" onClick={action('昇順に並び替え')}>
+            <Th sort="none" onSort={action('昇順に並び替え')}>
               Calories
               <br />
               (kcal)
@@ -175,7 +175,7 @@ export const All: Story = () => (
               </Th>
               <Th
                 sort="descending"
-                onClick={action('昇順に並び替え')}
+                onSort={action('昇順に並び替え')}
                 decorators={{ sortDirectionLabel: (text, { sort }) => `${sort} (${text})` }}
               >
                 Name

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -1,8 +1,7 @@
-import React, { FC, PropsWithChildren, ThHTMLAttributes, useMemo } from 'react'
+import React, { FC, PropsWithChildren, ReactNode, ThHTMLAttributes, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { DecoratorsType } from '../../types/props'
 import { Button } from '../Button'
 import { FaSortDownIcon, FaSortUpIcon } from '../Icon'
 import { Stack } from '../Layout'
@@ -10,13 +9,16 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { useThClassNames } from './useClassNames'
 
+type sortTypes = keyof typeof SORT_DIRECTION_LABEL
 export type Props = PropsWithChildren<{
   /** 並び替え状態 */
-  sort?: keyof typeof SORT_DIRECTION_LABEL
+  sort?: sortTypes
   /** 並び替えをクリックした時に発火するコールバック関数 */
   onClick?: () => void
   /** 文言を変更するための関数 */
-  decorators?: DecoratorsType<'sortDirectionLabel'>
+  decorators?: {
+    sortDirectionLabel: (text: string, { sort }: { sort: sortTypes }) => ReactNode
+  }
 }>
 type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props>
 
@@ -41,7 +43,8 @@ export const Th: FC<Props & ElementProps> = ({
   const sortLabel = useMemo(
     () =>
       sort &&
-      (decorators?.sortDirectionLabel?.(SORT_DIRECTION_LABEL[sort]) || SORT_DIRECTION_LABEL[sort]),
+      (decorators?.sortDirectionLabel?.(SORT_DIRECTION_LABEL[sort], { sort }) ||
+        SORT_DIRECTION_LABEL[sort]),
     [decorators, sort],
   )
 

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -12,18 +12,18 @@ import { useThClassNames } from './useClassNames'
 
 export type Props = PropsWithChildren<{
   /** 並び替え状態 */
-  sort?: 'ascending' | 'descending' | 'none'
+  sort?: keyof typeof SORT_DIRECTION_LABEL
   /** 並び替えをクリックした時に発火するコールバック関数 */
   onClick?: () => void
   /** 文言を変更するための関数 */
-  decorators?: DecoratorsType<'ascendingLabel' | 'descendingLabel' | 'noSortLabel'>
+  decorators?: DecoratorsType<'sortDirectionLabel'>
 }>
 type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props>
 
-const LABEL = {
+const SORT_DIRECTION_LABEL = {
   ascending: '昇順',
   descending: '降順',
-  noSort: '並び替えなし',
+  none: '並び替えなし',
 }
 
 export const Th: FC<Props & ElementProps> = ({
@@ -38,16 +38,12 @@ export const Th: FC<Props & ElementProps> = ({
   const classNames = useThClassNames()
   const wrapperClass = [className, classNames.wrapper].filter((c) => !!c).join(' ')
 
-  const sortLabel = useMemo(() => {
-    switch (sort) {
-      case 'ascending':
-        return decorators?.ascendingLabel?.(LABEL[sort]) || LABEL[sort]
-      case 'descending':
-        return decorators?.descendingLabel?.(LABEL[sort]) || LABEL[sort]
-      default:
-        return decorators?.noSortLabel?.(LABEL.noSort) || LABEL.noSort
-    }
-  }, [decorators, sort])
+  const sortLabel = useMemo(
+    () =>
+      sort &&
+      (decorators?.sortDirectionLabel?.(SORT_DIRECTION_LABEL[sort]) || SORT_DIRECTION_LABEL[sort]),
+    [decorators, sort],
+  )
 
   return (
     <Wrapper {...props} aria-sort={sort} className={wrapperClass} themes={theme}>

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -2,7 +2,6 @@ import React, { FC, PropsWithChildren, ReactNode, ThHTMLAttributes, useMemo } fr
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { Button } from '../Button'
 import { FaSortDownIcon, FaSortUpIcon } from '../Icon'
 import { Stack } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
@@ -51,8 +50,9 @@ export const Th: FC<Props & ElementProps> = ({
   return (
     <Wrapper {...props} aria-sort={sort} className={wrapperClass} themes={theme}>
       {sort ? (
-        <SortButton onClick={onClick} suffix={<SortIcon sort={sort} />} themes={theme}>
+        <SortButton onClick={onClick} themes={theme}>
           {children}
+          <SortIcon sort={sort} />
           <VisuallyHiddenText>{sortLabel}</VisuallyHiddenText>
         </SortButton>
       ) : (
@@ -65,34 +65,42 @@ export const Th: FC<Props & ElementProps> = ({
 const Wrapper = styled.th<{ themes: Theme; onClick?: () => void }>`
   ${({ themes: { fontSize, leading, color, space } }) => css`
     box-sizing: border-box;
-    position: relative;
-    height: calc(1em * ${leading.NORMAL} + ${space(0.5)} * 2);
     font-size: ${fontSize.S};
     font-weight: bold;
-    padding: ${space(0.5)} ${space(1)};
+    padding: ${space(0.75)} ${space(1)};
     color: ${color.TEXT_BLACK};
-    line-height: ${leading.NORMAL};
+    line-height: ${leading.TIGHT};
     vertical-align: middle;
   `}
 `
 
-const SortButton = styled(Button).attrs({ size: 's', wide: true })<{ themes: Theme }>`
-  ${({ themes: { color, fontSize, space } }) => css`
-    position: absolute;
-    inset: 0;
+const SortButton = styled.button<{
+  themes: Theme
+}>`
+  ${({ themes: { color, fontSize, shadow, space } }) => css`
+    cursor: pointer;
+    box-sizing: content-box;
+    display: inline-flex;
+    align-items: center;
+    column-gap: ${space(0.5)};
     justify-content: space-between;
+    margin: ${space(-0.75)} ${space(-1)};
     border: unset;
     background-color: unset;
-    padding: ${space(0.5)} ${space(1)};
+    padding: ${space(0.75)} ${space(1)};
+    text-align: left;
+    width: 100%;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
 
-    &:hover,
-    &:focus {
+    &:hover {
       background-color: ${color.hoverColor(color.HEAD)};
     }
 
-    &:focus {
-      /* フォーカスリングを前に出すため */
-      z-index: 1;
+    &:focus-visible {
+      ${shadow.focusIndicatorStyles}
     }
 
     .smarthr-ui-Icon {

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -48,9 +48,15 @@ export const Th: FC<Props & ElementProps> = ({
   )
 
   return (
-    <Wrapper {...props} aria-sort={sort} className={wrapperClass} themes={theme}>
+    <Wrapper
+      {...props}
+      onClick={sort && onClick}
+      aria-sort={sort}
+      className={wrapperClass}
+      themes={theme}
+    >
       {sort ? (
-        <SortButton onClick={onClick} themes={theme}>
+        <SortButton themes={theme}>
           {children}
           <SortIcon sort={sort} />
           <VisuallyHiddenText>{sortLabel}</VisuallyHiddenText>
@@ -63,7 +69,7 @@ export const Th: FC<Props & ElementProps> = ({
 }
 
 const Wrapper = styled.th<{ themes: Theme; onClick?: () => void }>`
-  ${({ themes: { fontSize, leading, color, space } }) => css`
+  ${({ themes: { fontSize, leading, color, shadow, space } }) => css`
     box-sizing: border-box;
     font-size: ${fontSize.S};
     font-weight: bold;
@@ -71,13 +77,26 @@ const Wrapper = styled.th<{ themes: Theme; onClick?: () => void }>`
     color: ${color.TEXT_BLACK};
     line-height: ${leading.TIGHT};
     vertical-align: middle;
+
+    &[aria-sort] {
+      cursor: pointer;
+
+      &:hover {
+        background-color: ${color.hoverColor(color.HEAD)};
+      }
+
+      /* :focus-visible-within の代替 */
+      &:has(:focus-visible) {
+        ${shadow.focusIndicatorStyles}
+      }
+    }
   `}
 `
 
 const SortButton = styled.button<{
   themes: Theme
 }>`
-  ${({ themes: { color, fontSize, shadow, space } }) => css`
+  ${({ themes: { fontSize, space } }) => css`
     cursor: pointer;
     box-sizing: content-box;
     display: inline-flex;
@@ -86,6 +105,7 @@ const SortButton = styled.button<{
     justify-content: space-between;
     margin: ${space(-0.75)} ${space(-1)};
     border: unset;
+    outline: unset;
     background-color: unset;
     padding: ${space(0.75)} ${space(1)};
     text-align: left;
@@ -94,14 +114,6 @@ const SortButton = styled.button<{
     font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
-
-    &:hover {
-      background-color: ${color.hoverColor(color.HEAD)};
-    }
-
-    &:focus-visible {
-      ${shadow.focusIndicatorStyles}
-    }
 
     .smarthr-ui-Icon {
       font-size: ${fontSize.M};

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -1,62 +1,102 @@
-import React, { ReactNode, TdHTMLAttributes, VFC } from 'react'
+import React, { FC, PropsWithChildren, ThHTMLAttributes, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { isTouchDevice } from '../../libs/ua'
+import { Button } from '../Button'
+import { FaSortDownIcon, FaSortUpIcon } from '../Icon'
+import { Stack } from '../Layout'
 
 import { useThClassNames } from './useClassNames'
 
-export type Props = {
-  /** `true` のとき、セルの色をハイライトする */
-  highlighted?: boolean
-  /** セルの内容 */
-  children?: ReactNode
-  /** セルをクリックした時に発火するコールバック関数 */
+export type Props = PropsWithChildren<{
+  /** 並び替え状態 */
+  sort?: 'ascending' | 'descending' | 'none'
+  /** 並び替えをクリックした時に発火するコールバック関数 */
   onClick?: () => void
-}
-type ElementProps = Omit<TdHTMLAttributes<HTMLTableCellElement>, keyof Props>
+}>
+type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props>
 
-export const Th: VFC<Props & ElementProps> = ({
-  highlighted = false,
+export const Th: FC<Props & ElementProps> = ({
+  children,
+  sort,
+  onClick,
   className = '',
   ...props
 }) => {
   const theme = useTheme()
   const classNames = useThClassNames()
-  const wrapperClass = [className, highlighted && 'highlighted', classNames.wrapper]
-    .filter((c) => !!c)
-    .join(' ')
+  const wrapperClass = [className, classNames.wrapper].filter((c) => !!c).join(' ')
 
-  return <StyledTh {...props} className={wrapperClass} themes={theme} />
+  return (
+    <Wrapper {...props} aria-sort={sort} className={wrapperClass} themes={theme}>
+      {sort ? (
+        <SortButton onClick={onClick} suffix={<SortIcon sort={sort} />} themes={theme}>
+          {children}
+        </SortButton>
+      ) : (
+        children
+      )}
+    </Wrapper>
+  )
 }
 
-const StyledTh = styled.th<{ themes: Theme; onClick?: () => void }>`
-  ${({ themes, onClick }) => {
-    const { fontSize, leading, spacingByChar, color, interaction } = themes
-
-    return css`
-      height: calc(1em * ${leading.NORMAL} + ${spacingByChar(0.5)} * 2);
-      font-size: ${fontSize.S};
-      font-weight: bold;
-      padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
-      color: ${color.TEXT_BLACK};
-      transition: ${isTouchDevice ? 'none' : `background-color ${interaction.hover.animation}`};
-      text-align: left;
-      line-height: 1.5;
-      vertical-align: middle;
-      box-sizing: border-box;
-
-      &.highlighted {
-        background-color: ${color.hoverColor(color.HEAD)};
-      }
-
-      ${onClick &&
-      css`
-        :hover {
-          background-color: ${color.hoverColor(color.HEAD)};
-          cursor: pointer;
-        }
-      `}
-    `
-  }}
+const Wrapper = styled.th<{ themes: Theme; onClick?: () => void }>`
+  ${({ themes: { fontSize, leading, color, space } }) => css`
+    box-sizing: border-box;
+    position: relative;
+    height: calc(1em * ${leading.NORMAL} + ${space(0.5)} * 2);
+    font-size: ${fontSize.S};
+    font-weight: bold;
+    padding: ${space(0.5)} ${space(1)};
+    color: ${color.TEXT_BLACK};
+    line-height: ${leading.NORMAL};
+    vertical-align: middle;
+  `}
 `
+
+const SortButton = styled(Button).attrs({ size: 's', wide: true })<{ themes: Theme }>`
+  ${({ themes: { color, fontSize, space } }) => css`
+    position: absolute;
+    inset: 0;
+    justify-content: space-between;
+    border: unset;
+    background-color: unset;
+    padding: ${space(0.5)} ${space(1)};
+
+    &:hover,
+    &:focus {
+      background-color: ${color.hoverColor(color.HEAD)};
+    }
+
+    &:focus {
+      /* フォーカスリングを前に出すため */
+      z-index: 1;
+    }
+
+    .smarthr-ui-Icon {
+      font-size: ${fontSize.M};
+    }
+  `}
+`
+
+const SortIcon: FC<Pick<Props, 'sort'>> = ({ sort }) => {
+  const sortLabel = useMemo(() => {
+    switch (sort) {
+      case 'ascending':
+        return '昇順'
+      case 'descending':
+        return '降順'
+      default:
+        return '並び替えなし'
+    }
+  }, [sort])
+
+  return (
+    <SortIconWraper aria-label={sortLabel}>
+      <FaSortUpIcon color={sort === 'ascending' ? 'TEXT_BLACK' : 'TEXT_DISABLED'} />
+      <FaSortDownIcon color={sort === 'descending' ? 'TEXT_BLACK' : 'TEXT_DISABLED'} />
+    </SortIconWraper>
+  )
+}
+
+const SortIconWraper = styled(Stack).attrs({ as: 'span', gap: -1, inline: true })``

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -16,7 +16,7 @@ export type Props = PropsWithChildren<{
   onSort?: () => void
   /** 文言を変更するための関数 */
   decorators?: {
-    sortDirectionLabel: (text: string, { sort }: { sort: sortTypes }) => ReactNode
+    sortDirectionIconAlt: (text: string, { sort }: { sort: sortTypes }) => ReactNode
   }
 }>
 type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props | 'onClick'>
@@ -42,7 +42,7 @@ export const Th: FC<Props & ElementProps> = ({
   const sortLabel = useMemo(
     () =>
       sort &&
-      (decorators?.sortDirectionLabel?.(SORT_DIRECTION_LABEL[sort], { sort }) ||
+      (decorators?.sortDirectionIconAlt?.(SORT_DIRECTION_LABEL[sort], { sort }) ||
         SORT_DIRECTION_LABEL[sort]),
     [decorators, sort],
   )

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -13,13 +13,13 @@ export type Props = PropsWithChildren<{
   /** 並び替え状態 */
   sort?: sortTypes
   /** 並び替えをクリックした時に発火するコールバック関数 */
-  onClick?: () => void
+  onSort?: () => void
   /** 文言を変更するための関数 */
   decorators?: {
     sortDirectionLabel: (text: string, { sort }: { sort: sortTypes }) => ReactNode
   }
 }>
-type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props>
+type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props | 'onClick'>
 
 const SORT_DIRECTION_LABEL = {
   ascending: '昇順',
@@ -30,7 +30,7 @@ const SORT_DIRECTION_LABEL = {
 export const Th: FC<Props & ElementProps> = ({
   children,
   sort,
-  onClick,
+  onSort,
   decorators,
   className = '',
   ...props
@@ -50,7 +50,7 @@ export const Th: FC<Props & ElementProps> = ({
   return (
     <Wrapper
       {...props}
-      onClick={sort && onClick}
+      onSort={sort && onSort}
       aria-sort={sort}
       className={wrapperClass}
       themes={theme}
@@ -68,7 +68,7 @@ export const Th: FC<Props & ElementProps> = ({
   )
 }
 
-const Wrapper = styled.th<{ themes: Theme; onClick?: () => void }>`
+const Wrapper = styled.th<{ themes: Theme; onSort?: () => void }>`
   ${({ themes: { fontSize, leading, color, shadow, space } }) => css`
     box-sizing: border-box;
     font-size: ${fontSize.S};

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -1,4 +1,11 @@
-import React, { FC, PropsWithChildren, ReactNode, ThHTMLAttributes, useMemo } from 'react'
+import React, {
+  AriaAttributes,
+  FC,
+  PropsWithChildren,
+  ReactNode,
+  ThHTMLAttributes,
+  useMemo,
+} from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -22,8 +29,8 @@ export type Props = PropsWithChildren<{
 type ElementProps = Omit<ThHTMLAttributes<HTMLTableCellElement>, keyof Props | 'onClick'>
 
 const SORT_DIRECTION_LABEL = {
-  ascending: '昇順',
-  descending: '降順',
+  asc: '昇順',
+  desc: '降順',
   none: '並び替えなし',
 }
 
@@ -46,12 +53,24 @@ export const Th: FC<Props & ElementProps> = ({
         SORT_DIRECTION_LABEL[sort]),
     [decorators, sort],
   )
+  const ariaSortProps = useMemo<
+    | {
+        'aria-sort': AriaAttributes['aria-sort']
+      }
+    | undefined
+  >(() => {
+    return (
+      sort && {
+        'aria-sort': sort === 'none' ? 'none' : `${sort}ending`,
+      }
+    )
+  }, [sort])
 
   return (
     <Wrapper
+      {...ariaSortProps}
       {...props}
       onSort={sort && onSort}
-      aria-sort={sort}
       className={wrapperClass}
       themes={theme}
     >
@@ -123,8 +142,8 @@ const SortButton = styled.button<{
 
 const SortIcon: FC<Pick<Props, 'sort'>> = ({ sort }) => (
   <SortIconWraper>
-    <FaSortUpIcon color={sort === 'ascending' ? 'TEXT_BLACK' : 'TEXT_DISABLED'} />
-    <FaSortDownIcon color={sort === 'descending' ? 'TEXT_BLACK' : 'TEXT_DISABLED'} />
+    <FaSortUpIcon color={sort === 'asc' ? 'TEXT_BLACK' : 'TEXT_DISABLED'} />
+    <FaSortDownIcon color={sort === 'desc' ? 'TEXT_BLACK' : 'TEXT_DISABLED'} />
   </SortIconWraper>
 )
 


### PR DESCRIPTION
## Related URL

- https://w3c.github.io/aria-practices/examples/table/sortable-table.html
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

半端に `onClick` が付き、利用側で実装する形になっていたため、smarthr-ui としてあるべき並び替え機能を実装しました。

### 考えられる状態

以下の状態に対して `sort?: 'ascending' | 'descending' | 'none'` という props を追加しました。

- sort できない列
- sort できるがしていない列
- 昇順で sort している
- 降順で sort している

この props は並び替え状態を見た目的に制御するだけでなく、`th[aria-sort]` としても使われます。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## 残タスク

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- [ ] 初期文言の decorators 化

## Capture

<!--
Please attach a capture if it looks different.
-->
