### PR TITLE
feat: MessageScreen のロゴを差し替えられるように修正

### DIFF
--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from '@storybook/react'
-import * as React from 'react'
+import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { Base } from '../Base'
@@ -8,12 +8,14 @@ import { FormGroup } from '../FormGroup'
 import { Input } from '../Input'
 import { TextLink } from '../TextLink'
 
+import { Footer } from './Footer'
 import { MessageScreen } from './MessageScreen'
 
 export default {
   title: 'Page Templates（ページテンプレート）/MessageScreen',
   component: MessageScreen,
   parameters: {
+    layout: 'fullscreen',
     withTheming: true,
   },
 }
@@ -151,6 +153,9 @@ export const WithoutChildren: Story = () => (
   />
 )
 WithoutChildren.storyName = 'without children'
+
+export const WithFooter: Story = () => <MessageScreen footer={<Footer />} />
+WithFooter.storyName = 'with footer'
 
 export const WithoutAllOptionalProps: Story = () => <MessageScreen />
 WithoutAllOptionalProps.storyName = 'without all optional props'

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -1,11 +1,12 @@
 import { Story } from '@storybook/react'
 import React from 'react'
-import styled, { css } from 'styled-components'
 
 import { Base } from '../Base'
 import { Button } from '../Button'
 import { FormGroup } from '../FormGroup'
 import { Input } from '../Input'
+import { Stack } from '../Layout'
+import { Text } from '../Text'
 import { TextLink } from '../TextLink'
 
 import { Footer } from './Footer'
@@ -16,7 +17,6 @@ export default {
   component: MessageScreen,
   parameters: {
     layout: 'fullscreen',
-    withTheming: true,
   },
 }
 
@@ -32,13 +32,13 @@ export const Full: Story = () => {
         },
       ]}
     >
-      <Description>
+      <p>
         いつも SmartHR をご利用いただきありがとうございます。
         <br />
         ただいまメンテナンスのため、一時サービスを停止しております。
         <br />
         ご迷惑をおかけいたしますが、ご理解のほどよろしくお願いいたします。
-      </Description>
+      </p>
     </MessageScreen>
   )
 }
@@ -58,38 +58,34 @@ export const WithoutTitle: Story = () => {
         },
       ]}
     >
-      <BoxWrapper>
-        <Box>
-          <List>
-            <li>
-              <FormGroup
-                title="メールアドレス"
-                titleType="subBlockTitle"
-                innerMargin="XXS"
-                htmlFor="id-email"
-              >
-                <Input name="email" id="id-email" width="100%" />
-              </FormGroup>
-            </li>
-            <li>
-              <FormGroup
-                title="パスワード"
-                titleType="subBlockTitle"
-                innerMargin="XXS"
-                htmlFor="id-password"
-              >
-                <Input name="password" id="id-password" width="100%" />
-              </FormGroup>
-            </li>
-          </List>
-          <Bottom>
+      <Base padding={1.5}>
+        <Stack gap={1.5}>
+          <Stack>
+            <FormGroup
+              title="メールアドレス"
+              titleType="subBlockTitle"
+              innerMargin="XXS"
+              htmlFor="id-email"
+            >
+              <Input name="email" id="id-email" width="22em" />
+            </FormGroup>
+            <FormGroup
+              title="パスワード"
+              titleType="subBlockTitle"
+              innerMargin="XXS"
+              htmlFor="id-password"
+            >
+              <Input name="password" id="id-password" width="22em" />
+            </FormGroup>
+          </Stack>
+          <Stack align="center">
             <Button variant="primary" wide>
               ログイン
             </Button>
             <TextLink href="http://example.com">パスワードをお忘れの方</TextLink>
-          </Bottom>
-        </Box>
-      </BoxWrapper>
+          </Stack>
+        </Stack>
+      </Base>
     </MessageScreen>
   )
 }
@@ -99,43 +95,40 @@ export const WithoutLinks: Story = () => {
   return (
     <MessageScreen
       title={
-        <>
-          株式会社 TEST INC
-          <br />
-          <Headline>専用ログイン画面</Headline>
-        </>
+        <Stack as="span" align="center" gap={0.5}>
+          <span>株式会社 TEST INC</span>
+          <Text size="L">専用ログイン画面</Text>
+        </Stack>
       }
     >
-      <Box>
-        <List>
-          <li>
+      <Base padding={1.5}>
+        <Stack gap={1.5}>
+          <Stack>
             <FormGroup
               title="社員番号またはメールアドレス"
               titleType="subBlockTitle"
               innerMargin="XXS"
               htmlFor="id-email"
             >
-              <Input name="email" id="id-email" width="100%" />
+              <Input name="email" id="id-email" width="22em" />
             </FormGroup>
-          </li>
-          <li>
             <FormGroup
               title="パスワード"
               titleType="subBlockTitle"
               innerMargin="XXS"
               htmlFor="id-password"
             >
-              <Input name="password" id="id-password" width="100%" />
+              <Input name="password" id="id-password" width="22em" />
             </FormGroup>
-          </li>
-        </List>
-        <Bottom>
-          <Button variant="primary" wide>
-            ログイン
-          </Button>
-          <TextLink href="http://example.com">パスワードをお忘れの方</TextLink>
-        </Bottom>
-      </Box>
+          </Stack>
+          <Stack align="center">
+            <Button variant="primary" wide>
+              ログイン
+            </Button>
+            <TextLink href="http://example.com">パスワードをお忘れの方</TextLink>
+          </Stack>
+        </Stack>
+      </Base>
     </MessageScreen>
   )
 }
