### PR TITLE
chore: DropdownコンポーネントにVRT用のStoryを追加

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -48,7 +48,27 @@ const preview: Preview = {
         ],
       },
     },
-    viewport: { viewports: INITIAL_VIEWPORTS },
+    viewport: {
+      viewports: {
+        ...INITIAL_VIEWPORTS,
+        vrtMobile: {
+          name: 'VRT Mobile',
+          styles: {
+            // iPhone15 Pro、 iPhone15、 iPhone14 Proのサイズを想定
+            width: '393px',
+            height: '852px',
+          },
+        },
+        vrtTablet: {
+          name: 'VRT Tablet',
+          styles: {
+            // iPad 第10世代、iPad Air 第4世代〜のサイズを想定
+            width: '820px',
+            height: '1180px',
+          },
+        }
+      }
+    },
     docs: {
       // ArgsTable は deprecated で、subcomponentsで複数コンポーネントの props を見せる機能は非推奨になった
       // ここでは、一旦v6.5->v7アップデート時に後方互換を保つために独自のpageを設定している

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -55,7 +55,7 @@ const ListMenu = () => (
     </ActionList>
   )
 
-const ControllableDropdown = () => {
+export const ControllableDropdown = () => {
   const [value, setValue] = React.useState('hoge')
   const [text, setText] = React.useState('')
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.name)

--- a/src/components/Dropdown/VRTDropdown.stories.tsx
+++ b/src/components/Dropdown/VRTDropdown.stories.tsx
@@ -1,0 +1,87 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { Dropdown } from './Dropdown'
+import { All, ControllableDropdown } from './Dropdown.stories'
+import { DropdownCloser } from './DropdownCloser'
+import { DropdownContent } from './DropdownContent'
+import { DropdownScrollArea } from './DropdownScrollArea'
+import { DropdownTrigger } from './DropdownTrigger'
+
+export default {
+  title: 'Buttons（ボタン）/Dropdown',
+  component: Dropdown,
+  subcomponents: {
+    DropdownTrigger,
+    DropdownContent,
+    DropdownCloser,
+    DropdownScrollArea,
+  },
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTOpenDropdownNarrow: StoryFn = () => (
+  <Wrapper>
+    <ControllableDropdown />
+  </Wrapper>
+)
+
+export const VRTOpenNested: StoryFn = () => (
+  <Wrapper>
+    <All />
+  </Wrapper>
+)
+
+export const VRTDropdownForcedColors: StoryFn = () => (
+  <Wrapper>
+    <All />
+  </Wrapper>
+)
+
+VRTOpenNested.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const button1 = await canvas.findByText('入れ子にできる Dropdown')
+  await userEvent.click(button1)
+  const body = canvasElement.ownerDocument.body
+  const button2 = await within(body).findByText('さらに入れ子にできる Dropdown')
+  await userEvent.click(button2)
+  const button3 = await within(body).findByText('いくらでも入れ子にできる Dropdown')
+  await userEvent.click(button3)
+}
+
+VRTOpenDropdownNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' }
+    },
+  },
+}
+VRTOpenDropdownNarrow.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const buttons = await canvas.findAllByRole('button')
+  userEvent.click(buttons[0])
+}
+
+VRTDropdownForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+VRTDropdownForcedColors.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const buttons = await canvas.findAllByRole('button')
+  userEvent.click(buttons[0])
+}
+
+const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`


### PR DESCRIPTION
## Overview
ビジュアルリグレッションテスト（VRT）を増やす取り組みで、#3751 でButtonコンポーネントにStoryを追加していますが、このPRではDropdownコンポーネントにも追加しました。

## What I did
### Dropdownコンポーネントに3つのVRT用Storyを追加
- VRT Open Nested
  - ネストしたドロップダウンがすべて開いた状態
- VRT Open Dropdown Narrow
  - ウィンドウ幅が狭い状態でドロップダウンを開いた状態
- VRT Dropdown Forced Colors
  - `forcedColors: 'active'` を適用した状態（ドロップシャドウが`none`になります）

### Viewportの追加
ウィンドウ幅が狭い状態の再現のため、`.storybook/preview.tsx` にモバイルとタブレットを想定したviewportのプリセットを追加しています。現状はモバイルのみVRT Open Dropdown Narrow で使用していますが、全てのStoryで、viewport切り替えのUIから選択可能です。

## Capture
### 幅が狭い状態
<img src="https://github.com/kufu/smarthr-ui/assets/7822534/c824b274-9922-4f7d-bd91-64e6abda54e8" width="600" alt="viewportがモバイルを想定した状態のStorybookの画面">

### 入れ子を全て開いた状態
<img src="https://github.com/kufu/smarthr-ui/assets/7822534/f55e7125-989a-4554-a287-a0cc0cc9445e" width="600" alt="入れ子のドロップダウンが全て開いているStorybookの画面">

### ForcedColors
