### PR TITLE
fix: FormControlのhtmlForとlabelIdが使えなくなっていたのを修正

### DIFF
--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -64,8 +64,8 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-lab
 export const FormGroup: React.FC<Props & ElementProps> = ({
   title,
   titleType = 'blockTitle',
-  htmlFor,
-  labelId,
+  htmlFor: htmlForProp,
+  labelId: labelIdProp,
   innerMargin,
   statusLabelProps = [],
   helpMessage,
@@ -79,8 +79,10 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   ...props
 }) => {
   const disabledClass = disabled ? 'disabled' : ''
-  const managedHtmlFor = useId(htmlFor)
-  const managedLabelId = useId(labelId)
+  const managedHtmlFor = useId()
+  const managedLabelId = useId()
+  const htmlFor = useMemo(() => htmlForProp || managedHtmlFor, [htmlForProp, managedHtmlFor])
+  const labelId = useMemo(() => labelIdProp || managedLabelId, [labelIdProp, managedLabelId])
   const isRoleGroup = as === 'fieldset'
   const statusLabelList = Array.isArray(statusLabelProps) ? statusLabelProps : [statusLabelProps]
 
@@ -90,24 +92,24 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
     () =>
       Object.entries({ helpMessage, exampleMessage, supplementaryMessage, errorMessages })
         .filter(({ 1: value }) => value)
-        .map(([key]) => `${managedHtmlFor}_${key}`)
+        .map(([key]) => `${htmlFor}_${key}`)
         .join(' '),
-    [helpMessage, exampleMessage, supplementaryMessage, errorMessages, managedHtmlFor],
+    [helpMessage, exampleMessage, supplementaryMessage, errorMessages, htmlFor],
   )
 
   return (
     <Wrapper
       {...props}
       disabled={disabled}
-      aria-labelledby={isRoleGroup ? managedLabelId : undefined}
+      aria-labelledby={isRoleGroup ? labelId : undefined}
       aria-describedby={isRoleGroup && describedbyIds ? describedbyIds : undefined}
       themes={theme}
       className={`${className} ${disabledClass} ${classNames.wrapper}`}
       as={as}
     >
       <FormLabel
-        htmlFor={!isRoleGroup ? managedHtmlFor : undefined}
-        id={managedLabelId}
+        htmlFor={!isRoleGroup ? htmlFor : undefined}
+        id={labelId}
         className={`${classNames.label}`}
         as={isRoleGroup ? 'legend' : 'label'}
       >
@@ -122,7 +124,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       </FormLabel>
 
       {helpMessage && (
-        <p className={classNames.helpMessage} id={`${managedHtmlFor}_helpMessage`}>
+        <p className={classNames.helpMessage} id={`${htmlFor}_helpMessage`}>
           {helpMessage}
         </p>
       )}
@@ -131,7 +133,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
           as="p"
           color="TEXT_GREY"
           italic
-          id={`${managedHtmlFor}_exampleMessage`}
+          id={`${htmlFor}_exampleMessage`}
           className={classNames.exampleMessage}
         >
           {exampleMessage}
@@ -139,7 +141,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       )}
 
       {errorMessages && (
-        <Stack gap={0} id={`${managedHtmlFor}_errorMessages`}>
+        <Stack gap={0} id={`${htmlFor}_errorMessages`}>
           {(Array.isArray(errorMessages) ? errorMessages : [errorMessages]).map(
             (message, index) => (
               <ErrorMessage themes={theme} key={index}>
@@ -151,7 +153,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       )}
 
       <ChildrenWrapper innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
-        {addIdToFirstInput(children, managedHtmlFor, describedbyIds)}
+        {addIdToFirstInput(children, htmlFor, describedbyIds)}
       </ChildrenWrapper>
 
       {supplementaryMessage && (
@@ -159,7 +161,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
           as="p"
           size="S"
           color="TEXT_GREY"
-          id={`${managedHtmlFor}_supplementaryMessage`}
+          id={`${htmlFor}_supplementaryMessage`}
           className={classNames.supplementaryMessage}
         >
           {supplementaryMessage}
@@ -169,7 +171,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   )
 }
 
-const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describedbyIds: string) => {
+const addIdToFirstInput = (children: ReactNode, htmlFor: string, describedbyIds: string) => {
   let foundFirstInput = false
 
   const addId = (targets: ReactNode): ReactNode[] | ReactNode => {
@@ -183,7 +185,7 @@ const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describe
       if (isInputElement(type)) {
         foundFirstInput = true
         return React.cloneElement(child as ReactElement, {
-          id: managedHtmlFor,
+          id: htmlFor,
           'aria-describedby': describedbyIds ? describedbyIds : undefined,
         })
       }

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -64,8 +64,8 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props | 'aria-lab
 export const FormGroup: React.FC<Props & ElementProps> = ({
   title,
   titleType = 'blockTitle',
-  htmlFor: htmlForProp,
-  labelId: labelIdProp,
+  htmlFor,
+  labelId,
   innerMargin,
   statusLabelProps = [],
   helpMessage,
@@ -79,10 +79,8 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   ...props
 }) => {
   const disabledClass = disabled ? 'disabled' : ''
-  const managedHtmlFor = useId()
-  const managedLabelId = useId()
-  const htmlFor = useMemo(() => htmlForProp || managedHtmlFor, [htmlForProp, managedHtmlFor])
-  const labelId = useMemo(() => labelIdProp || managedLabelId, [labelIdProp, managedLabelId])
+  const managedHtmlFor = useId(htmlFor)
+  const managedLabelId = useId(labelId)
   const isRoleGroup = as === 'fieldset'
   const statusLabelList = Array.isArray(statusLabelProps) ? statusLabelProps : [statusLabelProps]
 
@@ -92,24 +90,24 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
     () =>
       Object.entries({ helpMessage, exampleMessage, supplementaryMessage, errorMessages })
         .filter(({ 1: value }) => value)
-        .map(([key]) => `${htmlFor}_${key}`)
+        .map(([key]) => `${managedHtmlFor}_${key}`)
         .join(' '),
-    [helpMessage, exampleMessage, supplementaryMessage, errorMessages, htmlFor],
+    [helpMessage, exampleMessage, supplementaryMessage, errorMessages, managedHtmlFor],
   )
 
   return (
     <Wrapper
       {...props}
       disabled={disabled}
-      aria-labelledby={isRoleGroup ? labelId : undefined}
+      aria-labelledby={isRoleGroup ? managedLabelId : undefined}
       aria-describedby={isRoleGroup && describedbyIds ? describedbyIds : undefined}
       themes={theme}
       className={`${className} ${disabledClass} ${classNames.wrapper}`}
       as={as}
     >
       <FormLabel
-        htmlFor={!isRoleGroup ? htmlFor : undefined}
-        id={labelId}
+        htmlFor={!isRoleGroup ? managedHtmlFor : undefined}
+        id={managedLabelId}
         className={`${classNames.label}`}
         as={isRoleGroup ? 'legend' : 'label'}
       >
@@ -124,7 +122,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       </FormLabel>
 
       {helpMessage && (
-        <p className={classNames.helpMessage} id={`${htmlFor}_helpMessage`}>
+        <p className={classNames.helpMessage} id={`${managedHtmlFor}_helpMessage`}>
           {helpMessage}
         </p>
       )}
@@ -133,7 +131,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
           as="p"
           color="TEXT_GREY"
           italic
-          id={`${htmlFor}_exampleMessage`}
+          id={`${managedHtmlFor}_exampleMessage`}
           className={classNames.exampleMessage}
         >
           {exampleMessage}
@@ -141,7 +139,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       )}
 
       {errorMessages && (
-        <Stack gap={0} id={`${htmlFor}_errorMessages`}>
+        <Stack gap={0} id={`${managedHtmlFor}_errorMessages`}>
           {(Array.isArray(errorMessages) ? errorMessages : [errorMessages]).map(
             (message, index) => (
               <ErrorMessage themes={theme} key={index}>
@@ -153,7 +151,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
       )}
 
       <ChildrenWrapper innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
-        {addIdToFirstInput(children, htmlFor, describedbyIds)}
+        {addIdToFirstInput(children, managedHtmlFor, describedbyIds)}
       </ChildrenWrapper>
 
       {supplementaryMessage && (
@@ -161,7 +159,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
           as="p"
           size="S"
           color="TEXT_GREY"
-          id={`${htmlFor}_supplementaryMessage`}
+          id={`${managedHtmlFor}_supplementaryMessage`}
           className={classNames.supplementaryMessage}
         >
           {supplementaryMessage}
@@ -171,7 +169,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   )
 }
 
-const addIdToFirstInput = (children: ReactNode, htmlFor: string, describedbyIds: string) => {
+const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describedbyIds: string) => {
   let foundFirstInput = false
 
   const addId = (targets: ReactNode): ReactNode[] | ReactNode => {
@@ -185,7 +183,7 @@ const addIdToFirstInput = (children: ReactNode, htmlFor: string, describedbyIds:
       if (isInputElement(type)) {
         foundFirstInput = true
         return React.cloneElement(child as ReactElement, {
-          id: htmlFor,
+          id: managedHtmlFor,
           'aria-describedby': describedbyIds ? describedbyIds : undefined,
         })
       }

--- a/src/hooks/useId.tsx
+++ b/src/hooks/useId.tsx
@@ -12,24 +12,16 @@ const defaultContext: IdContextValue = {
 
 const IdContext = createContext<IdContextValue>(defaultContext)
 
-function useId_OLD(defaultId?: string) {
+function useId_OLD() {
   const context = useContext(IdContext)
-  return useMemo(
-    () => defaultId || `id-${context.prefix}-${++context.current}`,
-    [defaultId, context],
-  )
+  return useMemo(() => `id-${context.prefix}-${++context.current}`, [context])
 }
 
-export const useId = (defaultId?: string) => {
-  return generateUseId(defaultId)()
-}
+export const useId = (defaultId?: string): string => {
+  if (defaultId) return defaultId
 
-const generateUseId = (defaultId?: string) => {
-  if (defaultId) {
-    return () => defaultId
-  }
   // React v18 以降は React.useId を使う
-  return 'useId' in React ? React.useId : useId_OLD
+  return ('useId' in React ? React.useId : useId_OLD)()
 }
 
 export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {

--- a/src/hooks/useId.tsx
+++ b/src/hooks/useId.tsx
@@ -20,9 +20,17 @@ function useId_OLD(defaultId?: string) {
   )
 }
 
-export const useId =
+export const useId = (defaultId?: string) => {
+  return generateUseId(defaultId)()
+}
+
+const generateUseId = (defaultId?: string) => {
+  if (defaultId) {
+    return () => defaultId
+  }
   // React v18 以降は React.useId を使う
-  'useId' in React ? React.useId : useId_OLD
+  return 'useId' in React ? React.useId : useId_OLD
+}
 
 export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {
   const context = useContext(IdContext)


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`FormControl` の `htmlFor` と `labelId` に渡した値が `label` タグに設定されない不具合を修正します。

現状だと以下のように、`htmlFor` を使って独自の `input` タグなどと紐づけたい場合に、

```html
<FormControl title="ラベル" htmlFor="hoge">
  <MyInputComponent id="hoge" />
</FormControl>
```

レンダリング結果が以下のようになってしまい、`htmlFor` に渡したいはずの `hoge` が無視され、自動生成の ID が付与されてしまい、label と input を紐づけることができません。

```html
<label htmlFor=":r00">ラベル</label>
<input id="hoge" />
```

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

React18未満の場合は独自実装の `useId` を使うようになっていて、propsで渡した `htmlFor` と `labelId` の値がそのまま `label` タグに付与されるようになっていたんですが、
React18の場合は標準の `useId` が使われ、props `htmlFor` と `labelId` で渡した値が無視されていました。
https://github.com/kufu/smarthr-ui/blob/aceb775d89f90f8892fd5d90f549ae634fe89097/src/hooks/useId.tsx#L25

`htmlFor` と `labelId` が渡された場合はその値を直接 `label` タグに渡すように修正しました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
