### PR TITLE
feat: FilterDropdown にサイズ小オプションを追加

### DIFF
--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -180,6 +180,17 @@ const Render: React.FC = () => {
             </Stack>
           </FilterDropdown>
         </dd>
+        <dt>small button</dt>
+        <dd>
+          <FilterDropdown
+            isFiltered={isFiltered2}
+            onApply={() => setIsFiltered2(true)}
+            onReset={() => setIsFiltered2(false)}
+            triggerSize="s"
+          >
+            <p>You can change border color of the trigger button by setting `isFiltered`.</p>
+          </FilterDropdown>
+        </dd>
       </List>
     </Wrapper>
   )

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -153,7 +153,10 @@ const IsFilteredIconWrapper = styled.span<{
   color: ${({ isFiltered, themes }) => (isFiltered ? themes.color.MAIN : themes.color.TEXT_BLACK)};
   line-height: 1;
   ${({ themes: { space }, size }) => css`
-    transform: translate(${size === 's' ? space(-0.25) : 0});
+    ${size === 's' &&
+    css`
+      transform: translateX(${space(-0.25)});
+    `}
   `}
 
   & > [role='img'] + [role='img'] {

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -144,7 +144,11 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   )
 }
 
-const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean;  themes: Theme; size?: ButtonProps['size'] }>`
+const IsFilteredIconWrapper = styled.span<{
+  isFiltered: boolean
+  themes: Theme
+  size?: ButtonProps['size']
+}>`
   position: relative;
   color: ${({ isFiltered, themes }) => (isFiltered ? themes.color.MAIN : themes.color.TEXT_BLACK)};
   line-height: 1;

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
 import { Button } from '../../Button'
+import { ButtonProps } from '../../Button/BaseButton'
 import { FaCheckCircleIcon, FaFilterIcon, FaUndoAltIcon } from '../../Icon'
 import { Cluster, Stack } from '../../Layout'
 import { ResponseMessage } from '../../ResponseMessage'
@@ -25,7 +26,9 @@ type Props = {
   decorators?: DecoratorsType<
     'status' | 'triggerButton' | 'applyButton' | 'cancelButton' | 'resetButton'
   >
-  responseMessage?: ResponseMessageType
+  responseMessage?: ResponseMessageType,
+  /** 引き金となるボタンの大きさ */
+  triggerSize?: ButtonProps['size']
 }
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof Props>
 
@@ -47,6 +50,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   hasStatusText,
   decorators,
   responseMessage,
+  triggerSize,
   ...props
 }: Props) => {
   const themes = useTheme()
@@ -88,6 +92,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
               {isFiltered ? <FilteredCheckIcon aria-label={filteredIconAriaLabel} /> : null}
             </IsFilteredIconWrapper>
           }
+          size={triggerSize}
         >
           {triggerButton}
         </Button>

--- a/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -26,7 +26,7 @@ type Props = {
   decorators?: DecoratorsType<
     'status' | 'triggerButton' | 'applyButton' | 'cancelButton' | 'resetButton'
   >
-  responseMessage?: ResponseMessageType,
+  responseMessage?: ResponseMessageType
   /** 引き金となるボタンの大きさ */
   triggerSize?: ButtonProps['size']
 }
@@ -87,7 +87,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
         <Button
           {...props}
           suffix={
-            <IsFilteredIconWrapper isFiltered={isFiltered} themes={themes}>
+            <IsFilteredIconWrapper isFiltered={isFiltered} themes={themes} size={triggerSize}>
               <FaFilterIcon />
               {isFiltered ? <FilteredCheckIcon aria-label={filteredIconAriaLabel} /> : null}
             </IsFilteredIconWrapper>
@@ -144,10 +144,13 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   )
 }
 
-const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean; themes: Theme }>`
+const IsFilteredIconWrapper = styled.span<{ isFiltered: boolean;  themes: Theme; size?: ButtonProps['size'] }>`
   position: relative;
-  color: ${({ isFiltered, themes }) => isFiltered ? themes.color.MAIN : themes.color.TEXT_BLACK};
+  color: ${({ isFiltered, themes }) => (isFiltered ? themes.color.MAIN : themes.color.TEXT_BLACK)};
   line-height: 1;
+  ${({ themes: { space }, size }) => css`
+    transform: translate(${size === 's' ? space(-0.25) : 0});
+  `}
 
   & > [role='img'] + [role='img'] {
     position: absolute;


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://kufuinc.slack.com/archives/CGC58MW01/p1694669568761429

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

FilterDropdownを他のボタン類と合わせて使用する際にサイズの調整が効かずデザイン調整ができないため、FilterDropdownにトリガーのボタンサイズを渡せるようにしました。

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

FilterDropdownに`triggerSize` propsを生やしました（DropdownMenuButtonと同じI/Fです）

## Capture

<!--
Please attach a capture if it looks different.
-->

<img width="279" alt="スクリーンショット 2023-09-14 22 00 40" src="https://github.com/kufu/smarthr-ui/assets/1480182/fd9b8b95-3bf1-4acb-9704-0fde4ac3112c">

