### PR TITLE
chore: DatePicker の showAlternative のreturnにReactNodeを渡せるように変更

### DIFF
--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -50,6 +50,14 @@ export const All: Story = () => {
           showAlternative={() => '平成6年9月28日'}
         />
       </dd>
+      <dt>Show Alternative Formatted Date(ReactNode)</dt>
+      <dd>
+        <DatePicker
+          name="show_alternative"
+          value="1994/09/28"
+          showAlternative={() => <span data-translate="true">平成6年9月28日</span>}
+        />
+      </dd>
       <dt>Disabled</dt>
       <dd>
         <DatePicker name="disabled" disabled />

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import React, {
+  ReactNode,
   forwardRef,
   useCallback,
   useEffect,
@@ -48,7 +49,7 @@ type Props = {
   /** 表示する日付を独自にフォーマットする場合に、フォーマット処理を記述する関数 */
   formatDate?: (date: Date | null) => string
   /** 入出力用文字列と併記する別フォーマット処理を記述する関数 */
-  showAlternative?: (date: Date | null) => string
+  showAlternative?: (date: Date | null) => ReactNode
   /** 選択された日付が変わった時に発火するコールバック関数 */
   onChangeDate?: (date: Date | null, value: string, other: { errors: string[] }) => void
 }
@@ -126,7 +127,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
     const [inputRect, setInputRect] = useState<DOMRect | null>(null)
     const [isInputFocused, setIsInputFocused] = useState(false)
     const [isCalendarShown, setIsCalendarShown] = useState(false)
-    const [alternativeFormat, setAlternativeFormat] = useState<null | string>(null)
+    const [alternativeFormat, setAlternativeFormat] = useState<null | ReactNode>(null)
     const calenderId = useId()
 
     useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- DatePicker の showAlternative のreturn型をReactNodeに変更することで、翻訳用コンポーネントなどを指定可能にした

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
