### PR TITLE
feat!: FieldSet非推奨コンポーネントのヒント、エラーメッセージの配置をFormControlと揃える

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -6,6 +6,7 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
 import { Input } from '../Input'
+import { Stack } from '../Layout/Stack'
 import { StatusLabel } from '../StatusLabel'
 
 import { useClassNames } from './useClassNames'
@@ -43,6 +44,7 @@ export const FieldSet: FC<Props & ElementProps> = ({
   ...props
 }) => {
   const theme = useTheme()
+  const managedHtmlFor = useId()
   const helpId = useId()
   const classNames = useClassNames()
 
@@ -69,17 +71,20 @@ export const FieldSet: FC<Props & ElementProps> = ({
       </Title>
 
       {helpMessage && (
-        <Help id={helpId} themes={theme} className={classNames.help}>
+        <HelpMessage themes={theme} id={helpId} className={classNames.help}>
           {helpMessage}
-        </Help>
+        </HelpMessage>
       )}
-      {errorMessage &&
-        (Array.isArray(errorMessage) ? errorMessage : [errorMessage]).map((message, index) => (
-          <Error themes={theme} key={index} className={classNames.error}>
-            <ErrorIcon color={theme.color.DANGER} className={classNames.errorIcon} />
-            <ErrorText className={classNames.errorText}>{message}</ErrorText>
-          </Error>
-        ))}
+      {errorMessage && (
+        <StyledStack themes={theme} gap={0} id={`${managedHtmlFor}_errorMessages`}>
+          {(Array.isArray(errorMessage) ? errorMessage : [errorMessage]).map((message, index) => (
+            <ErrorMessage themes={theme} key={index} className={classNames.error}>
+              <FaExclamationCircleIcon text={message} className={classNames.errorText} />
+            </ErrorMessage>
+          ))}
+        </StyledStack>
+      )
+      }
 
       {children ? (
         children
@@ -111,25 +116,24 @@ const Title = styled.div<{ themes: Theme }>`
 const LabelHeading = styled(Heading)`
   display: inline-block;
 `
-const Help = styled.div<{ themes: Theme }>`
-  ${({ themes: { color, fontSize, spacingByChar } }) => css`
-    margin: ${spacingByChar(0.5)} 0 0 0;
-    font-size: ${fontSize.S};
-    line-height: 1;
-    color: ${color.TEXT_GREY};
+
+const HelpMessage = styled.p<{ themes: Theme }>`
+  ${({ themes: { spacingByChar } }) => css`
+    margin-bottom: ${spacingByChar(0.5)};
+
   `}
 `
-const Error = styled.div<{ themes: Theme }>`
-  ${({ themes: { fontSize, spacingByChar } }) => css`
-    margin: ${spacingByChar(0.5)} 0;
-    font-size: ${fontSize.S};
-    line-height: 1;
+const StyledStack = styled(Stack)<{ themes: Theme }>`
+  ${({ themes: { spacingByChar } }) => css`
+    margin-bottom: ${spacingByChar(0.5)};
+
   `}
 `
-const ErrorIcon = styled(FaExclamationCircleIcon)`
-  margin-right: 0.4rem;
-  vertical-align: middle;
-`
-const ErrorText = styled.span`
-  vertical-align: middle;
+
+const ErrorMessage = styled.p<{ themes: Theme }>`
+  ${({ themes: { color } }) => css`
+    .smarthr-ui-FieldSet-errorText {
+      color: ${color.DANGER};
+    }
+  `}
 `

--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -68,13 +68,11 @@ export const FieldSet: FC<Props & ElementProps> = ({
         {labelSuffix && labelSuffix}
       </Title>
 
-      {children ? (
-        children
-      ) : (
-        // eslint-disable-next-line smarthr/a11y-input-has-name-attribute
-        <Input {...props} error={!!errorMessage} className={classNames.input} />
+      {helpMessage && (
+        <Help id={helpId} themes={theme} className={classNames.help}>
+          {helpMessage}
+        </Help>
       )}
-
       {errorMessage &&
         (Array.isArray(errorMessage) ? errorMessage : [errorMessage]).map((message, index) => (
           <Error themes={theme} key={index} className={classNames.error}>
@@ -83,10 +81,11 @@ export const FieldSet: FC<Props & ElementProps> = ({
           </Error>
         ))}
 
-      {helpMessage && (
-        <Help id={helpId} themes={theme} className={classNames.help}>
-          {helpMessage}
-        </Help>
+      {children ? (
+        children
+      ) : (
+        // eslint-disable-next-line smarthr/a11y-input-has-name-attribute
+        <Input {...props} error={!!errorMessage} className={classNames.input} />
       )}
     </Wrapper>
   )
@@ -122,7 +121,7 @@ const Help = styled.div<{ themes: Theme }>`
 `
 const Error = styled.div<{ themes: Theme }>`
   ${({ themes: { fontSize, spacingByChar } }) => css`
-    margin: ${spacingByChar(0.5)} 0 0 0;
+    margin: ${spacingByChar(0.5)} 0;
     font-size: ${fontSize.S};
     line-height: 1;
   `}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- FieldSetは非推奨コンポーネントのため、FormControlに置き換えたい
- その際、メッセージやエラーメッセージの配置が変わってしまうため、UIの食い違いを防ぐため、大きな単位での作業になってしまいがちとなる
- なるべく小さな単位で置き換えすることができるよう、FieldSet非推奨コンポーネントのUIをFormControlによせることで置き換えしやすくしたい

## Capture

<!--
Please attach a capture if it looks different.
-->
<img width="408" alt="スクリーンショット 2023-09-28 14 06 00" src="https://github.com/kufu/smarthr-ui/assets/773467/dad26247-cc38-417a-8773-0b24500e06e5">
