### PR TITLE
feat: Tooltip に portalRootElement props を追加

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -29,6 +29,8 @@ type Props = {
   tabIndex?: number
   /** ツールチップを内包要素に紐付けるかどうか */
   ariaDescribedbyTarget?: 'wrapper' | 'inner'
+  /** ツールチップの要素を表示するルート要素 */
+  portalRootElement?: HTMLElement
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-describedby'>
 
@@ -42,6 +44,7 @@ export const Tooltip: FC<Props & ElementProps> = ({
   vertical = 'bottom',
   tabIndex = 0,
   ariaDescribedbyTarget = 'wrapper',
+  portalRootElement,
   className = '',
   onPointerEnter,
   onPointerLeave,
@@ -51,7 +54,7 @@ export const Tooltip: FC<Props & ElementProps> = ({
   onBlur,
   ...props
 }) => {
-  const [portalRoot, setPortalRoot] = useState<HTMLDivElement | null>(null)
+  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null)
   const [isVisible, setIsVisible] = useState(false)
   const [rect, setRect] = useState<DOMRect | null>(null)
   const ref = useRef<HTMLDivElement>(null)
@@ -93,13 +96,19 @@ export const Tooltip: FC<Props & ElementProps> = ({
   const isIcon = triggerType === 'icon'
 
   useEnhancedEffect(() => {
-    const element = document.createElement('div')
+    let element: HTMLElement
+    if (portalRootElement) {
+      element = portalRootElement
+    } else {
+      element = document.createElement('div')
+      document.body.appendChild(element)
+    }
     setPortalRoot(element)
-    document.body.appendChild(element)
     return () => {
+      if (portalRootElement) return
       document.body.removeChild(element)
     }
-  }, [])
+  }, [portalRootElement])
 
   const theme = useTheme()
   const classNames = useClassNames()


### PR DESCRIPTION
## Related URL

無

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

ツールチップが body 直下にレンダリングされている関係で、全画面 API を利用したときにツールチップが表示できなくなる問題があるので、どうにかしたい！

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`portalRootElement` という props を追加して、body 以外の要素内にツールチップをレンダリングできるようにした

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

LightTooltip には `portalRootElement` に `document.getElementById('storybook-root')` を指定した時の様子です 👁️ 
下記を確認してください！ 🙏 

- LightTooltip に対するツールチップは `<div id="storybook-root">` の直下にレンダリングされている
- horizontal=left & vertical=bottom (default) に対するツールチップは body の直下 (の div) にレンダリングされている

![スクリーンショット 2023-06-02 19 49 46](https://github.com/kufu/smarthr-ui/assets/14817308/45a5b8fe-af4b-4aef-9f4d-6a3b4070dc5a)


<!--
Please attach a capture if it looks different.
-->
