### PR TITLE
fix: DropdownMenuButton内にdisabledなButtonコンポーネントを設置するとstyle崩れが発生する場合がある問題を修正

### DIFF
--- a/src/components/Dialog/RemoteDialogTrigger.tsx
+++ b/src/components/Dialog/RemoteDialogTrigger.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement, cloneElement, useCallback, useMemo } from 'react'
 
+import { Button } from '../Button'
+
 import { TRIGGER_EVENT } from './useRemoteTrigger'
 
 const onClickRemoteDialogTrigger = (e: React.MouseEvent<HTMLElement>) => {
@@ -10,11 +12,13 @@ const onClickRemoteDialogTrigger = (e: React.MouseEvent<HTMLElement>) => {
   )
 }
 
-export const RemoteDialogTrigger: React.FC<{
-  targetId: string
-  onClick?: (open: () => void) => void
-  children: Omit<ReactElement, 'onClick' | 'aria-haspopup' | 'aria-controls'>
-}> = ({ targetId, children, onClick }) => {
+export const RemoteDialogTrigger: React.FC<
+  Pick<React.ComponentProps<typeof Button>, 'variant'> & {
+    targetId: string
+    onClick?: (open: () => void) => void
+    children: Omit<ReactElement, 'onClick' | 'aria-haspopup' | 'aria-controls' | 'variant'>
+  }
+> = ({ targetId, children, onClick, variant }) => {
   const actualOnClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       if (onClick) {
@@ -33,6 +37,7 @@ export const RemoteDialogTrigger: React.FC<{
         onClick: actualOnClick,
         'aria-haspopup': 'true',
         'aria-controls': targetId,
+        variant,
       }),
     [children, targetId, actualOnClick],
   )

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -58,6 +58,9 @@ const Template: React.FC<Omit<ComponentProps<typeof DropdownMenuButton>, 'childr
     <RemoteDialogTrigger targetId="hoge">
       <Button>Triggerのテスト</Button>
     </RemoteDialogTrigger>
+    <RemoteDialogTrigger targetId="hoge">
+      <Button disabled={true}>Triggerのテスト</Button>
+    </RemoteDialogTrigger>
   </DropdownMenuButton>
 )
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
<img width="1710" alt="253127675-dec2137f-95fc-45f4-8357-0e26894d12c6" src="https://github.com/kufu/smarthr-ui/assets/773467/6ac2fb60-8b92-4a6b-a43f-39f2196edc9a">
