### PR TITLE
fix: alias をやめる

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,6 @@ module.exports = {
     'jsx-a11y/no-static-element-interactions': 'warn',
     'smarthr/a11y-anchor-has-href-attribute': 'error',
     'smarthr/a11y-prohibit-input-placeholder': 'error',
+    'smarthr/require-barrel-import': 0,
   },
 }

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import { IconType } from 'react-icons'
 import styled, { css } from 'styled-components'
 
-import { FontSizes } from '@/themes/createFontSize'
-
 import { useSpacing } from '../../hooks/useSpacing'
 import { useTheme } from '../../hooks/useTheme'
+import { FontSizes } from '../../themes/createFontSize'
 import { AbstractSize, CharRelativeSize } from '../../themes/createSpacing'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,10 +17,7 @@
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "noEmitOnError": true,
-    "esModuleInterop": true,
-    "paths": {
-      "@/*": ["./src/*"],
-    },
+    "esModuleInterop": true
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*"]


### PR DESCRIPTION
tsconfig.json で `skipLibCheck: true` を設定していない環境では、ライブラリの型チェックをしにいきエラーが発生するそう。
根本解決方法が見つかるまでは alias は利用しない。