### PR TITLE
fix: FilterDropdown の効いていないスタイリングを修正

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -145,8 +145,8 @@ const BottomLayout = styled(Cluster).attrs({ gap: 1, align: 'center', justify: '
   `}
 `
 const ResetButtonLayout = styled.div<{ themes: Theme }>`
-  ${({ theme: { space } }) => css`
-    margin-block-start: ${space(-5)};
+  ${({ themes: { space } }) => css`
+    margin-inline-start: ${space(-0.5)};
   `}
 `
 const RightButtonLayout = styled(Cluster).attrs({


### PR DESCRIPTION
## Related URL

#3180 の修正以前にスタイリングの指定が間違っていたので修正。
Close #3184

デグレでした。
https://github.com/kufu/smarthr-ui/commit/beb0776a1f63aded4068392708c797f5a087b9b2#diff-606f422820a68705fd17c0c15e836ec13efbb4644897c5fc1f33a956e1d96c69L143

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
