### PR TITLE
feat: MouseEventを扱えるようにする

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -15,9 +15,9 @@ import { DropdownTrigger } from '../DropdownTrigger'
 
 type Props = {
   isFiltered?: boolean
-  onApply: () => void
-  onCancel?: () => void
-  onReset?: () => void
+  onApply: React.MouseEventHandler<HTMLButtonElement>
+  onCancel?: React.MouseEventHandler<HTMLButtonElement>
+  onReset?: React.MouseEventHandler<HTMLButtonElement>
   children: ReactNode
   hasStatusText?: boolean
   decorators?: DecoratorsType<
@@ -93,17 +93,17 @@ export const FilterDropdown: VFC<Props> = ({
         <BottomLayout themes={themes}>
           {onReset && (
             <ResetButtonLayout themes={themes}>
-              <Button variant="text" size="s" prefix={<FaUndoAltIcon />} onClick={() => onReset()}>
+              <Button variant="text" size="s" prefix={<FaUndoAltIcon />} onClick={onReset}>
                 {resetButton}
               </Button>
             </ResetButtonLayout>
           )}
           <RightButtonLayout>
             <DropdownCloser>
-              <Button onClick={() => onCancel?.()}>{cancelButton}</Button>
+              <Button onClick={onCancel}>{cancelButton}</Button>
             </DropdownCloser>
             <DropdownCloser>
-              <Button variant="primary" onClick={() => onApply()}>
+              <Button variant="primary" onClick={onApply}>
                 {applyButton}
               </Button>
             </DropdownCloser>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FilterDropdownで「適用」ボタンを押した際にバリデーションを行い、バリデーションエラーがある場合はDropdownを閉じないような挙動を実現したいです。

利用イメージ

```TypeScript
const handleApply = (e) => {
  const error = validate()
  if (error) e.stopPropagation()
}

<FilterDropdown onApply={handleApply} />
```

現状だと、`onApply` は何の引数も受け取らず、`onApply` 内の処理に応じてDropdownを閉じないような実装は不可能だったため、`onApply` に `onClick` のイベントを渡しつつ、`onApply` 内で `e.stopPropagation()` をすることで今回実現したいことを実装できるようにしました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`onApply`, `onCancel`, `onReset` の I/F を button の `onClick` と同じものにしました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
