### PR TITLE
feat: add onFocus and onBlur to SingleComboBox

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -113,6 +113,8 @@ export const Single: Story = () => {
             action('onChangeSelected')(item)
             setSelectedItem(item)
           }}
+          onFocus={action('onFocus')}
+          onBlur={action('onBlur')}
           data-test="single-combobox-default"
         />
       </dd>

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -224,7 +224,6 @@ export function SingleComboBox<T>({
         e.stopPropagation()
         return
       }
-      focus()
       if (inputRef.current) {
         inputRef.current.focus()
       }
@@ -232,7 +231,7 @@ export function SingleComboBox<T>({
         setIsExpanded(true)
       }
     },
-    [disabled, inputRef, isExpanded, setIsExpanded, focus],
+    [disabled, inputRef, isExpanded, setIsExpanded],
   )
   const actualOnChangeInput = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -53,6 +53,14 @@ type Props<T> = BaseProps<T> & {
    */
   onChangeSelected?: (selectedItem: ComboBoxItem<T> | null) => void
   /**
+   * コンポーネントがフォーカスされたときに発火するコールバック関数
+   */
+  onFocus?: () => void
+  /**
+   * コンポーネントからフォーカスが外れた時に発火するコールバック関数
+   */
+  onBlur?: () => void
+  /**
    * コンポーネント内のテキストを変更する関数/
    */
   decorators?: DecoratorsType<'noResultText'> & {
@@ -113,6 +121,8 @@ export function SingleComboBox<T>({
   onClear,
   onClearClick,
   onChangeSelected,
+  onFocus,
+  onBlur,
   decorators,
   inputAttributes,
   ...props
@@ -166,12 +176,14 @@ export function SingleComboBox<T>({
   })
 
   const focus = useCallback(() => {
+    onFocus && onFocus()
     setIsFocused(true)
     if (!isFocused) {
       setIsExpanded(true)
     }
-  }, [isFocused])
+  }, [onFocus, isFocused])
   const unfocus = useCallback(() => {
+    onBlur && onBlur()
     setIsFocused(false)
     setIsExpanded(false)
     setIsEditing(false)
@@ -180,7 +192,7 @@ export function SingleComboBox<T>({
       setInputValue(innerText(defaultItem.label))
       onSelect && onSelect(defaultItem)
     }
-  }, [selectedItem, defaultItem, onSelect])
+  }, [onBlur, selectedItem, defaultItem, onSelect])
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
@@ -239,7 +251,7 @@ export function SingleComboBox<T>({
     },
     [isEditing, setIsEditing, setInputValue, onChange, onChangeInput, onClear, onChangeSelected],
   )
-  const onFocus = useCallback(() => {
+  const handleFocus = useCallback(() => {
     if (!isFocused) {
       focus()
     }
@@ -361,7 +373,7 @@ export function SingleComboBox<T>({
           }
           onClick={onClickInput}
           onChange={actualOnChangeInput}
-          onFocus={onFocus}
+          onFocus={handleFocus}
           onCompositionStart={onCompositionStart}
           onCompositionEnd={onCompositionEnd}
           onKeyDown={onKeyDownInput}

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -183,6 +183,8 @@ export function SingleComboBox<T>({
     }
   }, [onFocus, isFocused])
   const unfocus = useCallback(() => {
+    if (!isFocused) return
+
     onBlur && onBlur()
     setIsFocused(false)
     setIsExpanded(false)
@@ -192,7 +194,7 @@ export function SingleComboBox<T>({
       setInputValue(innerText(defaultItem.label))
       onSelect && onSelect(defaultItem)
     }
-  }, [onBlur, selectedItem, defaultItem, onSelect])
+  }, [isFocused, onBlur, selectedItem, defaultItem, onSelect])
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

相談Slackスレッド: https://kufuinc.slack.com/archives/CGC58MW01/p1692149332295029

https://smarthr.atlassian.net/browse/YSG-1120

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

`SingleComboBox`に`onFocus`と`onBlur`を渡せるようにします。
`MultiComboBox`には存在するpropsなので、そちらと仕様を合わせています。

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- `SingleComboBox`に`onFocus`と`onBlur`を渡せるようにしました
- `SingleComboBox`にフォーカスしたときに`focus`が二重に実行される問題を解消しました
- `SingleComboBox`を設置したページで、ComboBoxの外をクリックすると`unfocus`が必ず実行される問題を解消しました

