### PR TITLE
fix: Checkbox の indeterminate に aria-checked を使わないように修正

### DIFF
--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -1,5 +1,5 @@
 import { transparentize } from 'polished'
-import React, { forwardRef, useCallback } from 'react'
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
@@ -27,17 +27,28 @@ export const CheckBoxInput = forwardRef<HTMLInputElement, Props>(
     )
     const classNames = useClassNames()
 
+    const inputRef = useRef<HTMLInputElement>(null)
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current,
+    )
+
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = mixed
+      }
+    }, [mixed])
+
     return (
       <Wrapper themes={theme}>
         {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
         <Input
           {...props}
-          {...(mixed && { 'aria-checked': 'mixed' })}
           type="checkbox"
           onChange={handleChange}
           className={classNames.checkBox}
           themes={theme}
-          ref={ref}
+          ref={inputRef}
           aria-invalid={props.error || undefined}
         />
         <Box className={boxClassName} themes={theme} error={props.error} />
@@ -84,7 +95,8 @@ const Box = styled.span<{ themes: Theme; error?: boolean }>`
       }
 
       /* FIXME: なぜか static classname になってしまうため & を重ねている */
-      input:checked + && {
+      input:checked + &&,
+      input:indeterminate + && {
         border-color: ${color.MAIN};
         background-color: ${color.MAIN};
         @media (prefers-contrast: more) {
@@ -146,7 +158,7 @@ const IconWrap = styled.span<{ themes: Theme }>`
       transform: translate(-50%, -50%);
       pointer-events: none;
 
-      input:not(:checked) ~ & > svg {
+      input:not(:checked, :indeterminate) ~ & > svg {
         fill: transparent;
       }
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->
https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/checkbox#%E6%9C%AA%E6%B1%BA%E5%AE%9A%E7%8A%B6%E6%85%8B%E3%81%AE%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%9C%E3%83%83%E3%82%AF%E3%82%B9

## Overview

アクセシビリティ再試験で発覚。
input[type=checkbox] は標準で checked 状態を持つため、`aria-checked` を付けると invalid な HTML とみなされる。
JavaScript で node.indeterminate = true にするのが正解らしいので、`mixed` が渡された時は `indeterminate = true` となるように修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
