### PR TITLE
feat: DropdownMenuButton の childrenに型的に渡される可能性のあるfalsyな値を許容する

### DIFF
--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -7,7 +7,16 @@ import { Cluster } from '../../Layout'
 
 import { DropdownMenuButton } from './DropdownMenuButton'
 
-const nullText: string = ''
+const emptyAry: any[] = []
+const falsyText: string = ''
+const falsyAry: any[] | undefined = undefined
+const falsyFunction: (() => void) | undefined = undefined
+const falsyObj: { [key: string]: any } | undefined = undefined
+
+const truthyText: string = 'ok'
+const truthyAry: any[] | undefined = ['ok']
+const truthyFunction: (() => void) | undefined = () => undefined
+const truthyObj: { [key: string]: any } | undefined = {}
 
 const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'children'>> = (props) => (
   <DropdownMenuButton {...props}>
@@ -22,11 +31,22 @@ const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'childr
     </Button>
     <Button>ヒントメッセージの設定</Button>
     <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    {nullText}
-    {false}
-    {undefined}
     {null}
-    {[].length && <Button>非表示になるテキスト</Button>}
+    {undefined}
+    {false}
+    {emptyAry.length && <Button>非表示になるボタン</Button>}
+    {falsyText && <Button>非表示になるボタン</Button>}
+    {falsyAry && <Button>非表示になるボタン</Button>}
+    {falsyFunction && <Button>非表示になるボタン</Button>}
+    {falsyObj && <Button>非表示になるボタン</Button>}
+    {truthyAry.length && <Button>表示になるボタン(length)</Button>}
+    {truthyText && <Button>表示になるボタン(text)</Button>}
+    {emptyAry && <Button>表示になるボタン(array)</Button>}
+    {
+      // @ts-ignore
+      truthyFunction && <Button>表示になるボタン(function)</Button>
+    }
+    {truthyObj && <Button>表示になるボタン(object)</Button>}
     <RemoteDialogTrigger targetId="hoge">
       <Button>Triggerのテスト</Button>
     </RemoteDialogTrigger>

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -7,7 +7,7 @@ import { Cluster } from '../../Layout'
 
 import { DropdownMenuButton } from './DropdownMenuButton'
 
-const flag = false
+const nullText: string = ''
 
 const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'children'>> = (props) => (
   <DropdownMenuButton {...props}>
@@ -22,7 +22,11 @@ const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'childr
     </Button>
     <Button>ヒントメッセージの設定</Button>
     <AnchorButton href="#h2-2">ログアウト</AnchorButton>
-    {flag && <Button>非表示になるテキスト</Button>}
+    {nullText}
+    {false}
+    {undefined}
+    {null}
+    {[].length && <Button>非表示になるテキスト</Button>}
     <RemoteDialogTrigger targetId="hoge">
       <Button>Triggerのテスト</Button>
     </RemoteDialogTrigger>

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -27,15 +27,8 @@ type ActionItemTruthyType =
   | ReactElement<ComponentProps<typeof RemoteDialogTrigger>>
 // HINT: このコンポーネントは以下のような記法で利用される場合が多いため、判定に利用されうる型を許容する
 // <DropdownMenuButton>{hoge && <Button {...props} />}</DropdownMenuButton>
-type ActionItemFalsyType =
-  | null
-  | undefined
-  | boolean
-  | number
-  | string
-  | ((...props: any[]) => any)
-  | { [key: string]: any }
-type ActionItem = ActionItemTruthlyType | ActionItemFalsyType
+type ActionItemFalsyType = null | undefined | boolean | 0 | ''
+type ActionItem = ActionItemTruthyType | ActionItemFalsyType
 
 type Props = {
   /** 引き金となるボタンラベル */
@@ -94,7 +87,7 @@ export const DropdownMenuButton: FC<Props & ElementProps> = ({
             {React.Children.map(children, (item, i) =>
               // MEMO: {flag && <Button/>}のような書き方に対応させる為、型を変換する
               // itemの存在チェックでfalsyな値は弾かれている想定
-              item ? <li key={i}>{actionItem(item as ActionItemTruthlyType)}</li> : null,
+              item ? <li key={i}>{actionItem(item as ActionItemTruthyType)}</li> : null,
             )}
           </ActionList>
         </DropdownScrollArea>

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -21,7 +21,7 @@ import { useClassNames } from './useClassNames'
 type Actions = ActionItem | ActionItem[]
 
 // これでコンポーネントを絞れるわけではないが Button[variant=text] を使ってほしいんだよ! という気持ち
-type ActionItemTruthlyType =
+type ActionItemTruthyType =
   | ReactElement<ComponentProps<typeof Button>>
   | ReactElement<ComponentProps<typeof AnchorButton>>
   | ReactElement<ComponentProps<typeof RemoteDialogTrigger>>

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -19,13 +19,24 @@ import { Stack } from '../../Layout'
 import { useClassNames } from './useClassNames'
 
 type Actions = ActionItem | ActionItem[]
+
 // これでコンポーネントを絞れるわけではないが Button[variant=text] を使ってほしいんだよ! という気持ち
-type ActionItem =
+type ActionItemTruthlyType =
   | ReactElement<ComponentProps<typeof Button>>
   | ReactElement<ComponentProps<typeof AnchorButton>>
   | ReactElement<ComponentProps<typeof RemoteDialogTrigger>>
+// HINT: このコンポーネントは以下のような記法で利用される場合が多いため、判定に利用されうる型を許容する
+// <DropdownMenuButton>{hoge && <Button {...props} />}</DropdownMenuButton>
+type ActionItemFalsyType =
   | null
+  | undefined
   | boolean
+  | number
+  | string
+  | ((...props: any[]) => any)
+  | { [key: string]: any }
+type ActionItem = ActionItemTruthlyType | ActionItemFalsyType
+
 type Props = {
   /** 引き金となるボタンラベル */
   label: ReactNode
@@ -81,8 +92,9 @@ export const DropdownMenuButton: FC<Props & ElementProps> = ({
         <DropdownScrollArea>
           <ActionList themes={themes} className={classNames.panel}>
             {React.Children.map(children, (item, i) =>
-              // MEMO: {flag && <Button/>}のような書き方に対応させるためbooleanの判定を入れています
-              item && typeof item !== 'boolean' ? <li key={i}>{actionItem(item)}</li> : null,
+              // MEMO: {flag && <Button/>}のような書き方に対応させる為、型を変換する
+              // itemの存在チェックでfalsyな値は弾かれている想定
+              item ? <li key={i}>{actionItem(item as ActionItemTruthlyType)}</li> : null,
             )}
           </ActionList>
         </DropdownScrollArea>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- DropdownMenuButtonのchildrenの型を調整した

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- DropdownMenuButtonのchildren内は `A && <Button />` のような判定が他用される
- Aにはbool以外にも `array.length` や `responseMessage` のようにnumberやstringなど、ほぼすべての型が利用される
  - 実際にはfalsy or ReactElement以外になることは利用目的的には存在しないはず
- 利用実態に合わせた型に変更したい

## Capture

<!--
Please attach a capture if it looks different.
-->
