### PR TITLE
feat: 白黒反転などの強制カラーモードに対応する

### DIFF
--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -94,6 +94,11 @@ const Box = styled.span<{ themes: Theme; error?: boolean }>`
         }
       }
 
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      @media (forced-colors: active) {
+        display: none;
+      }
+
       /* FIXME: なぜか static classname になってしまうため & を重ねている */
       input:checked + &&,
       input:indeterminate + && {
@@ -140,6 +145,12 @@ const Input = styled.input<{ themes: Theme }>`
       }
       &:focus-visible + span {
         ${shadow.focusIndicatorStyles};
+      }
+
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      @media (forced-colors: active) {
+        opacity: 1;
+        position: static;
       }
     `
   }}

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -65,6 +65,11 @@ const Box = styled.span<{ themes: Theme }>`
       background-color: ${color.WHITE};
       box-sizing: border-box;
 
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      @media (forced-colors: active) {
+          display: none;
+        }
+
       @media (prefers-contrast: more) {
         & {
           border: ${border.highContrast};
@@ -132,6 +137,12 @@ const Input = styled.input<{ themes: Theme }>`
       }
       &:focus-visible + span {
         box-shadow: ${shadow.focusIndicatorStyles};
+      }
+      
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      @media (forced-colors: active) {
+        position: initial;
+        opacity: 1;
       }
     `}
 `


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/jira/software/projects/SHRUI/boards/99/backlog?selectedIssue=SHRUI-715

## Overview

Windowsなどで提供されているカラーテーマによっては、ラジオボタンやチェックボックスがチェックされているかどうかがわからなかった。

## What I did

`forced-colors: active` メディアクエリを利用し、カラーがOSなどによって矯正されている場合は、ラジオボタンやチェックボックスをブラウザデフォルトのUIを表示し、選択状態がわかるようにした。

## Capture

Google Chromeの開発者ツールで、forced-colors: activeをEmulateしたときのキャプチャ

### Before

左の「RadioButton」ラベルがついたRadioButtonは選択されているにも関わらず、選択状態が分からない
<img width="596" alt="スクリーンショット。2つのラジオボタンがあり、両方が選択されてないように見える。" src="https://github.com/kufu/smarthr-ui/assets/6724665/5bf5c41b-fea3-4dd5-a53f-1091e3425f07">

### After

<img width="602" alt="スクリーンショット。2つのラジオボタンがあり、左が選択されている。" src="https://github.com/kufu/smarthr-ui/assets/6724665/6124a3b6-0ab1-48db-a3c7-90419517d51f">
