### PR TITLE
fix: Dialog の max-width が固定値になっている欠陥を修正

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -171,7 +171,7 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
       max-width: min(
         calc(100vw - max(${left || 0}px, ${space(0.5)}) - max(${right || 0}px, ${space(0.5)})),
         /* TODO: 幅の定数指定は、トークンが決まり theme に入ったら差し替える */
-        800px
+        ${exist($width) ? (typeof $width === 'number' ? `${$width}px` : $width) : '800px'}
       );
       border-radius: ${radius.m};
       background-color: ${color.WHITE};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Dialog に幅が指定されている場合は最大幅もその幅に合わせる。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
