### PR TITLE
chore: CSS Reset のツールバーにタイトルを設定

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -16,9 +16,9 @@ import '../src/styles/index.css'
 const preview: Preview = {
   globalTypes: {
     reset: {
-      name: 'Reset',
       defaultValue: 'smarthr-normalize',
       toolbar: {
+        title: 'CSS Reset',
         items: [
           { value: 'smarthr-normalize', title: 'smarthr-normalize' },
           { value: 'styled-reset', title: 'styled-reset' },
@@ -66,8 +66,8 @@ const preview: Preview = {
             width: '820px',
             height: '1180px',
           },
-        }
-      }
+        },
+      },
     },
     docs: {
       // ArgsTable は deprecated で、subcomponentsで複数コンポーネントの props を見せる機能は非推奨になった


### PR DESCRIPTION
<img width="764" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/39da3007-29a6-45c7-8702-65cd0945ecf6">

どのタイミングかわからないが、いつの間にか消えて警告が出ていたので修正。