### PR TITLE
fix: 存在しない onSort を使っていたため修正

### DIFF
--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -86,6 +86,7 @@ const Wrapper = styled.th<{ themes: Theme }>`
     font-size: ${fontSize.S};
     font-weight: bold;
     padding: ${space(0.75)} ${space(1)};
+    text-align: left;
     color: ${color.TEXT_BLACK};
     line-height: ${leading.TIGHT};
     vertical-align: middle;
@@ -120,7 +121,6 @@ const SortButton = styled.button<{
     outline: unset;
     background-color: unset;
     padding: ${space(0.75)} ${space(1)};
-    text-align: left;
     width: 100%;
     font-family: inherit;
     font-size: inherit;

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -67,15 +67,9 @@ export const Th: FC<Props & ElementProps> = ({
   }, [sort])
 
   return (
-    <Wrapper
-      {...ariaSortProps}
-      {...props}
-      onSort={sort && onSort}
-      className={wrapperClass}
-      themes={theme}
-    >
+    <Wrapper {...ariaSortProps} {...props} className={wrapperClass} themes={theme}>
       {sort ? (
-        <SortButton themes={theme}>
+        <SortButton themes={theme} onClick={onSort}>
           {children}
           <SortIcon sort={sort} />
           <VisuallyHiddenText>{sortLabel}</VisuallyHiddenText>
@@ -87,7 +81,7 @@ export const Th: FC<Props & ElementProps> = ({
   )
 }
 
-const Wrapper = styled.th<{ themes: Theme; onSort?: () => void }>`
+const Wrapper = styled.th<{ themes: Theme }>`
   ${({ themes: { fontSize, leading, color, shadow, space } }) => css`
     font-size: ${fontSize.S};
     font-weight: bold;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Th の onClick を onSort に変えた時に誤りがありました。
onSort は存在しないため button の onClick を使うよう修正しました。
sort と一緒にしか使えないのは変わっていません。

2023-02-24 13:07 追加
button にあたっていた `text-align: left` を th に当て直しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
