### PR TITLE
feat: FormGroup の振る舞いを改善

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -35,23 +35,13 @@ const content = () => {
     <Stack>
       <div>{lorem}</div>
       <div>
-        <FormGroup
-          title="Name"
-          titleType="subBlockTitle"
-          innerMargin="XXS"
-          htmlFor={`id-name-${id}`}
-        >
-          <Input name={`name_${id}`} id={`id-name-${id}`} />
+        <FormGroup title="Name" titleType="subBlockTitle">
+          <Input name={`name_${id}`} />
         </FormGroup>
       </div>
       <div>
-        <FormGroup
-          title="Email"
-          titleType="subBlockTitle"
-          innerMargin="XXS"
-          htmlFor={`id-email-${id}`}
-        >
-          <Input name={`email_${id}`} id={`id-email-${id}`} />
+        <FormGroup title="Email" titleType="subBlockTitle">
+          <Input name={`email_${id}`} />
         </FormGroup>
       </div>
     </Stack>

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -1,8 +1,9 @@
 import { Story } from '@storybook/react'
-import * as React from 'react'
-import styled, { css } from 'styled-components'
+import React from 'react'
 
 import { Input } from '../Input'
+import { Cluster, Stack } from '../Layout'
+import { Text } from '../Text'
 
 import { FormGroup } from './FormGroup'
 
@@ -14,150 +15,115 @@ export default {
   },
 }
 
-type SampleChildrenProps = {
-  id1?: string
-  id2?: string
-  disabled?: boolean
-}
-
-const SampleChildren: React.VFC<SampleChildrenProps> = ({ id1, id2, disabled }) => {
-  return (
-    <SampleWrapper>
-      <SampleFormGroup
-        title="first name"
-        titleType="subSubBlockTitle"
-        innerMargin="XXS"
-        htmlFor={id1}
-        disabled={disabled}
-      >
-        <Input name="id1" id={id1} disabled={disabled} />
-      </SampleFormGroup>
-      <SampleFormGroup
-        title="last name"
-        titleType="subSubBlockTitle"
-        innerMargin="XXS"
-        htmlFor={id2}
-        disabled={disabled}
-      >
-        <Input name="id2" id={id2} disabled={disabled} />
-      </SampleFormGroup>
-    </SampleWrapper>
-  )
-}
-
-const SampleStatusLabelProps = [
-  {
-    type: 'red' as const,
-    children: 'label 1' as const,
-  },
-  {
-    type: 'blue' as const,
-    children: 'label 2' as const,
-  },
-]
-
 export const All: Story = () => {
   return (
-    <Wrapper>
-      <Title>default</Title>
-      <Body>
-        <FormGroup title="Title" titleType="blockTitle" role="group">
-          <SampleChildren id1="id_1-1" id2="id_1-2" />
-        </FormGroup>
-      </Body>
-      <Title>with status label</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          role="group"
-        >
-          <SampleChildren id1="id_2-1" id2="id_2-2" />
-        </FormGroup>
-      </Body>
-      <Title>with help message</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          helpMessage="help message text"
-          role="group"
-        >
-          <SampleChildren id1="id_3-1" id2="id_3-2" />
-        </FormGroup>
-      </Body>
-      <Title>with error messages</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          errorMessages={['error message 1', 'error message 2']}
-          role="group"
-        >
-          <SampleChildren id1="id_4-1" id2="id_4-2" />
-        </FormGroup>
-      </Body>
-      <Title>with all options</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          helpMessage="help message text"
-          errorMessages={['error message 1', 'error message 2']}
-          role="group"
-        >
-          <SampleChildren id1="id_5-1" id2="id_5-2" />
-        </FormGroup>
-      </Body>
-      <Title>disabled</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          helpMessage="help message text"
-          errorMessages="error message"
+    <Stack gap={2} as="dl">
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          基本
+        </Text>
+        <dd>
+          <FormGroup title="フォームコントロール名">
+            <Input name="defaultInput" />
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          すべてのオプション
+        </Text>
+        <dd>
+          <FormGroup
+            title="氏名"
+            statusLabelProps={{ type: 'grey', children: '任意' }}
+            helpMessage="氏名を入力してください。"
+            errorMessages={'氏名が入力されていません。'}
+          >
+            <Input name="fullname" />
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          入れ子
+        </Text>
+        <dd>
+          <FormGroup
+            title="姓名"
+            statusLabelProps={{ type: 'grey', children: '任意' }}
+            helpMessage="姓名を入力してください。"
+            errorMessages="姓名が入力されていません。"
+            role="group"
+          >
+            <Cluster gap={1}>
+              <FormGroup
+                title="姓"
+                titleType="subSubBlockTitle"
+                errorMessages="姓が入力されていません。"
+              >
+                <Input name="lastName" />
+              </FormGroup>
+              <FormGroup
+                title="名"
+                titleType="subSubBlockTitle"
+                errorMessages="名が入力されていません。"
+              >
+                <Input name="firstName" />
+              </FormGroup>
+            </Cluster>
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          読み取り専用
+        </Text>
+        <dd>
+          <FormGroup title="姓名" role="group">
+            <Cluster gap={1}>
+              <FormGroup title="姓" titleType="subSubBlockTitle">
+                <Input name="lastName" value="草野" readOnly />
+              </FormGroup>
+              <FormGroup title="名" titleType="subSubBlockTitle">
+                <Input name="firstName" value="栄一郎" readOnly />
+              </FormGroup>
+            </Cluster>
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
           disabled
-          role="group"
-        >
-          <SampleChildren id1="id_6-1" id2="id_6-2" disabled />
-        </FormGroup>
-      </Body>
-    </Wrapper>
+        </Text>
+        <dd>
+          <FormGroup
+            title="フォームコントロール名"
+            helpMessage="このフォームグループは disabled です。内包するフォームグループは個別に disabled してください。"
+            errorMessages="すべてのフォームコントロールが disabled です。"
+            disabled
+          >
+            <Cluster gap={1}>
+              <FormGroup
+                title="姓"
+                titleType="subSubBlockTitle"
+                errorMessages="姓が入力されていません。"
+                disabled
+              >
+                <Input name="lastName" width="25em" />
+              </FormGroup>
+              <FormGroup
+                title="名"
+                titleType="subSubBlockTitle"
+                errorMessages="名が入力されていません。"
+                disabled
+              >
+                <Input name="firstName" width="25em" />
+              </FormGroup>
+            </Cluster>
+          </FormGroup>
+        </dd>
+      </Stack>
+    </Stack>
   )
 }
 All.storyName = 'all'
