### PR TITLE
feat: ハイコントラストモードに対応

### DIFF
--- a/src/components/Balloon/Balloon.tsx
+++ b/src/components/Balloon/Balloon.tsx
@@ -43,7 +43,7 @@ export const Balloon: VFC<Props & ElementProps> = ({
 // 1pxほど大きめに描画してbody部分と被るようにしています。
 const Base = styled.div<{ themes: Theme }>`
   ${({ themes }) => {
-    const { color, fontSize } = themes
+    const { border, color, fontSize } = themes
 
     return css`
       position: relative;
@@ -56,7 +56,7 @@ const Base = styled.div<{ themes: Theme }>`
       white-space: nowrap;
       transform: translateZ(0); /* safari で filter を正しく描画するために必要 */
 
-      &::before {
+      &::after {
         display: block;
         position: absolute;
         content: '';
@@ -66,59 +66,96 @@ const Base = styled.div<{ themes: Theme }>`
       background-color: ${color.WHITE};
       color: ${color.TEXT_BLACK};
 
-      &.top {
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+
         &::before {
+          display: block;
+          position: absolute;
+          content: '';
+          background-color: ${color.TEXT_BLACK};
+        }
+      }
+
+      &.top {
+        &::before,
+        &::after {
           top: -4px;
           width: 10px;
           height: 5px;
           clip-path: polygon(50% 0, 100% 100%, 0 100%);
         }
+
+        &::before {
+          top: -5px;
+        }
       }
       &.bottom {
-        &::before {
+        &::before,
+        &::after {
           bottom: -4px;
           width: 10px;
           height: 5px;
           clip-path: polygon(0 0, 100% 0, 50% 100%);
         }
+
+        &::before {
+          bottom: -5px;
+        }
       }
 
       &.right {
-        &::before {
+        &::before,
+        &::after {
           right: 24px;
         }
       }
       &.center {
-        &::before {
+        &::before,
+        &::after {
           left: 50%;
           transform: translateX(-5px);
         }
       }
       &.left {
-        &::before {
+        &::before,
+        &::after {
           left: 24px;
         }
       }
 
       &.middle {
-        &::before {
+        &::before,
+        &::after {
           top: 50%;
           transform: translateY(-5px);
         }
         &.left {
-          &::before {
+          &::before,
+          &::after {
             left: -4px;
             width: 5px;
             height: 10px;
             clip-path: polygon(100% 0, 100% 100%, 0 50%);
           }
+
+          &::before {
+            left: -5px;
+          }
         }
         &.right {
-          &::before {
+          &::before,
+          &::after {
             right: -4px;
             width: 5px;
             height: 10px;
             clip-path: polygon(0 0, 100% 50%, 0 100%);
+          }
+
+          &::before {
+            right: -5px;
           }
         }
       }

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -88,10 +88,16 @@ const Wrapper = styled.div<{
   $overflow: Props['overflow']
   $layer: (typeof layerMap)[LayerKeys]
 }>`
-  ${({ themes: { color, shadow }, $padding, $radius, $overflow, $layer }) => css`
+  ${({ themes: { border, color, shadow }, $padding, $radius, $overflow, $layer }) => css`
     box-shadow: ${shadow[$layer]};
     border-radius: ${$radius};
     background-color: ${color.WHITE};
+    @media (prefers-contrast: more) {
+      & {
+        border: ${border.highContrast};
+      }
+    }
+
     ${$padding.block && `padding-block: ${useSpacing($padding.block)};`}
     ${$padding.inline && `padding-inline: ${useSpacing($padding.inline)};`}
     ${$overflow &&

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -89,6 +89,12 @@ const baseStyles = css<StyleProps>(({ wide, $loading, themes }) => {
       ${shadow.focusIndicatorStyles}
     }
 
+    @media (prefers-contrast: more) {
+      & {
+        border: ${border.highContrast};
+      }
+    }
+
     /* baseline より下の leading などの余白を埋める */
     .smarthr-ui-Icon,
     svg {
@@ -168,6 +174,12 @@ function variantStyles(variant: Variant, theme: Theme) {
         focus: css`
           border-color: ${color.hoverColor(color.BORDER)};
           background-color: ${color.hoverColor(color.WHITE)};
+
+          @media (prefers-contrast: more) {
+            & {
+              border-color: ${color.TEXT_BLACK};
+            }
+          }
         `,
         disabled: css`
           border-color: ${color.disableColor(color.BORDER)};
@@ -220,6 +232,7 @@ function variantStyles(variant: Variant, theme: Theme) {
           background-color: ${color.hoverColor(color.WHITE)};
         `,
         disabled: css`
+          border-color: transparent;
           background-color: transparent;
           color: ${color.TEXT_DISABLED};
         `,

--- a/src/components/Calendar/CalendarTable.tsx
+++ b/src/components/Calendar/CalendarTable.tsx
@@ -131,6 +131,12 @@ const DateCell = styled.span<{ themes: Theme; isToday?: boolean; isSelected?: bo
     ${isToday &&
     css`
       border: ${border.shorthand};
+
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+      }
     `}
 
     ${isSelected &&

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -77,10 +77,21 @@ const Box = styled.span<{ themes: Theme; error?: boolean }>`
       box-sizing: border-box;
       pointer-events: none;
 
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+      }
+
       /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input:checked + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
+        @media (prefers-contrast: more) {
+          & {
+            border: ${border.highContrast};
+          }
+        }
       }
 
       /* FIXME: なぜか static classname になってしまうため & を重ねている */

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -412,6 +412,12 @@ const Container = styled.div<{ themes: Theme; width: number | string }>`
       color: ${color.TEXT_GREY};
       cursor: text;
 
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+      }
+
       &.focused {
         box-shadow: ${shadow.OUTLINE};
       }

--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -36,6 +36,12 @@ const Wrapper = styled(Stack).attrs({ gap: 0.25 })<{ themes: Theme }>`
   ${({ themes: { border } }) => css`
     border-bottom: ${border.shorthand};
     border-bottom-style: dotted;
+
+    @media (prefers-contrast: more) {
+      & {
+        border-bottom: ${border.highContrast};
+      }
+    }
   `}
 `
 

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -152,7 +152,7 @@ const Layout = styled.div`
 `
 const Inner = styled.div<StyleProps & { themes: Theme }>`
   ${({ themes, $width, top, right, bottom, left }) => {
-    const { color, radius, shadow, spacingByChar } = themes
+    const { border, color, radius, shadow, spacingByChar } = themes
     const positionRight = exist(right) ? `${right}px` : 'auto'
     const positionBottom = exist(bottom) ? `${bottom}px` : 'auto'
     const positionTop = exist(top) ? `${top}px` : 'auto'
@@ -187,6 +187,12 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
       background-color: ${color.WHITE};
       box-shadow: ${shadow.LAYER3};
       transform: translate(${translateX}, ${translateY});
+
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+      }
     `
   }}
 `

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -161,6 +161,12 @@ const Wrapper = styled.span<{
     padding-inline: ${space(0.5)};
     width: ${typeof $width === 'number' ? `${$width}px` : $width};
 
+    @media (prefers-contrast: more) {
+      & {
+        border: ${border.highContrast};
+      }
+    }
+
     &:focus-within {
       ${shadow.focusIndicatorStyles};
     }

--- a/src/components/InputFile/InputFile.tsx
+++ b/src/components/InputFile/InputFile.tsx
@@ -193,6 +193,12 @@ const InputWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
     padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
     font-size: ${fontSize.M};
 
+    @media (prefers-contrast: more) {
+      & {
+        border: ${border.highContrast};
+      }
+    }
+
     &.small {
       padding: ${spacingByChar(0.5)};
       font-size: ${fontSize.S};

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -128,6 +128,12 @@ const Line = styled.div<{ themes: Theme }>`
 
       &.primary {
         border-color: ${color.BRAND};
+
+        @media (prefers-contrast: more) {
+          & {
+            border-color: ${color.MAIN};
+          }
+        }
       }
       &.light {
         border-color: ${color.WHITE};

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -65,10 +65,22 @@ const Box = styled.span<{ themes: Theme }>`
       background-color: ${color.WHITE};
       box-sizing: border-box;
 
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+      }
+
       /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input:checked + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
+
+        @media (prefers-contrast: more) {
+          & {
+            border: ${border.highContrast};
+          }
+        }
 
         &::before {
           position: absolute;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -159,6 +159,11 @@ const StyledSelect = styled.select<{
     line-height: ${leading.NONE};
     color: ${color.TEXT_BLACK};
     width: 100%;
+    @media (prefers-contrast: more) {
+      & {
+        border: ${border.highContrast};
+      }
+    }
 
     /* padding に依る積み上げでは文字が見切れてしまうため */
     min-height: calc(${fontSize.M} + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);

--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -79,6 +79,12 @@ const Wrapper = styled.span<{ themes: Theme }>`
         border-color: ${color.BORDER};
         color: ${color.TEXT_GREY};
 
+        @media (prefers-contrast: more) {
+          & {
+            border: ${border.highContrast};
+          }
+        }
+
         &.bold {
           border-color: ${color.TEXT_GREY};
           background-color: ${color.TEXT_GREY};

--- a/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
+++ b/src/components/StatusLabel/__snapshots__/StatusLabel.test.tsx.snap
@@ -78,6 +78,12 @@ exports[`StatusLabel should be match snapshot 1`] = `
   border-color: #23221e;
 }
 
+@media (prefers-contrast:more) {
+  .c0.grey {
+    border: 1px solid #23221e;
+  }
+}
+
 <span
   className="c0 grey  smarthr-ui-StatusLabel"
 >

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -44,7 +44,7 @@ export const Table: VFC<Props & ElementProps> = ({
 
 const Wrapper = styled.table<{ fixedHead: boolean; themes: Theme }>`
   ${({ fixedHead, themes }) => {
-    const { color, zIndex } = themes
+    const { border, color, zIndex } = themes
 
     return css`
       width: 100%;
@@ -68,6 +68,14 @@ const Wrapper = styled.table<{ fixedHead: boolean; themes: Theme }>`
 
       th {
         background-color: ${color.HEAD};
+      }
+
+      @media (prefers-contrast: more) {
+        &,
+        & th,
+        & td {
+          border: ${border.highContrast};
+        }
       }
     `
   }}

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -176,6 +176,12 @@ const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: 
     color: ${color.TEXT_BLACK};
     width: ${textAreaWidth};
 
+    @media (prefers-contrast: more) {
+      & {
+        border: ${border.highContrast};
+      }
+    }
+
     ${error &&
     css`
       border-color: ${color.DANGER};

--- a/src/themes/createBorder.ts
+++ b/src/themes/createBorder.ts
@@ -5,6 +5,7 @@ import { ColorProperty, defaultColor } from './createColor'
 const defaultLineWidth = '1px'
 const defaultLineStyle = 'solid'
 const defaultLineColor = defaultColor.BORDER
+const highContrastBorderColor = defaultColor.GREY_100
 
 export interface BorderProperty {
   lineWidth?: string
@@ -16,12 +17,14 @@ export interface CreatedBorderTheme {
   lineWidth: string
   lineStyle: string
   shorthand: string
+  highContrast: string
 }
 
 export const defaultBorder: CreatedBorderTheme = {
   lineWidth: defaultLineWidth,
   lineStyle: defaultLineStyle,
   shorthand: `${defaultLineWidth} ${defaultLineStyle} ${defaultLineColor}`,
+  highContrast: `${defaultLineWidth} ${defaultLineStyle} ${highContrastBorderColor}`,
 }
 
 export const createBorder = (userBorder: BorderProperty = {}, userColor: ColorProperty = {}) => {


### PR DESCRIPTION
## Related URL

## Overview

コントラスト比が高い視覚表現が必要なユーザーが、OSの高コントラスト設定をした時にUIも高コントラストにする

## What I did

`prefers-contrast: more` の時に `border` を `color.GREY_100` にする

## Capture

### Button
<img width="290" alt="ButtonコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206357-a56baf27-b1b0-4791-b554-6d7e7a7188d4.png">

### AccordionPanel
<img width="784" alt="AccordionPanelコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206369-679cb43a-3d00-48c6-ac5f-f7f2751ebf50.png">

### Balloon
<img width="352" alt="BalloonコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット " src="https://user-images.githubusercontent.com/6724665/228206374-85db9f42-ff6b-486e-bce5-b665fbae3fa5.png">

### Base
<img width="738" alt="BaseコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206378-023f4ba3-876c-4d88-bafd-2e7c1909edc3.png">

### Calendar
<img width="339" alt="CalendarコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206385-78b1660a-6ee7-4f99-a750-94e4dfe1362c.png">

### DefinitionList
<img width="777" alt="DefinitionListコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206391-23c9631a-bda5-480f-ad79-465075b91acc.png">

### Table
<img width="761" alt="TableコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206395-e0894906-ba0b-4c17-b66e-e45df58aadec.png">

### Checkbox
<img width="288" alt="CheckboxコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206403-dd548945-ce85-4cc5-aac1-b990fc78ba82.png">

### Input
<img width="259" alt="InputコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206408-9a86c154-12d2-4411-977d-75b50fa4e09d.png">

### Radio
<img width="137" alt="RadioコンポーネントをmacOSのハイコントラストモードでレンダリングしたスクリーンショット" src="https://user-images.githubusercontent.com/6724665/228206412-b3b7a636-c81c-4161-ad9f-736adc05ffb5.png">
