### PR TITLE
fix!: ActionDialogWithTriggerとRemoteTriggerActionDialogのonPressEscapeの引数にclose()が渡っていないのを修正

### DIFF
--- a/src/components/Dialog/ActionDialogWithTrigger/ActionDialogWithTrigger.tsx
+++ b/src/components/Dialog/ActionDialogWithTrigger/ActionDialogWithTrigger.tsx
@@ -6,18 +6,20 @@ import { ActionDialog } from '../ActionDialog'
 type ToggleModalActionType = () => void
 
 export const ActionDialogWithTrigger: React.FC<
-  Omit<React.ComponentProps<typeof ActionDialog>, 'isOpen' | 'onClickClose'> & {
+  Omit<React.ComponentProps<typeof ActionDialog>, 'isOpen' | 'onClickClose' | 'onPressEscape'> & {
     trigger: Omit<ReactElement, 'onClick' | 'aria-haspopup' | 'aria-controls'>
     onClickTrigger?: (open: ToggleModalActionType) => void
     onClickClose?: (close: ToggleModalActionType) => void
+    onPressEscape?: (close: ToggleModalActionType) => void
   }
-> = ({ id, trigger, onClickTrigger, onClickClose, ...props }) => {
+> = ({ id, trigger, onClickTrigger, onClickClose, onPressEscape, ...props }) => {
   const generatedId = useId()
   const actualId = id || generatedId
   const [isOpen, setIsOpen] = useState(false)
 
   const open = useCallback(() => setIsOpen(true), [])
   const close = useCallback(() => setIsOpen(false), [])
+
   const onClickOpen = useCallback(() => {
     if (onClickTrigger) {
       return onClickTrigger(open)
@@ -25,6 +27,7 @@ export const ActionDialogWithTrigger: React.FC<
 
     open()
   }, [onClickTrigger, open])
+
   const actualOnClickClose = useCallback(() => {
     if (onClickClose) {
       return onClickClose(close)
@@ -32,6 +35,14 @@ export const ActionDialogWithTrigger: React.FC<
 
     close()
   }, [onClickClose, close])
+
+  const actualOnPressEscape = useCallback(() => {
+    if (onPressEscape) {
+      return onPressEscape(close)
+    }
+
+    close()
+  }, [onPressEscape, close])
 
   const actualTrigger = useMemo(
     () =>
@@ -46,7 +57,13 @@ export const ActionDialogWithTrigger: React.FC<
   return (
     <>
       {actualTrigger}
-      <ActionDialog {...props} isOpen={isOpen} onClickClose={actualOnClickClose} id={actualId} />
+      <ActionDialog
+        {...props}
+        isOpen={isOpen}
+        onClickClose={actualOnClickClose}
+        onPressEscape={actualOnPressEscape}
+        id={actualId}
+      />
     </>
   )
 }

--- a/src/components/Dialog/RemoteTriggerActionDialog/RemoteTriggerActionDialog.tsx
+++ b/src/components/Dialog/RemoteTriggerActionDialog/RemoteTriggerActionDialog.tsx
@@ -7,7 +7,19 @@ type Props = Omit<React.ComponentProps<typeof ActionDialog>, 'isOpen' | 'onClick
   Parameters<typeof useRemoteTrigger>[0]
 
 export const RemoteTriggerActionDialog: React.FC<Props> = ({ id, onClickClose, ...props }) => {
-  const { isOpen, onClickClose: actualOnClickClose } = useRemoteTrigger({ id, onClickClose })
+  const {
+    isOpen,
+    onClickClose: actualOnClickClose,
+    onPressEscape,
+  } = useRemoteTrigger({ id, onClickClose })
 
-  return <ActionDialog {...props} id={id} isOpen={isOpen} onClickClose={actualOnClickClose} />
+  return (
+    <ActionDialog
+      {...props}
+      id={id}
+      isOpen={isOpen}
+      onClickClose={actualOnClickClose}
+      onPressEscape={onPressEscape}
+    />
+  )
 }

--- a/src/components/Dialog/useRemoteTrigger.ts
+++ b/src/components/Dialog/useRemoteTrigger.ts
@@ -4,10 +4,12 @@ export const TRIGGER_EVENT = 'smarthr-ui:remote-dialog-trigger-dispatch'
 
 export function useRemoteTrigger({
   onClickClose: orgOnClickClose,
+  onPressEscape: orgOnPressEscape,
   id,
 }: {
   id: string
   onClickClose?: (close: () => void) => void
+  onPressEscape?: (close: () => void) => void
 }) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -20,6 +22,16 @@ export function useRemoteTrigger({
 
     setIsOpen(false)
   }, [orgOnClickClose])
+
+  const onPressEscape = useCallback(() => {
+    if (orgOnPressEscape) {
+      return orgOnPressEscape(() => {
+        setIsOpen(false)
+      })
+    }
+
+    setIsOpen(false)
+  }, [orgOnPressEscape])
 
   useEffect(() => {
     const handler = ((e: Event & { detail: { id: string } }) => {
@@ -38,5 +50,6 @@ export function useRemoteTrigger({
   return {
     isOpen,
     onClickClose,
+    onPressEscape,
   }
 }


### PR DESCRIPTION
## Related URL

なし

## Overview

- ActionDialogWithTriggerとRemoteTriggerActionDialogで、onPressEscapeを明示的に渡した場合、useStateの状態を変更するためのclose関数が引数に渡ってきていません
- 実質onPressEscapeを明示的に渡せなくなっているため、修正します

## What I did

- onPressEscapeの型を修正し、close関数が引数に渡すように調整しました

## Capture

<!--
Please attach a capture if it looks different.
-->