-
-const Wrapper = styled.dl`
-  display: block;
-  padding: 24px;
-  margin: 0;
-`
-
-const Title = styled.dt(
-  ({ theme }) => css`
-    display: block;
-    padding: 0;
-    margin: 0 0 16px;
-    color: ${theme.color.TEXT_GREY};
-    font-style: italic;
-  `,
-)
-
-const Body = styled.dd`
-  display: block;
-  padding: 0;
-  margin: 0 0 32px;
-`
-
-const SampleWrapper = styled.div`
-  display: flex;
-  align-items: flex-start;
-`
-
-const SampleFormGroup = styled(FormGroup)`
-  margin-right: 16px;
-`

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -37,7 +37,9 @@ export const All: Story = () => {
             title="氏名"
             statusLabelProps={{ type: 'grey', children: '任意' }}
             helpMessage="氏名を入力してください。"
+            exampleMessage="例：草野栄一郎"
             errorMessages={'氏名が入力されていません。'}
+            supplementaryMessage="※ 補足文はフォームコントロールの下に表示します。"
           >
             <Input name="fullname" />
           </FormGroup>

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -13,6 +13,7 @@ import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
 import { Cluster, Stack } from '../Layout'
 import { StatusLabel } from '../StatusLabel'
+import { Text } from '../Text'
 
 import { useClassNames } from './useClassNames'
 
@@ -34,8 +35,12 @@ type Props = PropsWithChildren<{
   statusLabelProps?: StatusLabelProps | StatusLabelProps[]
   /** タイトルの下に表示するヘルプメッセージ */
   helpMessage?: ReactNode
+  /** タイトルの下に表示する入力例 */
+  exampleMessage?: ReactNode
   /** タイトルの下に表示するエラーメッセージ */
   errorMessages?: ReactNode | ReactNode[]
+  /** フォームコントロールの下に表示する補足メッセージ */
+  supplementaryMessage?: string
   /** `true` のとき、文字色を `TEXT_DISABLED` にする */
   disabled?: boolean
   /** コンポーネントに適用するクラス名 */
@@ -51,7 +56,9 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   innerMargin,
   statusLabelProps = [],
   helpMessage,
+  exampleMessage,
   errorMessages,
+  supplementaryMessage,
   disabled,
   className = '',
   children,
@@ -65,73 +72,85 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
 
   const theme = useTheme()
   const classNames = useClassNames()
+  const describedbyIds = `${managedHtmlFor}_helpMessage ${managedHtmlFor}_exampleMessage ${managedHtmlFor}_supplementaryMessage ${managedHtmlFor}_errorMessage`
 
   return (
     <Wrapper
       {...props}
-      gap={innerMargin || isRoleGroup ? 1 : 0.5}
+      gap={0.25}
       aria-labelledby={isRoleGroup ? managedLabelId : undefined}
-      aria-describedby={
-        isRoleGroup ? `${managedHtmlFor}_helpMessage ${managedHtmlFor}_errorMessage` : undefined
-      }
+      aria-describedby={isRoleGroup ? describedbyIds : undefined}
       themes={theme}
       className={`${className} ${disabledClass} ${classNames.wrapper}`}
     >
-      <Stack gap={0.5}>
-        <Cluster
-          align="center"
-          htmlFor={managedHtmlFor}
-          id={managedLabelId}
-          className={`${classNames.label}`}
-          as="label"
-        >
-          <GroupLabel tag="span" type={titleType}>
-            {title}
-          </GroupLabel>
-          {statusLabelList.length > 0 && (
-            <Cluster gap={0.25} as="span">
-              {statusLabelList.map((statusLabelProp, index) => (
-                <StatusLabel {...statusLabelProp} key={index} />
-              ))}
-            </Cluster>
-          )}
-        </Cluster>
-
-        {helpMessage && (
-          <p className={classNames.helpMessage} id={`${managedHtmlFor}_helpMessage`}>
-            {helpMessage}
-          </p>
-        )}
-
-        {errorMessages && (
-          <Stack gap={0} id={`${managedHtmlFor}_errorMessage`}>
-            {(Array.isArray(errorMessages) ? errorMessages : [errorMessages]).map(
-              (message, index) => (
-                <p key={index}>
-                  <FaExclamationCircleIcon
-                    color={disabled ? 'TEXT_DISABLED' : 'DANGER'}
-                    text={message}
-                    className={classNames.errorMessage}
-                  />
-                </p>
-              ),
+      <Stack gap={innerMargin || isRoleGroup ? 1 : 0.5}>
+        <Stack gap={0.5}>
+          <Cluster
+            align="center"
+            htmlFor={managedHtmlFor}
+            id={managedLabelId}
+            className={`${classNames.label}`}
+            as="label"
+          >
+            <GroupLabel tag="span" type={titleType}>
+              {title}
+            </GroupLabel>
+            {statusLabelList.length > 0 && (
+              <Cluster gap={0.25} as="span">
+                {statusLabelList.map((statusLabelProp, index) => (
+                  <StatusLabel {...statusLabelProp} key={index} />
+                ))}
+              </Cluster>
             )}
-          </Stack>
-        )}
+          </Cluster>
+
+          {helpMessage && (
+            <p className={classNames.helpMessage} id={`${managedHtmlFor}_helpMessage`}>
+              {helpMessage}
+            </p>
+          )}
+          {exampleMessage && (
+            <Text as="p" color="TEXT_GREY" italic id={`${managedHtmlFor}_exampleMessage`}>
+              {exampleMessage}
+            </Text>
+          )}
+
+          {errorMessages && (
+            <Stack gap={0} id={`${managedHtmlFor}_errorMessage`}>
+              {(Array.isArray(errorMessages) ? errorMessages : [errorMessages]).map(
+                (message, index) => (
+                  <p key={index}>
+                    <FaExclamationCircleIcon
+                      color={disabled ? 'TEXT_DISABLED' : 'DANGER'}
+                      text={message}
+                      className={classNames.errorMessage}
+                    />
+                  </p>
+                ),
+              )}
+            </Stack>
+          )}
+        </Stack>
+
+        {React.Children.map(children, (child, i) => {
+          // id があるので、最初の要素以外には付与しない
+          if (!React.isValidElement(child) || i > 0) {
+            return child
+          }
+
+          return React.cloneElement(child as ReactElement, {
+            id: managedHtmlFor,
+            disabled,
+            'aria-describedby': describedbyIds,
+          })
+        })}
       </Stack>
 
-      {React.Children.map(children, (child, i) => {
-        // id があるので、最初の要素以外には付与しない
-        if (!React.isValidElement(child) || i > 0) {
-          return child
-        }
-
-        return React.cloneElement(child as ReactElement, {
-          id: managedHtmlFor,
-          disabled,
-          'aria-describedby': `${managedHtmlFor}_helpMessage ${managedHtmlFor}_errorMessage`,
-        })
-      })}
+      {supplementaryMessage && (
+        <Text as="p" size="S" color="TEXT_GREY" id={`${managedHtmlFor}_supplementaryMessage`}>
+          {supplementaryMessage}
+        </Text>
+      )}
     </Wrapper>
   )
 }

--- a/src/components/FormGroup/useClassNames.ts
+++ b/src/components/FormGroup/useClassNames.ts
@@ -9,11 +9,9 @@ export function useClassNames() {
   return useMemo(
     () => ({
       wrapper: generate(),
-      title: generate('title'),
       label: generate('label'),
       helpMessage: generate('helpMessage'),
       errorMessage: generate('errorMessage'),
-      body: generate('body'),
     }),
     [generate],
   )

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -61,21 +61,11 @@ export const WithoutTitle: Story = () => {
       <Base padding={1.5}>
         <Stack gap={1.5}>
           <Stack>
-            <FormGroup
-              title="メールアドレス"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-email"
-            >
-              <Input name="email" id="id-email" width="22em" />
+            <FormGroup title="メールアドレス">
+              <Input name="email" width="22em" />
             </FormGroup>
-            <FormGroup
-              title="パスワード"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-password"
-            >
-              <Input name="password" id="id-password" width="22em" />
+            <FormGroup title="パスワード">
+              <Input name="password" width="22em" />
             </FormGroup>
           </Stack>
           <Stack align="center">
@@ -104,21 +94,11 @@ export const WithoutLinks: Story = () => {
       <Base padding={1.5}>
         <Stack gap={1.5}>
           <Stack>
-            <FormGroup
-              title="社員番号またはメールアドレス"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-email"
-            >
-              <Input name="email" id="id-email" width="22em" />
+            <FormGroup title="社員番号またはメールアドレス">
+              <Input name="email" width="22em" />
             </FormGroup>
-            <FormGroup
-              title="パスワード"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-password"
-            >
-              <Input name="password" id="id-password" width="22em" />
+            <FormGroup title="パスワード">
+              <Input name="password" width="22em" />
             </FormGroup>
           </Stack>
           <Stack align="center">


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FormGroup の振る舞いを改善しました。

- htmlFor を渡さなくても内部的に id を紐付けるように修正
- helpMessage や errorMessage が適切に紐付けられるように修正
- statusLabel を配列でなくても指定できるように修正
- StatusLabel を label に含めるように修正
- 入力例と補足文を追加
- innerMargin の良いデフォルトを指定
- titleType の良いデフォルトを指定
- 不要なマークアップを削除

ほか、Story を見直しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
