### PR TITLE
refactor: postcss のバージョン固定を解除

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,8 +163,7 @@
     "@types/react": "^18.2.17",
     "minimist": "1.2.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "postcss": "8.4.27"
+    "react-dom": "^18.2.0"
   },
   "standard-version": {
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10455,7 +10455,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
 
-postcss@8.4.27, postcss@^8.4.19, postcss@^8.4.25:
+postcss@^8.4.19, postcss@^8.4.25:
   version "8.4.27"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
   integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==


### PR DESCRIPTION
stylelint の不具合に依って指定していた postcss のバージョン固定を解除。