@@ -159,49 +152,3 @@ WithFooter.storyName = 'with footer'
 
 export const WithoutAllOptionalProps: Story = () => <MessageScreen />
 WithoutAllOptionalProps.storyName = 'without all optional props'
-
-const Description = styled.div(
-  ({ theme }) => css`
-    color: ${theme.color.TEXT_BLACK};
-    font-size: ${theme.fontSize.M};
-    line-height: 21px;
-    text-align: center;
-  `,
-)
-
-const BoxWrapper = styled.div`
-  margin-bottom: 16px;
-`
-const Box = styled(Base)`
-  width: 400px;
-  padding: 24px;
-  box-sizing: border-box;
-`
-const List = styled.ul`
-  margin: 0 0 24px;
-  padding: 0;
-  list-style: none;
-
-  > li:first-child {
-    margin-bottom: 16px;
-  }
-`
-const Bottom = styled.div`
-  width: 180px;
-  margin: 0 auto;
-  text-align: center;
-
-  > *:first-child {
-    margin-bottom: 24px;
-  }
-`
-const Headline = styled.span(
-  ({ theme }) => css`
-    display: inline-block;
-    width: 100%;
-    margin-top: 16px;
-    color: ${theme.color.TEXT_BLACK};
-    font-size: ${theme.fontSize.L};
-    text-align: center;
-  `,
-)

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -147,8 +147,7 @@ export const WithoutChildren: Story = () => (
 )
 WithoutChildren.storyName = 'without children'
 
-export const WithFooter: Story = () => <MessageScreen footer={<Footer />} />
+export const WithFooter: Story = () => (
+  <MessageScreen links={[{ label: 'ホームへ', url: 'http://example.com' }]} footer={<Footer />} />
+)
 WithFooter.storyName = 'with footer'
