### PR TITLE
feat: FormGroup とフォームコントロールを内部的に id で紐づくように修正

### DIFF
--- a/src/components/AccordionPanel/AccordionPanel.stories.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.stories.tsx
@@ -35,13 +35,13 @@ const content = () => {
     <Stack>
       <div>{lorem}</div>
       <div>
-        <FormGroup title="Name" htmlFor={`id-name-${id}`}>
-          <Input name={`name_${id}`} id={`id-name-${id}`} />
+        <FormGroup title="Name">
+          <Input name={`name_${id}`} />
         </FormGroup>
       </div>
       <div>
-        <FormGroup title="Email" htmlFor={`id-email-${id}`}>
-          <Input name={`email_${id}`} id={`id-email-${id}`} />
+        <FormGroup title="Email">
+          <Input name={`email_${id}`} />
         </FormGroup>
       </div>
     </Stack>

--- a/src/components/FormControl/FormControl.stories.tsx
+++ b/src/components/FormControl/FormControl.stories.tsx
@@ -20,8 +20,8 @@ export const All: StoryFn = () => {
           基本
         </Text>
         <dd>
-          <FormControl title="フォームコントロール名" htmlFor="form_1">
-            <Input name="defaultInput" id="form_1" />
+          <FormControl title="フォームコントロール名">
+            <Input name="defaultInput" />
           </FormControl>
         </dd>
       </Stack>
@@ -35,9 +35,8 @@ export const All: StoryFn = () => {
             statusLabelProps={{ type: 'grey', children: '任意' }}
             helpMessage="氏名を入力してください。"
             errorMessages={'氏名が入力されていません。'}
-            htmlFor="form_2"
           >
-            <Input name="fullname" id="form_2" />
+            <Input name="fullname" />
           </FormControl>
         </dd>
       </Stack>
@@ -46,8 +45,8 @@ export const All: StoryFn = () => {
           読み取り専用
         </Text>
         <dd>
-          <FormControl title="氏名" htmlFor="form_5">
-            <Input name="fullname" value="草野栄一郎" readOnly id="form_5" />
+          <FormControl title="氏名">
+            <Input name="fullname" value="草野栄一郎" readOnly />
           </FormControl>
         </dd>
       </Stack>

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -20,8 +20,8 @@ export const All: StoryFn = () => {
           基本
         </Text>
         <dd>
-          <FormGroup title="フォームコントロール名" htmlFor="form_1">
-            <Input name="defaultInput" id="form_1" />
+          <FormGroup title="フォームコントロール名">
+            <Input name="defaultInput" />
           </FormGroup>
         </dd>
       </Stack>
@@ -35,9 +35,8 @@ export const All: StoryFn = () => {
             statusLabelProps={{ type: 'grey', children: '任意' }}
             helpMessage="氏名を入力してください。"
             errorMessages={'氏名が入力されていません。'}
-            htmlFor="form_2"
           >
-            <Input name="fullname" id="form_2" />
+            <Input name="fullname" />
           </FormGroup>
         </dd>
       </Stack>
@@ -58,17 +57,15 @@ export const All: StoryFn = () => {
                 title="姓"
                 titleType="subSubBlockTitle"
                 errorMessages="姓が入力されていません。"
-                htmlFor="form_3"
               >
-                <Input name="lastName" id="form_3" />
+                <Input name="lastName" />
               </FormGroup>
               <FormGroup
                 title="名"
                 titleType="subSubBlockTitle"
                 errorMessages="名が入力されていません。"
-                htmlFor="form_4"
               >
-                <Input name="firstName" id="form_4" />
+                <Input name="firstName" />
               </FormGroup>
             </Cluster>
           </FormGroup>
@@ -81,11 +78,11 @@ export const All: StoryFn = () => {
         <dd>
           <FormGroup title="姓名" as="fieldset">
             <Cluster gap={1}>
-              <FormGroup title="姓" titleType="subSubBlockTitle" htmlFor="form_5">
-                <Input name="lastName" value="草野" readOnly id="form_5" />
+              <FormGroup title="姓" titleType="subSubBlockTitle">
+                <Input name="lastName" value="草野" readOnly />
               </FormGroup>
-              <FormGroup title="名" titleType="subSubBlockTitle" htmlFor="form_6">
-                <Input name="firstName" value="栄一郎" readOnly id="form_6" />
+              <FormGroup title="名" titleType="subSubBlockTitle">
+                <Input name="firstName" value="栄一郎" readOnly />
               </FormGroup>
             </Cluster>
           </FormGroup>
@@ -108,17 +105,15 @@ export const All: StoryFn = () => {
                 title="姓"
                 titleType="subSubBlockTitle"
                 errorMessages="姓が入力されていません。"
-                htmlFor="form_7"
               >
-                <Input name="lastName" id="form_7" />
+                <Input name="lastName" />
               </FormGroup>
               <FormGroup
                 title="名"
                 titleType="subSubBlockTitle"
                 errorMessages="名が入力されていません。"
-                htmlFor="form_8"
               >
-                <Input name="firstName" id="form_8" />
+                <Input name="firstName" />
               </FormGroup>
             </Cluster>
           </FormGroup>

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -12,6 +12,7 @@ import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { MultiComboBox, SingleComboBox } from '../ComboBox'
 import { DatePicker } from '../DatePicker'
+import { DropZone } from '../DropZone'
 import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
 import { CurrencyInput, Input } from '../Input'
@@ -158,6 +159,7 @@ const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describe
 }
 
 /**
+ * - CheckBox / RadioButton は内部に label を含むため対象外
  * - SearchInput は label を含むため対象外
  * - InputWithTooltip は領域が狭く FormControl を置けない場所での私用を想定しているため対象外
  *
@@ -172,7 +174,8 @@ const isInputElement = (type: string | React.JSXElementConstructor<any>) =>
   type === Select ||
   type === SingleComboBox ||
   type === MultiComboBox ||
-  type === InputFile
+  type === InputFile ||
+  type === DropZone
 
 const Wrapper = styled(Stack).attrs({
   // 基本的にはすべて 0.5 幅、グルーピングしたフォームコントロール群との余白は ChildrenWrapper で調整する

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -10,10 +10,14 @@ import styled, { css } from 'styled-components'
 import { useId } from '../../hooks/useId'
 import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
+import { MultiComboBox, SingleComboBox } from '../ComboBox'
 import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
+import { Input } from '../Input'
 import { Cluster, Stack } from '../Layout'
+import { Select } from '../Select'
 import { StatusLabel } from '../StatusLabel'
+import { Textarea } from '../Textarea'
 
 import { useClassNames } from './useClassNames'
 
@@ -119,20 +123,42 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       )}
 
       <ChildrenWrapper innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
-        {React.Children.map(children, (child, i) => {
-          // id があるので、最初の要素以外には付与しない
-          if (!React.isValidElement(child) || i > 0) {
-            return child
-          }
-
-          return React.cloneElement(child as ReactElement, {
-            id: managedHtmlFor,
-            'aria-describedby': describedbyIds,
-          })
-        })}
+        {addIdToFirstInput(children, managedHtmlFor, describedbyIds)}
       </ChildrenWrapper>
     </Wrapper>
   )
+}
+
+const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describedbyIds: string) => {
+  let foundFirstInput = false
+
+  const addId = (targets: ReactNode): ReactNode[] | ReactNode => {
+    return React.Children.map(targets, (child) => {
+      if (foundFirstInput || !React.isValidElement(child)) {
+        return child
+      }
+
+      const { type } = child
+
+      if (
+        type === Input ||
+        type === Textarea ||
+        type === Select ||
+        type === SingleComboBox ||
+        type === MultiComboBox
+      ) {
+        foundFirstInput = true
+        return React.cloneElement(child as ReactElement, {
+          id: managedHtmlFor,
+          'aria-describedby': describedbyIds,
+        })
+      }
+
+      return React.cloneElement(child, {}, addId(child.props.children))
+    })
+  }
+
+  return addId(children)
 }
 
 const Wrapper = styled(Stack).attrs({

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -11,9 +11,11 @@ import { useId } from '../../hooks/useId'
 import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { MultiComboBox, SingleComboBox } from '../ComboBox'
+import { DatePicker } from '../DatePicker'
 import { Heading, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
-import { Input } from '../Input'
+import { CurrencyInput, Input } from '../Input'
+import { InputFile } from '../InputFile'
 import { Cluster, Stack } from '../Layout'
 import { Select } from '../Select'
 import { StatusLabel } from '../StatusLabel'
@@ -140,13 +142,7 @@ const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describe
 
       const { type } = child
 
-      if (
-        type === Input ||
-        type === Textarea ||
-        type === Select ||
-        type === SingleComboBox ||
-        type === MultiComboBox
-      ) {
+      if (isInputElement(type)) {
         foundFirstInput = true
         return React.cloneElement(child as ReactElement, {
           id: managedHtmlFor,
@@ -160,6 +156,23 @@ const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describe
 
   return addId(children)
 }
+
+/**
+ * - SearchInput は label を含むため対象外
+ * - InputWithTooltip は領域が狭く FormControl を置けない場所での私用を想定しているため対象外
+ *
+ * @param type
+ * @returns
+ */
+const isInputElement = (type: string | React.JSXElementConstructor<any>) =>
+  type === Input ||
+  type === CurrencyInput ||
+  type === Textarea ||
+  type === DatePicker ||
+  type === Select ||
+  type === SingleComboBox ||
+  type === MultiComboBox ||
+  type === InputFile
 
 const Wrapper = styled(Stack).attrs({
   // 基本的にはすべて 0.5 幅、グルーピングしたフォームコントロール群との余白は ChildrenWrapper で調整する

--- a/src/components/MessageScreen/MessageScreen.stories.tsx
+++ b/src/components/MessageScreen/MessageScreen.stories.tsx
@@ -61,21 +61,11 @@ export const WithoutTitle: Story = () => {
       <Base padding={1.5}>
         <Stack gap={1.5}>
           <Stack>
-            <FormGroup
-              title="メールアドレス"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-email"
-            >
-              <Input name="email" id="id-email" width="22em" />
+            <FormGroup title="メールアドレス" titleType="subBlockTitle" innerMargin="XXS">
+              <Input name="email" width="22em" />
             </FormGroup>
-            <FormGroup
-              title="パスワード"
-              titleType="subBlockTitle"
-              innerMargin="XXS"
-              htmlFor="id-password"
-            >
-              <Input name="password" id="id-password" width="22em" />
+            <FormGroup title="パスワード" titleType="subBlockTitle" innerMargin="XXS">
+              <Input name="password" width="22em" />
             </FormGroup>
           </Stack>
           <Stack align="center">
@@ -104,11 +94,11 @@ export const WithoutLinks: Story = () => {
       <Base padding={1.5}>
         <Stack gap={1.5}>
           <Stack>
-            <FormGroup title="社員番号またはメールアドレス" htmlFor="id-email">
-              <Input name="email" id="id-email" width="22em" />
+            <FormGroup title="社員番号またはメールアドレス">
+              <Input name="email" width="22em" />
             </FormGroup>
-            <FormGroup title="パスワード" htmlFor="id-password">
-              <Input name="password" id="id-password" width="22em" />
+            <FormGroup title="パスワード">
+              <Input name="password" width="22em" />
             </FormGroup>
           </Stack>
           <Stack align="center">

--- a/src/components/NewFieldset/Fieldset.stories.tsx
+++ b/src/components/NewFieldset/Fieldset.stories.tsx
@@ -63,17 +63,15 @@ export const All: StoryFn = () => {
                   title="姓"
                   titleType="subBlockTitle"
                   errorMessages="姓が入力されていません。"
-                  htmlFor="form_3"
                 >
-                  <Input name="lastName" id="form_3" />
+                  <Input name="lastName" />
                 </FormControl>
                 <FormControl
                   title="名"
                   titleType="subBlockTitle"
                   errorMessages="名が入力されていません。"
-                  htmlFor="form_4"
                 >
-                  <Input name="firstName" id="form_4" />
+                  <Input name="firstName" />
                 </FormControl>
               </Cluster>
             </Stack>
@@ -109,17 +107,15 @@ export const All: StoryFn = () => {
                   title="姓"
                   titleType="subBlockTitle"
                   errorMessages="姓が入力されていません。"
-                  htmlFor="form_7"
                 >
-                  <Input name="lastName" id="form_7" />
+                  <Input name="lastName" />
                 </FormControl>
                 <FormControl
                   title="名"
                   titleType="subBlockTitle"
                   errorMessages="名が入力されていません。"
-                  htmlFor="form_8"
                 >
-                  <Input name="firstName" id="form_8" />
+                  <Input name="firstName" />
                 </FormControl>
               </Cluster>
             </Stack>


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-595
- #3356 

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FormGroup は内包するフォームコントロールを知っているので、内部的に id を生成して紐付けるように修正した。
#3356 のマージ後にマージします。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- htmlFor を渡さなくても内部的に id を紐付けるように修正
- helpMessage や errorMessage が適切に紐付けられるように修正

### やってないこと

別 PR で対応予定です。

- 入力例と補足文を追加

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
