### PR TITLE
chore: ButtonのdisabledDetailオプション利用時に表示されるアイコンが小さくなってしまう場合に対処する

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -116,6 +116,9 @@ const DisabledDetailWrapper = styled(Cluster).attrs({
         /* Tooltip との距離を変えずに反応範囲を広げるために negative space を使う */
         margin: ${space(-0.25)};
         padding: ${space(0.25)};
+
+        /* global styleなどでborder-boxが適用されている場合表示崩れを起こす為、content-boxを指定する */
+        box-sizing: content-box;
         color: ${color.TEXT_GREY};
       }
     }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- Button disabledDetail オプションで表示されるアイコンが表示崩れする場合があるため対応したい

## Capture

<!--
Please attach a capture if it looks different.
-->
