### PR TITLE
feat: Input に read-only な視覚的表現を追加

### DIFF
--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,10 +1,10 @@
 import { action } from '@storybook/addon-actions'
 import { Story } from '@storybook/react'
-import * as React from 'react'
-import styled, { css } from 'styled-components'
+import React from 'react'
+import styled from 'styled-components'
 
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaSearchIcon } from '../Icon'
+import { Stack } from '../Layout'
 
 import { CurrencyInput } from './CurrencyInput'
 import { Input } from './Input'
@@ -20,63 +20,67 @@ export default {
 }
 
 export const All: Story = () => {
-  const theme = useTheme()
-
   return (
     <List>
-      <li>
-        <Txt>text</Txt>
+      <ListItem>
+        <p>text</p>
         <Input name="text" type="text" defaultValue="string" />
-      </li>
-      <li>
-        <Txt>number</Txt>
+      </ListItem>
+      <ListItem>
+        <p>number</p>
         <Input name="number" type="number" defaultValue="1" />
-      </li>
-      <li>
-        <Txt>password</Txt>
-        <Input name="password" type="password" defaultValue="password" />{' '}
-      </li>{' '}
-      <li>
-        <Txt>width (with %)</Txt>
+      </ListItem>
+      <ListItem>
+        <p>password</p>
+        <Input name="password" type="password" defaultValue="password" />
+      </ListItem>
+      <ListItem>
+        <p>width (with %)</p>
         <Input name="width_with_percent" defaultValue="width: 100%" width="100%" />
-      </li>
-      <li>
-        <Txt>width (with px)</Txt>
+      </ListItem>
+      <ListItem>
+        <p>width (with px)</p>
         <Input name="width_with_px" defaultValue="width: 100px" width="100px" />
-      </li>
-      <li>
-        <Txt>onChange</Txt>
+      </ListItem>
+      <ListItem>
+        <p>onChange</p>
         <Input name="onChange" onChange={action('onChange!!')} />
-      </li>
-      <li>
-        <Txt>onBlur</Txt>
+      </ListItem>
+      <ListItem>
+        <p>onBlur</p>
         <Input name="onBlur" onBlur={action('onBlur!!')} />
-      </li>
-      <li>
-        <Txt>disabled</Txt>
+      </ListItem>
+      <ListItem>
+        <p>readonly</p>
+        <Input name="redOnly" value="これは read-only な input テキスト" readOnly />
+      </ListItem>
+      <ListItem>
+        <p>disabled</p>
         <Input name="disabled" disabled={true} defaultValue="これは disabled なテキスト" />
-      </li>
-      <li>
-        <Txt>error</Txt>
+      </ListItem>
+      <ListItem>
+        <p>error</p>
         <Input name="error" error={true} />
-      </li>
-      <li>
-        <Txt>disabled and error</Txt>
+      </ListItem>
+      <ListItem>
+        <p>disabled and error</p>
+        <p>
+          <code>disabled</code>は<code>error</code>よりも優先されます。
+        </p>
         <Input name="disabled" disabled={true} error={true} />
-        <Note themes={theme}> `disabled` takes precedence over `error`</Note>
-      </li>
-      <li>
-        <Txt>prefix</Txt>
+      </ListItem>
+      <ListItem>
+        <p>prefix</p>
         <Input name="prefix" prefix={<FaSearchIcon />} />
-      </li>
-      <li>
-        <Txt>suffix</Txt>
+      </ListItem>
+      <ListItem>
+        <p>suffix</p>
         <Input name="suffix" suffix={<FaSearchIcon />} />
-      </li>
-      <li>
-        <Txt>extending style (width 50%)</Txt>
+      </ListItem>
+      <ListItem>
+        <p>extending style (width 50%)</p>
         <StyledInput name="extending_style" />
-      </li>
+      </ListItem>
     </List>
   )
 }
@@ -85,47 +89,31 @@ All.storyName = 'all'
 export const Currency: Story = () => {
   const [value, setValue] = React.useState('1234567890')
   return (
-    <Wrapper>
-      <Txt>currency (add comma to integer every 3 digits)</Txt>
-      <CurrencyInput
-        name="currency"
-        value={value}
-        onChange={(e) => {
-          action('changed')(e)
-          setValue(e.target.value)
-        }}
-        onFormatValue={(formatted) => {
-          action('formatted')(formatted)
-          setValue(formatted)
-        }}
-      />
-    </Wrapper>
+    <List>
+      <ListItem>
+        <p>currency (add comma to integer every 3 digits)</p>
+        <CurrencyInput
+          name="currency"
+          value={value}
+          onChange={(e) => {
+            action('changed')(e)
+            setValue(e.target.value)
+          }}
+          onFormatValue={(formatted) => {
+            action('formatted')(formatted)
+            setValue(formatted)
+          }}
+        />
+      </ListItem>
+    </List>
   )
 }
 Currency.storyName = 'CurrencyInput'
 
 export { Default as SearchInput } from './SearchInput/SearchInput.stories'
 
