### PR TITLE
fix: style属性に渡すプロパティのため、camel caseに変更する

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -481,7 +481,7 @@ const InputWrapper = styled.div.attrs(({ $hidden }: InputWrapperProps) => ({
     ? {
         position: 'absolute',
         opacity: '0',
-        'pointer-events': 'none',
+        pointerEvents: 'none',
       }
     : undefined,
 }))<InputWrapperProps>`


### PR DESCRIPTION
## Related URL

* https://github.com/kufu/smarthr-ui/commit/0b2c3e06e61692109bb4b2c7254e448889a60fb0#diff-99591a6bd0570c02c5bf0202f232fa3976be1bb4d82ee52eea61c3f0fc5275c9R484

## Overview

* 上記の修正にでスタイル属性に`pointer-events`を当てたが、スタイル属性はcamelケースで指定する必要があるためエラーになる
  * `Warning: Unsupported style property pointer-events. Did you mean pointerEvents?`

## What I did

* kebabケースからcamelケースに修正しエラーを解消した

## Capture

<!--
Please attach a capture if it looks different.
-->
