### PR TITLE
fix: CheckBox の wrapper を span に変える

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -47,7 +47,7 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
 )
 
 // Use flex-start to support multi-line text.
-const Wrapper = styled.div`
+const Wrapper = styled.span`
   display: inline-flex;
   align-items: flex-start;
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

アクセシビリティ試験で発覚。
Th/TdCheckbox などで label > CheckBox となる可能性があるため、wrappaer を span に変更。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
