### PR TITLE
feat: 翻訳用コンポーネントなどを差し込み可能にするため string型 を ReactNode に変更する

### DIFF
--- a/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
+++ b/src/components/BackgroundJobsPanel/BackgroundJobsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, VFC, useEffect, useState } from 'react'
+import React, { ComponentProps, ReactNode, VFC, useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
@@ -20,9 +20,9 @@ export type JobProps = {
   /** ジョブのステータス */
   status: Status
   /** ジョブ名 */
-  name: string
+  name: ReactNode
   /** ジョブの説明 */
-  description: string
+  description: ReactNode
   /** ジョブがキャンセル可能かどうか */
   isCancelable?: boolean
 }

--- a/src/components/BackgroundJobsPanel/OmittableJobText.tsx
+++ b/src/components/BackgroundJobsPanel/OmittableJobText.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Tooltip } from '../Tooltip'
 
 type Props = {
-  children: string
+  children: React.ReactNode
   className?: string
 }
 

--- a/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -60,7 +60,7 @@ export type BaseProps = {
 type responseMessageType =
   | {
       status: 'success' | 'error'
-      text: string
+      text: ReactNode
     }
   | {
       status: 'processing'

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -33,7 +33,7 @@ type Props = StyleProps & {
   /** tertiary 領域に表示するボタン */
   tertiaryButton?: ReactNode
   /** エラーメッセージ */
-  errorText?: string
+  errorText?: ReactNode
   /**
    * エラーメッセージのアイコン（`FaExclamationCircleIcon` を指定）
    */

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -26,7 +26,7 @@ type Props = {
   /** タイトルの下に表示するヘルプメッセージ */
   helpMessage?: ReactNode
   /** タイトルの下に表示するエラーメッセージ */
-  errorMessages?: string | string[]
+  errorMessages?: ReactNode | ReactNode[]
   /** `true` のとき、文字色を `TEXT_DISABLED` にする */
   disabled?: boolean
   /** コンポーネントに適用するクラス名 */
@@ -84,17 +84,15 @@ export const FormGroup: VFC<Props & ElementProps> = ({
       )}
 
       {errorMessages &&
-        (typeof errorMessages === 'string' ? [errorMessages] : errorMessages).map(
-          (message, index) => (
-            <ErrorMessage themes={theme} key={index} className={classNames.errorMessage}>
-              <ErrorIcon
-                color={disabled ? theme.color.TEXT_DISABLED : theme.color.DANGER}
-                themes={theme}
-              />
-              <span>{message}</span>
-            </ErrorMessage>
-          ),
-        )}
+        (Array.isArray(errorMessages) ? errorMessages : [errorMessages]).map((message, index) => (
+          <ErrorMessage themes={theme} key={index} className={classNames.errorMessage}>
+            <ErrorIcon
+              color={disabled ? theme.color.TEXT_DISABLED : theme.color.DANGER}
+              themes={theme}
+            />
+            <span>{message}</span>
+          </ErrorMessage>
+        ))}
       <Body themes={theme} margin={innerMargin} className={classNames.body}>
         {children}
       </Body>

--- a/src/components/SideNav/SideNavItem.tsx
+++ b/src/components/SideNav/SideNavItem.tsx
@@ -14,7 +14,7 @@ type Props = {
   /** アイテムの識別子 */
   id: string
   /** アイテムのタイトル */
-  title: string
+  title: ReactNode
   /** タイトルのプレフィックスの内容。通常、StatusLabel の配置に用います。 */
   prefix?: ReactNode
   /** 選択されているアイテムかどうか */


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- 翻訳用コンポーネントなどを差し込めるようにstring型が指定されている箇所をReactNodeに変更します

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
