### PR TITLE
[DO NOT MERGE] NewBalloon のスタイルの差分を検知する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,10 @@ commands:
           command: yarn test-storybook:ci
       - store_test_results:
           path: junit.xml
+  run-chromatic-for-new-components:
+    steps:
+      - checkout
+      - run: npx ts-node ./scripts/replaceImportSpecifiers.ts && yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
   run-chromatic:
     steps:
       - checkout
@@ -108,6 +112,11 @@ jobs:
     steps:
       - setup-for-test
       - run-chromatic
+  chromatic-deployment-for-new-components:
+    executor: node-active-lts
+    steps:
+      - setup-for-test
+      - run-chromatic-for-new-components
   chromatic-deployment-master:
     executor: node-active-lts
     steps:
@@ -123,6 +132,12 @@ workflows:
       - a11y-test:
           context: smarthr-dockerhub
       - chromatic-deployment:
+          filters:
+            branches:
+              ignore:
+                - master
+          context: smarthr-dockerhub
+      - chromatic-deployment-for-new-components:
           filters:
             branches:
               ignore:

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "stylelint-config-styled-components": "^0.1.1",
     "testcafe": "3.3.0",
     "ts-loader": "^9.4.4",
+    "ts-morph": "^19.0.0",
     "ts-node": "^10.9.1",
     "ttypescript": "^1.5.15",
     "typescript": "^5.2.2",

