### PR TITLE
fix: Textarea は label 内に含まれる可能性があるため span として提供

### DIFF
--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -205,11 +205,12 @@ const StyledTextarea = styled.textarea<Props & { themes: Theme; textAreaWidth?: 
   `}
 `
 
-const Counter = styled.div<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize, color } = themes
+const Counter = styled.span<{ themes: Theme }>`
+  ${({ themes: { fontSize, color } }) => {
     return css`
+      display: block;
       font-size: ${fontSize.S};
+
       > span {
         font-weight: bold;
         color: ${color.TEXT_GREY};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

アクセシビリティ試験で発覚。
label > Textarea となる可能性があるため、wrapper を span として提供。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
