### PR TITLE
test: masterブランチマージ後のChromaticビルドを自動Acceptにし、Approve済みの差分が検出されないようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,14 @@ commands:
           command: yarn test-storybook:ci
       - store_test_results:
           path: junit.xml
-  # chromatic
   run-chromatic:
     steps:
       - checkout
       - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
+  run-chromatic-master:
+    steps:
+      - checkout
+      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes
   install-noto-sans-cjk-jp:
     steps:
       - run:
@@ -105,6 +108,11 @@ jobs:
     steps:
       - setup-for-test
       - run-chromatic
+  chromatic-deployment-master:
+    executor: node-active-lts
+    steps:
+      - setup-for-test
+      - run-chromatic-master
 workflows:
   multiple_builds:
     jobs:
@@ -115,4 +123,14 @@ workflows:
       - a11y-test:
           context: smarthr-dockerhub
       - chromatic-deployment:
+          filters:
+            branches:
+              ignore:
+                - master
+          context: smarthr-dockerhub
+      - chromatic-deployment-master:
+          filters:
+            branches:
+              only:
+                - master
           context: smarthr-dockerhub


### PR DESCRIPTION
## Related URL

参考
https://uga-box.hatenablog.com/entry/2022/05/09/000000

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Chromaticの差分が毎回出てしまう問題ですが、masterにマージする際にSquash Mergeを使っているのが原因っぽかったです。
コミットごとにChromaticでApproveをしていますが、Squash Mergeをすることでmasterブランチにマージ後に新規コミットとしてChromaticが検出するため、未確認の差分が毎回発生していたようです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

上記の記事を参考にしつつmasterブランチでのchromaticビルドは自動Acceptするようにしました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
