### PR TITLE
fix: Calendar の初期表示を修正

### DIFF
--- a/src/components/Calendar/Calendar.stories.tsx
+++ b/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const All: Story = () => {
   const [value, setValue] = useState(new Date(2020, 0, 1))
-  const [value2, setValue2] = useState(new Date(2020, 0, 20))
+  const [value2, setValue2] = useState(new Date())
   return (
     <List>
       <dt>Default</dt>
@@ -26,11 +26,35 @@ export const All: Story = () => {
           data-test="calendar-1"
         />
       </dd>
-      <dt>You can set term of selectable date by setting [from] and [to].</dt>
+      <dt>from–to が過去の場合、to を表示する</dt>
       <dd>
         <Calendar
           from={new Date(2020, 0, 10)}
           to={new Date(2020, 1, 10)}
+          onSelectDate={(e, date) => {
+            action('selected')(e, date)
+            setValue2(date)
+          }}
+          value={value2}
+        />
+      </dd>
+      <dt>from–to が未来の場合、from を表示する</dt>
+      <dd>
+        <Calendar
+          from={new Date(2100, 0, 10)}
+          to={new Date(2200, 1, 10)}
+          onSelectDate={(e, date) => {
+            action('selected')(e, date)
+            setValue2(date)
+          }}
+          value={value2}
+        />
+      </dd>
+      <dt>現在が from–to 内の場合、現在を表示する</dt>
+      <dd>
+        <Calendar
+          from={new Date(1900, 0, 10)}
+          to={new Date(2200, 1, 10)}
           onSelectDate={(e, date) => {
             action('selected')(e, date)
             setValue2(date)

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -28,11 +28,11 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
   ({ from = minDate, to, onSelectDate, value, ...props }, ref) => {
     const themes = useTheme()
     const classNames = useClassNames()
-    const fromDay = dayjs(getFromDate(from))
-    const toDay = dayjs(getToDate(to))
+    const fromDate = dayjs(getFromDate(from))
+    const toDate = dayjs(getToDate(to))
     const today = dayjs()
-    const currentDay = toDay.isBefore(today) ? toDay : fromDay.isAfter(today) ? fromDay : today
-    const isValidValue = value && isBetween(value, fromDay.toDate(), toDay.toDate())
+    const currentDay = toDate.isBefore(today) ? toDate : fromDate.isAfter(today) ? fromDate : today
+    const isValidValue = value && isBetween(value, fromDate.toDate(), toDate.toDate())
 
     const [currentMonth, setCurrentMonth] = useState(isValidValue ? dayjs(value) : currentDay)
     const [isSelectingYear, setIsSelectingYear] = useState(false)
@@ -78,7 +78,7 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
           </Button>
           <MonthButtons className={classNames.calendar.monthButtons}>
             <Button
-              disabled={isSelectingYear || prevMonth.isBefore(fromDay, 'month')}
+              disabled={isSelectingYear || prevMonth.isBefore(fromDate, 'month')}
               onClick={() => setCurrentMonth(prevMonth)}
               size="s"
               square
@@ -87,7 +87,7 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
               <FaChevronLeftIcon alt="前の月へ" />
             </Button>
             <Button
-              disabled={isSelectingYear || nextMonth.isAfter(toDay, 'month')}
+              disabled={isSelectingYear || nextMonth.isAfter(toDate, 'month')}
               onClick={() => setCurrentMonth(nextMonth)}
               size="s"
               square
@@ -99,8 +99,8 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
         </Header>
         <TableLayout>
           <YearPicker
-            fromYear={fromDay.year()}
-            toYear={toDay.year()}
+            fromYear={fromDate.year()}
+            toYear={toDate.year()}
             selectedYear={value?.getFullYear()}
             onSelectYear={(year) => {
               setCurrentMonth(currentMonth.year(year))
@@ -111,8 +111,8 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
           />
           <CalendarTable
             current={currentMonth.toDate()}
-            from={fromDay.toDate()}
-            to={toDay.toDate()}
+            from={fromDate.toDate()}
+            to={toDate.toDate()}
             onSelectDate={onSelectDate}
             selected={isValidValue ? value : null}
           />

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -28,12 +28,13 @@ export const Calendar = forwardRef<HTMLElement, Props & ElementProps>(
   ({ from = minDate, to, onSelectDate, value, ...props }, ref) => {
     const themes = useTheme()
     const classNames = useClassNames()
-    const now = dayjs().startOf('date')
     const fromDay = dayjs(getFromDate(from))
     const toDay = dayjs(getToDate(to))
+    const today = dayjs()
+    const currentDay = toDay.isBefore(today) ? toDay : fromDay.isAfter(today) ? fromDay : today
     const isValidValue = value && isBetween(value, fromDay.toDate(), toDay.toDate())
 
-    const [currentMonth, setCurrentMonth] = useState(isValidValue ? dayjs(value) : now)
+    const [currentMonth, setCurrentMonth] = useState(isValidValue ? dayjs(value) : currentDay)
     const [isSelectingYear, setIsSelectingYear] = useState(false)
 
     const yearPickerId = useId()

--- a/src/components/Calendar/calendarHelper.ts
+++ b/src/components/Calendar/calendarHelper.ts
@@ -1,4 +1,7 @@
 import dayjs from 'dayjs'
+import dayjsIsBetween from 'dayjs/plugin/isBetween'
+
+dayjs.extend(dayjsIsBetween)
 
 export const daysInWeek = ['日', '月', '火', '水', '木', '金', '土']
 
@@ -45,11 +48,5 @@ export function getMonthArray(date: Date) {
 }
 
 export function isBetween(date: Date, from: Date, to: Date) {
-  const time = date.getTime()
-
-  return (
-    time >= toRoundDate(from).getTime() && time < dayjs(toRoundDate(to)).add(1, 'day').valueOf()
-  )
+  return dayjs(date).isBetween(from, to, 'day', '[]')
 }
-
-const toRoundDate = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(), d.getDate())


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-607

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DatePicker から Calendar を表示したとき、必ず現在月が表示されてしまい不便なため以下のように修正しました。

- from–toが過去の場合は、toを表示する
- from–toが未来の場合は、fromを表示する
- それ以外の場合は、現在の月を表示する

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
