### PR TITLE
chore: Calendar の Story に毎回差分が出ないようにする

### DIFF
--- a/src/components/Calendar/Calendar.stories.tsx
+++ b/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 export const All: Story = () => {
   const [value, setValue] = useState(new Date(2020, 0, 1))
-  const [value2, setValue2] = useState(new Date())
+  const [value2, setValue2] = useState(new Date(2023, 3, 1))
   return (
     <List>
       <dt>Default</dt>
@@ -50,7 +50,7 @@ export const All: Story = () => {
           value={value2}
         />
       </dd>
-      <dt>現在が from–to 内の場合、現在を表示する</dt>
+      <dt>現在（2023/04/01）が from–to 内の場合、現在を表示する</dt>
       <dd>
         <Calendar
           from={new Date(1900, 0, 10)}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

表題のとおりです。
Calendar の Story の内部で `new Date()` が使われており、ビルドの度にその日の日付の状態でスナップショットが取られてしまい、関係のないPRでも差分が出てしまっていました。

差分の例
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=6445d467687d687ba00508dc

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

現在を 2023/04/01 とし、ビルドごとに Calendar の Story に差分が出ないようにしました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
