### PR TITLE
fix: Select の文字位置が Firefox でズレていたので修正

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -51,7 +51,7 @@ export const Select = forwardRef(
       onChange,
       onChangeValue,
       error = false,
-      width = 'auto',
+      width,
       hasBlank = false,
       decorators,
       size = 'default',
@@ -62,7 +62,7 @@ export const Select = forwardRef(
     ref: ForwardedRef<HTMLSelectElement>,
   ) => {
     const theme = useTheme()
-    const widthStyle = typeof width === 'number' ? `${width}px` : width
+    const $width = typeof width === 'number' ? `${width}px` : width
     const handleChange = useCallback(
       (e: ChangeEvent<HTMLSelectElement>) => {
         if (onChange) onChange(e)
@@ -83,8 +83,8 @@ export const Select = forwardRef(
 
     return (
       <Wrapper
+        $width={$width}
         className={`${className} ${classNames.wrapper} ${generateSizeClassName(size)}`}
-        $width={widthStyle}
       >
         {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
         <StyledSelect
@@ -135,13 +135,10 @@ export const Select = forwardRef(
 
 const generateSizeClassName = (size: Props<string>['size']) => (size === 's' ? '--small' : '')
 
-const Wrapper = styled.span<{
-  $width: string
-}>`
-  ${({ $width }) => css`
-    box-sizing: border-box;
+const Wrapper = styled.span<{ $width?: string }>`
+  ${({ $width = 'auto' }) => css`
     position: relative;
-    display: block;
+    display: inline-block;
     width: ${$width};
   `}
 `
@@ -163,14 +160,14 @@ const StyledSelect = styled.select<{
     color: ${color.TEXT_BLACK};
     width: 100%;
 
+    /* padding に依る積み上げでは文字が見切れてしまうため */
+    min-height: calc(${fontSize.M} + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
+
     @media (prefers-contrast: more) {
       & {
         border: ${border.highContrast};
       }
     }
-
-    /* padding に依る積み上げでは文字が見切れてしまうため */
-    min-height: calc(${fontSize.M} + ${spacingByChar(0.75)} * 2 + ${border.lineWidth} * 2);
 
     ${error &&
     css`

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -156,6 +156,7 @@ const StyledSelect = styled.select<{
     border-radius: ${radius.m};
     border: ${border.shorthand};
     background-color: ${color.WHITE};
+    padding-block: ${spacingByChar(0.75)};
     padding-inline: ${spacingByChar(0.5)} ${spacingByChar(2)};
     font-size: ${fontSize.M};
     line-height: ${leading.NONE};
@@ -193,6 +194,7 @@ const StyledSelect = styled.select<{
     }
 
     .--small & {
+      padding-block: ${spacingByChar(0.5)};
       padding-inline: ${spacingByChar(0.5)};
       font-size: ${fontSize.S};
 


### PR DESCRIPTION
## Overview

before | after
--- | ---
<img width="364" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/79910da2-3671-49b6-9a38-78dd1f27a3aa"> | <img width="364" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/218a1028-743c-41dc-b80e-ceda1b3adcf0">

Chrome は VRT で確認。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- ブロック方向の padding を足しました
- 他フォーム要素と合わせて、display を `inline-block` にしました
- 不要な box-sizing の指定を消しました
- 他、細かな書き方を修正しました