-const List = styled.ul`
-  padding: 0 24px;
-  list-style: none;
-
-  & > li:not(:first-child) {
-    margin-top: 16px;
-  }
-`
-const Txt = styled.p`
-  margin: 0 0 8px;
-`
+const List = styled(Stack).attrs({ as: 'ul' })``
+const ListItem = styled(Stack).attrs({ gap: 0.5, as: 'ListItem', align: 'flex-start' })``
 const StyledInput = styled(Input)`
   width: 50%;
-`
-const Note = styled.div<{ themes: Theme }>`
-  ${({ themes }) => css`
-    margin-top: 8px;
-    color: ${themes.color.TEXT_GREY};
-  `}
-`
-const Wrapper = styled.div`
-  padding: 24px;
 `

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -36,7 +36,10 @@ type Props = {
 type ElementProps = Omit<InputHTMLAttributes<HTMLInputElement>, keyof Props>
 
 export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
-  ({ onFocus, onBlur, autoFocus, prefix, suffix, className = '', width, ...props }, ref) => {
+  (
+    { onFocus, onBlur, autoFocus, prefix, suffix, className = '', width, readOnly, ...props },
+    ref,
+  ) => {
     const theme = useTheme()
     const innerRef = useRef<HTMLInputElement>(null)
 
@@ -78,6 +81,7 @@ export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
       <Wrapper
         themes={theme}
         $width={width}
+        $readOnly={readOnly} // Firefox に :has が来たら置き換えられそう
         $disabled={props.disabled}
         error={props.error}
         onClick={() => innerRef.current?.focus()}
@@ -94,6 +98,7 @@ export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
           onFocus={handleFocus}
           onBlur={handleBlur}
           onWheel={handleWheel}
+          readOnly={readOnly}
           ref={innerRef}
           themes={theme}
           aria-invalid={props.error || undefined}
@@ -118,20 +123,25 @@ const Wrapper = styled.span<{
   themes: Theme
   $width?: string | number
   $disabled?: boolean
+  $readOnly: ElementProps['readOnly']
   error?: boolean
-}>(({ themes, $width = 'auto', $disabled, error }) => {
-  const { border, color, radius, shadow, spacingByChar } = themes
-  return css`
+}>`
+  ${({
+    themes: { border, color, radius, shadow, space },
+    $width = 'auto',
+    $readOnly,
+    $disabled,
+    error,
+  }) => css`
     cursor: text;
     box-sizing: border-box;
     display: inline-flex;
-    gap: ${spacingByChar(0.5)};
+    gap: ${space(0.5)};
     align-items: center;
     border-radius: ${radius.m};
     border: ${border.shorthand};
     background-color: ${color.WHITE};
-    padding-right: ${spacingByChar(0.5)};
-    padding-left: ${spacingByChar(0.5)};
+    padding-inline: ${space(0.5)};
     width: ${typeof $width === 'number' ? `${$width}px` : $width};
 
     &:focus-within {
@@ -142,50 +152,54 @@ const Wrapper = styled.span<{
     css`
       border-color: ${color.DANGER};
     `}
+    ${$readOnly &&
+    css`
+      border-color: ${color.BACKGROUND};
+      background-color: ${color.BACKGROUND};
+    `}
     ${$disabled &&
     css`
       pointer-events: none;
       border-color: ${color.disableColor(color.BORDER)};
       background-color: ${color.hoverColor(color.WHITE)};
     `}
-  `
-})
-const StyledInput = styled.input<Props & { themes: Theme }>(
-  ({ themes: { fontSize, leading, color, radius, spacingByChar } }) =>
-    css`
-      flex-grow: 1;
+  `}
+`
 
-      display: inline-block;
-      outline: none;
-      border-radius: ${radius.m};
-      border: none;
-      background-color: transparent;
-      padding: ${spacingByChar(0.75)} 0;
-      font-size: ${fontSize.M};
-      line-height: ${leading.NONE};
-      color: ${color.TEXT_BLACK};
-      width: 100%;
+const StyledInput = styled.input<Props & { themes: Theme }>`
+  ${({ themes: { fontSize, leading, color, space } }) => css`
+    flex-grow: 1;
 
-      /* font-size * line-height で高さが思うように行かないので、相対値の font-size で高さを指定 */
-      height: ${fontSize.M};
+    display: inline-block;
+    outline: none;
+    border: none;
+    background-color: transparent;
+    padding-block: ${space(0.75)};
+    font-size: ${fontSize.M};
+    line-height: ${leading.NONE};
+    color: ${color.TEXT_BLACK};
+    width: 100%;
 
-      &::placeholder {
-        color: ${color.TEXT_GREY};
-      }
+    /* font-size * line-height で高さが思うように行かないので、相対値の font-size で高さを指定 */
+    height: ${fontSize.M};
 
-      &[disabled] {
-        color: ${color.TEXT_DISABLED};
-        -webkit-text-fill-color: ${color.TEXT_DISABLED};
-        opacity: 1;
-      }
-    `,
-)
-const Affix = styled.span<{ themes: Theme }>(
-  ({ themes: { color } }) => css`
+    &::placeholder {
+      color: ${color.TEXT_GREY};
+    }
+
+    &[disabled] {
+      color: ${color.TEXT_DISABLED};
+      -webkit-text-fill-color: ${color.TEXT_DISABLED};
+      opacity: 1;
+    }
+  `}
+`
+const Affix = styled.span<{ themes: Theme }>`
+  ${({ themes: { color } }) => css`
     flex-shrink: 0;
 
     display: flex;
     align-items: center;
     color: ${color.TEXT_GREY};
-  `,
-)
+  `}
+`

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -12,6 +12,7 @@ import React, {
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { GreyScaleColors } from '../../themes/createColor'
 
 import { useClassNames } from './useClassNames'
 
@@ -28,6 +29,8 @@ type Props = {
   prefix?: ReactNode
   /** コンポーネント内の末尾に表示する内容 */
   suffix?: ReactNode
+  /** 背景色。readOnly を下地の上に載せる場合に使う */
+  bgColor?: GreyScaleColors | 'WHITE'
   /**
    * @deprecated placeholder属性は非推奨です。別途ヒント用要素を設置するか、それらの領域を確保出来ない場合はTooltipコンポーネントの利用を検討してください。
    */
@@ -37,7 +40,18 @@ type ElementProps = Omit<InputHTMLAttributes<HTMLInputElement>, keyof Props>
 
 export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
   (
-    { onFocus, onBlur, autoFocus, prefix, suffix, className = '', width, readOnly, ...props },
+    {
+      onFocus,
+      onBlur,
+      autoFocus,
+      prefix,
+      suffix,
+      className = '',
+      width,
+      readOnly,
+      bgColor,
+      ...props
+    },
     ref,
   ) => {
     const theme = useTheme()
@@ -82,6 +96,7 @@ export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
         themes={theme}
         $width={width}
         $readOnly={readOnly} // Firefox に :has が来たら置き換えられそう
+        bgColor={bgColor}
         $disabled={props.disabled}
         error={props.error}
         onClick={() => innerRef.current?.focus()}
@@ -124,6 +139,7 @@ const Wrapper = styled.span<{
   $width?: string | number
   $disabled?: boolean
   $readOnly: ElementProps['readOnly']
+  bgColor?: Props['bgColor']
   error?: boolean
 }>`
   ${({
@@ -132,6 +148,7 @@ const Wrapper = styled.span<{
     $readOnly,
     $disabled,
     error,
+    bgColor,
   }) => css`
     cursor: text;
     box-sizing: border-box;
@@ -140,7 +157,7 @@ const Wrapper = styled.span<{
     align-items: center;
     border-radius: ${radius.m};
     border: ${border.shorthand};
-    background-color: ${color.WHITE};
+    background-color: ${bgColor ? color[bgColor] : color.WHITE};
     padding-inline: ${space(0.5)};
     width: ${typeof $width === 'number' ? `${$width}px` : $width};
 
@@ -154,8 +171,8 @@ const Wrapper = styled.span<{
     `}
     ${$readOnly &&
     css`
-      border-color: ${color.BACKGROUND};
-      background-color: ${color.BACKGROUND};
+      border-color: ${bgColor ? color[bgColor] : color.BACKGROUND};
+      background-color: ${bgColor ? color[bgColor] : color.BACKGROUND};
     `}
     ${$disabled &&
     css`


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-602

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

フォームコントロールの変化しない値を表すための `readOnly` 機能を追加しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
