### PR TITLE
fix: HeadlineArea を deprecated にする

### DIFF
--- a/src/components/HeadlineArea/HeadlineArea.stories.tsx
+++ b/src/components/HeadlineArea/HeadlineArea.stories.tsx
@@ -4,18 +4,18 @@ import * as React from 'react'
 import { HeadlineArea } from './HeadlineArea'
 
 export default {
-  title: 'Data Display（データ表示）/HeadlineArea',
+  title: 'Data Display（データ表示）/HeadlineArea（非推奨）',
   component: HeadlineArea,
 }
 
 const heading = {
-  children: 'HeadlineArea',
+  children: 'HeadlineArea（非推奨）',
 }
 
 export const All: Story = () => (
   <HeadlineArea
     heading={heading}
-    description="画面説明テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト"
+    description="このコンポーネントの使用は非推奨です。Stackを使って書き換えてください。"
   />
 )
 All.storyName = 'all'

--- a/src/components/HeadlineArea/HeadlineArea.tsx
+++ b/src/components/HeadlineArea/HeadlineArea.tsx
@@ -22,6 +22,9 @@ type Props = {
 
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
+/**
+ * @deprecated `HeadlineArea` は非推奨です。`Stack` で書き換えてください。
+ */
 export const HeadlineArea: VFC<Props & ElementProps> = ({
   heading,
   description,


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-606
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Stack が作られたため、HeadlineArea は不要になりました。

以下のように書き換えることを推奨します。

```tsx
<Stack>
  <Heading>見出し</Heading>
  <p>説明</p>
</Stack>
```

Stack であれば `gap` プロパティで間隔の調整もできます。
また `<p />` は `<Text />` を使っても良いです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
