### PR TITLE
fix: InputFileの背景色指定漏れに対応する

### DIFF
--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -183,6 +183,7 @@ const FileList = styled.ul<{ themes: Theme }>(({ themes }) => {
 const InputWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
   const { border, color, fontSize, leading, radius, shadow, spacingByChar } = themes
   return css`
+    background-color: ${color.WHITE};
     position: relative;
     display: inline-flex;
     font-weight: bold;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- InputFileの非hover時の背景が未指定だったため追加します

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
