### PR TITLE
feat: Badge を追加

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -57,7 +57,8 @@ export const All: StoryFn = () => {
               </Badge>
             </Cluster>
             <p>
-              標準では0値を表示しません。<code>showZero</code> を与えると表示します。
+              標準では<code>count=0</code>の場合は Badge を表示しません。<code>showZero</code>{' '}
+              を与えると表示します。
             </p>
             <Cluster gap={0.75} align="center">
               <Badge count={0} />

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -26,15 +26,15 @@ export const All: StoryFn = () => {
               <Badge count={100} />
             </Cluster>
             <p>
-              <code>type=&quot;dot&quot;</code> を与えるとドットのみの表示になります。
+              <code>dot</code> を与えるとドットのみの表示になります。
               <code>count</code> を与えても無視します。
               <br />
               視覚情報しか持たないため、別途アクセシブルネームを与える必要があります。
             </p>
             <Cluster gap={0.75} align="center">
-              <Badge type="dot" />
+              <Badge dot />
               <VisuallyHiddenText>通知があります</VisuallyHiddenText>
-              <Badge type="dot" count={9} />
+              <Badge dot count={9} />
               <VisuallyHiddenText>通知があります</VisuallyHiddenText>
             </Cluster>
             <p>
@@ -52,7 +52,7 @@ export const All: StoryFn = () => {
               <Badge count={9}>
                 <FaBellIcon />
               </Badge>
-              <Badge type="dot">
+              <Badge dot>
                 <FaBellIcon />
               </Badge>
             </Cluster>
@@ -76,14 +76,14 @@ export const All: StoryFn = () => {
         <Dt>色</Dt>
         <dd>
           <Cluster gap={1.5}>
-            <Badge count={9}>
-              <FaBellIcon />
-            </Badge>
-            <Badge count={9} color="DANGER">
-              <FaBellIcon />
-            </Badge>
-            <Badge type="dot" />
-            <Badge type="dot" color="DANGER" />
+            <Badge count={9} />
+            <Badge count={9} type="grey" />
+            <Badge count={9} type="yellow" />
+            <Badge count={9} type="red" />
+            <Badge dot />
+            <Badge dot type="grey" />
+            <Badge dot type="yellow" />
+            <Badge dot type="red" />
           </Cluster>
         </dd>
       </Stack>

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { FaBellIcon } from '../Icon'
 import { Cluster, Stack } from '../Layout'
 import { Text } from '../Text'
+import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { Badge } from './Badge'
 
@@ -31,8 +32,10 @@ export const All: StoryFn = () => {
               視覚情報しか持たないため、別途アクセシブルネームを与える必要があります。
             </p>
             <Cluster gap={0.75} align="center">
-              <Badge type="dot" aria-label="通知があります" />
-              <Badge type="dot" count={9} aria-label="通知があります。" />
+              <Badge type="dot" />
+              <VisuallyHiddenText>通知があります</VisuallyHiddenText>
+              <Badge type="dot" count={9} />
+              <VisuallyHiddenText>通知があります</VisuallyHiddenText>
             </Cluster>
             <p>
               最大値の標準は99です。必要に応じて <code>overflowCount</code> で変えられます。

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,91 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { FaBellIcon } from '../Icon'
+import { Cluster, Stack } from '../Layout'
+import { Text } from '../Text'
+
+import { Badge } from './Badge'
+
+export default {
+  title: 'States（状態）/Badge',
+  component: Badge,
+}
+
+export const All: StoryFn = () => {
+  return (
+    <Stack as="dl" gap={3}>
+      <Stack>
+        <Dt>種類</Dt>
+        <dd>
+          <Stack align="flex-start">
+            <Cluster gap={0.75} align="center">
+              <Badge count={9} />
+              <Badge count={100} />
+            </Cluster>
+            <p>
+              <code>type=&quot;dot&quot;</code> を与えるとドットのみの表示になります。
+              <code>count</code> を与えても無視します。
+              <br />
+              視覚情報しか持たないため、別途アクセシブルネームを与える必要があります。
+            </p>
+            <Cluster gap={0.75} align="center">
+              <Badge type="dot" aria-label="通知があります" />
+              <Badge type="dot" count={9} aria-label="通知があります。" />
+            </Cluster>
+            <p>
+              最大値の標準は99です。必要に応じて <code>overflowCount</code> で変えられます。
+            </p>
+            <Cluster gap={0.75}>
+              <Badge count={1000} />
+              <Badge count={1000} overflowCount={10} />
+              <Badge count={1000} overflowCount={999} />
+            </Cluster>
+            <p>
+              <code>children</code> を与えると、その右肩に表示します。
+            </p>
+            <Cluster gap={1.5}>
+              <Badge count={9}>
+                <FaBellIcon />
+              </Badge>
+              <Badge type="dot">
+                <FaBellIcon />
+              </Badge>
+            </Cluster>
+            <p>
+              標準では0値を表示しません。<code>showZero</code> を与えると表示します。
+            </p>
+            <Cluster gap={0.75} align="center">
+              <Badge count={0} />
+              <Badge count={0} showZero />
+              <Badge count={0}>
+                <FaBellIcon />
+              </Badge>
+              <Badge count={0} showZero>
+                <FaBellIcon />
+              </Badge>
+            </Cluster>
+          </Stack>
+        </dd>
+      </Stack>
+      <Stack>
+        <Dt>色</Dt>
+        <dd>
+          <Cluster gap={1.5}>
+            <Badge count={9}>
+              <FaBellIcon />
+            </Badge>
+            <Badge count={9} color="DANGER">
+              <FaBellIcon />
+            </Badge>
+            <Badge type="dot" />
+            <Badge type="dot" color="DANGER" />
+          </Cluster>
+        </dd>
+      </Stack>
+    </Stack>
+  )
+}
+
+const Dt = styled(Text).attrs({ forwardedAs: 'dt', weight: 'bold', color: 'TEXT_GREY' })``

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -8,10 +8,15 @@ const definedColors = ['MAIN', 'DANGER'] as const
 type DefinedColor = (typeof definedColors)[number]
 
 type BaseProps = PropsWithChildren<{
+  /** 件数 */
   count?: number
+  /** 最大表示件数。この数を超えた場合は{最大表示件数+}と表示される */
   overflowCount?: number
+  /** 0値を表示するかどうか */
   showZero?: boolean
+  /** 種類。dot： ドット表示 */
   type?: 'dot'
+  /** 色 */
   color?: DefinedColor
 }>
 type BadgeProps = Omit<HTMLAttributes<HTMLElement>, keyof BaseProps> & BaseProps
@@ -35,6 +40,7 @@ export const Badge: React.FC<BadgeProps> = ({
     withChildren: !!children,
   }
 
+  // ドット表示でもなく、0値を表示するでもない場合は何も表示しない
   if (!displayDot && !children && actualCount === undefined) return null
 
   return (

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -4,8 +4,14 @@ import styled, { css } from 'styled-components'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { Text } from '../Text'
 
-const definedColors = ['MAIN', 'DANGER'] as const
-type DefinedColor = (typeof definedColors)[number]
+const definedColors = {
+  grey: 'TEXT_GREY',
+  blue: 'MAIN',
+  yellow: 'WARNING_YELLOW',
+  red: 'DANGER',
+} as const
+type Color = keyof typeof definedColors
+type ColorName = (typeof definedColors)[Color]
 
 type BaseProps = PropsWithChildren<{
   /** 件数 */
@@ -14,39 +20,40 @@ type BaseProps = PropsWithChildren<{
   overflowCount?: number
   /** 0値を表示するかどうか */
   showZero?: boolean
-  /** 種類。dot： ドット表示 */
-  type?: 'dot'
-  /** 色 */
-  color?: DefinedColor
+  /** 色の種類 */
+  type?: Color
+  /** ドット表示するかどうか */
+  dot?: boolean
 }>
 type BadgeProps = Omit<HTMLAttributes<HTMLElement>, keyof BaseProps> & BaseProps
+
+const getColorName = (type: Color): ColorName => definedColors[type]
 
 export const Badge: React.FC<BadgeProps> = ({
   count,
   overflowCount = 99,
   showZero = false,
-  type,
-  color = 'MAIN',
+  type = 'blue',
+  dot = false,
   children,
   ...props
 }) => {
   const theme = useTheme()
 
   const actualCount = count && count > 0 ? count : showZero ? 0 : undefined
-  const displayDot = type === 'dot'
   const badgeProps = {
     themes: theme,
-    colorName: color,
+    colorName: getColorName(type),
     withChildren: !!children,
   }
 
   // ドット表示でもなく、0値を表示するでもない場合は何も表示しない
-  if (!displayDot && !children && actualCount === undefined) return null
+  if (!dot && !children && actualCount === undefined) return null
 
   return (
     <BadgeWrapper {...props}>
       {children}
-      {displayDot ? (
+      {dot ? (
         <Dot {...badgeProps} />
       ) : (
         actualCount !== undefined && (
@@ -64,7 +71,7 @@ const BadgeWrapper = styled.span`
   display: inline-flex;
   display: flex;
 `
-const badgeBaseStyle = css<{ themes: Theme; colorName: DefinedColor; withChildren: boolean }>`
+const badgeBaseStyle = css<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
   ${({ themes: { color, radius }, colorName, withChildren }) => css`
     ${withChildren &&
     css`
@@ -86,18 +93,18 @@ const badgeBaseStyle = css<{ themes: Theme; colorName: DefinedColor; withChildre
 `
 const Pill = styled(Text).attrs({
   size: 'XS',
-})<{ themes: Theme; colorName: DefinedColor; withChildren: boolean }>`
-  ${({ themes: { color } }) => css`
+})<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
+  ${({ themes: { color }, colorName }) => css`
     ${badgeBaseStyle}
 
     padding-inline: 0.5em;
     font-variant-numeric: tabular-nums;
-    color: ${color.WHITE};
+    color: ${colorName === 'WARNING_YELLOW' ? color.TEXT_BLACK : color.WHITE};
     min-width: 1.75em;
     height: 1.75em;
   `}
 `
-const Dot = styled.span<{ themes: Theme; colorName: DefinedColor; withChildren: boolean }>`
+const Dot = styled.span<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
   ${badgeBaseStyle}
 
   width: 0.625em;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -27,8 +27,6 @@ type BaseProps = PropsWithChildren<{
 }>
 type BadgeProps = Omit<HTMLAttributes<HTMLElement>, keyof BaseProps> & BaseProps
 
-const getColorName = (type: Color): ColorName => definedColors[type]
-
 export const Badge: React.FC<BadgeProps> = ({
   count,
   overflowCount = 99,
@@ -43,7 +41,7 @@ export const Badge: React.FC<BadgeProps> = ({
   const actualCount = count && count > 0 ? count : showZero ? 0 : undefined
   const badgeProps = {
     themes: theme,
-    colorName: getColorName(type),
+    colorName: definedColors[type],
     withChildren: !!children,
   }
 
@@ -69,7 +67,6 @@ export const Badge: React.FC<BadgeProps> = ({
 const BadgeWrapper = styled.span`
   position: relative;
   display: inline-flex;
-  display: flex;
 `
 const badgeBaseStyle = css<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
   ${({ themes: { color, radius }, colorName, withChildren }) => css`

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -86,7 +86,7 @@ const badgeBaseStyle = css<{ themes: Theme; colorName: ColorName; withChildren: 
     align-items: center;
     justify-content: center;
 
-    box-shadow: 0 0 0 1px ${color.WHITE};
+    box-shadow: 0 0 0 1px ${colorName === 'WARNING_YELLOW' ? color.TEXT_BLACK : color.WHITE};
     border-radius: ${radius.full};
     background-color: ${color[colorName]};
   `}

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,99 @@
+import React, { HTMLAttributes, PropsWithChildren } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+import { Text } from '../Text'
+
+const definedColors = ['MAIN', 'DANGER'] as const
+type DefinedColor = (typeof definedColors)[number]
+
+type BaseProps = PropsWithChildren<{
+  count?: number
+  overflowCount?: number
+  showZero?: boolean
+  type?: 'dot'
+  color?: DefinedColor
+}>
+type BadgeProps = Omit<HTMLAttributes<HTMLElement>, keyof BaseProps> & BaseProps
+
+export const Badge: React.FC<BadgeProps> = ({
+  count,
+  overflowCount = 99,
+  showZero = false,
+  type,
+  color = 'MAIN',
+  children,
+  ...props
+}) => {
+  const theme = useTheme()
+
+  const actualCount = count && count > 0 ? count : showZero ? 0 : undefined
+  const displayDot = type === 'dot'
+  const badgeProps = {
+    themes: theme,
+    colorName: color,
+    withChildren: !!children,
+  }
+
+  if (!displayDot && !children && actualCount === undefined) return null
+
+  return (
+    <BadgeWrapper {...props}>
+      {children}
+      {displayDot ? (
+        <Dot {...badgeProps} />
+      ) : (
+        actualCount !== undefined && (
+          <Pill {...badgeProps}>
+            {actualCount > overflowCount ? `${overflowCount}+` : actualCount}
+          </Pill>
+        )
+      )}
+    </BadgeWrapper>
+  )
+}
+
+const BadgeWrapper = styled.span`
+  position: relative;
+  display: inline-flex;
+  display: flex;
+`
+const badgeBaseStyle = css<{ themes: Theme; colorName: DefinedColor; withChildren: boolean }>`
+  ${({ themes: { color, radius }, colorName, withChildren }) => css`
+    ${withChildren &&
+    css`
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      translate: 50% -50%;
+    `}
+
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    box-shadow: 0 0 0 1px ${color.WHITE};
+    border-radius: ${radius.full};
+    background-color: ${color[colorName]};
+  `}
+`
+const Pill = styled(Text).attrs({
+  size: 'XS',
+})<{ themes: Theme; colorName: DefinedColor; withChildren: boolean }>`
+  ${({ themes: { color } }) => css`
+    ${badgeBaseStyle}
+
+    padding-inline: 0.5em;
+    font-variant-numeric: tabular-nums;
+    color: ${color.WHITE};
+    min-width: 1.75em;
+    height: 1.75em;
+  `}
+`
+const Dot = styled.span<{ themes: Theme; colorName: DefinedColor; withChildren: boolean }>`
+  ${badgeBaseStyle}
+
+  width: 0.625em;
+  height: 0.625em;
+`

--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { Badge } from './Badge'

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ export { SectioningFragment, Article, Aside, Nav, Section } from './components/S
 export { VisuallyHiddenText } from './components/VisuallyHiddenText'
 export * from './components/SpreadsheetTable'
 export * from './components/ResponseMessage'
+export * from './components/Badge'
 
 // layout components
 export { Center, Cluster, LineUp, Reel, Stack, Sidebar } from './components/Layout'


### PR DESCRIPTION
## Overview

<img width="610" alt="Badge の Story のスクリーンショット" src="https://github.com/kufu/smarthr-ui/assets/19403400/38d6674a-9060-4efd-8583-93d2811742d5">


通知や件数を表示するためのコンポーネントです。
NotificationBadge という命名も考えましたが、通知以外でも使われる可能性があるため Badge としました。

- 数字を表示するか、ドットを表示するか選択できます
  - 今後テキストを表示したい要望が出る可能性がありますが、まずは数字のみを実装します
- count=0 の場合にコンポーネントを表示するかどうか選択できます。デフォルトでは0は表示しません
- 何件まで数えるかを指定できます。デフォルトは99件です
- children を与えると、その children の右肩に表示します
  - 表示位置は、現状右肩だけですが、今後課題が見つかった時に対応予定です
- 色は blue | grey | yellow | red から選択できます。デフォルトは blue です。