### PR TITLE
feat: Tailwind CSS の設定ファイルを追加

### DIFF
--- a/smarthr-ui-preset.ts
+++ b/smarthr-ui-preset.ts
@@ -1,0 +1,151 @@
+import { defaultColor } from './src/themes/createColor'
+import { defaultFontSize, defaultHtmlFontSize } from './src/themes/createFontSize'
+import { defaultShadow } from './src/themes/createShadow'
+import { createSpacingByChar, primitiveTokens as spacingSizes } from './src/themes/createSpacing'
+import { defaultZIndex } from './src/themes/createZindex'
+
+import type { Config } from 'tailwindcss'
+
+const spacingByChar = createSpacingByChar(defaultHtmlFontSize / 2)
+
+// この preset を各プロダクトでも読み込んでもらう想定
+export default {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    backgroundColor: {
+      black: defaultColor.GREY_100,
+      white: defaultColor.WHITE,
+      disabled: defaultColor.GREY_30,
+      link: defaultColor.TEXT_LINK,
+      background: defaultColor.BACKGROUND,
+      column: defaultColor.COLUMN,
+      'base-grey': defaultColor.BASE_GREY,
+      'over-background': defaultColor.OVER_BACKGROUND,
+      head: defaultColor.HEAD,
+      'action-background': defaultColor.ACTION_BACKGROUND,
+      main: defaultColor.MAIN,
+      danger: defaultColor.DANGER,
+      'warning-yellow': defaultColor.WARNING_YELLOW,
+      overlay: defaultColor.OVERLAY,
+      scrim: defaultColor.SCRIM,
+      inherit: 'inherit',
+      transparent: 'transparent',
+    },
+    borderColor: {
+      DEFAULT: defaultColor.BORDER,
+      black: defaultColor.GREY_100,
+      white: defaultColor.WHITE,
+      grey: defaultColor.GREY_65,
+      main: defaultColor.MAIN,
+      danger: defaultColor.DANGER,
+      disabled: defaultColor.GREY_30,
+      inherit: 'inherit',
+      transparent: 'transparent',
+    },
+    colors: {
+      black: defaultColor.GREY_100,
+      white: defaultColor.WHITE,
+      main: defaultColor.MAIN,
+      brand: defaultColor.BRAND,
+      grey: {
+        DEFAULT: defaultColor.GREY_65,
+        5: defaultColor.GREY_5,
+        6: defaultColor.GREY_6,
+        7: defaultColor.GREY_7,
+        9: defaultColor.GREY_9,
+        20: defaultColor.GREY_20,
+        30: defaultColor.GREY_30,
+        65: defaultColor.GREY_65,
+        100: defaultColor.GREY_100,
+      },
+      inherit: 'inherit',
+      transparent: 'transparent',
+      current: 'currentColor',
+    },
+    borderRadius: {
+      none: '0',
+      s: '0.25rem',
+      m: '0.375rem',
+      l: '0.5rem',
+      full: '9999px',
+    },
+    boxShadow: {
+      'layer-0': defaultShadow.LAYER0,
+      'layer-1': defaultShadow.LAYER1,
+      'layer-2': defaultShadow.LAYER2,
+      'layer-3': defaultShadow.LAYER3,
+      'layer-4': defaultShadow.LAYER4,
+      outline: defaultShadow.OUTLINE,
+      none: 'none',
+    },
+    fontSize: {
+      '2xs': defaultFontSize.XXS,
+      xs: defaultFontSize.XS,
+      sm: defaultFontSize.S,
+      base: defaultFontSize.M,
+      lg: defaultFontSize.L,
+      xl: defaultFontSize.XL,
+      '2xl': defaultFontSize.XXL,
+    },
+    lineHeight: {
+      none: '1',
+      tight: '1.25',
+      normal: '1.5',
+      loose: '1.75',
+    },
+    maxWidth: {
+      none: 'none',
+      full: '100%',
+      min: 'min-content',
+      max: 'max-content',
+      fit: 'fit-content',
+    },
+    outlineColor: {
+      DEFAULT: defaultColor.OUTLINE,
+    },
+    spacing: {
+      px: '1px',
+      ...spacingSizes
+        .map((size) => {
+          return {
+            [size]: spacingByChar(size),
+          }
+        })
+        .reduce((a, c) => Object.assign(a, c), {}),
+    },
+    stroke: {
+      black: defaultColor.GREY_100,
+    },
+    textColor: {
+      black: defaultColor.GREY_100,
+      white: defaultColor.WHITE,
+      disabled: defaultColor.GREY_30,
+      link: defaultColor.TEXT_LINK,
+      grey: defaultColor.GREY_65,
+      inherit: 'inherit',
+      transparent: 'transparent',
+    },
+    zIndex: {
+      auto: 'auto',
+      0: '0',
+      'fixed-menu': `${defaultZIndex.FIXED_MENU}`,
+      'overlap-base': `${defaultZIndex.OVERLAP_BASE}`,
+      overlap: `${defaultZIndex.OVERLAP}`,
+      'flash-message': `${defaultZIndex.FLASH_MESSAGE}`,
+    },
+    // 継承するのはこっち。なんかある?
+    extend: {},
+  },
+  corePlugins: {
+    preflight: false,
+    boxShadowColor: false,
+    caretColor: false,
+    divideColor: false,
+    fontFamily: false,
+    placeholderColor: false,
+    ringColor: false,
+    ringOffsetColor: false,
+    textDecorationColor: false,
+  },
+  plugins: [],
+} satisfies Config

