### PR TITLE
fix: ResetButtonLayoutに渡された値の再修正

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -92,11 +92,9 @@ export const FilterDropdown: VFC<Props> = ({
         </DropdownScrollArea>
         <BottomLayout themes={themes}>
           {onReset && (
-            <ResetButtonLayout themes={themes}>
-              <Button variant="text" size="s" prefix={<FaUndoAltIcon />} onClick={() => onReset()}>
-                {resetButton}
-              </Button>
-            </ResetButtonLayout>
+            <Button variant="text" size="s" prefix={<FaUndoAltIcon />} onClick={() => onReset()}>
+              {resetButton}
+            </Button>
           )}
           <RightButtonLayout>
             <DropdownCloser>
@@ -144,11 +142,7 @@ const BottomLayout = styled(Cluster).attrs({ gap: 1, align: 'center', justify: '
     padding: ${space(1)} ${space(1.5)};
   `}
 `
-const ResetButtonLayout = styled.div<{ themes: Theme }>`
-  ${({ themes: { space } }) => css`
-    margin-block-start: ${space(-5)};
-  `}
-`
+
 const RightButtonLayout = styled(Cluster).attrs({
   gap: { column: 1, row: 0.5 },
   justify: 'flex-end',

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -145,7 +145,7 @@ const BottomLayout = styled(Cluster).attrs({ gap: 1, align: 'center', justify: '
   `}
 `
 const ResetButtonLayout = styled.div<{ themes: Theme }>`
-  ${({ theme: { space } }) => css`
+  ${({ themes: { space } }) => css`
     margin-block-start: ${space(-5)};
   `}
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
https://github.com/kufu/smarthr-ui/pull/3181 でResetButtonLayoutにthemeを渡すように変更しましたが、一部修正が漏れていたので再修正しました。




<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
<img width="400" alt="スクリーンショット 2023-03-09 19 19 14" src="https://user-images.githubusercontent.com/31817322/223993816-7d962cf7-6626-4264-9a6b-446d4ec7e121.png">

### ▼画面表示幅が狭い時
<img width="400" alt="スクリーンショット 2023-03-09 19 19 50" src="https://user-images.githubusercontent.com/31817322/223993851-03f8a364-b5f4-4877-bde8-b3352abd1bf3.png">
<!--
Please attach a capture if it looks different.
-->
