### PR TITLE
chore: revert update dependency glob to 10.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-smarthr": "^6.12.1",
     "eslint-plugin-storybook": "^0.6.14",
     "fs-extra": "^11.1.1",
-    "glob": "^10.3.9",
+    "glob": "^10.3.6",
     "http-server": "^14.1.1",
     "husky": "^8.0.3",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7569,7 +7569,7 @@ glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
 
-glob@^10.0.0, glob@^10.2.2, glob@^10.3.9:
+glob@^10.0.0, glob@^10.2.2, glob@^10.3.6:
   version "10.3.9"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.9.tgz#181ae87640ecce9b2fc5b96e4e2d70b7c3629ab8"
   integrity sha512-2tU/LKevAQvDVuVJ9pg9Yv9xcbSh+TqHuTaXTNbQwf+0kDl9Fm6bMovi4Nm5c8TVvfxo2LLcqCGtmO9KoJaGWg==


### PR DESCRIPTION
Reverts kufu/smarthr-ui#3749