### PR TITLE
fix!: FloatArea の top / bottom をデザイントークンで指定するように修正

### DIFF
--- a/src/components/FloatArea/FloatArea.stories.tsx
+++ b/src/components/FloatArea/FloatArea.stories.tsx
@@ -23,28 +23,28 @@ export const All: Story = () => (
       tertiaryButton={<Button>preview</Button>}
       errorIcon={<FaExclamationCircleIcon color="DANGER" />}
       errorText="これはfixedのFloatAreaです。"
-      top={36}
+      top={2}
       width="80%"
       fixed
     />
     <Stack>
-      {[...Array(15)].map((_, index) => (
-        <>
-          {index === 13 && (
-            <FloatArea
-              primaryButton={<Button variant="primary">Submit</Button>}
-              secondaryButton={<Button>Cancel</Button>}
-              tertiaryButton={<Button>preview</Button>}
-              errorIcon={<FaExclamationCircleIcon color="DANGER" />}
-              errorText="これはstickyのFloatAreaです。"
-              bottom={24}
-            />
-          )}
+      {[...Array(15)].map((_, index) =>
+        index === 13 ? (
+          <FloatArea
+            primaryButton={<Button variant="primary">Submit</Button>}
+            secondaryButton={<Button>Cancel</Button>}
+            tertiaryButton={<Button>preview</Button>}
+            errorIcon={<FaExclamationCircleIcon color="DANGER" />}
+            errorText="これはstickyのFloatAreaです。"
+            bottom={1.5}
+            key={index}
+          />
+        ) : (
           <Base key={index}>
             <p>複数の従業員項目を掛け合わせて（クロス集計）分析できる「レポート」を作成します。</p>
           </Base>
-        </>
-      ))}
+        ),
+      )}
     </Stack>
   </>
 )
@@ -56,12 +56,12 @@ export const WithoutTertiary: Story = () => (
     secondaryButton={<Button>Cancel</Button>}
     errorIcon={<FaExclamationCircleIcon color="DANGER" />}
     errorText="This is the error text."
-    bottom="24px"
+    bottom={1.5}
   />
 )
 WithoutTertiary.storyName = 'withoutTertiary'
 
 export const OnlyPrimary: Story = () => (
-  <FloatArea primaryButton={<Button variant="primary">Submit</Button>} top={32} />
+  <FloatArea primaryButton={<Button variant="primary">Submit</Button>} top={2} />
 )
 OnlyPrimary.storyName = 'onlyPrimary'

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -1,14 +1,16 @@
 import React, {
   ComponentProps,
+  FC,
   FunctionComponentElement,
   HTMLAttributes,
   ReactNode,
-  VFC,
 } from 'react'
 import styled, { css } from 'styled-components'
 
+import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { DialogBase as BaseComponent } from '../Base'
+import { AbstractSize, CharRelativeSize } from '../../themes/createSpacing'
+import { Base as shrBase } from '../Base'
 import { FaExclamationCircleIcon } from '../Icon'
 import { Cluster, LineUp } from '../Layout'
 import { Text } from '../Text'
@@ -16,10 +18,10 @@ import { Text } from '../Text'
 import { useClassNames } from './useClassNames'
 
 type StyleProps = {
-  /** コンポーネントの上端から、包含ブロックの上端までの距離 */
-  top?: number | string
-  /** コンポーネントの下端から、包含ブロックの下端までの距離 */
-  bottom?: number | string
+  /** コンポーネントの上端から、包含ブロックの上端までの間隔（基準フォントサイズの相対値または抽象値） */
+  top?: CharRelativeSize | AbstractSize
+  /** コンポーネントの下端から、包含ブロックの下端までの間隔（基準フォントサイズの相対値または抽象値） */
+  bottom?: CharRelativeSize | AbstractSize
   /** コンポーネントの `z-index` 値 */
   zIndex?: number
 }
@@ -45,11 +47,7 @@ type Props = StyleProps & {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-const exist = (value: any) => {
-  return value !== undefined && value !== null
-}
-
-export const FloatArea: VFC<Props & ElementProps> = ({
+export const FloatArea: FC<Props & ElementProps> = ({
   primaryButton,
   secondaryButton,
   tertiaryButton,
@@ -92,24 +90,17 @@ export const FloatArea: VFC<Props & ElementProps> = ({
   )
 }
 
-const Base = styled(BaseComponent)<StyleProps & { themes: Theme; $width?: string; fixed: boolean }>`
-  ${({ themes: { spacingByChar }, top, bottom, $width, fixed, zIndex = 500 }) =>
+const Base = styled(shrBase).attrs({ layer: 3 })<
+  StyleProps & { themes: Theme; $width: Props['width']; fixed: Props['fixed'] }
+>`
+  ${({ themes: { space }, top, bottom, $width, fixed, zIndex = 500 }) =>
     css`
       position: ${fixed ? 'fixed' : 'sticky'};
-      ${exist(top) &&
-      css`
-        top: ${typeof top === 'number' ? `${top}px` : top};
-      `}
-      ${exist(bottom) &&
-      css`
-        bottom: ${typeof bottom === 'number' ? `${bottom}px` : bottom};
-      `}
+      ${(top || top === 0) && `top: ${useSpacing(top)};`}
+      ${(bottom || bottom === 0) && `bottom: ${useSpacing(bottom)};`}
       z-index: ${zIndex};
-      ${$width &&
-      css`
-        width: ${$width};
-      `}
-      padding: ${spacingByChar(1)};
+      padding: ${space(1)};
+      ${$width && `width: ${$width};`}
     `}
 `
 const RightSide = styled.div`


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

```ts
top?: number | string
bottom?: number | string
```

となっていたところを `CharRelativeSize | AbstractSize` としました。

`16px` や `24` といった値を渡すことはできなくなります。
基本的には `top / bottom` も余白と同じ扱いなため、余白のデザイントークンを使用してください。
（どうしても固定値を使いたい場合は styled-components で wrap してください。）

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
