### PR TITLE
fix: InformationPanelのHeadingが自動計算されるようにマークアップを変更する

### DIFF
--- a/src/components/InformationPanel/InformationPanel.stories.tsx
+++ b/src/components/InformationPanel/InformationPanel.stories.tsx
@@ -2,6 +2,7 @@ import { Story } from '@storybook/react'
 import React from 'react'
 
 import { Stack } from '../Layout'
+import { SectioningFragment } from '../SectioningContent'
 
 import { InformationPanel } from './InformationPanel'
 
@@ -15,26 +16,26 @@ export const All: Story = () => (
     <InformationPanel title="書類に記載する扶養家族" togglable={false}>
       借り換え直前の残高3,000万円、借り換え後の借入額2,900万円の場合→借り換え後の借入額が少ないので「借り換え後の借入額の方が少ない・同じ」を選択
     </InformationPanel>
-    <InformationPanel
-      title={<span>SmartHRの項目一覧表をダウンロード</span>}
-      titleTag="h4"
-      type="success"
-      active={false}
-    >
-      従業員リストをダウンロードする際に指定するフォーマットを、カスタマイズして登録、管理できます。登録したフォーマットを利用することで、外部システムへの取り込みに適したファイルを書き出せます。詳しくは、カスタムダウンロードフォーマットの追加・編集・削除を参照してください。
-    </InformationPanel>
-    <InformationPanel
-      title={<span>SmartHRの項目一覧表をダウンロード</span>}
-      titleTag="h4"
-      type="success"
-      decorators={{
-        openButtonLabel: (txt) => `open.(${txt})`,
-        closeButtonLabel: (txt) => `close.(${txt})`,
-      }}
-      active={false}
-    >
-      従業員リストをダウンロードする際に指定するフォーマットを、カスタマイズして登録、管理できます。登録したフォーマットを利用することで、外部システムへの取り込みに適したファイルを書き出せます。詳しくは、カスタムダウンロードフォーマットの追加・編集・削除を参照してください。
-    </InformationPanel>
+    <SectioningFragment>
+      <InformationPanel
+        title={<span>SmartHRの項目一覧表をダウンロード1</span>}
+        type="success"
+        active={false}
+      >
+        従業員リストをダウンロードする際に指定するフォーマットを、カスタマイズして登録、管理できます。登録したフォーマットを利用することで、外部システムへの取り込みに適したファイルを書き出せます。詳しくは、カスタムダウンロードフォーマットの追加・編集・削除を参照してください。
+      </InformationPanel>
+      <InformationPanel
+        title={<span>SmartHRの項目一覧表をダウンロード2</span>}
+        type="success"
+        decorators={{
+          openButtonLabel: (txt) => `open.(${txt})`,
+          closeButtonLabel: (txt) => `close.(${txt})`,
+        }}
+        active={false}
+      >
+        従業員リストをダウンロードする際に指定するフォーマットを、カスタマイズして登録、管理できます。登録したフォーマットを利用することで、外部システムへの取り込みに適したファイルを書き出せます。詳しくは、カスタムダウンロードフォーマットの追加・編集・削除を参照してください。
+      </InformationPanel>
+    </SectioningFragment>
     <InformationPanel title="項目全体がわかるよう撮影してください" type="warning" togglable={false}>
       離職日の翌日から1ヶ月ごとにさかのぼって区切り、それぞれの期間中に賃金支払基礎日数が11日以上ある、または、賃金支払の基礎となった時間が80時間以上ある期間を入力します。この期間を被保険者期間と言い、失業給付を受けるためには原則としてこの被保険者期間が2年間のうち12ヶ月必要となります。
     </InformationPanel>

--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -9,6 +9,7 @@ import { Heading, HeadingTagTypes } from '../Heading'
 import { FaCaretDownIcon, FaCaretUpIcon } from '../Icon'
 import { Cluster, Stack } from '../Layout'
 import { ResponseMessage } from '../ResponseMessage'
+import { SectioningFragment } from '../SectioningContent'
 
 import { useClassNames } from './useClassNames'
 
@@ -17,7 +18,9 @@ import type { DecoratorsType } from '../../types'
 type Props = {
   /** パネルのタイトル */
   title: React.ReactNode
-  /** タイトル部分の HTML タグ */
+  /**
+   * @deprecated titleTagは非推奨です
+   */
   titleTag?: HeadingTagTypes
   /** 表示する情報のタイプ */
   type?: 'success' | 'info' | 'warning' | 'error' | 'sync'
@@ -40,7 +43,7 @@ const CLOSE_BUTTON_LABEL = '閉じる'
 
 export const InformationPanel: FC<Props & Omit<BaseElementProps, keyof Props>> = ({
   title,
-  titleTag = 'h3',
+  titleTag,
   type = 'info',
   togglable = true,
   active: activeProps = true,
@@ -71,44 +74,48 @@ export const InformationPanel: FC<Props & Omit<BaseElementProps, keyof Props>> =
   const classNames = useClassNames()
 
   return (
-    <Wrapper
-      {...props}
-      className={`${className} ${classNames.wrapper}`}
-      themes={theme}
-      role="region"
-      aria-labelledby={titleId}
-    >
-      <Stack gap={1.25}>
-        <Header themes={theme} togglable={togglable}>
-          <Heading type="blockTitle" tag={titleTag} id={titleId} className={classNames.title}>
-            <ResponseMessage type={type} iconGap={0.5}>
-              {title}
-            </ResponseMessage>
-          </Heading>
-          {togglable && (
-            <TogglableButton
-              suffix={active ? <FaCaretUpIcon /> : <FaCaretDownIcon />}
-              size="s"
-              onClick={handleClickTrigger}
-              aria-expanded={togglable ? active : undefined}
-              aria-controls={contentId}
-              className={classNames.closeButton}
-            >
-              {active
-                ? decorators?.closeButtonLabel?.(CLOSE_BUTTON_LABEL) || CLOSE_BUTTON_LABEL
-                : decorators?.openButtonLabel?.(OPEN_BUTTON_LABEL) || OPEN_BUTTON_LABEL}
-            </TogglableButton>
-          )}
-        </Header>
-        <Content themes={theme} id={contentId} aria-hidden={!active} className={classNames.content}>
-          {children}
-        </Content>
-      </Stack>
+    <Wrapper {...props} className={`${className} ${classNames.wrapper}`} themes={theme}>
+      {/* HINT: Wrapperをsectionにしているため余計なタグを出力しないようSectioningFragmentを利用する */}
+      <SectioningFragment>
+        <Stack gap={1.25}>
+          <Header themes={theme} togglable={togglable}>
+            <Heading type="blockTitle" tag={titleTag} id={titleId} className={classNames.title}>
+              <ResponseMessage type={type} iconGap={0.5}>
+                {title}
+              </ResponseMessage>
+            </Heading>
+            {togglable && (
+              <TogglableButton
+                suffix={active ? <FaCaretUpIcon /> : <FaCaretDownIcon />}
+                size="s"
+                onClick={handleClickTrigger}
+                aria-expanded={togglable ? active : undefined}
+                aria-controls={contentId}
+                className={classNames.closeButton}
+              >
+                {active
+                  ? decorators?.closeButtonLabel?.(CLOSE_BUTTON_LABEL) || CLOSE_BUTTON_LABEL
+                  : decorators?.openButtonLabel?.(OPEN_BUTTON_LABEL) || OPEN_BUTTON_LABEL}
+              </TogglableButton>
+            )}
+          </Header>
+          <Content
+            themes={theme}
+            id={contentId}
+            aria-hidden={!active}
+            className={classNames.content}
+          >
+            {children}
+          </Content>
+        </Stack>
+      </SectioningFragment>
     </Wrapper>
   )
 }
 
-const Wrapper = styled(Base)<{ themes: Theme }>`
+const Wrapper = styled(Base).attrs(() => ({
+  forwardedAs: 'section',
+}))<{ themes: Theme }>`
   ${({ themes: { spacingByChar, shadow } }) => css`
     padding: ${spacingByChar(1.5)};
     box-shadow: ${shadow.LAYER3};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- InformationPanelのHeadingが自動計算されるようにSectioningContentでマークアップします

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
