### PR TITLE
fix: Storybook関連ファイルでも @/ エイリアスを利用可能にする

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -39,14 +39,12 @@ const config: StorybookConfig = {
     autodocs: true,
   },
   webpackFinal: async (config) => {
-    config.resolve = {
-      ...config.resolve,
-    }
-    config.resolve.alias = {
-      ...config.resolve.alias,
+    const resolve = config.resolve || {}
+    resolve.alias = {
+      ...resolve.alias,
       '@': path.resolve(__dirname, '../src'),
     }
-    return config
+    return { ...config, resolve }
   },
 }
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -38,6 +38,16 @@ const config: StorybookConfig = {
   docs: {
     autodocs: true,
   },
+  webpackFinal: async (config) => {
+    config.resolve = {
+      ...config.resolve,
+    }
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@': path.resolve(__dirname, '../src'),
+    }
+    return config
+  },
 }
 
 export default config


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-709

## Overview

Story ファイルで`@`エイリアスによるモジュールの参照ができていない状態になっていたためtsconfigと同様にエイリアスを利用できるように設定を追加したい

## What I did

`.storybook/main.ts`で webpack のエイリアス設定を追加

## Capture

<!--
Please attach a capture if it looks different.
-->
