### PR TITLE
chore: ビルド対象からテストファイルを除外

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx"],
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx", "src/**/__tests__"],
 }


### PR DESCRIPTION
## Related URL

N/A

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

一部のテストファイルがパッケージに含まれているようでした。不要なので除外したいです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`*.test.*` のようなファイル名のテストファイルはビルド対象から除外されているのですが、 `__tests__/*` にあるテストファイルはビルドされていました。こちらもビルド対象から除外しました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

`npm build` 後、`npm pack --dry-run` した結果の比較：

### master (de4f67e1630a107a183bbfe2bab6995f8f8b8b2e)

<img width="703" alt="image" src="https://user-images.githubusercontent.com/9423/224530260-1ad4dbdd-4b54-4e6a-9483-71b3490281a7.png">


### このPRによる変更後

<img width="621" alt="image" src="https://user-images.githubusercontent.com/9423/224530256-9497b38a-1592-4f7a-a3f3-f07d52e05b31.png">


<!--
Please attach a capture if it looks different.
-->
