### PR TITLE
feat!: FloatArea の errorText / errorIcon を廃止し、フィードバックメッセージを表示する responseMessage を追加

### DIFF
--- a/src/components/FloatArea/FloatArea.stories.tsx
+++ b/src/components/FloatArea/FloatArea.stories.tsx
@@ -1,10 +1,9 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 
 import { Base } from '../Base'
 import { Button } from '../Button'
 import { Heading } from '../Heading'
-import { FaExclamationCircleIcon } from '../Icon'
 import { Stack } from '../Layout'
 
 import { FloatArea } from './FloatArea'
@@ -22,15 +21,14 @@ export default {
   },
 }
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <>
     <Heading>書類に記載する扶養家族</Heading>
     <FloatArea
       primaryButton={<Button variant="primary">Submit</Button>}
       secondaryButton={<Button>Cancel</Button>}
       tertiaryButton={<Button>preview</Button>}
-      errorIcon={<FaExclamationCircleIcon color="DANGER" />}
-      errorText="これはfixedのFloatAreaです。"
+      responseMessage={{ status: 'error', text: 'これはfixedのFloatAreaです。' }}
       top={2}
       width="80%"
       fixed
@@ -42,8 +40,7 @@ export const All: Story = () => (
             primaryButton={<Button variant="primary">Submit</Button>}
             secondaryButton={<Button>Cancel</Button>}
             tertiaryButton={<Button>preview</Button>}
-            errorIcon={<FaExclamationCircleIcon color="DANGER" />}
-            errorText="これはstickyのFloatAreaです。"
+            responseMessage={{ status: 'success', text: 'これはstickyのFloatAreaです。' }}
             bottom={1.5}
             key={index}
           />
@@ -58,18 +55,17 @@ export const All: Story = () => (
 )
 All.storyName = 'all'
 
-export const WithoutTertiary: Story = () => (
+export const WithoutTertiary: StoryFn = () => (
   <FloatArea
     primaryButton={<Button variant="primary">Submit</Button>}
     secondaryButton={<Button>Cancel</Button>}
-    errorIcon={<FaExclamationCircleIcon color="DANGER" />}
-    errorText="This is the error text."
+    responseMessage={{ status: 'error', text: 'これはエラーテキストです。' }}
     bottom={1.5}
   />
 )
 WithoutTertiary.storyName = 'withoutTertiary'
 
-export const OnlyPrimary: Story = () => (
+export const OnlyPrimary: StoryFn = () => (
   <FloatArea primaryButton={<Button variant="primary">Submit</Button>} top={2} />
 )
 OnlyPrimary.storyName = 'onlyPrimary'

--- a/src/components/FloatArea/FloatArea.tsx
+++ b/src/components/FloatArea/FloatArea.tsx
@@ -1,19 +1,13 @@
-import React, {
-  ComponentProps,
-  FC,
-  FunctionComponentElement,
-  HTMLAttributes,
-  ReactNode,
-} from 'react'
+import React, { FC, HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useSpacing } from '../../hooks/useSpacing'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { AbstractSize, CharRelativeSize } from '../../themes/createSpacing'
+import { ResponseMessageType } from '../../types'
 import { Base as shrBase } from '../Base'
-import { FaExclamationCircleIcon } from '../Icon'
-import { Cluster, LineUp } from '../Layout'
-import { Text } from '../Text'
+import { Cluster } from '../Layout'
+import { ResponseMessage } from '../ResponseMessage'
 
 import { useClassNames } from './useClassNames'
 
@@ -32,12 +26,8 @@ type Props = StyleProps & {
   secondaryButton?: ReactNode
   /** tertiary 領域に表示するボタン */
   tertiaryButton?: ReactNode
-  /** エラーメッセージ */
-  errorText?: ReactNode
-  /**
-   * エラーメッセージのアイコン（`FaExclamationCircleIcon` を指定）
-   */
-  errorIcon?: FunctionComponentElement<ComponentProps<typeof FaExclamationCircleIcon>>
+  /** 操作に対するフィードバックメッセージ */
+  responseMessage?: ResponseMessageType
   /** 上下の位置を固定するかどうか */
   fixed?: boolean
   /** コンポーネントの幅 */
@@ -51,8 +41,7 @@ export const FloatArea: FC<Props & ElementProps> = ({
   primaryButton,
   secondaryButton,
   tertiaryButton,
-  errorText,
-  errorIcon,
+  responseMessage,
   fixed = false,
   className = '',
   width,
@@ -72,12 +61,11 @@ export const FloatArea: FC<Props & ElementProps> = ({
       <Cluster gap={1}>
         {tertiaryButton && tertiaryButton}
         <RightSide>
-          <Cluster gap={1}>
-            {errorText && (
-              <ErrorMessage gap={0.25} vAlign="center" as="p" className={classNames.errorText}>
-                {errorIcon && <ErrorIcon themes={theme}>{errorIcon}</ErrorIcon>}
-                <Text size="S">{errorText}</Text>
-              </ErrorMessage>
+          <Cluster gap={1} align="center">
+            {(responseMessage?.status === 'success' || responseMessage?.status === 'error') && (
+              <ResponseMessage type={responseMessage.status}>
+                {responseMessage.text}
+              </ResponseMessage>
             )}
             <Cluster gap={1}>
               {secondaryButton && secondaryButton}
@@ -104,16 +92,5 @@ const Base = styled(shrBase).attrs({ layer: 3 })<
     `}
 `
 const RightSide = styled.div`
-  margin-left: auto;
-`
-const ErrorMessage = styled(LineUp)`
-  margin-top: 0;
-  margin-bottom: 0;
-`
-const ErrorIcon = styled.span<{ themes: Theme }>`
-  flex-shrink: 0;
-
-  > svg {
-    display: block; /* 隙間対策 */
-  }
+  margin-inline-start: auto;
 `

--- a/src/components/FloatArea/useClassNames.ts
+++ b/src/components/FloatArea/useClassNames.ts
@@ -10,7 +10,6 @@ export const useClassNames = () => {
   return useMemo(
     () => ({
       wrapper: generate(),
-      errorText: generate('errorText'),
     }),
     [generate],
   )


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-663
- https://smarthr.atlassian.net/browse/SHRUI-695

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FloatArea の I/F が特殊だったため、ActionDialog や FilterDialog と合わせました。

差分を減らすために #3449 を base ブランチに指定しています。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- errorText / errorIcon を削除
- responseMessage を追加
- 内部的に ResponseMessage で書き換え
- Story を修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
