### PR TITLE
fix: Pagination の aria-label の内容が aria-current とダブっているため調整する

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
 import { userEvent } from '@storybook/testing-library'
-import * as React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { Pagination } from './Pagination'
@@ -11,46 +11,56 @@ export default {
   component: Pagination,
 }
 
-const Template: Story = () => (
-  <List>
-    <li>
-      <Txt>default</Txt>
-      <Pagination current={7} total={13} onClick={action('click!!')} />
-    </li>
-    <li>
-      <Txt>padding = 1</Txt>
-      <Pagination current={7} total={13} onClick={action('click!!')} padding={1} />
-    </li>
-    <li>
-      <Txt>current = 1, total = 5</Txt>
-      <Pagination current={1} total={5} onClick={action('click!!')} />
-    </li>
-    <li>
-      <Txt>current = 5, total = 5</Txt>
-      <Pagination current={5} total={5} onClick={action('click!!')} />
-    </li>
-    <li>
-      <Txt>current = 2, total = 3</Txt>
-      <Pagination current={2} total={3} onClick={action('click!!')} />
-    </li>
-    <li>
-      <Txt>current = 1, total = 2</Txt>
-      <Pagination current={1} total={2} onClick={action('click!!')} />
-    </li>
-    <li>
-      <Txt>current = 1, total = 1</Txt>
-      <Pagination current={1} total={1} onClick={action('click!!')} />
-    </li>
-    <li>
-      <Txt>current = 1, total = 5, withoutNumbers = true</Txt>
-      <Pagination current={1} total={5} onClick={action('click!!')} withoutNumbers />
-    </li>
-    <li>
-      <Txt>current = 2, total = 5, withoutNumbers = true</Txt>
-      <Pagination current={2} total={5} onClick={action('click!!')} withoutNumbers />
-    </li>
-  </List>
-)
+const Template: Story = () => {
+  const [current, setCurrent] = useState(7)
+
+  return (
+    <List>
+      <li>
+        <Txt>default</Txt>
+        <Pagination
+          current={current}
+          total={13}
+          onClick={(page) => {
+            setCurrent(page)
+          }}
+        />
+      </li>
+      <li>
+        <Txt>padding = 1</Txt>
+        <Pagination current={7} total={13} onClick={action('click!!')} padding={1} />
+      </li>
+      <li>
+        <Txt>current = 1, total = 5</Txt>
+        <Pagination current={1} total={5} onClick={action('click!!')} />
+      </li>
+      <li>
+        <Txt>current = 5, total = 5</Txt>
+        <Pagination current={5} total={5} onClick={action('click!!')} />
+      </li>
+      <li>
+        <Txt>current = 2, total = 3</Txt>
+        <Pagination current={2} total={3} onClick={action('click!!')} />
+      </li>
+      <li>
+        <Txt>current = 1, total = 2</Txt>
+        <Pagination current={1} total={2} onClick={action('click!!')} />
+      </li>
+      <li>
+        <Txt>current = 1, total = 1</Txt>
+        <Pagination current={1} total={1} onClick={action('click!!')} />
+      </li>
+      <li>
+        <Txt>current = 1, total = 5, withoutNumbers = true</Txt>
+        <Pagination current={1} total={5} onClick={action('click!!')} withoutNumbers />
+      </li>
+      <li>
+        <Txt>current = 2, total = 5, withoutNumbers = true</Txt>
+        <Pagination current={2} total={5} onClick={action('click!!')} withoutNumbers />
+      </li>
+    </List>
+  )
+}
 
 export const All = Template.bind({})
 

--- a/src/components/Pagination/PaginationItem.tsx
+++ b/src/components/Pagination/PaginationItem.tsx
@@ -19,7 +19,7 @@ export const PaginationItem: VFC<Props> = ({ page, currentPage, onClick }) => {
         className="active"
         themes={theme}
         aria-current="page"
-        aria-label={`${page}ページ目、現在のページ`}
+        aria-label={`${page}ページ目`}
         disabled
       >
         {page}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- Pagination の aria-label の内容に `現在のページ` と表示されるパターンが存在するがその場合 `aria-current="page"` がもれなく設定されている
- 意味合いが同じであるため、 aria-label の内容を調整し、冗長な部分をなくしたい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
