### PR TITLE
feat: チェックボックスを Th に入れる場合の幅を調整

### DIFF
--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -109,6 +109,11 @@ const Wrapper = styled.th<{ themes: Theme; onSort?: () => void }>`
         ${shadow.focusIndicatorStyles}
       }
     }
+
+    /* どんな状況でもチェックボックスの幅で計算するための小さい値 */
+    &:has(input[type='checkbox']) {
+      width: 1px;
+    }
   `}
 `
 


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-610

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Th 内で CheckBox を使う場合に、必ず styled-components で wrap する必要があったため、開発者が意識しなくとも幅が調整されるようにしました。

リファインメント時には `<CheckBoxTh />` の作成を検討していましたが、チェックボックス専用の Th を作るよりも内部的に判定する方が筋が良いと考えました。`:has(type=checkbox)` を使う弊害は特に思い浮かびませんでした。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
