### PR TITLE
chore: smarthr-ui-props.jsonがリリースに含まれるようworkflowを調整

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           git checkout master
           git cherry-pick $NEW_TAG
+      - name: update ui-props.json
+        run: |
+          yarn export:ui-props
+          git add public/exports/smarthr-ui-props.json && git diff --cached --exit-code --quiet || git commit -m 'chore: Update smarthr-ui-props.json'
       - name: craete pull request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -50,8 +50,6 @@ jobs:
       - name: push branch
         run: |
           git checkout -b release-candidate
-          yarn export:ui-props
-          git add public/exports/smarthr-ui-props.json && git diff --cached --exit-code --quiet || git commit -m 'chore: Update smarthr-ui-props.json'
           git push origin release-candidate
       - name: release issue labels
         if: ${{ env.IS_PRERELEASE == 'false' }}


### PR DESCRIPTION
## Related URL
https://github.com/kufu/smarthr-ui/pull/3267

## Overview
`public/exports/smarthr-ui-props.json`の更新がうまくリリースに反映できていたかったため、コミットを追加するタイミングを調整しました。

## What I did
`release-candidate`ではなく、リリース処理の開始時点の`master`ブランチもしくは`merge-release-v...`ブランチにpushされている必要がありそうでしたので、`merge-release-v...`ブランチとPRが作られる直前にコミットを作成する（pushはしない）ように変更しました。

## Capture
UIコンポーネント自体への影響はありません