### PR TITLE
fix: Select は label 内に含まれる可能性があるため span として提供

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -135,12 +135,13 @@ export const Select = forwardRef(
 
 const generateSizeClassName = (size: Props<string>['size']) => (size === 's' ? '--small' : '')
 
-const Wrapper = styled.div<{
+const Wrapper = styled.span<{
   $width: string
 }>`
   ${({ $width }) => css`
-    position: relative;
     box-sizing: border-box;
+    position: relative;
+    display: block;
     width: ${$width};
   `}
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

アクセシビリティ試験で発覚。
label > Select となる可能性を考慮して、wrapper 要素を span に変更。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
