### PR TITLE
chore: 不必要な Storybook 起動オプションを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "prepublishOnly": "run-s clean lint build",
     "release": "standard-version",
     "release:dryrun": "standard-version --dry-run",
-    "storybook": "storybook dev -p 6006 -s ./public",
+    "storybook": "storybook dev -p 6006",
     "dev": "run-s storybook",
     "test": "jest",
     "test:update-snapshot": "jest --updateSnapshot",


### PR DESCRIPTION
## Related URL

- #3370

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Storybook 起動時に警告が表示されます。

<img width="1005" alt="image" src="https://github.com/kufu/smarthr-ui/assets/9423/2c09831d-4ccd-472c-8509-f6aedf547a35">

リポジトリルートの `public` を参照するためには `-s ../public` のようにすべきなのですが、そもそも開発時に `public` 内のディレクトリ参照する必要がなくなっています。(関連: #3370)

オプションを整理して良さそうです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Storybook 開発サーバー起動時の引数 `-s ./public` を削除

※ `storybook build` にも同様のオプション `-s ./public` が存在しているのですが、こちらは `-s ../public` に変更したり削除したりすると問題があるためそのままにしています。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

N/A

<!--
Please attach a capture if it looks different.
-->
