### PR TITLE
fix: alias import を相対パスに置き換え

### DIFF
--- a/src/components/Table/ThCheckbox.tsx
+++ b/src/components/Table/ThCheckbox.tsx
@@ -1,9 +1,8 @@
 import React, { forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 
-import { DecoratorsType } from '@/types/props'
-
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { DecoratorsType } from '../../types/props'
 import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
 import { Center } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

alias import になってる箇所があったため修正。
念の為、他に alias import になってる箇所がないか調べてないことを確認しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
