### PR TITLE
fix: TabItemがselectedでない場合にもborderが表示されてしまう場合があるため、transparent指定ではなく、border有無を切り替えるstyleに変更

### DIFF
--- a/src/components/TabBar/TabItem.tsx
+++ b/src/components/TabBar/TabItem.tsx
@@ -62,6 +62,10 @@ const resetButtonStyle = css`
   padding: 0;
   appearance: none;
 `
+
+const borderWidth = 3
+const ItemHeight = 40
+
 const ItemButton = styled.button<{ themes: Theme }>`
   ${resetButtonStyle}
   ${({ themes }) => {
@@ -70,8 +74,7 @@ const ItemButton = styled.button<{ themes: Theme }>`
       font-weight: bold;
       font-size: ${fontSize.M};
       color: ${color.TEXT_GREY};
-      height: 40px;
-      border-bottom: solid 3px transparent;
+      height: ${ItemHeight + borderWidth}px;
       padding: 0 ${spacingByChar(1.5)};
       box-sizing: border-box;
       transition: ${isTouchDevice
@@ -81,7 +84,8 @@ const ItemButton = styled.button<{ themes: Theme }>`
       &.selected {
         position: relative;
         color: ${color.TEXT_BLACK};
-        border-color: ${color.MAIN};
+        height: ${ItemHeight}px;
+        border-bottom: solid ${borderWidth}px ${color.MAIN};
       }
 
       :hover {

--- a/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -33,8 +33,7 @@ exports[`TabBar should be match snapshot 1`] = `
   font-weight: bold;
   font-size: 1rem;
   color: #706d65;
-  height: 40px;
-  border-bottom: solid 3px transparent;
+  height: 43px;
   padding: 0 24px;
   box-sizing: border-box;
   -webkit-transition: background-color .3s ease-out,color .3s ease-out;
@@ -44,7 +43,8 @@ exports[`TabBar should be match snapshot 1`] = `
 .c2.selected {
   position: relative;
   color: #23221e;
-  border-color: #0077c7;
+  height: 40px;
+  border-bottom: solid 3px #0077c7;
 }
 
 .c2:hover {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- 低コントラストモードなどで transparent指定のborderが表示されてしまう場合があり、selectedな場合と見分けがつきづらくなることがある
- border自体の有無を切り替えることで問題を解決したい

## Capture

<!--
Please attach a capture if it looks different.
-->
