### PR TITLE
feat: FilterDropdown の trigger に任意の button props を渡せるようにする

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -92,6 +92,21 @@ export const Default: Story = () => {
             </p>
           </FilterDropdown>
         </dd>
+        <dt>disabled</dt>
+        <dd>
+          <FilterDropdown
+            onApply={() => setIsFiltered(true)}
+            onCancel={() => setIsFiltered(false)}
+            onReset={() => {
+              setValue('hoge')
+              setText('')
+            }}
+            isFiltered={isFiltered}
+            disabled
+          >
+            disabled
+          </FilterDropdown>
+        </dd>
         <dt>Custom text</dt>
         <dd>
           <FilterDropdown

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, VFC, useMemo } from 'react'
+import React, { ButtonHTMLAttributes, FC, ReactNode, useMemo } from 'react'
 import innerText from 'react-innertext'
 import styled, { css } from 'styled-components'
 
@@ -24,6 +24,7 @@ type Props = {
     'status' | 'triggerButton' | 'applyButton' | 'cancelButton' | 'resetButton'
   >
 }
+type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof Props>
 
 const STATUS_FILTERED_TEXT = '適用中'
 const TRIGGER_BUTTON_TEXT = '絞り込み'
@@ -34,7 +35,7 @@ const RESET_BUTTON_TEXT = '絞り込み条件を解除'
 const executeDecorator = (defaultText: string, decorator: DecoratorType | undefined) =>
   decorator?.(defaultText) || defaultText
 
-export const FilterDropdown: VFC<Props> = ({
+export const FilterDropdown: FC<Props & ElementProps> = ({
   isFiltered = false,
   onApply,
   onCancel,
@@ -42,6 +43,7 @@ export const FilterDropdown: VFC<Props> = ({
   children,
   hasStatusText,
   decorators,
+  ...props
 }: Props) => {
   const themes = useTheme()
   const status: ReactNode = useMemo(
@@ -73,6 +75,7 @@ export const FilterDropdown: VFC<Props> = ({
     <Dropdown>
       <DropdownTrigger>
         <Button
+          {...props}
           suffix={
             <IsFilteredIconWrapper isFiltered={isFiltered} themes={themes}>
               <FaFilterIcon />


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FilterDropdown の trigger button を disabled にしたいケースがある
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

DropdownMenuButton を参考に、trigger button に任意の button props を渡せるようにした。
https://github.com/kufu/smarthr-ui/blob/9dfcbfd25fe051320ac8130d9c1097952e876ebc/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx#L39

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
