### PR TITLE
fix: SSR を使用時に useLayoutEffect の警告が出ないようにする

### DIFF
--- a/src/components/Calendar/YearPicker.tsx
+++ b/src/components/Calendar/YearPicker.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, VFC, useLayoutEffect, useRef } from 'react'
+import React, { FC, HTMLAttributes, useEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -22,7 +22,7 @@ type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const YearPicker: VFC<Props & ElementProps> = ({
+export const YearPicker: FC<Props & ElementProps> = ({
   selectedYear,
   fromYear,
   toYear,
@@ -41,7 +41,7 @@ export const YearPicker: VFC<Props & ElementProps> = ({
     .fill(null)
     .map((_, i) => fromYear + i)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (focusingRef.current && isDisplayed) {
       focusingRef.current.focus()
       focusingRef.current.blur()

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -4,7 +4,7 @@ import React, {
   KeyboardEvent,
   ReactNode,
   useCallback,
-  useLayoutEffect,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -255,7 +255,7 @@ export function MultiComboBox<T>({
 
   useOuterClick([outerRef, listBoxRef], blur)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isInputControlled) {
       setUncontrolledInputValue('')
     }

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -4,7 +4,7 @@ import React, {
   MouseEvent,
   ReactNode,
   useCallback,
-  useLayoutEffect,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -321,7 +321,7 @@ export function SingleComboBox<T>({
     }, [unfocus]),
   )
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (selectedItem) {
       setInputValue(selectedItem.label)
     } else {

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -5,13 +5,13 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from 'react'
 import styled, { css } from 'styled-components'
 
+import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'
 import { useId } from '../../hooks/useId'
 import { usePortal } from '../../hooks/usePortal'
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -140,7 +140,7 @@ export function useListBox<T>({
     }
   }, [activeOption, listBoxRef, navigationType])
 
-  useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     if (isExpanded) {
       // options の更新毎に座標を再計算する
       calculateRect()

--- a/src/components/ComboBox/usePartialRendering.tsx
+++ b/src/components/ComboBox/usePartialRendering.tsx
@@ -1,12 +1,4 @@
-import React, {
-  FC,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const OPTION_INCREMENT_AMOUNT = 100
 
@@ -53,7 +45,7 @@ export function usePartialRendering<T>({
 const Intersection: FC<{ onIntersect: () => void }> = ({ onIntersect }) => {
   const ref = useRef<HTMLDivElement>(null)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const target = ref.current
     if (target === null) {
       return

--- a/src/components/DatePicker/Portal.tsx
+++ b/src/components/DatePicker/Portal.tsx
@@ -1,13 +1,7 @@
-import React, {
-  ReactNode,
-  forwardRef,
-  useImperativeHandle,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
+import React, { ReactNode, forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
+import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'
 import { usePortal } from '../../hooks/usePortal'
 import { Theme, useTheme } from '../../hooks/useTheme'
 
@@ -30,7 +24,7 @@ export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, children }
   const containerRef = useRef<HTMLDivElement>(null)
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(ref, () => containerRef.current)
 
-  useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     if (!containerRef.current) {
       return
     }

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -1,11 +1,11 @@
 import React, {
   ComponentProps,
+  FC,
   MouseEvent,
   ReactNode,
   RefObject,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -88,7 +88,7 @@ type Props = {
 const DIALOG_HANDLER_ARIA_LABEL = 'ダイアログの位置'
 const CLOSE_BUTTON_ICON_ALT = '閉じる'
 
-export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
+export const ModelessDialog: FC<Props & BaseElementProps> = ({
   header,
   children,
   footer,
@@ -230,7 +230,7 @@ export const ModelessDialog: React.VFC<Props & BaseElementProps> = ({
     }
   }, [isOpen, centering.top])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isOpen) {
       setPosition({ x: 0, y: 0 })
       focusTargetRef.current?.focus()

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, VFC, createContext, useLayoutEffect, useRef, useState } from 'react'
+import React, { FC, HTMLAttributes, createContext, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -25,7 +25,7 @@ export const DropdownContentInnerContext = createContext<DropdownContentInnerCon
   maxHeight: '',
 })
 
-export const DropdownContentInner: VFC<Props & ElementProps> = ({
+export const DropdownContentInner: FC<Props & ElementProps> = ({
   triggerRect,
   scrollable,
   children,
@@ -42,7 +42,7 @@ export const DropdownContentInner: VFC<Props & ElementProps> = ({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const focusTargetRef = useRef<HTMLDivElement>(null)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (wrapperRef.current) {
       setContentBox(
         getContentBoxStyle(
@@ -65,7 +65,7 @@ export const DropdownContentInner: VFC<Props & ElementProps> = ({
     }
   }, [triggerRect])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isActive) {
       focusTargetRef.current?.focus()
     }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,15 +1,8 @@
-import React, {
-  HTMLAttributes,
-  ReactElement,
-  ReactNode,
-  VFC,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
+import React, { FC, HTMLAttributes, ReactElement, ReactNode, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { css } from 'styled-components'
 
+import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'
 import { useId } from '../../hooks/useId'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { Props as BalloonProps } from '../Balloon'
@@ -39,7 +32,7 @@ type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-describedby'>
 
-export const Tooltip: VFC<Props & ElementProps> = ({
+export const Tooltip: FC<Props & ElementProps> = ({
   message,
   children,
   triggerType,
@@ -99,7 +92,7 @@ export const Tooltip: VFC<Props & ElementProps> = ({
 
   const isIcon = triggerType === 'icon'
 
-  useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     const element = document.createElement('div')
     setPortalRoot(element)
     document.body.appendChild(element)

--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, VFC, useLayoutEffect, useRef, useState } from 'react'
+import React, { FC, ReactNode, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -18,7 +18,7 @@ type Props = {
   vertical: 'top' | 'middle' | 'bottom' | 'auto'
 }
 
-export const TooltipPortal: VFC<Props> = ({
+export const TooltipPortal: FC<Props> = ({
   message,
   id,
   isVisible,
@@ -44,7 +44,7 @@ export const TooltipPortal: VFC<Props> = ({
   )
 
   const outerMargin = 10
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!portalRef.current || !parentRect) {
       return
     }
@@ -84,7 +84,7 @@ export const TooltipPortal: VFC<Props> = ({
     }
   }, [horizontal, parentRect, vertical])
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isVisible || !portalRef.current || !actualHorizontal || !actualVertical || !parentRect) {
       return
     }

--- a/src/hooks/useEnhancedEffect.ts
+++ b/src/hooks/useEnhancedEffect.ts
@@ -1,0 +1,3 @@
+import { useEffect, useLayoutEffect } from 'react'
+
+export const useEnhancedEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect

--- a/src/hooks/usePortal.tsx
+++ b/src/hooks/usePortal.tsx
@@ -4,11 +4,12 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useLayoutEffect,
   useMemo,
   useRef,
 } from 'react'
 import { createPortal } from 'react-dom'
+
+import { useEnhancedEffect } from './useEnhancedEffect'
 
 interface ParentContextValue {
   seqs: number[]
@@ -28,7 +29,7 @@ export function usePortal() {
   const parent = useContext(ParentContext)
   const parentSeqs = parent.seqs.concat(currentSeq)
 
-  useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     if (!portalRoot) {
       return
     }


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-583

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

表題のとおりです、`useLayoutEffect` はSSRで使えず、大量に警告が出てしまうため、

- `useEffect` に置き換えられる箇所は置き換える
- 無理な箇所は SSR 時のみ `useEffect` を使うようにする

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`useLayoutEffect` 利用箇所に対して一つずつ Storybook 上で動作確認し、上記の対応をしました。

動作確認をしてダメそうだったのは大雑把に以下のような箇所でした。

- portal 用の要素を `document.body.appendChild` している箇所
  - その後に focus をしている箇所で e2e がコケたりした
- DOM 更新前の座標を計算し、Dropdown などを表示している箇所
  - これは動作はするが、Dropdownがちらつくなどした

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
