### PR TITLE
fix: TextLink から不要な hover スタイルを削除

### DIFF
--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -72,10 +72,6 @@ const StyledAnchor = styled.a<{ themes: Theme }>`
       box-shadow: 0 1px 0 0;
       color: ${color.TEXT_LINK};
 
-      &:hover {
-        color: ${color.hoverColor(color.TEXT_LINK)};
-      }
-
       &:not([href]) {
         box-shadow: none;
       }


### PR DESCRIPTION
視覚的な差の少ない :hover スタイルが指定されていた。
User Agent Stylesheet でも hover の指定はないため、smarthr-ui でも `:hover` は不要と判断した。

## 参考にした User Agent Stylesheet

- [Chrome](https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css)
- [Safari](https://trac.webkit.org/browser/trunk/Source/WebCore/css/html.css)
- [Firefox](https://searchfox.org/mozilla-central/source/layout/style/res/html.css)