### PR TITLE
feat!: ActionDialog の processing を Button の loading で置き換え

### DIFF
--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, VFC, useCallback } from 'react'
+import React, { FC, ReactNode, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -6,8 +6,7 @@ import { DecoratorsType } from '../../types/props'
 import { Button } from '../Button'
 import { HeadingTagTypes } from '../Heading'
 import { FaCheckCircleIcon, FaExclamationCircleIcon } from '../Icon'
-import { Stack } from '../Layout'
-import { Loader } from '../Loader'
+import { Cluster, Stack } from '../Layout'
 import { Text } from '../Text'
 
 import { useOffsetHeight } from './dialogHelper'
@@ -72,7 +71,7 @@ export type ActionDialogContentInnerProps = BaseProps & {
 
 const CLOSE_BUTTON_LABEL = 'キャンセル'
 
-export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
+export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
   children,
   title,
   titleId,
@@ -118,7 +117,7 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
         {children}
       </Body>
       <ActionArea themes={theme} ref={bottomRef} className={classNames.actionArea}>
-        <ButtonArea themes={theme} className={classNames.buttonArea}>
+        <ButtonArea className={classNames.buttonArea}>
           <Button
             onClick={onClickClose}
             disabled={closeDisabled || isRequestProcessing}
@@ -129,86 +128,60 @@ export const ActionDialogContentInner: VFC<ActionDialogContentInnerProps> = ({
           <Button
             variant={actionTheme}
             onClick={handleClickAction}
-            disabled={actionDisabled || isRequestProcessing}
+            disabled={actionDisabled}
+            loading={isRequestProcessing}
             className={classNames.actionButton}
           >
             {actionText}
           </Button>
         </ButtonArea>
         {responseMessage && (
-          <MessageWrapper role="alert" className={classNames.alert} themes={theme}>
-            {responseMessage.status === 'success' ? (
-              <FaCheckCircleIcon color={theme.color.MAIN} />
-            ) : responseMessage.status === 'error' ? (
-              <FaExclamationCircleIcon color={theme.color.DANGER} />
-            ) : (
-              <Spinner size="s" themes={theme} />
+          <>
+            {responseMessage.status === 'success' && (
+              <Message>
+                <FaCheckCircleIcon
+                  color={theme.color.MAIN}
+                  text={responseMessage.text}
+                  role="alert"
+                />
+              </Message>
             )}
-            <Message themes={theme}>{responseMessage.text}</Message>
-          </MessageWrapper>
+            {responseMessage.status === 'error' && (
+              <Message>
+                <FaExclamationCircleIcon
+                  color={theme.color.DANGER}
+                  text={responseMessage.text}
+                  role="alert"
+                />
+              </Message>
+            )}
+          </>
         )}
       </ActionArea>
     </>
   )
 }
 
-const TitleArea = styled(Stack)<{ themes: Theme; as: HeadingTagTypes }>(
-  ({ themes: { border, spacing } }) => css`
+const TitleArea = styled(Stack)<{ themes: Theme; as: HeadingTagTypes }>`
+  ${({ themes: { border, space } }) => css`
     margin-block: unset;
     border-bottom: ${border.shorthand};
-    padding: ${spacing.XS} ${spacing.S};
-  `,
-)
+    padding: ${space(1)} ${space(1.5)};
+  `}
+`
 const Body = styled.div<{ offsetHeight: number }>`
-  ${({ offsetHeight }) => {
-    return css`
-      max-height: calc(100vh - ${offsetHeight}px);
-      overflow: auto;
-    `
-  }}
+  ${({ offsetHeight }) => css`
+    max-height: calc(100vh - ${offsetHeight}px);
+    overflow: auto;
+  `}
 `
-const ActionArea = styled.div<{ themes: Theme }>(({ themes: { spacing, border } }) => {
-  return css`
-    display: flex;
-    flex-direction: column;
+const ActionArea = styled(Stack).attrs({ gap: 0.5 })<{ themes: Theme }>`
+  ${({ themes: { space, border } }) => css`
     border-top: ${border.shorthand};
-    padding: ${spacing.XS} ${spacing.S};
-
-    &&& > * + * {
-      margin-top: 0.5rem;
-    }
-  `
-})
-const ButtonArea = styled.div<{ themes: Theme }>(({ themes: { spacing } }) => {
-  return css`
-    display: flex;
-    justify-content: flex-end;
-
-    > * + * {
-      margin-left: ${spacing.XS};
-    }
-  `
-})
-const MessageWrapper = styled.div<{ themes: Theme }>`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  margin-top: 0;
-  margin-bottom: 0;
-  font-size: ${({ themes }) => themes.fontSize.M};
+    padding: ${space(1)} ${space(1.5)};
+  `}
 `
-const Spinner = styled(Loader)<{ themes: Theme }>`
-  &&& {
-    > div {
-      width: 18px;
-      height: 18px;
-    }
-
-    > div > div {
-      border-color: ${({ themes }) => themes.color.TEXT_GREY};
-    }
-  }
-`
-const Message = styled.span<{ themes: Theme }>`
-  margin-left: ${({ themes }) => themes.spacingByChar(0.25)};
+const ButtonArea = styled(Cluster).attrs({ gap: { row: 0.5, column: 1 }, justify: 'flex-end' })``
+const Message = styled.div`
+  text-align: right;
 `

--- a/src/components/Dialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialogContentInner.tsx
@@ -58,10 +58,14 @@ export type BaseProps = {
   decorators?: DecoratorsType<'closeButtonLabel'>
 }
 
-type responseMessageType = {
-  status: 'success' | 'error' | 'processing'
-  text: string
-}
+type responseMessageType =
+  | {
+      status: 'success' | 'error'
+      text: string
+    }
+  | {
+      status: 'processing'
+    }
 
 export type ActionDialogContentInnerProps = BaseProps & {
   onClickClose: () => void

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
-import React, { useRef, useState } from 'react'
+import React, { ComponentProps, useRef, useState } from 'react'
 import styled from 'styled-components'
 
 import { Button } from '../Button'
@@ -200,10 +200,8 @@ Message_Dialog.parameters = {
 export const Action_Dialog: Story = () => {
   const [openedDialog, setOpenedDialog] = useState<'normal' | 'opened' | null>(null)
   const [value, setValue] = React.useState('Apple')
-  const [responseMessage, setResponseMessage] = useState<{
-    status: 'success' | 'error' | 'processing'
-    text: string
-  }>()
+  const [responseMessage, setResponseMessage] =
+    useState<ComponentProps<typeof ActionDialog>['responseMessage']>()
   const openedFocusRef = useRef<HTMLInputElement>(null)
   const onClickClose = () => {
     setOpenedDialog(null)
@@ -280,7 +278,6 @@ export const Action_Dialog: Story = () => {
             onClick={() =>
               setResponseMessage({
                 status: 'processing',
-                text: '保存中',
               })
             }
           >

--- a/src/components/Dialog/useClassNames.ts
+++ b/src/components/Dialog/useClassNames.ts
@@ -22,7 +22,6 @@ export function useClassNames() {
         buttonArea: generateForDialog('buttonArea'),
         closeButton: generateForDialog('closeButton'),
         actionButton: generateForDialog('actionButton'),
-        alert: generateForDialog('alert'),
       },
       modelessDialog: {
         wrapper: generateForModeless(),


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Button に loading は追加されたため、ActionDialog の processing を置き換えました。
I/F に変更はありません。

また、内部的なレイアウトも見た目はそのままに SmartHR UI で置き換えました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

before | after
--- | ---
![image](https://user-images.githubusercontent.com/19403400/221111909-9d392a59-a5b3-4052-9d77-24a645c5a28b.png) | ![image](https://user-images.githubusercontent.com/19403400/221111673-a68f08ce-b5dd-4d67-84d1-cb8fdd3f3950.png)