### PR TITLE
fix: DatePicker の width を指定できるように修正

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -56,7 +56,7 @@ export const All: Story = () => {
       </dd>
       <dt>Extending style (width: 50%)</dt>
       <dd>
-        <ExtendingDatePicker name="extending_style" onChangeDate={action('change')} />
+        <DatePicker name="extending_style" width="50%" onChangeDate={action('change')} />
       </dd>
       <dt className="bottom">Place on the page bottom</dt>
       <dd>
@@ -77,8 +77,4 @@ const List = styled.dl`
   dt.bottom {
     margin-top: 1000px;
   }
-`
-
-const ExtendingDatePicker = styled(DatePicker)`
-  width: 50%;
 `

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -39,6 +39,8 @@ type Props = {
   placeholder?: string
   /** フォームにエラーがあるかどうか */
   error?: boolean
+  /** コンポーネントの幅 */
+  width?: number | string
   /** コンポーネントに適用するクラス名 */
   className?: string
   /** 入力を独自にパースする場合に、パース処理を記述する関数 */
@@ -72,6 +74,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
       from = DEFAULT_FROM,
       to,
       disabled,
+      width,
       error,
       className = '',
       parseInput,
@@ -246,6 +249,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
 
     return (
       <Container
+        $width={width}
         className={`${className} ${classNames.wrapper}`}
         onClick={() => {
           if (!disabled && !isCalendarShown) {
@@ -264,9 +268,9 @@ export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
         }}
       >
         <div ref={inputWrapperRef}>
-          <StyledInput
+          <Input
             {...inputAttrs}
-            type="text"
+            width="100%"
             name={name}
             onChange={() => {
               if (isCalendarShown) {
@@ -334,11 +338,11 @@ export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
   },
 )
 
-const Container = styled.div`
-  display: inline-block;
-`
-const StyledInput = styled(Input)`
-  width: 100%;
+const Container = styled.div<{ $width: Props['width'] }>`
+  ${({ $width = 'auto' }) => css`
+    display: inline-block;
+    width: ${typeof $width === 'number' ? `${$width}px` : $width};
+  `}
 `
 const InputSuffixLayout = styled.span<{ themes: Theme }>(({ themes: { spacingByChar } }) => {
   return css`


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-643

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DatePicker に width props で幅指定ができなかったため修正しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
