### PR TITLE
fix: MultiComboBox の width / disabled が DOM に渡らないように修正

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -302,7 +302,7 @@ export function MultiComboBox<T>({
       <Container
         {...props}
         themes={theme}
-        width={width}
+        $width={width}
         ref={outerRef}
         className={wrapperClassNames}
         onClick={(e) => {
@@ -387,7 +387,7 @@ export function MultiComboBox<T>({
           )}
         </InputArea>
 
-        <Suffix themes={theme} disabled={disabled}>
+        <Suffix themes={theme} $disabled={disabled}>
           <FaCaretDownIcon color={caretIconColor} />
         </Suffix>
 
@@ -397,14 +397,14 @@ export function MultiComboBox<T>({
   )
 }
 
-const Container = styled.div<{ themes: Theme; width: number | string }>`
-  ${({ themes, width }) => {
+const Container = styled.div<{ themes: Theme; $width: number | string }>`
+  ${({ themes, $width }) => {
     const { border, radius, color, shadow, spacingByChar } = themes
 
     return css`
       display: inline-flex;
       min-width: calc(62px + 32px + ${spacingByChar(0.5)} * 2);
-      width: ${typeof width === 'number' ? `${width}px` : width};
+      width: ${typeof $width === 'number' ? `${$width}px` : $width};
       min-height: 40px;
       border-radius: ${radius.m};
       border: ${border.shorthand};
@@ -497,8 +497,8 @@ const Placeholder = styled.p<{ themes: Theme }>`
     `
   }}
 `
-const Suffix = styled.div<{ themes: Theme; disabled: boolean }>`
-  ${({ themes: { color, spacingByChar }, disabled }) => {
+const Suffix = styled.div<{ themes: Theme; $disabled: boolean }>`
+  ${({ themes: { color, spacingByChar }, $disabled }) => {
     const space = spacingByChar(0.5)
 
     return css`
@@ -509,7 +509,7 @@ const Suffix = styled.div<{ themes: Theme; disabled: boolean }>`
       padding: ${space};
       padding-left: calc(${space} + 1px);
       box-sizing: border-box;
-      cursor: ${disabled ? 'not-allowed' : 'pointer'};
+      cursor: ${$disabled ? 'not-allowed' : 'pointer'};
 
       &::before {
         content: '';

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -41,7 +41,7 @@ type Props<T> = {
 type Rect = {
   top: number
   left: number
-  width: number
+  $width: number | string
   height?: number
 }
 
@@ -73,7 +73,7 @@ export function useListBox<T>({
   const [listBoxRect, setListBoxRect] = useState<Rect>({
     top: 0,
     left: 0,
-    width: 0,
+    $width: 0,
   })
 
   const calculateRect = useCallback(() => {
@@ -111,7 +111,7 @@ export function useListBox<T>({
     setListBoxRect({
       top,
       left: rect.left + window.pageXOffset,
-      width: rect.width,
+      $width: rect.width,
       height,
     })
   }, [listBoxRef, triggerRef])
@@ -218,7 +218,7 @@ export function useListBox<T>({
           <Container
             {...listBoxRect}
             themes={theme}
-            $width={dropdownWidth || listBoxRect.width}
+            $width={dropdownWidth || listBoxRect.$width}
             id={listBoxId}
             ref={listBoxRef}
             role="listbox"
@@ -297,7 +297,7 @@ export function useListBox<T>({
   }
 }
 
-const Wrapper = styled.div<Rect>(({ top, left, width }) => {
+const Wrapper = styled.div<Rect>(({ top, left, $width }) => {
   return css`
     /*
     ドロップダウンリストをInputの幅に対する相対値で指定できるように、Inputの幅のdivを親要素にする
@@ -305,16 +305,11 @@ const Wrapper = styled.div<Rect>(({ top, left, width }) => {
     position: absolute;
     top: ${top}px;
     left: ${left}px;
-    width: ${width}px;
+    width: ${$width}px;
   `
 })
 
-const Container = styled.div<
-  Rect & {
-    themes: Theme
-    $width: string | number
-  }
->(({ left, $width, height, themes }) => {
+const Container = styled.div<Rect & { themes: Theme }>(({ left, $width, height, themes }) => {
   const { color, fontSize, spacingByChar, radius, shadow, zIndex } = themes
   return css`
     position: absolute;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

アクセシビリティ試験で発覚。
width / disabled な不要に渡されていたため、transient props を使って修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
