### PR TITLE
fix: BulkActionRow や EmptyTableBody の colspan を算出するように変更

### DIFF
--- a/src/components/Table/BulkActionRow.tsx
+++ b/src/components/Table/BulkActionRow.tsx
@@ -1,9 +1,10 @@
-import React, { HTMLAttributes, ReactNode, VFC } from 'react'
+import React, { FC, HTMLAttributes, ReactNode } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
 import { useBulkActionRowClassNames } from './useClassNames'
+import { useTableHeadCellCount } from './useTableHeadCellCount'
 
 export type Props = {
   /** 一括操作エリアの内容 */
@@ -13,16 +14,15 @@ export type Props = {
 }
 type ElementProps = Omit<HTMLAttributes<HTMLTableRowElement>, keyof Props>
 
-export const BulkActionRow: VFC<Props & ElementProps> = ({
-  className = '',
-  children,
-  ...props
-}) => {
+export const BulkActionRow: FC<Props & ElementProps> = ({ className = '', children, ...props }) => {
   const themes = useTheme()
   const classNames = useBulkActionRowClassNames()
+
+  const { ref, count } = useTableHeadCellCount<HTMLTableRowElement>()
+
   return (
-    <tr {...props} className={`${className} ${classNames.wrapper}`}>
-      <Cell colSpan={1000} themes={themes}>
+    <tr {...props} ref={ref} className={`${className} ${classNames.wrapper}`}>
+      <Cell colSpan={count} themes={themes}>
         {children}
       </Cell>
     </tr>
@@ -30,11 +30,11 @@ export const BulkActionRow: VFC<Props & ElementProps> = ({
 }
 
 const Cell = styled.td<{ themes: Theme }>(({ themes }) => {
-  const { fontSize, border, color, spacingByChar } = themes
+  const { fontSize, border, color, space } = themes
   return css`
     border-top: ${border.shorthand};
     background-color: ${color.ACTION_BACKGROUND};
-    padding: ${spacingByChar(1)};
+    padding: ${space(1)};
     font-size: ${fontSize.M};
   `
 })

--- a/src/components/Table/BulkActionRow.tsx
+++ b/src/components/Table/BulkActionRow.tsx
@@ -18,10 +18,10 @@ export const BulkActionRow: FC<Props & ElementProps> = ({ className = '', childr
   const themes = useTheme()
   const classNames = useBulkActionRowClassNames()
 
-  const { ref, count } = useTableHeadCellCount<HTMLTableRowElement>()
+  const { countHeadCellRef, count } = useTableHeadCellCount<HTMLTableRowElement>()
 
   return (
-    <tr {...props} ref={ref} className={`${className} ${classNames.wrapper}`}>
+    <tr {...props} ref={countHeadCellRef} className={`${className} ${classNames.wrapper}`}>
       <Cell colSpan={count} themes={themes}>
         {children}
       </Cell>

--- a/src/components/Table/EmptyTableBody.tsx
+++ b/src/components/Table/EmptyTableBody.tsx
@@ -22,10 +22,10 @@ export const EmptyTableBody: React.FC<Props & ElementProps> = ({
   padding = 4,
   ...props
 }) => {
-  const { ref, count } = useTableHeadCellCount<HTMLTableSectionElement>()
+  const { countHeadCellRef, count } = useTableHeadCellCount<HTMLTableSectionElement>()
 
   return (
-    <tbody {...props} ref={ref}>
+    <tbody {...props} ref={countHeadCellRef}>
       <tr>
         <StyledTd colSpan={count} padding={padding}>
           <Center>{children}</Center>

--- a/src/components/Table/EmptyTableBody.tsx
+++ b/src/components/Table/EmptyTableBody.tsx
@@ -5,6 +5,7 @@ import { useSpacing } from '../../hooks/useSpacing'
 import { Center } from '../Layout'
 
 import { Td } from './Td'
+import { useTableHeadCellCount } from './useTableHeadCellCount'
 
 import type { Gap } from '../../types'
 
@@ -21,10 +22,12 @@ export const EmptyTableBody: React.FC<Props & ElementProps> = ({
   padding = 4,
   ...props
 }) => {
+  const { ref, count } = useTableHeadCellCount<HTMLTableSectionElement>()
+
   return (
-    <tbody {...props}>
+    <tbody {...props} ref={ref}>
       <tr>
-        <StyledTd colSpan={1000} padding={padding}>
+        <StyledTd colSpan={count} padding={padding}>
           <Center>{children}</Center>
         </StyledTd>
       </tr>

--- a/src/components/Table/useTableHeadCellCount.ts
+++ b/src/components/Table/useTableHeadCellCount.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef, useState } from 'react'
+
+export const useTableHeadCellCount = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null)
+  const [count, setCount] = useState(1000)
+
+  useEffect(() => {
+    if (ref.current) {
+      const parentTable = ref.current.closest('table')
+      const cells = parentTable?.querySelectorAll('thead > tr:first-child > th')
+      setCount(cells?.length || 0)
+    }
+  }, [ref])
+
+  return { ref, count }
+}

--- a/src/components/Table/useTableHeadCellCount.ts
+++ b/src/components/Table/useTableHeadCellCount.ts
@@ -1,16 +1,15 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export const useTableHeadCellCount = <T extends HTMLElement>() => {
-  const ref = useRef<T>(null)
   const [count, setCount] = useState(1000)
 
-  useEffect(() => {
-    if (ref.current) {
-      const parentTable = ref.current.closest('table')
+  const countHeadCellRef = useCallback((node: T) => {
+    if (node !== null) {
+      const parentTable = node.closest('table')
       const cells = parentTable?.querySelectorAll('thead > tr:first-child > th')
       setCount(cells?.length || 0)
     }
-  }, [ref])
+  }, [])
 
-  return { ref, count }
+  return { count, countHeadCellRef }
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

アクセシビリティ試験で発覚。
colspan="1000" は invalid な HTML だったため、hooks で算出するように変更。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