-
-export const WithoutAllOptionalProps: Story = () => <MessageScreen />
-WithoutAllOptionalProps.storyName = 'without all optional props'

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -50,29 +50,27 @@ export const MessageScreen: FC<Props & ElementProps> = ({
       <Box>
         <Logo className={classNames.logo}>{logo}</Logo>
 
-        {(title || children || (links && links.length)) && (
-          <Stack align="center">
-            {title && <Heading className={classNames.title}>{title}</Heading>}
+        <Stack align="center">
+          {title && <Heading className={classNames.title}>{title}</Heading>}
 
-            {children && <Content className={classNames.content}>{children}</Content>}
+          {children && <Content className={classNames.content}>{children}</Content>}
 
-            {links && links.length && (
-              <Links className={classNames.linkList}>
-                {links.map((link, index) => (
-                  <li key={index}>
-                    <TextLink
-                      {...(link.target ? { target: link.target } : {})}
-                      href={link.url}
-                      className={classNames.link}
-                    >
-                      {link.label}
-                    </TextLink>
-                  </li>
-                ))}
-              </Links>
-            )}
-          </Stack>
-        )}
+          {links?.length && (
+            <Links className={classNames.linkList}>
+              {links.map((link, index) => (
+                <li key={index}>
+                  <TextLink
+                    {...(link.target ? { target: link.target } : {})}
+                    href={link.url}
+                    className={classNames.link}
+                  >
+                    {link.label}
+                  </TextLink>
+                </li>
+              ))}
+            </Links>
+          )}
+        </Stack>
       </Box>
 
       {footer && <FooterArea className={classNames.footer}>{footer}</FooterArea>}

--- a/src/components/MessageScreen/MessageScreen.tsx
+++ b/src/components/MessageScreen/MessageScreen.tsx
@@ -1,14 +1,17 @@
-import React, { HTMLAttributes, ReactNode, VFC } from 'react'
+import React, { FC, HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { Heading } from '../Heading'
+import { Center, Stack } from '../Layout'
 import { SmartHRLogo } from '../SmartHRLogo'
 import { TextLink } from '../TextLink'
 
-import { Footer } from './Footer'
 import { useClassNames } from './useClassNames'
 
 type Props = {
+  /** ロゴ */
+  logo?: ReactNode
   /** コンテンツの上に表示されるタイトル */
   title?: ReactNode
   /** コンテンツの下に表示されるアンカー要素のリスト */
@@ -22,16 +25,20 @@ type Props = {
   }>
   /** 表示するコンテンツ */
   children?: ReactNode
+  /** フッター */
+  footer?: ReactNode
   /** コンポーネントに適用するクラス名 */
   className?: string
 }
 
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const MessageScreen: VFC<Props & ElementProps> = ({
+export const MessageScreen: FC<Props & ElementProps> = ({
+  logo = <SmartHRLogo fill="brand" />,
   title,
   links,
   children,
+  footer,
   className = '',
   ...props
 }) => {
@@ -41,108 +48,55 @@ export const MessageScreen: VFC<Props & ElementProps> = ({
   return (
     <Wrapper {...props} themes={theme} className={`${className} ${classNames.wrapper}`}>
       <Box>
-        <Logo className={classNames.logo}>
-          <SmartHRLogo fill="brand" />
-        </Logo>
+        <Logo className={classNames.logo}>{logo}</Logo>
 
-        {title && (
-          <Title themes={theme} className={classNames.title}>
-            {title}
-          </Title>
-        )}
+        {(title || children || (links && links.length)) && (
+          <Stack align="center">
+            {title && <Heading className={classNames.title}>{title}</Heading>}
 
-        {children && (
-          <Content themes={theme} className={classNames.content}>
-            {children}
-          </Content>
-        )}
+            {children && <Content className={classNames.content}>{children}</Content>}
 
-        {links && links.length && (
-          <Links themes={theme} className={classNames.linkList}>
-            {links.map((link, index) => (
-              <li key={index}>
-                <TextLink
-                  {...(link.target ? { target: link.target } : {})}
-                  href={link.url}
-                  className={classNames.link}
-                >
-                  {link.label}
-                </TextLink>
-              </li>
-            ))}
-          </Links>
+            {links && links.length && (
+              <Links className={classNames.linkList}>
+                {links.map((link, index) => (
+                  <li key={index}>
+                    <TextLink
+                      {...(link.target ? { target: link.target } : {})}
+                      href={link.url}
+                      className={classNames.link}
+                    >
+                      {link.label}
+                    </TextLink>
+                  </li>
+                ))}
+              </Links>
+            )}
+          </Stack>
         )}
       </Box>
 
-      <FooterArea themes={theme} className={classNames.footer}>
-        <Footer />
-      </FooterArea>
+      {footer && <FooterArea className={classNames.footer}>{footer}</FooterArea>}
     </Wrapper>
   )
 }
 
-const Wrapper = styled.div<{ themes: Theme }>`
+const Wrapper = styled(Center).attrs({ minHeight: '100vh', verticalCentering: true })<{
+  themes: Theme
+}>`
   ${({ themes }) => {
     const { color } = themes
 
     return css`
-      display: flex;
-      justify-content: center;
-      flex-direction: column;
-      align-items: center;
-      min-height: 100vh;
       background-color: ${color.BACKGROUND};
     `
   }}
 `
-const Box = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: auto 0;
+const Box = styled(Stack).attrs({ gap: 1.5, align: 'center' })`
+  margin-block: auto;
 `
 const Logo = styled.div``
-const Title = styled.h1<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, spacingByChar, color } = themes
-
-    return css`
-      margin: ${spacingByChar(1.5)} 0 0;
-      background-color: ${color.BACKGROUND};
-      color: ${color.TEXT_BLACK};
-      font-weight: normal;
-      font-size: ${fontSize.XL};
-      line-height: 1;
-    `
-  }}
-`
-const Content = styled.div<{ themes: Theme }>`
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      margin-top: ${spacingByChar(1)};
-    `
-  }}
-`
-const Links = styled.ul<{ themes: Theme }>`
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      margin: ${spacingByChar(1)} 0 0;
-      padding: 0;
-      list-style: none;
-      text-align: center;
-      line-height: 1;
-
-      > li:not(:first-child) {
-        margin-top: ${spacingByChar(1)};
-      }
-    `
-  }}
-`
-const FooterArea = styled.div<{ themes: Theme }>`
-  ${({ themes: { spacingByChar } }) => {
-    return css`
-      width: 100%;
-      padding-top: ${spacingByChar(1)};
-    `
-  }}
+const Content = styled.div``
+const Links = styled(Stack).attrs({ as: 'ul', gap: 0.5, align: 'center' })``
+const FooterArea = styled.div`
+  align-self: stretch;
 `


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-594

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

MessageScreen のロゴを props で渡せるようにしました。未指定の場合は SmartHR ロゴが出ます。

ほか、以下の対応を行いました。

- footer も外から渡せるように変更
- footer はデフォルトなしに変更
- スタイリングを見直し
- Story を整理

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
