### PR TITLE
docs: Icon の story にアイコン名を表示させる

### DIFF
--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -125,6 +125,8 @@ export const createIcon = (SvgIcon: IconType) => {
     )
   }
 
+  Icon.displayName = SvgIcon.name || ''
+
   return Icon
 }
 

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -125,7 +125,7 @@ export const createIcon = (SvgIcon: IconType) => {
     )
   }
 
-  Icon.displayName = SvgIcon.name || ''
+  Icon.displayName = SvgIcon.name
 
   return Icon
 }


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-674

## Overview

アイコンの名前が storybook 上で確認できなくなっていたので、見えるようにしたい

## What I did

Icon を別コンポーネントでラップすることで displayName が消滅してしまっていたため、明示的に displayName を設定するようにした

## Capture

### Before

![image](https://user-images.githubusercontent.com/11153463/235032562-b3786504-1363-4314-bc2c-342ff9e2ce31.png)

### After

![image](https://user-images.githubusercontent.com/11153463/235032496-dd237081-055a-4016-bf52-a3ff5166fd1a.png)
