### PR TITLE
fix: FilterDropdownのResetButtonLayoutにthemeを渡すようにする

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -92,7 +92,7 @@ export const FilterDropdown: VFC<Props> = ({
         </DropdownScrollArea>
         <BottomLayout themes={themes}>
           {onReset && (
-            <ResetButtonLayout>
+            <ResetButtonLayout themes={themes}>
               <Button variant="text" size="s" prefix={<FaUndoAltIcon />} onClick={() => onReset()}>
                 {resetButton}
               </Button>
@@ -144,7 +144,7 @@ const BottomLayout = styled(Cluster).attrs({ gap: 1, align: 'center', justify: '
     padding: ${space(1)} ${space(1.5)};
   `}
 `
-const ResetButtonLayout = styled.div`
+const ResetButtonLayout = styled.div<{ themes: Theme }>`
   ${({ theme: { space } }) => css`
     margin-block-start: ${space(-5)};
   `}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
ResetButtonLayoutにthemeが渡されていなかったため修正を加えました。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
