### PR TITLE
fix: ResponseMessage から不要な props を削除

### DIFF
--- a/src/components/ResponseMessage/ResponseMessage.tsx
+++ b/src/components/ResponseMessage/ResponseMessage.tsx
@@ -13,11 +13,9 @@ type Props = PropsWithChildren<{
   type: 'info' | 'success' | 'warning' | 'error' | 'sync'
 }>
 
-export const ResponseMessage: React.FC<Props & ComponentProps<typeof FaCheckCircleIcon>> = ({
-  type,
-  children,
-  ...other
-}) => {
+export const ResponseMessage: React.FC<
+  Props & Omit<ComponentProps<typeof FaCheckCircleIcon>, 'text'>
+> = ({ type, children, ...other }) => {
   const theme = useTheme()
   const { color } = theme
 


### PR DESCRIPTION
内部的に Icon with Text を使っており、Icon が持つ `text` が ResponseMessage にも表出してしまっていた。

https://smarthr.atlassian.net/browse/SHRUI-718