### PR TITLE
fix: SideMenuItem の :focusを :focus-visible に変更

### DIFF
--- a/src/components/Experimental/SideMenu/SideMenuItem.tsx
+++ b/src/components/Experimental/SideMenu/SideMenuItem.tsx
@@ -73,7 +73,7 @@ const Item = styled.li<{ current: Props['current']; themes: Theme }>`
         background-color: ${color.hoverColor(color.GREY_9)};
       }
 
-      &:focus {
+      &:focus-visible {
         /* フォーカスリングを前に出したいので、スタッキングコンテキストを発生させている */
         position: relative;
         z-index: 1;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- SideMenuItem に `:focus` が 指定されておりクリック時にフォーカスリングが表示されるのですが、 `:focus-visible` の方が自然な挙動に思えたので変更しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- SideMenuItem の `:focus` を `:focus-visible` に変更

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

SideMenuItem クリック時
| Before | After |
| --- | --- |
|![image](https://github.com/kufu/smarthr-ui/assets/16136015/000f6760-1eb9-4294-b76f-aa5eef342a2d)|![image](https://github.com/kufu/smarthr-ui/assets/16136015/0e0aa8e6-e5c6-43d9-8dcc-4f5980a2a383)|

<!--
Please attach a capture if it looks different.
-->
