### PR TITLE
fix: FilterDropdown が狭い画面幅でも使えるように修正

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { MultiComboBox, SingleComboBox } from '../../ComboBox'
 import { Input } from '../../Input'
+import { Stack } from '../../Layout'
 import { RadioButton } from '../../RadioButton'
 
 import { FilterDropdown } from './FilterDropdown'
@@ -33,11 +34,11 @@ export const Default: Story = () => {
             }}
             isFiltered={isFiltered}
           >
-            <Text>
+            <p>
               `FilterDropdown` provide specific interface to be able to filter data.
               <br />
               You can control inputs for filtering conditions as children components.
-            </Text>
+            </p>
             <RadioButtonList>
               <li>
                 <RadioButton name="hoge" checked={value === 'hoge'} onChange={onChangeValue}>
@@ -61,9 +62,11 @@ export const Default: Story = () => {
             <Description>
               ↓<br />↓
             </Description>
-            <Text>Children content is scrollable.</Text>
-            <PartSingleComboBox name="single" />
-            <PartMultiComboBox name="multi" />
+            <Stack gap={0.5}>
+              <p>Children content is scrollable.</p>
+              <PartSingleComboBox name="single" />
+              <PartMultiComboBox name="multi" />
+            </Stack>
           </FilterDropdown>
         </dd>
         <dt>Filtered</dt>
@@ -73,7 +76,7 @@ export const Default: Story = () => {
             onApply={() => setIsFiltered2(true)}
             onReset={() => setIsFiltered2(false)}
           >
-            <Text>You can change border color of the trigger button by setting `isFiltered`.</Text>
+            <p>You can change border color of the trigger button by setting `isFiltered`.</p>
           </FilterDropdown>
         </dd>
         <dt>Filtered has status text</dt>
@@ -84,9 +87,9 @@ export const Default: Story = () => {
             onReset={() => setIsFiltered3(false)}
             hasStatusText
           >
-            <Text>
+            <p>
               You can change border text and color of the trigger button by setting `isFiltered`.
-            </Text>
+            </p>
           </FilterDropdown>
         </dd>
         <dt>Custom text</dt>
@@ -104,9 +107,9 @@ export const Default: Story = () => {
               resetButton: (txt) => <span data-wovn-enable="true">{`reset.(${txt})`}</span>,
             }}
           >
-            <Text>
+            <p>
               You can change border text and color of the trigger button by setting `isFiltered`.
-            </Text>
+            </p>
           </FilterDropdown>
         </dd>
       </List>
@@ -131,10 +134,6 @@ const List = styled.dl`
   dd {
     margin: 0;
   }
-`
-const Text = styled.p`
-  margin: 0;
-  color: ${({ theme }) => theme.color.TEXT_BLACK};
 `
 const Description = styled.p`
   margin: 0;
@@ -194,17 +193,14 @@ const PartSingleComboBox: React.FC<{ name: string }> = ({ name }) => {
   }, [])
 
   return (
-    <div>
-      <SingleComboBox
-        name={name}
-        items={items}
-        selectedItem={selectedItem}
-        defaultItem={items[0]}
-        width={400}
-        onSelect={handleSelectItem}
-        onClear={handleClear}
-      />
-    </div>
+    <SingleComboBox
+      name={name}
+      items={items}
+      selectedItem={selectedItem}
+      defaultItem={items[0]}
+      onSelect={handleSelectItem}
+      onClear={handleClear}
+    />
   )
 }
 const PartMultiComboBox: React.FC<{ name: string }> = ({ name }) => {
@@ -262,22 +258,19 @@ const PartMultiComboBox: React.FC<{ name: string }> = ({ name }) => {
   )
 
   return (
-    <div>
-      <MultiComboBox
-        name={name}
-        items={items}
-        selectedItems={selectedItems}
-        width={400}
-        dropdownHelpMessage="入力でフィルタリングできます。"
-        onDelete={handleDelete}
-        onSelect={handleSelectItem}
-        onChangeSelected={(selected) => {
-          action('onChangeSelected')(selected)
-          setSelectedItems(selected)
-        }}
-        onFocus={action('onFocus')}
-        onBlur={action('onBlur')}
-      />
-    </div>
+    <MultiComboBox
+      name={name}
+      items={items}
+      selectedItems={selectedItems}
+      dropdownHelpMessage="入力でフィルタリングできます。"
+      onDelete={handleDelete}
+      onSelect={handleSelectItem}
+      onChangeSelected={(selected) => {
+        action('onChangeSelected')(selected)
+        setSelectedItems(selected)
+      }}
+      onFocus={action('onFocus')}
+      onBlur={action('onBlur')}
+    />
   )
 }

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -100,12 +100,12 @@ export const FilterDropdown: VFC<Props> = ({
           )}
           <RightButtonLayout>
             <DropdownCloser>
+              <Button onClick={() => onCancel?.()}>{cancelButton}</Button>
+            </DropdownCloser>
+            <DropdownCloser>
               <Button variant="primary" onClick={() => onApply()}>
                 {applyButton}
               </Button>
-            </DropdownCloser>
-            <DropdownCloser>
-              <Button onClick={() => onCancel?.()}>{cancelButton}</Button>
             </DropdownCloser>
           </RightButtonLayout>
         </BottomLayout>
@@ -149,7 +149,9 @@ const ResetButtonLayout = styled.div`
     margin-block-start: ${space(-5)};
   `}
 `
-const RightButtonLayout = styled(Cluster).attrs({ gap: 1 })`
-  flex-direction: row-reverse;
+const RightButtonLayout = styled(Cluster).attrs({
+  gap: { column: 1, row: 0.5 },
+  justify: 'flex-end',
+})`
   margin-inline-start: auto;
 `

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -1,11 +1,12 @@
 import React, { ReactNode, VFC, useMemo } from 'react'
 import innerText from 'react-innertext'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
 import { DecoratorType, DecoratorsType } from '../../../types/props'
 import { Button } from '../../Button'
 import { FaCheckCircleIcon, FaFilterIcon, FaUndoAltIcon } from '../../Icon'
+import { Cluster } from '../../Layout'
 import { Dropdown } from '../Dropdown'
 import { DropdownCloser } from '../DropdownCloser'
 import { DropdownContent } from '../DropdownContent'
@@ -87,7 +88,7 @@ export const FilterDropdown: VFC<Props> = ({
       {hasStatusText && isFiltered ? <StatusText themes={themes}>{status}</StatusText> : null}
       <DropdownContent controllable>
         <DropdownScrollArea>
-          <ContentLayout>{children}</ContentLayout>
+          <ContentLayout themes={themes}>{children}</ContentLayout>
         </DropdownScrollArea>
         <BottomLayout themes={themes}>
           {onReset && (
@@ -99,12 +100,12 @@ export const FilterDropdown: VFC<Props> = ({
           )}
           <RightButtonLayout>
             <DropdownCloser>
-              <Button onClick={() => onCancel?.()}>{cancelButton}</Button>
-            </DropdownCloser>
-            <DropdownCloser>
               <Button variant="primary" onClick={() => onApply()}>
                 {applyButton}
               </Button>
+            </DropdownCloser>
+            <DropdownCloser>
+              <Button onClick={() => onCancel?.()}>{cancelButton}</Button>
             </DropdownCloser>
           </RightButtonLayout>
         </BottomLayout>
@@ -130,22 +131,25 @@ const StatusText = styled.span<{ themes: Theme }>`
   margin-left: ${({ themes }) => themes.spacing.XXS};
   font-size: ${({ themes }) => themes.fontSize.S};
 `
-const ContentLayout = styled.div`
-  padding: 24px;
+const ContentLayout = styled.div<{ themes: Theme }>`
+  ${({ themes: { space } }) => css`
+    padding: ${space(1.5)};
+  `}
 `
-const BottomLayout = styled.div<{ themes: Theme }>`
-  display: flex;
-  align-items: center;
-  border-top: 1px solid ${({ themes }) => themes.color.BORDER};
-  padding: 16px 24px;
+const BottomLayout = styled(Cluster).attrs({ gap: 1, align: 'center', justify: 'space-between' })<{
+  themes: Theme
+}>`
+  ${({ themes: { border, space } }) => css`
+    border-block-start: ${border.shorthand};
+    padding: ${space(1)} ${space(1.5)};
+  `}
 `
 const ResetButtonLayout = styled.div`
-  margin-left: -8px;
+  ${({ theme: { space } }) => css`
+    margin-block-start: ${space(-5)};
+  `}
 `
-const RightButtonLayout = styled.div`
-  display: flex;
-  margin-left: auto;
-  & > *:not(:first-child) {
-    margin-left: 16px;
-  }
+const RightButtonLayout = styled(Cluster).attrs({ gap: 1 })`
+  flex-direction: row-reverse;
+  margin-inline-start: auto;
 `


### PR DESCRIPTION
## Related URL

#3042 

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FilterDropdown が幅の狭い画面で機能しないことがわかったので修正。

- Cluster を使い、適切にレスポンシブするように修正
- 不要に幅指定している Story の記述を修正
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

iPhone SE など 320px を想定してキャプチャ。

before | after
--- | ---
![image](https://user-images.githubusercontent.com/19403400/219365113-6884bc08-4123-4252-b6e0-6abef1311bed.png) |  ![image](https://user-images.githubusercontent.com/19403400/219364808-52aec771-1f81-4938-af36-473cca98d5c4.png)