### PR TITLE
fix: Dialog に width を指定した場合に max-width が効かなくなる欠陥を修正

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -152,7 +152,7 @@ const Layout = styled.div`
 `
 const Inner = styled.div<StyleProps & { themes: Theme }>`
   ${({ themes, $width, top, right, bottom, left }) => {
-    const { border, color, radius, shadow, spacingByChar } = themes
+    const { border, color, radius, shadow, space } = themes
     const positionRight = exist(right) ? `${right}px` : 'auto'
     const positionBottom = exist(bottom) ? `${bottom}px` : 'auto'
     const positionTop = exist(top) ? `${top}px` : 'auto'
@@ -160,29 +160,19 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
     const translateX = exist(right) || exist(left) ? '0' : 'calc((100vw - 100%) / 2)'
     const translateY = exist(top) || exist(bottom) ? '0' : 'calc((100vh - 100%) / 2)'
 
-    const widthStyles = exist($width)
-      ? // width が指定されているときは width 設定
-        css`
-          width: ${typeof $width === 'number' ? `${$width}px` : $width};
-        `
-      : exist(left) && exist(right)
-      ? // left, right が両方指定されているときは、それに任せる
-        null
-      : // 幅を確定できる指定がされていない場合は、viewport を超えないように上限設定
-        css`
-          max-width: min(
-            calc(
-              100vw - max(${left || 0}px, ${spacingByChar(0.5)}) -
-                max(${right || 0}px, ${spacingByChar(0.5)})
-            ),
-            800px
-          );
-        ` /* TODO: 幅の定数指定は、トークンが決まり theme に入ったら差し替える */
-
     return css`
       position: absolute;
       inset: ${positionTop} ${positionRight} ${positionBottom} ${positionLeft};
-      ${widthStyles};
+      ${exist($width) &&
+      css`
+        width: ${typeof $width === 'number' ? `${$width}px` : $width};
+      `}
+      /* viewport を超えないように上限設定 */
+      max-width: min(
+        calc(100vw - max(${left || 0}px, ${space(0.5)}) - max(${right || 0}px, ${space(0.5)})),
+        /* TODO: 幅の定数指定は、トークンが決まり theme に入ったら差し替える */
+        800px
+      );
       border-radius: ${radius.m};
       background-color: ${color.WHITE};
       box-shadow: ${shadow.LAYER3};


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-675

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Dialog に width を与えると、max-width が消え、モバイルなどの横幅が狭い画面の場合に見切れる欠陥があった。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

max-width は width の有無に限らず必ず指定した。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
