### PR TITLE
fix: FormControl の子要素に幅が指定できない欠陥を修正

### DIFF
--- a/src/components/FormControl/FormControl.stories.tsx
+++ b/src/components/FormControl/FormControl.stories.tsx
@@ -36,7 +36,7 @@ export const All: StoryFn = () => {
             helpMessage="氏名を入力してください。"
             errorMessages={'氏名が入力されていません。'}
           >
-            <Input name="fullname" />
+            <Input name="fullname" width="100%" />
           </FormControl>
         </dd>
       </Stack>

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -90,8 +90,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       className={`${className} ${disabledClass} ${classNames.wrapper}`}
       as={as}
     >
-      <Cluster
-        align="center"
+      <FormLabel
         htmlFor={managedHtmlFor}
         id={managedLabelId}
         className={`${classNames.label}`}
@@ -105,7 +104,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
             ))}
           </Cluster>
         )}
-      </Cluster>
+      </FormLabel>
 
       {helpMessage && (
         <p className={classNames.helpMessage} id={`${managedHtmlFor}_helpMessage`}>
@@ -180,8 +179,6 @@ const isInputElement = (type: string | React.JSXElementConstructor<any>) =>
 const Wrapper = styled(Stack).attrs({
   // 基本的にはすべて 0.5 幅、グルーピングしたフォームコントロール群との余白は ChildrenWrapper で調整する
   gap: 0.5,
-  // flex-item が stretch してクリッカブル領域が広がりすぎないようにする
-  align: 'flex-start',
 })<{ themes: Theme }>`
   ${({ themes: { color } }) => css`
     &[disabled] {
@@ -217,6 +214,11 @@ const Wrapper = styled(Stack).attrs({
       }
     }
   `}
+`
+
+const FormLabel = styled(Cluster).attrs({ align: 'center' })`
+  // flex-item が stretch してクリッカブル領域が広がりすぎないようにする
+  align-self: start;
 `
 
 const GroupLabel = styled(Heading).attrs({ tag: 'span' })``


### PR DESCRIPTION
FormGroup の children を受ける wrapper が Stack で、`align-items: flex-start` を指定していたため、外から children への幅を指定しにくい状態になっていた。
元々、ラベルが横伸びしないように指定した `align-items: flex-start` だったため、ラベルのみ `align-self: start` を指定することで回避した。