### PR TITLE
feat!: DefinitionList を画面サイズに応じて列数を変化させる

### DIFF
--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -28,6 +28,12 @@ const items = [
   },
   {
     term: '部署',
+    description: (
+      <p>
+        <code>fullWidth</code>{' '}
+        は項目の幅を最大化にし、できるだけ説明を折り返さずに表示できますグループ
+      </p>
+    ),
     fullWidth: true,
   },
   {

--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -27,11 +27,12 @@ const items = [
     description: '草野 栄一郎',
   },
   {
-    term: '雇用形態',
-    description: '正社員',
+    term: '部署',
+    fullWidth: true,
   },
   {
-    term: '部署',
+    term: '雇用形態',
+    description: '正社員',
   },
   {
     term: '在籍状況',
@@ -70,8 +71,8 @@ export const All: StoryFn = () => {
       <Stack gap={0.5}>
         <Heading type="blockTitle">標準</Heading>
         <p>
-          基本的にカラム数を指定する必要はありません。各アイテムは幅 12–30em
-          の範囲で余った領域を埋めていきます。
+          基本的にカラム数を指定する必要はありません。各アイテムは最低幅 12em
+          を保ちながら余った領域を埋めていきます。
         </p>
         <Base padding={1.5} overflow="auto">
           <DefinitionList items={items} />

--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -1,11 +1,10 @@
-import { Story } from '@storybook/react'
-import * as React from 'react'
-import styled from 'styled-components'
+import { StoryFn } from '@storybook/react'
+import React from 'react'
 
-import { useTheme } from '../../hooks/useTheme'
 import { Base } from '../Base'
 import { Heading } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
+import { Cluster, Stack } from '../Layout'
 import { Text } from '../Text'
 
 import { DefinitionList } from './DefinitionList'
@@ -18,50 +17,42 @@ export default {
   },
 }
 
-const DefinitionListItems = [
+const items = [
   {
-    term: 'term 1',
-    description: 'description 1',
+    term: '社員番号',
+    description: '001',
   },
   {
-    term: 'term 2',
+    term: '氏名',
+    description: '草野 栄一郎',
+  },
+  {
+    term: '雇用形態',
+    description: '正社員',
+  },
+  {
+    term: '部署',
+  },
+  {
+    term: '在籍状況',
+    description: '在職中',
+  },
+  {
+    term: '入社年月日',
+    description: '2023/06/05',
+  },
+  {
+    term: '退職年月日',
     description: '-',
   },
   {
-    term: 'term 3',
-    description: 'description 3',
-  },
-  {
-    term: 'term 4',
-    description: 'description 4',
-  },
-  {
-    term: 'term 5',
-  },
-]
-
-const Item = () => {
-  const themes = useTheme()
-  return (
-    <Term>
-      <span>term 7</span>
-      <Alert>
-        <FaExclamationCircleIcon size={11} color={themes.color.DANGER} />
-        <AlertText>error occurred</AlertText>
-      </Alert>
-    </Term>
-  )
-}
-
-const customizedItems = [
-  ...DefinitionListItems,
-  {
-    term: 'term 6',
-    description: 'description 6',
-  },
-  {
-    term: <Item />,
-    description: 'description 7',
+    term: (
+      <Cluster align="center">
+        <span>何らかの用語</span>
+        <FaExclamationCircleIcon color="DANGER" text="何らかのエラーメッセージ" />
+      </Cluster>
+    ),
+    description: 'エラーメッセージを持つ用語の説明',
   },
   {
     term: '折り返されたくない要素は nowrap',
@@ -71,60 +62,40 @@ const customizedItems = [
     term: '標準は折返し',
     description: 'so-much-longer-email-address@example.com',
   },
-  {
-    term: 'term 9',
-    description: 'description 9',
-  },
 ]
 
-export const All: Story = () => {
+export const All: StoryFn = () => {
   return (
-    <Wrapper>
-      <Title type="sectionTitle">single column</Title>
-      <Content>
-        <DefinitionList items={DefinitionListItems} layout="single"></DefinitionList>
-      </Content>
+    <Stack gap={1.5}>
+      <Stack gap={0.5}>
+        <Heading type="blockTitle">標準</Heading>
+        <p>
+          基本的にカラム数を指定する必要はありません。各アイテムは幅 12–30em
+          の範囲で余った領域を埋めていきます。
+        </p>
+        <Base padding={1.5} overflow="auto">
+          <DefinitionList items={items} />
+        </Base>
+      </Stack>
 
-      <Title type="sectionTitle">two column</Title>
-      <Content>
-        <DefinitionList items={DefinitionListItems} layout="double"></DefinitionList>
-      </Content>
+      <p>
+        最大列数を制限することも出来ます。画面幅が狭い場合は標準と同じ動きをしますが、指定した最大列数以上には増えず幅が広がります。
+      </p>
 
-      <Title type="sectionTitle">three column</Title>
-      <Content>
-        <DefinitionList items={DefinitionListItems} layout="triple"></DefinitionList>
-      </Content>
+      <Stack gap={0.5}>
+        <Heading type="blockTitle">最大2列の場合</Heading>
+        <Base padding={1.5} overflow="auto">
+          <DefinitionList items={items} maxColumns={2} />
+        </Base>
+      </Stack>
 
-      <Title type="sectionTitle">customized</Title>
-      <Content>
-        <DefinitionList items={customizedItems} layout="double" />
-      </Content>
-    </Wrapper>
+      <Stack gap={0.5}>
+        <Heading type="blockTitle">最大3列の場合</Heading>
+        <Base padding={1.5} overflow="auto">
+          <DefinitionList items={items} maxColumns={3} />
+        </Base>
+      </Stack>
+    </Stack>
   )
 }
 All.storyName = 'all'
-
-const Wrapper = styled.div`
-  padding: 24px;
-`
-const Title = styled(Heading)`
-  margin: 0 0 16px;
-`
-const Content = styled(Base)`
-  margin: 0 0 32px;
-  padding: 24px;
-`
-const Term = styled.span`
-  display: flex;
-  align-items: center;
-`
-const Alert = styled.span`
-  display: flex;
-  align-items: center;
-  margin-left: 8px;
-`
-const AlertText = styled.span`
-  margin-left: 4px;
-  color: ${({ theme }) => theme.color.TEXT_BLACK};
-  font-size: ${({ theme }) => theme.fontSize.S};
-`

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -23,12 +23,13 @@ export const DefinitionList: FC<Props & ElementProps> = ({ items, maxColumns, cl
 
   return (
     <Wrapper className={`${className} ${classNames.definitionList.wrapper}`}>
-      {items.map(({ term, description, className: itemClassName }, index) => (
+      {items.map(({ term, description, fullWidth, className: itemClassName }, index) => (
         <Item
           term={term}
           description={description}
           key={index}
           maxColumns={maxColumns}
+          fullWidth={fullWidth}
           className={itemClassName}
           themes={theme}
         />
@@ -41,20 +42,23 @@ const Wrapper = styled(Cluster).attrs({ as: 'dl', gap: 1.5 })`
   margin-block: initial;
 `
 
-const Item = styled(DefinitionListItem)<{ themes: Theme; maxColumns: Props['maxColumns'] }>`
-  ${({ maxColumns, themes: { space } }) => css`
+const Item = styled(DefinitionListItem)<{
+  themes: Theme
+  maxColumns: Props['maxColumns']
+  fullWidth?: boolean
+}>`
+  ${({ maxColumns, fullWidth, themes: { space } }) => css`
     flex-grow: 1;
     ${maxColumns &&
     css`
       /* (全体幅 - (溝 * (最大列数 - 1)) / 最大列数 */
       flex-basis: calc((100% - ${space(1.5)} * ${maxColumns - 1}) / ${maxColumns});
     `}
+    ${fullWidth &&
+    css`
+      flex-basis: 100%;
+    `}
 
     min-width: 12em;
-    /* 最大列数を指定した場合は、理想的な max-width 以上に広がる可能性がある */
-    ${!maxColumns &&
-    css`
-      max-width: 30em;
-    `}
   `}
 `

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -1,28 +1,23 @@
-import React, { FC, HTMLAttributes } from 'react'
+import React, { ComponentProps, FC, HTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { Cluster } from '../Layout'
 
-import { DefinitionListItem, DefinitionListItemProps } from './DefinitionListItem'
+import { DefinitionListItem } from './DefinitionListItem'
 import { useClassNames } from './useClassNames'
 
-type LayoutType = 'single' | 'double' | 'triple'
 type Props = {
   /** 定義リストのアイテムの配列 */
-  items: DefinitionListItemProps[]
-  /** 列のレイアウト */
-  layout?: LayoutType
+  items: Array<ComponentProps<typeof DefinitionListItem>>
+  /** 最大列数 */
+  maxColumns?: number
   /** コンポーネントに適用するクラス名 */
   className?: string
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDListElement>, keyof Props>
 
-export const DefinitionList: FC<Props & ElementProps> = ({
-  items,
-  layout = 'single',
-  className = '',
-}) => {
+export const DefinitionList: FC<Props & ElementProps> = ({ items, maxColumns, className = '' }) => {
   const theme = useTheme()
   const classNames = useClassNames()
 
@@ -33,7 +28,7 @@ export const DefinitionList: FC<Props & ElementProps> = ({
           term={term}
           description={description}
           key={index}
-          layout={layout}
+          maxColumns={maxColumns}
           className={itemClassName}
           themes={theme}
         />
@@ -42,27 +37,24 @@ export const DefinitionList: FC<Props & ElementProps> = ({
   )
 }
 
-const column = (layout: LayoutType) => {
-  switch (layout) {
-    case 'single':
-      return 1
-    case 'double':
-      return 2
-    case 'triple':
-      return 3
-  }
-}
-
 const Wrapper = styled(Cluster).attrs({ as: 'dl', gap: 1.5 })`
   margin-block: initial;
 `
 
-const Item = styled(DefinitionListItem)<{ themes: Theme; layout: LayoutType }>`
-  ${({ layout, themes: { space } }) => {
-    const $columns = column(layout)
-    return css`
-      flex-basis: calc((100% - (${space(1.5)} * ${$columns - 1})) / ${$columns});
-      flex-shrink: 1;
-    `
-  }}
+const Item = styled(DefinitionListItem)<{ themes: Theme; maxColumns: Props['maxColumns'] }>`
+  ${({ maxColumns, themes: { space } }) => css`
+    flex-grow: 1;
+    ${maxColumns &&
+    css`
+      /* (全体幅 - (溝 * (最大列数 - 1)) / 最大列数 */
+      flex-basis: calc((100% - ${space(1.5)} * ${maxColumns - 1}) / ${maxColumns});
+    `}
+
+    min-width: 12em;
+    /* 最大列数を指定した場合は、理想的な max-width 以上に広がる可能性がある */
+    ${!maxColumns &&
+    css`
+      max-width: 30em;
+    `}
+  `}
 `

--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Text'
 
 import { useClassNames } from './useClassNames'
 
-export type DefinitionListItemProps = {
+type DefinitionListItemProps = {
   term: ReactNode
   description?: ReactNode
   className?: string

--- a/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/src/components/DefinitionList/DefinitionListItem.tsx
@@ -10,6 +10,7 @@ import { useClassNames } from './useClassNames'
 type DefinitionListItemProps = {
   term: ReactNode
   description?: ReactNode
+  fullWidth?: boolean
   className?: string
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof DefinitionListItemProps>


### PR DESCRIPTION
## Related URL

#3245 への別案 

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

DefinitionList の I/F と振る舞いを見直しました。

- 標準では画面幅に応じて列数が増減
- `maxColumns` を指定すると、`maxColumns` 以内の列数で増減

確認用 Story： https://63d0ccabb5d2dd29825524ab-isuyqpytba.chromatic.com/?path=/story/data-display%EF%BC%88%E3%83%87%E3%83%BC%E3%82%BF%E8%A1%A8%E7%A4%BA%EF%BC%89-definitionlist--all

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `layout` は削除
- 最大列数を指定する `macColumns` を追加
- 標準のデフォルト幅は 12em–30em とした
  - 12em は日付が余裕を持って閲覧できる幅
  - 30em は長すぎず短すぎず CJK における最適幅の min 値
- 不要な型定義の export を削除
- Story を整理

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## 気になってること

- nowrap を組みあせた時の段落ちがいまいち
- アイテム幅をはみ出てしまう場合に必ず段落ちさせつつ、余った領域は `flex-grow` する方法はないかしら
  - item に `fill?: boolean` みたいな props を渡せてもいいかも?
  - `fill = true` の時、`max-width` を消して、`flex-basis: 100%` とするイメージ

## Capture

<!--
Please attach a capture if it looks different.
-->

Close #3245