### PR TITLE
fix: AccodionPanelのマークアップを修正し、Section内にHeadingが存在する状態にします

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelContent.tsx
+++ b/src/components/AccordionPanel/AccordionPanelContent.tsx
@@ -72,7 +72,7 @@ export const AccordionPanelContent: VFC<Props & ElementProps> = ({
   )
 }
 
-const CollapseContainer = styled.section`
+const CollapseContainer = styled.div`
   height: 0;
   overflow: hidden;
   transition: height ${duration}ms ease;

--- a/src/components/AccordionPanel/AccordionPanelItem.tsx
+++ b/src/components/AccordionPanel/AccordionPanelItem.tsx
@@ -1,5 +1,7 @@
 import React, { HTMLAttributes, VFC, createContext } from 'react'
 
+import { Section } from '../SectioningContent'
+
 import { useClassNames } from './useClassNames'
 
 type Props = {
@@ -29,9 +31,9 @@ export const AccordionPanelItem: VFC<Props & ElementProps> = ({
         name,
       }}
     >
-      <div {...props} className={`${className} ${classNames.item}`}>
+      <Section {...props} className={`${className} ${classNames.item}`}>
         {children}
-      </div>
+      </Section>
     </AccordionPanelItemContext.Provider>
   )
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- AccordionPanelのマークアップを修正し、SectioningContentで自動レベリングされるようにします

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- AccordionPanelのマークアップが以下の様になっていた

```
<div>
  <heading />
  <section>hoge</section>
</div>
```

- 関連性的には以下が正しいはず

```
<section>
  <heading />
  <div>hoge</div>
</section>
```

- また、Accordionの利用を想定した場合、自動的にSectionによってレベリングされても不自然ではなさそうなのでSectioningContentを利用するようにします

## Capture

<!--
Please attach a capture if it looks different.
-->
