### PR TITLE
chore: スマパタのStorybookも同時に見れるようにする

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -26,4 +26,10 @@ module.exports = {
       },
     },
   ],
+  refs: {
+    'smarthr-patterns': {
+      title: 'SmartHR Patterns',
+      url: 'https://main--62f0ae48c21b0728fd1a5c85.chromatic.com',
+    },
+  },
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Storybook の Composition という機能を使用し、SmartHR UI の Storybook 上でスマパタの Storybook も同時に見れるようにしてみました。

https://storybook.js.org/docs/react/sharing/storybook-composition

コンポーネントのStoryと、実際のパターン例のStoryが同時に見れるようになるのでめっちゃ良い気がしています。


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

![スクリーンショット_2023-02-24_17_08_58](https://user-images.githubusercontent.com/32166731/221126177-52cb3cda-6f63-49b7-8f55-3782c6a1bce7.png)


<!--
Please attach a capture if it looks different.
-->
