### PR TITLE
fix: Text の color や leading などの属性を DOM から隠す

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -56,11 +56,11 @@ export const Text: React.FC<PropsWithChildren<TextProps & ComponentProps<'span'>
   as: Component = emphasis ? 'em' : 'span',
   ...props
 }) => {
-  const { size, italic, color, leading, whiteSpace, className } = props
+  const { size, italic, color, leading, whiteSpace, className, ...others } = props
   const styles = useMemo(
     () => text({ size, weight, italic, color, leading, whiteSpace, className }),
     [size, weight, italic, color, leading, whiteSpace, className],
   )
 
-  return <Component {...props} className={styles} />
+  return <Component {...others} className={styles} />
 }


### PR DESCRIPTION
## Overview

color や leading といった props が DOM に流し込まれていたため明示的に絞った。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