--- a/src/themes/createShadow.ts
+++ b/src/themes/createShadow.ts
@@ -45,14 +45,21 @@ const createOutline = (color: string) => `0 0 0 2px white, 0 0 0 4px ${color}`
 const defaultOutline = createOutline(defaultColor.OUTLINE)
 const defaultOutlineMargin = '4px'
 
+const createLayerShadow = (depth: number) =>
+  depth === 0
+    ? 'none'
+    : `0 ${2 ** (depth - 1)}px ${2 ** depth}px ${depth - 1 >= 0 ? 2 ** (depth - 2) : 0}px ${
+        defaultColor.TRANSPARENCY_30
+      }`
+
 export const defaultShadow = {
   BASE: `${defaultColor.TRANSPARENCY_15} 0 0 4px 0`,
   DIALOG: `${defaultColor.TRANSPARENCY_30} 0 4px 10px 0`,
-  LAYER0: 'none',
-  LAYER1: `0 1px 2px 0 ${defaultColor.TRANSPARENCY_30}`,
-  LAYER2: `0 2px 4px 1px ${defaultColor.TRANSPARENCY_30}`,
-  LAYER3: `0 4px 8px 2px ${defaultColor.TRANSPARENCY_30}`,
-  LAYER4: `0 8px 16px 4px ${defaultColor.TRANSPARENCY_30}`,
+  LAYER0: createLayerShadow(0),
+  LAYER1: createLayerShadow(1),
+  LAYER2: createLayerShadow(2),
+  LAYER3: createLayerShadow(3),
+  LAYER4: createLayerShadow(4),
   OUTLINE: defaultOutline,
   OUTLINE_MARGIN: defaultOutlineMargin,
 }

--- a/src/themes/createSpacing.ts
+++ b/src/themes/createSpacing.ts
@@ -19,7 +19,7 @@ export interface CreatedSpacingTheme {
 
 export type CreatedSpacingByCharTheme = (size: CharRelativeSize) => string
 
-const primitiveTokens = [
+export const primitiveTokens = [
   0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 8, -0.25, -0.5, -0.75, -1, -1.25, -1.5, -2,
   -2.5, -3, -3.5, -4, -8,
 ] as const


### PR DESCRIPTION
## Overview

smarthr-ui の Tailwind CSS 用設定ファイルを追加しました。

- 色は絞った方がよさそうだったため、必要なもの以外は corePlugin で無効化しています
- styled-components のデザイントークンでは大文字だった変数も Tailwind CSS では小文字の方が良いと考え修正しています
- deprecated な値は移行していません

完璧に対応できている気はしていないため、コンポーネントの移行を行いつつ修正できればと考えています。

この PR では設定ファイル以外の変更を含めていないため、確認は以下 PR をローカルで触ると良さそうです。
https://github.com/kufu/smarthr-ui/pull/3616

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- 移行・設定したデザイントークン
  - backgroundColor
  - borderColor
  - borderRadius
  - boxShadow
  - colors
  - fontSize
  - lineHeight
  - maxWIdth
    - 現状利用していないTシャツサイズを塞ぐ
  - outlineColor
  - spacing
  - stroke
  - textColor
  - zIndex
- 無効化した設定
  - preflight
  - boxShadowColor
  - caretColor
  - divideColor
  - fontFamily
  - placeholderColor
  - ringColor
  - ringOffsetColor
  - textDecorationColor

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
