### PR TITLE
feat!: Icon の size をデザイントークンで指定するように変更

### DIFF
--- a/src/components/ComboBox/MultiSelectedItem.tsx
+++ b/src/components/ComboBox/MultiSelectedItem.tsx
@@ -77,7 +77,7 @@ export function MultiSelectedItem<T>({
             tabIndex={-1}
           >
             <FaTimesCircleIcon
-              size={11}
+              size="XS"
               color="inherit"
               alt={decorators?.destroyButtonIconAlt?.(DESTROY_BUTTON_TEXT) || DESTROY_BUTTON_TEXT}
             />

--- a/src/components/ComboBox/MultiSelectedItem.tsx
+++ b/src/components/ComboBox/MultiSelectedItem.tsx
@@ -77,7 +77,6 @@ export function MultiSelectedItem<T>({
             tabIndex={-1}
           >
             <FaTimesCircleIcon
-              size="XS"
               color="inherit"
               alt={decorators?.destroyButtonIconAlt?.(DESTROY_BUTTON_TEXT) || DESTROY_BUTTON_TEXT}
             />

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -85,9 +85,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
           suffix={
             <IsFilteredIconWrapper isFiltered={isFiltered} themes={themes}>
               <FaFilterIcon />
-              {isFiltered ? (
-                <FaCheckCircleIcon size={8} aria-label={filteredIconAriaLabel} />
-              ) : null}
+              {isFiltered ? <SmallFaCheckCircleIcon aria-label={filteredIconAriaLabel} /> : null}
             </IsFilteredIconWrapper>
           }
         >
@@ -153,6 +151,10 @@ const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean; themes: Theme }
     right: -4px;
     bottom: 2px;
   }
+`
+const SmallFaCheckCircleIcon = styled(FaCheckCircleIcon)`
+  width: 0.5em;
+  height: 0.5em;
 `
 const StatusText = styled.span<{ themes: Theme }>`
   margin-left: ${({ themes }) => themes.spacing.XXS};

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -85,7 +85,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
           suffix={
             <IsFilteredIconWrapper isFiltered={isFiltered} themes={themes}>
               <FaFilterIcon />
-              {isFiltered ? <SmallFaCheckCircleIcon aria-label={filteredIconAriaLabel} /> : null}
+              {isFiltered ? <FilteredCheckIcon aria-label={filteredIconAriaLabel} /> : null}
             </IsFilteredIconWrapper>
           }
         >
@@ -152,7 +152,7 @@ const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean; themes: Theme }
     bottom: 2px;
   }
 `
-const SmallFaCheckCircleIcon = styled(FaCheckCircleIcon)`
+const FilteredCheckIcon = styled(FaCheckCircleIcon)`
   width: 0.5em;
   height: 0.5em;
 `

