### PR TITLE
feat: AppLauncher の多言語化対応

### DIFF
--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -1,7 +1,8 @@
-import React, { HTMLAttributes, ReactNode } from 'react'
+import React, { HTMLAttributes, ReactNode, useMemo } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
+import { DecoratorsType } from '../../../types/props'
 import { Button } from '../../Button'
 import { Dropdown, DropdownContent, DropdownScrollArea, DropdownTrigger } from '../../Dropdown'
 import { Heading } from '../../Heading'
@@ -23,13 +24,26 @@ type Category = {
 type Props = {
   apps: Category[]
   urlToShowAll?: string | null
+  /** コンポーネント内の文言を変更するための関数を設定 */
+  decorators?: DecoratorsType<'buttonLabel'>
 }
-
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>
 
-export const AppLauncher: React.FC<Props & ElementProps> = ({ apps, urlToShowAll, ...props }) => {
+const BUTTON_LABEL = 'アプリ'
+
+export const AppLauncher: React.FC<Props & ElementProps> = ({
+  apps,
+  urlToShowAll,
+  decorators,
+  ...props
+}) => {
   const theme = useTheme()
   const classNames = useClassNames()
+
+  const buttonLabel = useMemo(
+    () => decorators?.buttonLabel?.(BUTTON_LABEL) || BUTTON_LABEL,
+    [decorators],
+  )
 
   const baseApps = apps.find(({ type }) => type === 'base')
   const others = apps.filter((category) => category !== baseApps)
@@ -38,7 +52,7 @@ export const AppLauncher: React.FC<Props & ElementProps> = ({ apps, urlToShowAll
     <Dropdown {...props}>
       <DropdownTrigger>
         <AppsButton themes={theme} prefix={<FaToolboxIcon />}>
-          アプリ
+          {buttonLabel}
         </AppsButton>
       </DropdownTrigger>
       <DropdownContent controllable>

--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react'
+import React, { HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
@@ -13,9 +13,9 @@ import { useClassNames } from './useClassNames'
 
 type Category = {
   type?: string
-  heading: string
+  heading: ReactNode
   items: Array<{
-    label: string
+    label: ReactNode
     url: string
     target?: string
   }>

--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -25,11 +25,11 @@ type Props = {
   apps: Category[]
   urlToShowAll?: string | null
   /** コンポーネント内の文言を変更するための関数を設定 */
-  decorators?: DecoratorsType<'buttonLabel'>
+  decorators?: DecoratorsType<'triggerLabel'>
 }
 type ElementProps = Omit<HTMLAttributes<HTMLElement>, keyof Props>
 
-const BUTTON_LABEL = 'アプリ'
+const TRIGGER_LABEL = 'アプリ'
 
 export const AppLauncher: React.FC<Props & ElementProps> = ({
   apps,
@@ -40,8 +40,8 @@ export const AppLauncher: React.FC<Props & ElementProps> = ({
   const theme = useTheme()
   const classNames = useClassNames()
 
-  const buttonLabel = useMemo(
-    () => decorators?.buttonLabel?.(BUTTON_LABEL) || BUTTON_LABEL,
+  const triggerLabel = useMemo(
+    () => decorators?.triggerLabel?.(TRIGGER_LABEL) || TRIGGER_LABEL,
     [decorators],
   )
 
@@ -52,7 +52,7 @@ export const AppLauncher: React.FC<Props & ElementProps> = ({
     <Dropdown {...props}>
       <DropdownTrigger>
         <AppsButton themes={theme} prefix={<FaToolboxIcon />}>
-          {buttonLabel}
+          {triggerLabel}
         </AppsButton>
       </DropdownTrigger>
       <DropdownContent controllable>


### PR DESCRIPTION
## Related URL

🍐 

## Overview

AppLauncher のトリガーとなる「アプリ」というボタンラベルや、中身のコンテンツが現在翻訳の対応ができていないため、対応したい。

## What I did

- string で渡さなければいけない props を ReactNode に変更した
- decorators props を生やした

## Capture

🍐 