--- a/scripts/replaceImportSpecifiers.ts
+++ b/scripts/replaceImportSpecifiers.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { Project } from 'ts-morph'
+
+const project = new Project()
+function findFiles(directory: string, regex: RegExp): string[] {
+  const filePaths: string[] = []
+  function recursivelySearch(currentDir: string) {
+    const entries = fs.readdirSync(currentDir)
+    for (const entry of entries) {
+      const entryPath = path.join(currentDir, entry)
+      const stat = fs.statSync(entryPath)
+
+      if (stat.isDirectory()) {
+        recursivelySearch(entryPath)
+      } else if (stat.isFile() && regex.test(entryPath)) {
+        filePaths.push(entryPath)
+      }
+    }
+  }
+  recursivelySearch(directory)
+  return filePaths
+}
+
+// { '/Users/aoyagi/smarthr-ui/src/components/Button': '/Users/aoyagi/smarthr-ui/src/components/Button/new' } 的な map を作る
+function getComponentReplaceMap() {
+  const newComponentFilePaths = findFiles(path.join(__dirname, '../src/components'), new RegExp(/\/index\.ts$/))
+  const componentReplaceMap: Map<string, string> = new Map()
+
+  for (const filePath of newComponentFilePaths) {
+    const code = fs.readFileSync(filePath, 'utf-8')
+    const file = project.createSourceFile(filePath, code, { overwrite: true })
+    const statements = file.getStatementsWithComments()
+    for (const statement of statements) {
+      const commentRanges = statement.getLeadingCommentRanges()
+      for (const commentRange of commentRanges) {
+        const commentString = commentRange.getText()
+        const match = commentString.match(/\/\*\s@new\s(.+)\s\*\//)
+        const componentName = match && match[1]
+        if (componentName) {
+          const keyPath = path.join(__dirname, '../src/components', componentName)
+          componentReplaceMap.set(keyPath, path.dirname(filePath))
+        }
+      }
+    }
+  }
+  return componentReplaceMap
+}
+
+function replaceImportDeclaration(componentReplaceMap: Map<string, string>) {
+  const storyFilePaths = findFiles(path.join(__dirname, '../src/components'), new RegExp(/stories\.tsx$/))
+
+  for (const filePath of storyFilePaths) {
+    const code = fs.readFileSync(filePath, 'utf-8')
+    const file = project.createSourceFile(filePath, code, { overwrite: true })
+    const importDeclarations = file.getImportDeclarations()
+    for (const importDeclaration of importDeclarations) {
+      const importPath = importDeclaration.getModuleSpecifierValue()
+      const importAbsolutePath = path.join(path.dirname(filePath), importPath) // `../Button` -> `/Users/aoyagi/smarthr-ui/src/components/Button`
+      const newComponentAbsolutePath = componentReplaceMap.get(importAbsolutePath)
+      if (newComponentAbsolutePath) {
+        importDeclaration.getModuleSpecifier().replaceWithText(`'${newComponentAbsolutePath}'`)
+      }
+    }
+    file.saveSync()
+  }
+}
+
+const componentReplaceMap = getComponentReplaceMap()
+replaceImportDeclaration(componentReplaceMap)

--- a/src/components/Balloon/Balloon.stories.tsx
+++ b/src/components/Balloon/Balloon.stories.tsx
@@ -2,7 +2,7 @@ import { Story } from '@storybook/react'
 import * as React from 'react'
 import styled from 'styled-components'
 
-import { Balloon } from './Balloon'
+import { Balloon } from '.'
 
 export default {
   title: 'Data Display（データ表示）/Balloon',

--- a/src/components/new/Balloon/Balloon.tsx
+++ b/src/components/new/Balloon/Balloon.tsx
@@ -109,7 +109,7 @@ const Base = styled.div<{ themes: Theme }>`
       &.right {
         &::before,
         &::after {
-          right: 24px;
+          right: 48px;
         }
       }
       &.center {

--- a/src/components/new/Balloon/Balloon.tsx
+++ b/src/components/new/Balloon/Balloon.tsx
@@ -1,0 +1,164 @@
+import React, { HTMLAttributes, ReactNode, VFC } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../../hooks/useTheme'
+
+import { useClassNames } from './useClassNames'
+
+export type BalloonTheme = 'light' | 'dark'
+
+export type Props = {
+  /** 吹き出しの垂直位置 */
+  horizontal: 'right' | 'center' | 'left'
+  /** 吹き出しの水平位置 */
+  vertical: 'top' | 'middle' | 'bottom'
+  /** コンポーネントに適用するクラス名 */
+  className?: string
+  /** バルーン内のコンテンツ */
+  children?: ReactNode
+  /** レンダリングするタグ */
+  as?: 'div' | 'span'
+}
+
+type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+
+export const Balloon: VFC<Props & ElementProps> = ({
+  horizontal,
+  vertical,
+  className = '',
+  ...props
+}) => {
+  if (horizontal === 'center' && vertical === 'middle') {
+    throw new Error('"vertical" can not be specified as "middle" when "horizontal" is "center".')
+  }
+
+  const themes = useTheme()
+  const { wrapper } = useClassNames()
+  const classNames = `${horizontal} ${vertical} ${className} ${wrapper}`
+
+  return <Base {...props} className={classNames} themes={themes} />
+}
+
+// HINT: trianble部分はRetinaディスプレイなどで途切れてしまう場合があるので
+// 1pxほど大きめに描画してbody部分と被るようにしています。
+const Base = styled.div<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { border, color, fontSize } = themes
+
+    return css`
+      position: relative;
+      display: inline-block;
+      font-size: ${fontSize.S};
+      border-radius: 4px;
+      filter: drop-shadow(
+        0 2px 2.5px rgba(0, 0, 0, 0.33)
+      ); /* drop-shadow は spread-radius を受け付けないので shadow.LAYER2 に近い値をハードコーディングしている */
+      white-space: nowrap;
+      transform: translateZ(0); /* safari で filter を正しく描画するために必要 */
+
+      &::after {
+        display: block;
+        position: absolute;
+        content: '';
+        background-color: ${color.WHITE};
+      }
+
+      background-color: ${color.WHITE};
+      color: ${color.TEXT_BLACK};
+
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+
+        &::before {
+          display: block;
+          position: absolute;
+          content: '';
+          background-color: ${color.TEXT_BLACK};
+        }
+      }
+
+      &.top {
+        &::before,
+        &::after {
+          top: -4px;
+          width: 10px;
+          height: 5px;
+          clip-path: polygon(50% 0, 100% 100%, 0 100%);
+        }
+
+        &::before {
+          top: -5px;
+        }
+      }
+      &.bottom {
+        &::before,
+        &::after {
+          bottom: -4px;
+          width: 10px;
+          height: 5px;
+          clip-path: polygon(0 0, 100% 0, 50% 100%);
+        }
+
+        &::before {
+          bottom: -5px;
+        }
+      }
+
+      &.right {
+        &::before,
+        &::after {
+          right: 24px;
+        }
+      }
+      &.center {
+        &::before,
+        &::after {
+          left: 50%;
+          transform: translateX(-5px);
+        }
+      }
+      &.left {
+        &::before,
+        &::after {
+          left: 24px;
+        }
+      }
+
+      &.middle {
+        &::before,
+        &::after {
+          top: 50%;
+          transform: translateY(-5px);
+        }
+        &.left {
+          &::before,
+          &::after {
+            left: -4px;
+            width: 5px;
+            height: 10px;
+            clip-path: polygon(100% 0, 100% 100%, 0 50%);
+          }
+
+          &::before {
+            left: -5px;
+          }
+        }
+        &.right {
+          &::before,
+          &::after {
+            right: -4px;
+            width: 5px;
+            height: 10px;
+            clip-path: polygon(0 0, 100% 50%, 0 100%);
+          }
+
+          &::before {
+            right: -5px;
+          }
+        }
+      }
+    `
+  }}
+`

--- a/src/components/new/Balloon/index.ts
+++ b/src/components/new/Balloon/index.ts
@@ -1,0 +1,2 @@
+/* @new Balloon */
+export * from './Balloon'

--- a/src/components/new/Balloon/useClassNames.ts
+++ b/src/components/new/Balloon/useClassNames.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../../hooks/useClassNameGenerator'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator('Balloon')
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+    }),
+    [generate],
+  )
+}

