### PR TITLE
fix: onAdd の型を ReactNode から string に変更

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -84,11 +84,11 @@ export const Single: Story = () => {
     setSelectedItem(null)
   }, [])
   const handleAddItem = useCallback(
-    (label: ReactNode) => {
+    (label: string) => {
       action('onAdd')(label)
       const newItem = {
         label,
-        value: `new-value-${seq}`,
+        value: label,
       }
       setItems([...items, newItem])
       setSelectedItem(newItem)
@@ -340,11 +340,11 @@ export const Multi: Story = () => {
     [selectedItems],
   )
   const handleAddItem = useCallback(
-    (label: ReactNode) => {
+    (label: string) => {
       action('onAdd')(label)
       const newItem = {
         label,
-        value: `new-value-${seq}`,
+        value: label,
       }
       setItems([...items, newItem])
       setSelectedItems([...selectedItems, newItem])

--- a/src/components/ComboBox/types.ts
+++ b/src/components/ComboBox/types.ts
@@ -70,7 +70,7 @@ export type BaseProps<T> = {
   /**
    * `items` 内に存在しないアイテムが追加されたときに発火するコールバック関数
    */
-  onAdd?: (label: ReactNode) => void
+  onAdd?: (label: string) => void
   /**
    * アイテムが選択された時に発火するコールバック関数
    */

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -29,7 +29,7 @@ type Props<T> = {
   options: Array<ComboBoxOption<T>>
   dropdownHelpMessage?: ReactNode
   dropdownWidth?: string | number
-  onAdd?: (label: ReactNode) => void
+  onAdd?: (label: string) => void
   onSelect: (item: ComboBoxItem<T>) => void
   isExpanded: boolean
   isLoading?: boolean
@@ -163,7 +163,7 @@ export function useListBox<T>({
         }
         e.stopPropagation()
         if (activeOption.isNew) {
-          onAdd && onAdd(activeOption.item.label)
+          onAdd && onAdd(activeOption.item.value)
         } else {
           onSelect(activeOption.item)
         }
@@ -191,7 +191,7 @@ export function useListBox<T>({
       // HINT: Dropdown系コンポーネント内でComboBoxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
       // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
       requestAnimationFrame(() => {
-        onAdd && onAdd(option.item.label)
+        onAdd && onAdd(option.item.value)
       })
     },
     [onAdd],


### PR DESCRIPTION
## Related URL

#3270 

## Overview

上記に記載したPRの対応で `ComboBoxItem["label"]` の型が `ReactNode`に変更された。
この際、`onAdd`関数の引数として定義している label の型も同様に`ReactNode`に変更されているが、onAdd関数はユーザーが items に選択肢として存在しない label 名を selectedItems に新規追加する場合に発火する関数であり、文字列として処理をする想定になっている。（入力フォームに入力した値がReactNodeであるはずがない）

ComboBoxを利用する場合にonAddによって items に存在しない任意の文字を追加した場合、onAddの引数で受け取った label をもとに`{ label, value: label }`といった形でそれらしい要素を追加する関数を用意する必要があるが、onAddの引数の型が`string` → `ReactNode`になったことによって string 型である value に対して ReactNode を割り当てようとすることになって既存の実装を破壊してしまうケースがあった。

上述したとおりだが、ユーザーが ComboBox に任意で入力した新規の選択項目の値が ReactNode であるはずがないので文字列型としてよしなに要素を追加できるように修正した。

## What I did

- `ComboBox["onAdd"]`の型を以下の様に変更
  - ```diff
    - onAdd?: (label: ReactNode) => void
    + onAdd?: (label: string) => void
    ```
- 関連箇所の修正
  - `useListBox#handleAdd`などのユーザーから selectedItems に存在しない任意の文字列の要素を新規で追加された場合、Item の value と label は同じ文字列の値（ユーザーによって入力された文字列）が割り当てられている状態になるので、型の都合が良い value を参照するように修正しています

## Capture

<!--
Please attach a capture if it looks different.
-->
