### PR TITLE
chore: smarthr-ui-props.jsonをstandard-versionで更新する方法に変更

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -59,10 +59,6 @@ jobs:
         run: |
           git checkout master
           git cherry-pick $NEW_TAG
-      - name: update ui-props.json
-        run: |
-          yarn export:ui-props
-          git add public/exports/smarthr-ui-props.json && git diff --cached --exit-code --quiet || git commit -m 'chore: Update smarthr-ui-props.json'
       - name: craete pull request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "lint:tsc": "tsc --noEmit",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "prepublishOnly": "run-s clean lint build",
-    "release": "standard-version",
+    "release": "standard-version -a",
     "release:dryrun": "standard-version --dry-run",
     "storybook": "storybook dev -p 6006 -s ./public",
     "dev": "run-s storybook",
@@ -165,5 +165,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "postcss": "8.4.23"
+  },
+  "standard-version": {
+    "scripts": {
+      "prerelease": "run-s build:lib write:ui-props && git add public/exports/smarthr-ui-props.json"
+    }
   }
 }


### PR DESCRIPTION
## Related URL
https://github.com/kufu/smarthr-ui/pull/3267
https://github.com/kufu/smarthr-ui/pull/3289

## Overview
リリースのGitHub Actionsで更新した`smarthr-ui-props.json`が、次回のリリース時にコンフリクトする問題が起きたため、jsonの更新方法を見直しました。

## What I did
### 以前の状態
- standard-versionが作るリリースコミット（直近ではv30.10.0のタグがついているこのコミット https://github.com/kufu/smarthr-ui/commit/d9bae7bada04b8e91ace47e3290e4a9f851ee709 ）には、CHANGELOG.mdとpackage.jsonの2つのファイルの変更が含まれている
- その後、上記のコミットを[masterからcherry-pick](https://github.com/kufu/smarthr-ui/blob/6f135710ffc15530b90a4623da8933f55daf31b4/.github/workflows/publishRelease.yml#L59-L61)し、さらに`smarthr-ui-props.json`の[更新コミット](https://github.com/kufu/smarthr-ui/pull/3361/commits/fed1a4dda0589c8550be6f2d15a2d0240945510d)を追加して、リリースのPRを作る
  - リリースのPRにはコミットが2つ含まれている：https://github.com/kufu/smarthr-ui/pull/3361/commits

ここまでは一見問題なかったのですが、次回のリリース作業で、[v3.10.0のタグをcheckoutして、そこにmasterをマージする](https://github.com/kufu/smarthr-ui/blob/6f135710ffc15530b90a4623da8933f55daf31b4/.github/workflows/startRelease.yml#L33-L36)ので、そこでコンフリクトが発生してそうです。

### 変更後
standard-versionが作るリリースコミットに、`smarthr-ui-props.json`も含めてしまえば、そのままmasterからcherry-pickするので、コンフリクトは起きないのではないかと考え、そのように実装しました。

standard-versionのlifecycle scriptsという機能を利用して、`prerelease`のタイミングでjsonファイルの更新をフックしています。また、`-a`オプションで、standard-versionが作るコミットは1つにまとめる指定をしています。

参考にしたドキュメント：https://github.com/conventional-changelog/standard-version#committing-generated-artifacts-in-the-release-commit

#### 影響
リリースコミットに、`CHANGELOG.md`、`package.json`に加えて、`smarthr-ui-props.json`の変更が含まれることになります。

## Capture
UIコンポーネント自体への影響はありません