### PR TITLE
fix: Dialog に width が指定されていない場合の max-width を vieport からの計算に変更

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -160,6 +160,7 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
     const translateX = exist(right) || exist(left) ? '0' : 'calc((100vw - 100%) / 2)'
     const translateY = exist(top) || exist(bottom) ? '0' : 'calc((100vh - 100%) / 2)'
 
+    const actualWidth = typeof $width === 'number' ? `${$width}px` : $width
     const minimumMaxWidth = `calc(100vw - max(${left || 0}px, ${space(0.5)}) - max(${
       right || 0
     }px, ${space(0.5)}))`
@@ -167,15 +168,13 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
     return css`
       position: absolute;
       inset: ${positionTop} ${positionRight} ${positionBottom} ${positionLeft};
-      ${exist($width) &&
-      css`
-        width: ${typeof $width === 'number' ? `${$width}px` : $width};
-      `}
       /* viewport を超えないように上限設定 */
-      max-width:
-        ${exist($width)
-        ? `min(${minimumMaxWidth}, ${typeof $width === 'number' ? `${$width}px` : $width})`
-        : minimumMaxWidth};
+      max-width: ${minimumMaxWidth};
+      ${exist(actualWidth) &&
+      css`
+        width: ${actualWidth};
+        max-width: min(${minimumMaxWidth}, ${actualWidth});
+      `}
       border-radius: ${radius.m};
       background-color: ${color.WHITE};
       box-shadow: ${shadow.LAYER3};

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -160,6 +160,10 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
     const translateX = exist(right) || exist(left) ? '0' : 'calc((100vw - 100%) / 2)'
     const translateY = exist(top) || exist(bottom) ? '0' : 'calc((100vh - 100%) / 2)'
 
+    const minimumMaxWidth = `calc(100vw - max(${left || 0}px, ${space(0.5)}) - max(${
+      right || 0
+    }px, ${space(0.5)}))`
+
     return css`
       position: absolute;
       inset: ${positionTop} ${positionRight} ${positionBottom} ${positionLeft};
@@ -168,11 +172,10 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
         width: ${typeof $width === 'number' ? `${$width}px` : $width};
       `}
       /* viewport を超えないように上限設定 */
-      max-width: min(
-        calc(100vw - max(${left || 0}px, ${space(0.5)}) - max(${right || 0}px, ${space(0.5)})),
-        /* TODO: 幅の定数指定は、トークンが決まり theme に入ったら差し替える */
-        ${exist($width) ? (typeof $width === 'number' ? `${$width}px` : $width) : '800px'}
-      );
+      max-width:
+        ${exist($width)
+        ? `min(${minimumMaxWidth}, ${typeof $width === 'number' ? `${$width}px` : $width})`
+        : minimumMaxWidth};
       border-radius: ${radius.m};
       background-color: ${color.WHITE};
       box-shadow: ${shadow.LAYER3};


### PR DESCRIPTION
## Related URL

#3453

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

#3453 で width を指定していない Dialog の最大幅も `800px` になってしまっていたので修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

width が指定されていない場合は vieport 幅から最低限の margin を除いた値が最大となるように修正。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
