### PR TITLE
fix: DatePicker の和暦入力後に Enter で変換されないバグを修正

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -277,23 +277,24 @@ export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
                 switchCalendarVisibility(false)
               }
             }}
-            onKeyPress={(e) => {
-              if (e.key === 'Enter') {
+            onKeyPress={({ key, currentTarget: { value: inputString } }) => {
+              if (key === 'Enter') {
                 switchCalendarVisibility(!isCalendarShown)
+                const newDate = stringToDate(inputString)
+                updateDate(newDate)
               }
             }}
             onFocus={() => {
               setIsInputFocused(true)
               switchCalendarVisibility(true)
             }}
-            onBlur={(e) => {
+            onBlur={({ target: { value: inputString } }) => {
               setIsInputFocused(false)
-              const inputString = e.target.value
               if (inputString === '') {
                 updateDate(null)
                 return
               }
-              const newDate = parseInput ? parseInput(inputString) : parseJpnDateString(inputString)
+              const newDate = stringToDate(inputString)
               updateDate(newDate)
             }}
             suffix={


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-585

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

和暦入力時、フォーカスを外すと変換されるが Enter を押しても変換されない問題が発生していた。
Enter 押下時に変換もかけるよう修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
