### PR TITLE
chore: GitHub Actions で node のバージョンを .node-version と合わせた

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: '.node-version'
           registry-url: 'https://registry.npmjs.org'
       - name: git config
         run: |

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: '.node-version'
       - name: git config
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

GitHub Actions で Node のバージョンを直接指定するよりも `.node-version` を参照させた方が、 Node のバージョン上がった時の修正が楽かなーと思い PR 出させていただきました！

もし PR の出し方に問題あったり、そもそも修正自体に問題ある場合は気軽にご指摘いただければ。

なお、 e2e.yml では Node のバージョンを `18` ではなく `20` で直接指定していますが、[理由がありそう](https://github.com/kufu/smarthr-ui/pull/3514)だったのでそのままにしてます。

https://github.com/hiroki0525/smarthr-ui/blob/4f4300a2c2a03f465097e0e2c88651d080fc07dc/.github/workflows/e2e.yml#L19

余談ですが、 [Node の v20 の LTS が 10/24 からスタート](https://github.com/nodejs/Release) です。

## What I did

GitHub Actions で Node のバージョンを直接指定するのではなく `.node-version` を参照させるようにした。

[参考 URL](https://github.com/actions/setup-node#:~:text=from%20node%2Dversion.-,node%2Dversion%2Dfile,-%3A%20%27%27)

## Capture

なし
