### PR TITLE
fix: Th のソートアイコンがフォントサイズに依って重なるバグを修正

### DIFF
--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -10,7 +10,6 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaSortDownIcon, FaSortUpIcon } from '../Icon'
-import { Stack } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { useThClassNames } from './useClassNames'
@@ -140,4 +139,11 @@ const SortIcon: FC<Pick<Props, 'sort'>> = ({ sort }) => (
   </SortIconWraper>
 )
 
-const SortIconWraper = styled(Stack).attrs({ as: 'span', gap: -1, inline: true })``
+const SortIconWraper = styled.span`
+  display: inline-flex;
+  flex-direction: column;
+
+  .smarthr-ui-Icon + .smarthr-ui-Icon {
+    margin-top: -1em;
+  }
+`


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-682

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

手元で以下のスタイルを充てて確認しました。

```tsx
  const theme = createTheme({
    fontSize: {
      htmlFontSize: 10,
      S: '1.1rem',
      M: '1.4rem',
      L: '1.8rem',
      XL: '2.4rem',
    },
  })

const SmartHRGlobalStyle = createGlobalStyle`
  ${CssBaseLine}

  html {
    font-size: 62.5%;
  }
`
```

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
