### PR TITLE
feat!: FormGroup をセマンティックに扱えるよう修正

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -35,22 +35,12 @@ const content = () => {
     <Stack>
       <div>{lorem}</div>
       <div>
-        <FormGroup
-          title="Name"
-          titleType="subBlockTitle"
-          innerMargin="XXS"
-          htmlFor={`id-name-${id}`}
-        >
+        <FormGroup title="Name" htmlFor={`id-name-${id}`}>
           <Input name={`name_${id}`} id={`id-name-${id}`} />
         </FormGroup>
       </div>
       <div>
-        <FormGroup
-          title="Email"
-          titleType="subBlockTitle"
-          innerMargin="XXS"
-          htmlFor={`id-email-${id}`}
-        >
+        <FormGroup title="Email" htmlFor={`id-email-${id}`}>
           <Input name={`email_${id}`} id={`id-email-${id}`} />
         </FormGroup>
       </div>

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactNode, VFC } from 'react'
+import React, { FC, HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
@@ -29,9 +29,9 @@ type Props = Omit<React.ComponentProps<typeof Input>, 'error'> & {
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 /**
- * @deprecated The FieldSet component is deprecated, so use FormGroup component instead.
+ * @deprecated `Fieldset` コンポーネントは非推奨です。代わりに `FormControl` を使ってください。
  */
-export const FieldSet: VFC<Props & ElementProps> = ({
+export const FieldSet: FC<Props & ElementProps> = ({
   label,
   labelType = 'subBlockTitle',
   labelTagType = 'span',

--- a/src/components/FormControl/FormControl.stories.tsx
+++ b/src/components/FormControl/FormControl.stories.tsx
@@ -1,0 +1,57 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+
+import { Input } from '../Input'
+import { Stack } from '../Layout'
+import { Text } from '../Text'
+
+import { FormControl } from './FormControl'
+
+export default {
+  title: 'Forms（フォーム）/FormControl',
+  component: FormControl,
+}
+
+export const All: StoryFn = () => {
+  return (
+    <Stack gap={2} as="dl">
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          基本
+        </Text>
+        <dd>
+          <FormControl title="フォームコントロール名" htmlFor="form_1">
+            <Input name="defaultInput" id="form_1" />
+          </FormControl>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          すべてのオプション
+        </Text>
+        <dd>
+          <FormControl
+            title="氏名"
+            statusLabelProps={{ type: 'grey', children: '任意' }}
+            helpMessage="氏名を入力してください。"
+            errorMessages={'氏名が入力されていません。'}
+            htmlFor="form_2"
+          >
+            <Input name="fullname" id="form_2" />
+          </FormControl>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          読み取り専用
+        </Text>
+        <dd>
+          <FormControl title="氏名" htmlFor="form_5">
+            <Input name="fullname" value="草野栄一郎" readOnly id="form_5" />
+          </FormControl>
+        </dd>
+      </Stack>
+    </Stack>
+  )
+}
+All.storyName = 'all'

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -1,0 +1,9 @@
+import React, { ComponentProps } from 'react'
+
+import { FormGroup } from '../FormGroup'
+
+type Props = Omit<ComponentProps<typeof FormGroup>, 'as'>
+
+export const FormControl: React.FC<Props> = FormGroup
+// 一部スタイリングが内部的に FormGroup という名前に依存しているため置き換え
+FormControl.displayName = 'FormGroup'

--- a/src/components/FormControl/index.ts
+++ b/src/components/FormControl/index.ts
@@ -1,0 +1,1 @@
+export { FormControl } from './FormControl'

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -47,11 +47,11 @@ export const All: Story = () => {
         </Text>
         <dd>
           <FormGroup
+            as="fieldset"
             title="姓名"
             statusLabelProps={{ type: 'grey', children: '任意' }}
             helpMessage="姓名を入力してください。"
             errorMessages="姓名が入力されていません。"
-            role="group"
           >
             <Cluster gap={1}>
               <FormGroup
@@ -97,11 +97,11 @@ export const All: Story = () => {
         </Text>
         <dd>
           <FormGroup
+            as="fieldset"
             title="disabled なフォームグループ"
             helpMessage="このフォームグループは disabled です。内包するフォームグループを個別に disabled する必要はありません。"
             errorMessages="すべてのフォームコントロールが disabled です。"
             disabled
-            role="group"
           >
             <Cluster gap={1}>
               <FormGroup

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React from 'react'
 
 import { Input } from '../Input'
@@ -8,11 +8,11 @@ import { Text } from '../Text'
 import { FormGroup } from './FormGroup'
 
 export default {
-  title: 'Forms（フォーム）/FormGroup',
+  title: 'Forms（フォーム）/FormGroup（非推奨）',
   component: FormGroup,
 }
 
-export const All: Story = () => {
+export const All: StoryFn = () => {
   return (
     <Stack gap={2} as="dl">
       <Stack>
@@ -79,7 +79,7 @@ export const All: Story = () => {
           読み取り専用
         </Text>
         <dd>
-          <FormGroup title="姓名" role="group">
+          <FormGroup title="姓名" as="fieldset">
             <Cluster gap={1}>
               <FormGroup title="姓" titleType="subSubBlockTitle" htmlFor="form_5">
                 <Input name="lastName" value="草野" readOnly id="form_5" />

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -1,163 +1,130 @@
 import { Story } from '@storybook/react'
-import * as React from 'react'
-import styled, { css } from 'styled-components'
+import React from 'react'
 
 import { Input } from '../Input'
+import { Cluster, Stack } from '../Layout'
+import { Text } from '../Text'
 
 import { FormGroup } from './FormGroup'
 
 export default {
   title: 'Forms（フォーム）/FormGroup',
   component: FormGroup,
-  parameters: {
-    withTheming: true,
-  },
 }
-
-type SampleChildrenProps = {
-  id1?: string
-  id2?: string
-  disabled?: boolean
-}
-
-const SampleChildren: React.VFC<SampleChildrenProps> = ({ id1, id2, disabled }) => {
-  return (
-    <SampleWrapper>
-      <SampleFormGroup
-        title="first name"
-        titleType="subSubBlockTitle"
-        innerMargin="XXS"
-        htmlFor={id1}
-        disabled={disabled}
-      >
-        <Input name="id1" id={id1} disabled={disabled} />
-      </SampleFormGroup>
-      <SampleFormGroup
-        title="last name"
-        titleType="subSubBlockTitle"
-        innerMargin="XXS"
-        htmlFor={id2}
-        disabled={disabled}
-      >
-        <Input name="id2" id={id2} disabled={disabled} />
-      </SampleFormGroup>
-    </SampleWrapper>
-  )
-}
-
-const SampleStatusLabelProps = [
-  {
-    type: 'red' as const,
-    children: 'label 1' as const,
-  },
-  {
-    type: 'blue' as const,
-    children: 'label 2' as const,
-  },
-]
 
 export const All: Story = () => {
   return (
-    <Wrapper>
-      <Title>default</Title>
-      <Body>
-        <FormGroup title="Title" titleType="blockTitle" role="group">
-          <SampleChildren id1="id_1-1" id2="id_1-2" />
-        </FormGroup>
-      </Body>
-      <Title>with status label</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          role="group"
-        >
-          <SampleChildren id1="id_2-1" id2="id_2-2" />
-        </FormGroup>
-      </Body>
-      <Title>with help message</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          helpMessage="help message text"
-          role="group"
-        >
-          <SampleChildren id1="id_3-1" id2="id_3-2" />
-        </FormGroup>
-      </Body>
-      <Title>with error messages</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          errorMessages={['error message 1', 'error message 2']}
-          role="group"
-        >
-          <SampleChildren id1="id_4-1" id2="id_4-2" />
-        </FormGroup>
-      </Body>
-      <Title>with all options</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          helpMessage="help message text"
-          errorMessages={['error message 1', 'error message 2']}
-          role="group"
-        >
-          <SampleChildren id1="id_5-1" id2="id_5-2" />
-        </FormGroup>
-      </Body>
-      <Title>disabled</Title>
-      <Body>
-        <FormGroup
-          title="Title"
-          titleType="blockTitle"
-          statusLabelProps={SampleStatusLabelProps}
-          helpMessage="help message text"
-          errorMessages="error message"
+    <Stack gap={2} as="dl">
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          基本
+        </Text>
+        <dd>
+          <FormGroup title="フォームコントロール名" htmlFor="form_1">
+            <Input name="defaultInput" id="form_1" />
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          すべてのオプション
+        </Text>
+        <dd>
+          <FormGroup
+            title="氏名"
+            statusLabelProps={{ type: 'grey', children: '任意' }}
+            helpMessage="氏名を入力してください。"
+            errorMessages={'氏名が入力されていません。'}
+            htmlFor="form_2"
+          >
+            <Input name="fullname" id="form_2" />
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          入れ子
+        </Text>
+        <dd>
+          <FormGroup
+            title="姓名"
+            statusLabelProps={{ type: 'grey', children: '任意' }}
+            helpMessage="姓名を入力してください。"
+            errorMessages="姓名が入力されていません。"
+            role="group"
+          >
+            <Cluster gap={1}>
+              <FormGroup
+                title="姓"
+                titleType="subSubBlockTitle"
+                errorMessages="姓が入力されていません。"
+                htmlFor="form_3"
+              >
+                <Input name="lastName" id="form_3" />
+              </FormGroup>
+              <FormGroup
+                title="名"
+                titleType="subSubBlockTitle"
+                errorMessages="名が入力されていません。"
+                htmlFor="form_4"
+              >
+                <Input name="firstName" id="form_4" />
+              </FormGroup>
+            </Cluster>
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          読み取り専用
+        </Text>
+        <dd>
+          <FormGroup title="姓名" role="group">
+            <Cluster gap={1}>
+              <FormGroup title="姓" titleType="subSubBlockTitle" htmlFor="form_5">
+                <Input name="lastName" value="草野" readOnly id="form_5" />
+              </FormGroup>
+              <FormGroup title="名" titleType="subSubBlockTitle" htmlFor="form_6">
+                <Input name="firstName" value="栄一郎" readOnly id="form_6" />
+              </FormGroup>
+            </Cluster>
+          </FormGroup>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
           disabled
-          role="group"
-        >
-          <SampleChildren id1="id_6-1" id2="id_6-2" disabled />
-        </FormGroup>
-      </Body>
-    </Wrapper>
+        </Text>
+        <dd>
+          <FormGroup
+            title="disabled なフォームグループ"
+            helpMessage="このフォームグループは disabled です。内包するフォームグループを個別に disabled する必要はありません。"
+            errorMessages="すべてのフォームコントロールが disabled です。"
+            disabled
+            role="group"
+          >
+            <Cluster gap={1}>
+              <FormGroup
+                title="姓"
+                titleType="subSubBlockTitle"
+                errorMessages="姓が入力されていません。"
+                htmlFor="form_7"
+              >
+                <Input name="lastName" id="form_7" />
+              </FormGroup>
+              <FormGroup
+                title="名"
+                titleType="subSubBlockTitle"
+                errorMessages="名が入力されていません。"
+                htmlFor="form_8"
+              >
+                <Input name="firstName" id="form_8" />
+              </FormGroup>
+            </Cluster>
+          </FormGroup>
+        </dd>
+      </Stack>
+    </Stack>
   )
 }
 All.storyName = 'all'
-
-const Wrapper = styled.dl`
-  display: block;
-  padding: 24px;
-  margin: 0;
-`
-
-const Title = styled.dt(
-  ({ theme }) => css`
-    display: block;
-    padding: 0;
-    margin: 0 0 16px;
-    color: ${theme.color.TEXT_GREY};
-    font-style: italic;
-  `,
-)
-
-const Body = styled.dd`
-  display: block;
-  padding: 0;
-  margin: 0 0 32px;
-`
-
-const SampleWrapper = styled.div`
-  display: flex;
-  align-items: flex-start;
-`
-
-const SampleFormGroup = styled(FormGroup)`
-  margin-right: 16px;
-`

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps, HTMLAttributes, PropsWithChildren, ReactNode } f
 import styled, { css } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
+import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
@@ -38,6 +39,9 @@ type Props = PropsWithChildren<{
 }>
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-labelledby'>
 
+/**
+ * @deprecated `FormGroup` コンポーネントは非推奨です。代わりに `FormControl` や `Fieldset` を使ってください。
+ */
 export const FormGroup: React.FC<Props & ElementProps> = ({
   title,
   titleType = 'blockTitle',
@@ -101,7 +105,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
         </Stack>
       )}
 
-      <ChildrenWrapper innerMargin={innerMargin} isRoleGroup={isRoleGroup} themes={theme}>
+      <ChildrenWrapper innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
         {children}
       </ChildrenWrapper>
     </Wrapper>
@@ -120,13 +124,31 @@ const Wrapper = styled(Stack).attrs({
 
       /* 個別指定されている色を上書く */
       .smarthr-ui-Heading,
-      .smarthr-ui-FormGroup-errorMessage {
+      .smarthr-ui-FormGroup-errorMessage,
+      .smarthr-ui-RadioButton-label,
+      .smarthr-ui-CheckBox-label {
+        cursor: revert;
         color: inherit;
       }
 
       .smarthr-ui-Input {
         border-color: ${color.disableColor(color.BORDER)};
         background-color: ${color.hoverColor(color.WHITE)};
+      }
+
+      .smarthr-ui-RadioButton-radioButton,
+      .smarthr-ui-CheckBox-checkBox {
+        cursor: revert;
+
+        &[checked] + span,
+        & + span {
+          border-color: ${color.disableColor(color.BORDER)};
+          background-color: ${color.disableColor(color.BORDER)};
+        }
+
+        &:hover + span {
+          box-shadow: none;
+        }
       }
     }
   `}
@@ -145,13 +167,12 @@ const ErrorMessage = styled.p<{ themes: Theme }>`
 const ChildrenWrapper = styled.div<{
   innerMargin: Props['innerMargin']
   isRoleGroup: boolean
-  themes: Theme
 }>`
-  ${({ innerMargin, isRoleGroup, themes: { space } }) => css`
+  ${({ innerMargin, isRoleGroup }) => css`
     ${(innerMargin || isRoleGroup) &&
     css`
       &&& {
-        margin-block-start: ${space(innerMargin || isRoleGroup ? 1 : 0.5)};
+        margin-block-start: ${useSpacing(innerMargin || (isRoleGroup ? 1 : 0.5))};
       }
     `}
   `}

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -34,6 +34,7 @@ type Props = PropsWithChildren<{
   disabled?: boolean
   /** コンポーネントに適用するクラス名 */
   className?: string
+  as?: string | React.ComponentType<any>
 }>
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-labelledby'>
 
@@ -47,13 +48,14 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   helpMessage,
   errorMessages,
   disabled,
+  as = 'div',
   className = '',
   children,
   ...props
 }) => {
   const disabledClass = disabled ? 'disabled' : ''
   const managedLabelId = useId(labelId)
-  const isRoleGroup = props.role === 'group'
+  const isRoleGroup = as === 'fieldset'
   const statusLabelList = Array.isArray(statusLabelProps) ? statusLabelProps : [statusLabelProps]
 
   const theme = useTheme()
@@ -66,7 +68,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       aria-labelledby={isRoleGroup ? managedLabelId : undefined}
       themes={theme}
       className={`${className} ${disabledClass} ${classNames.wrapper}`}
-      as={isRoleGroup ? 'fieldset' : 'div'}
+      as={as}
     >
       <Cluster
         align="center"

--- a/src/components/FormGroup/useClassNames.ts
+++ b/src/components/FormGroup/useClassNames.ts
@@ -9,11 +9,9 @@ export function useClassNames() {
   return useMemo(
     () => ({
       wrapper: generate(),
-      title: generate('title'),
       label: generate('label'),
       helpMessage: generate('helpMessage'),
       errorMessage: generate('errorMessage'),
-      body: generate('body'),
     }),
     [generate],
   )

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -104,20 +104,10 @@ export const WithoutLinks: Story = () => {
       <Base padding={1.5}>
         <Stack gap={1.5}>
           <Stack>
-            <FormGroup
-              title="社員番号またはメールアドレス"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-email"
-            >
+            <FormGroup title="社員番号またはメールアドレス" htmlFor="id-email">
               <Input name="email" id="id-email" width="22em" />
             </FormGroup>
-            <FormGroup
-              title="パスワード"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-password"
-            >
+            <FormGroup title="パスワード" htmlFor="id-password">
               <Input name="password" id="id-password" width="22em" />
             </FormGroup>
           </Stack>

--- a/src/components/NewFieldset/Fieldset.stories.tsx
+++ b/src/components/NewFieldset/Fieldset.stories.tsx
@@ -1,0 +1,132 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+
+import { CheckBox } from '../CheckBox'
+import { FormControl } from '../FormControl'
+import { Input } from '../Input'
+import { Cluster, Stack } from '../Layout'
+import { RadioButton } from '../RadioButton'
+import { Text } from '../Text'
+
+import { Fieldset } from './Fieldset'
+
+export default {
+  title: 'Forms（フォーム）/Fieldset',
+  component: Fieldset,
+}
+
+export const All: StoryFn = () => {
+  return (
+    <Stack gap={2} as="dl">
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          基本
+        </Text>
+        <Stack as="dd">
+          <Fieldset title="就業形態" innerMargin={0.5}>
+            <Cluster gap={1.25}>
+              <RadioButton name="employment" defaultChecked={true}>
+                正社員
+              </RadioButton>
+              <RadioButton name="employment">契約社員</RadioButton>
+              <RadioButton name="employment">派遣社員</RadioButton>
+              <RadioButton name="employment">アルバイト</RadioButton>
+              <RadioButton name="employment">その他</RadioButton>
+            </Cluster>
+          </Fieldset>
+          <Fieldset title="その他の設定" innerMargin={0.5}>
+            <CheckBox name="includeBoardMembers">役員を含める</CheckBox>
+          </Fieldset>
+        </Stack>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          入れ子
+        </Text>
+        <dd>
+          <Fieldset
+            title="アカウントの設定"
+            statusLabelProps={{ type: 'grey', children: '任意' }}
+            errorMessages="入力されていない項目があります。"
+          >
+            <Stack>
+              <Fieldset title="設定の有無" titleType="subBlockTitle" innerMargin={0.5}>
+                <Cluster gap={1.25}>
+                  <RadioButton name="existsConfig" defaultChecked={true}>
+                    あり
+                  </RadioButton>
+                  <RadioButton name="existsConfig">なし</RadioButton>
+                </Cluster>
+              </Fieldset>
+              <Cluster gap={1}>
+                <FormControl
+                  title="姓"
+                  titleType="subBlockTitle"
+                  errorMessages="姓が入力されていません。"
+                  htmlFor="form_3"
+                >
+                  <Input name="lastName" id="form_3" />
+                </FormControl>
+                <FormControl
+                  title="名"
+                  titleType="subBlockTitle"
+                  errorMessages="名が入力されていません。"
+                  htmlFor="form_4"
+                >
+                  <Input name="firstName" id="form_4" />
+                </FormControl>
+              </Cluster>
+            </Stack>
+          </Fieldset>
+        </dd>
+      </Stack>
+      <Stack>
+        <Text italic color="TEXT_GREY" as="dt">
+          disabled
+        </Text>
+        <dd>
+          <Fieldset
+            title="disabled なフォームグループ"
+            helpMessage="このフォームグループは disabled です。内包するフォームグループを個別に disabled する必要はありません。"
+            errorMessages="すべてのフォームコントロールが disabled です。"
+            disabled
+          >
+            <Stack>
+              <Fieldset title="就業形態" innerMargin={0.5}>
+                <Cluster gap={1.25}>
+                  <RadioButton name="employment2">正社員</RadioButton>
+                  <RadioButton name="employment2">契約社員</RadioButton>
+                  <RadioButton name="employment2">派遣社員</RadioButton>
+                  <RadioButton name="employment2">アルバイト</RadioButton>
+                  <RadioButton name="employment2">その他</RadioButton>
+                </Cluster>
+              </Fieldset>
+              <Fieldset title="その他の設定" innerMargin={0.5}>
+                <CheckBox name="includeBoardMembers">役員を含める</CheckBox>
+              </Fieldset>
+              <Cluster gap={1}>
+                <FormControl
+                  title="姓"
+                  titleType="subBlockTitle"
+                  errorMessages="姓が入力されていません。"
+                  htmlFor="form_7"
+                >
+                  <Input name="lastName" id="form_7" />
+                </FormControl>
+                <FormControl
+                  title="名"
+                  titleType="subBlockTitle"
+                  errorMessages="名が入力されていません。"
+                  htmlFor="form_8"
+                >
+                  <Input name="firstName" id="form_8" />
+                </FormControl>
+              </Cluster>
+            </Stack>
+          </Fieldset>
+        </dd>
+      </Stack>
+    </Stack>
+  )
+}
+All.storyName = 'all'

--- a/src/components/NewFieldset/Fieldset.tsx
+++ b/src/components/NewFieldset/Fieldset.tsx
@@ -1,0 +1,7 @@
+import React, { ComponentProps } from 'react'
+
+import { FormGroup } from '../FormGroup'
+
+export const Fieldset: React.FC<ComponentProps<typeof FormGroup>> = (props) => {
+  return <FormGroup {...props} as="fieldset" />
+}

--- a/src/components/NewFieldset/index.ts
+++ b/src/components/NewFieldset/index.ts
@@ -1,0 +1,1 @@
+export { Fieldset } from './Fieldset'

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,8 @@ export { Calendar } from './components/Calendar'
 export { DatePicker } from './components/DatePicker'
 export { SegmentedControl, SegmentedControlOption } from './components/SegmentedControl'
 export { FormGroup } from './components/FormGroup'
+export { FormControl } from './components/FormControl'
+export { Fieldset } from './components/NewFieldset'
 export {
   BackgroundJobsPanel,
   BackgroundJobsList,


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-595
- #3232 

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FormGroup が見た目に依った実装になっていたため見直しました。
`role="group"` を与えると `fieldset > legend` として振る舞います。

I/F こそ変わっていませんが、内部的に不要な `class` を消したため BREAKING CHANGE とします。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- role=group の場合は、fieldset > legend と振る舞うように修正
  - fieldset[disabled] の場合の見た目を調整
- statusLabel を配列でなくても指定できるように修正
- StatusLabel を label に含めるように修正
- innerMargin の良いデフォルトを指定し、基本的に指定はいらないように修正
- titleType の良いデフォルトを指定
- 不要なマークアップを削除
- Story を見直し

### やってないこと

別 PR で対応予定です。

- htmlFor を渡さなくても内部的に id を紐付けるように修正
- helpMessage や errorMessage が適切に紐付けられるように修正
- 入力例と補足文を追加

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