--- a/src/components/FieldSet/FieldSet.stories.tsx
+++ b/src/components/FieldSet/FieldSet.stories.tsx
@@ -63,7 +63,7 @@ export const All: Story = () => {
           label="labelSuffix"
           labelSuffix={
             <Suffix>
-              <FaExclamationCircleIcon size={12} color={themes.color.TEXT_GREY} />
+              <FaExclamationCircleIcon color={themes.color.TEXT_GREY} />
               <SuffixText>suffix text</SuffixText>
             </Suffix>
           }
@@ -90,7 +90,7 @@ export const All: Story = () => {
           }
           labelSuffix={
             <Suffix>
-              <FaExclamationCircleIcon size={12} color={themes.color.TEXT_GREY} />
+              <FaExclamationCircleIcon color={themes.color.TEXT_GREY} />
               <SuffixText>suffix text</SuffixText>
             </Suffix>
           }

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -10,7 +10,7 @@ import { Text } from '../Text'
 import * as Icons from './Icon'
 import { generateIcon } from './generateIcon'
 
-const { FaAddressBookIcon, FaBullhornIcon, FaInfoCircleIcon } = Icons
+const { FaAddressBookIcon, FaBullhornIcon, FaInfoCircleIcon, WarningIcon } = Icons
 
 export default {
   title: 'Media（メディア）/Icon',

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -85,6 +85,7 @@ export const Size: Story = () => (
     <FaAddressBookIcon size="L" />
     <FaAddressBookIcon size="XL" />
     <FaAddressBookIcon size="XXL" />
+    <WarningIcon size="XXL" />
   </Cluster>
 )
 

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -78,12 +78,13 @@ export const Color: Story = () => (
 
 export const Size: Story = () => (
   <Cluster>
-    <FaAddressBookIcon size={16} />
-    <FaAddressBookIcon size={24} />
-    <FaAddressBookIcon size={32} />
-    <FaAddressBookIcon size="1em" />
-    <FaAddressBookIcon size="1.5em" />
-    <FaAddressBookIcon size="2em" />
+    <FaAddressBookIcon size="XXS" />
+    <FaAddressBookIcon size="XS" />
+    <FaAddressBookIcon size="S" />
+    <FaAddressBookIcon size="M" />
+    <FaAddressBookIcon size="L" />
+    <FaAddressBookIcon size="XL" />
+    <FaAddressBookIcon size="XXL" />
   </Cluster>
 )
 

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -42,7 +42,7 @@ interface IconProps {
    */
   color?: LiteralUnion<DefinedColor>
   /**
-   * アイコンの大きさ
+   * アイコンの大きさ（フォントサイズの抽象値）
    */
   size?: FontSizes
 }

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -43,6 +43,7 @@ interface IconProps {
   color?: LiteralUnion<DefinedColor>
   /**
    * アイコンの大きさ（フォントサイズの抽象値）
+   * @deprecated 親要素やデフォルトフォントサイズが継承されるため固定値の指定は非推奨
    */
   size?: FontSizes
 }

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -100,6 +100,7 @@ export const createIcon = (SvgIcon: IconType) => {
         stroke="currentColor"
         fill="currentColor"
         strokeWidth="0"
+        // size は react-icons のアイコンの大きさ、width / height は自前で SVG からアイコンを作る場合の大きさ指定
         size={iconSize}
         width={iconSize}
         height={iconSize}

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { IconBaseProps, IconType } from 'react-icons'
+import { IconType } from 'react-icons'
 import styled, { css } from 'styled-components'
+
+import { FontSizes } from '@/themes/createFontSize'
 
 import { useSpacing } from '../../hooks/useSpacing'
 import { useTheme } from '../../hooks/useTheme'
@@ -41,9 +43,8 @@ interface IconProps {
   color?: LiteralUnion<DefinedColor>
   /**
    * アイコンの大きさ
-   * @deprecated 親要素やデフォルトフォントサイズが継承されるため固定値の指定は非推奨
    */
-  size?: IconBaseProps['size']
+  size?: FontSizes
 }
 
 type ElementProps = Omit<React.SVGAttributes<SVGAElement>, keyof IconProps>
@@ -72,6 +73,7 @@ export const createIcon = (SvgIcon: IconType) => {
     text,
     iconGap = 0.25,
     right = false,
+    size,
     ...props
   }) => {
     const hasLabelByAria =
@@ -90,14 +92,16 @@ export const createIcon = (SvgIcon: IconType) => {
     const classNames = useClassNames()
 
     const existsText = !!text
+    const iconSize = size ? theme.fontSize[size] : '1em' // 指定がない場合は親要素のフォントサイズを継承する
     const svgIcon = (
       <SvgIcon
         {...props}
         stroke="currentColor"
         fill="currentColor"
         strokeWidth="0"
-        width="1em"
-        height="1em"
+        size={iconSize}
+        width={iconSize}
+        height={iconSize}
         color={replacedColor}
         className={`${className} ${classNames.wrapper}`}
         role={role}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-668

## Overview

size は文字列・数値指定で px 単位を指定する非推奨なプロパティとして定義されていたが、デザイントークンによる指定で調整可能にしてサイズ変更を簡単かつ柔軟に指定できるようにしたい。

## What I did

- size の型を `FontSizes`型に変更
- 指定されたトークンに応じて`rem`値を算出するロジックを追加
  - テキストとアイコンを同等の扱いにするためText コンポーネントの実装に合わせている
- 既存コンポーネントの size に数値で px 指定している箇所の修正

## Capture

![image](https://github.com/kufu/smarthr-ui/assets/38499847/6c9a5e39-4233-4a07-80ee-6efeb782183a)