--- a/src/components/new/index.ts
+++ b/src/components/new/index.ts
@@ -1,0 +1,1 @@
+export { Balloon } from './Balloon'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3465,6 +3465,16 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
+"@ts-morph/common@~0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.20.0.tgz#3f161996b085ba4519731e4d24c35f6cba5b80af"
+  integrity sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==
+  dependencies:
+    fast-glob "^3.2.12"
+    minimatch "^7.4.3"
+    mkdirp "^2.1.6"
+    path-browserify "^1.0.1"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -5309,6 +5319,11 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
+code-block-writer@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-12.0.0.tgz#4dd58946eb4234105aff7f0035977b2afdc2a770"
+  integrity sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==
+
 coffeescript@^2.3.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-2.5.1.tgz#b2442a1f2c806139669534a54adc35010559d16a"
@@ -7001,7 +7016,7 @@ fast-fifo@^1.1.0, fast-fifo@^1.2.0:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.2.0.tgz#2ee038da2468e8623066dee96958b0c1763aa55a"
   integrity sha512-NcvQXt7Cky1cNau15FWy64IjuO8X0JijhTBBrJj1YlxlDfRkJXNaK9RFUjwpfDPzMdv7wB38jr53l9tkNLxnWg==
 
-fast-glob@^3.0.3, fast-glob@^3.2.9, fast-glob@^3.3.1:
+fast-glob@^3.0.3, fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
@@ -10040,6 +10055,13 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^7.4.3:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
+  integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.1.tgz#8a555f541cf976c622daf078bb28f29fb927c253"
@@ -10101,6 +10123,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@^0.5.5:
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+
+mkdirp@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.1.6.tgz#964fbcb12b2d8c5d6fbc62a963ac95a273e2cc19"
+  integrity sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -12972,6 +12999,14 @@ ts-loader@^9.4.4:
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+ts-morph@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-19.0.0.tgz#43e95fb0156c3fe3c77c814ac26b7d0be2f93169"
+  integrity sha512-D6qcpiJdn46tUqV45vr5UGM2dnIEuTGNxVhg0sk5NX11orcouwj6i1bMqZIz2mZTZB1Hcgy7C3oEVhAT+f6mbQ==
+  dependencies:
+    "@ts-morph/common" "~0.20.0"
+    code-block-writer "^12.0.0"
 
 ts-node@^10.8.1, ts-node@^10.9.1:
   version "10.9.1"


### PR DESCRIPTION
new ディレクトリ内に tailwind で描かれた新たな Balloon というコンポーネントを追加したときを想定しています。

`replaceImportSpecifiers.ts` を実行すると既存の Balloon コンポーネントの storybook が新しい Balloon コンポーネントを参照するように書き換わるので、それによって既存の Balloon と新しい Balloon のリグレッションテストを行っています。
このプルリクでは、新 Balloon のスタイルを意図的に書き換えて、差分が検知されることを確かめています。

実行結果は CircleCI の `chromatic-deployment-for-new-components` というジョブの詳細を確認してください。