### PR TITLE
fix: DropdownMenuButton に渡した props を引き金となるボタンに渡すよう修正

### DIFF
--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -1,4 +1,11 @@
-import React, { ComponentProps, HTMLAttributes, ReactElement, ReactNode, VFC, useMemo } from 'react'
+import React, {
+  ButtonHTMLAttributes,
+  ComponentProps,
+  FC,
+  ReactElement,
+  ReactNode,
+  useMemo,
+} from 'react'
 import innerText from 'react-innertext'
 import styled, { css } from 'styled-components'
 
@@ -26,17 +33,14 @@ type Props = {
   triggerSize?: ButtonProps['size']
   /** 引き金となるボタンをアイコンのみとするかどうか */
   onlyIconTrigger?: boolean
-  /** 引き金となるボタンの `disabled` 属性の値 */
-  disabled?: boolean
 }
-type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>
+type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof Props>
 
-export const DropdownMenuButton: VFC<Props & ElementProps> = ({
+export const DropdownMenuButton: FC<Props & ElementProps> = ({
   label,
   children,
   triggerSize,
   onlyIconTrigger = false,
-  disabled = false,
   className = '',
   ...props
 }) => {
@@ -59,12 +63,12 @@ export const DropdownMenuButton: VFC<Props & ElementProps> = ({
   )
 
   return (
-    <Dropdown {...props}>
+    <Dropdown>
       <DropdownTrigger className={`${classNames.wrapper}${className && ` ${className}`}`}>
         <TriggerButton
+          {...props}
           suffix={triggerSuffix}
           size={triggerSize}
-          disabled={disabled}
           square={onlyIconTrigger}
           className={classNames.trigger}
         >


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-582

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DropdownMenuButton に data-spec を適切に渡せないバグを修正しました。
実装的にも認知的にも引き金となるボタンに props を渡すほうが自然と考えて修正しています。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
