### PR TITLE
feat: TextLink を Tailwind CSS 化

### DIFF
--- a/smarthr-ui-preset.ts
+++ b/smarthr-ui-preset.ts
@@ -59,6 +59,7 @@ export default {
       'layer-3': defaultShadow.LAYER3,
       'layer-4': defaultShadow.LAYER4,
       outline: defaultShadow.OUTLINE,
+      "link-underline": defaultShadow.LINK_UNDERLINE,
       none: 'none',
     },
     colors: {

--- a/smarthr-ui-preset.ts
+++ b/smarthr-ui-preset.ts
@@ -59,7 +59,7 @@ export default {
       'layer-3': defaultShadow.LAYER3,
       'layer-4': defaultShadow.LAYER4,
       outline: defaultShadow.OUTLINE,
-      "link-underline": defaultShadow.LINK_UNDERLINE,
+      underline: defaultShadow.UNDERLINE,
       none: 'none',
     },
     colors: {

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -15,7 +15,7 @@ type Props = VariantProps<typeof textLink> & {
 
 const textLink = tv({
   slots: {
-    anchor: 'shr-text-link shr-no-underline shr-shadow-link-underline [&:not([href])]:shr-shadow-none',
+    anchor: 'shr-text-link shr-no-underline shr-shadow-underline [&:not([href])]:shr-shadow-none',
     prefixWrapper: 'shr-me-0.25 shr-align-middle',
     suffixWrapper: 'shr-ms-0.25 shr-align-middle',
   },

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -1,11 +1,10 @@
 import React, { AnchorHTMLAttributes, ReactNode, forwardRef, useMemo } from 'react'
-import styled, { css } from 'styled-components'
+import { VariantProps, tv } from 'tailwind-variants'
 
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaExternalLinkAltIcon } from '../Icon'
 
 type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof Props>
-type Props = {
+type Props = VariantProps<typeof textLink> & {
   /** リンクをクリックした時に発火するコールバック関数 */
   onClick?: (e: React.MouseEvent) => void
   /** テキストの前に表示するアイコン */
@@ -14,9 +13,16 @@ type Props = {
   suffix?: ReactNode
 }
 
+const textLink = tv({
+  slots: {
+    anchor: 'shr-text-link shr-no-underline shr-shadow-link-underline [&:not([href])]:shr-shadow-none',
+    prefixWrapper: 'shr-me-0.25 shr-align-middle',
+    suffixWrapper: 'shr-ms-0.25 shr-align-middle',
+  },
+})
+
 export const TextLink = forwardRef<HTMLAnchorElement, Props & ElementProps>(
-  ({ href, target, onClick, children, prefix, suffix, ...props }, ref) => {
-    const theme = useTheme()
+  ({ href, target, onClick, children, prefix, suffix, className, ...others }, ref) => {
     const actualSuffix = useMemo(() => {
       if (target === '_blank' && suffix === undefined) {
         return <FaExternalLinkAltIcon aria-label="別タブで開く" />
@@ -47,46 +53,21 @@ export const TextLink = forwardRef<HTMLAnchorElement, Props & ElementProps>(
       }
     }, [href, onClick])
 
+    const { anchor, prefixWrapper, suffixWrapper } = useMemo(() => textLink(), [])
+
     return (
-      <StyledAnchor
-        {...props}
+      <a
+        {...others}
         ref={ref}
         href={actualHref}
         target={target}
         onClick={actualOnClick}
-        themes={theme}
+        className={anchor({ className })}
       >
-        {prefix && <PrefixWrapper themes={theme}>{prefix}</PrefixWrapper>}
+        {prefix && <span className={prefixWrapper()}>{prefix}</span>}
         {children}
-        {actualSuffix && <SuffixWrapper themes={theme}>{actualSuffix}</SuffixWrapper>}
-      </StyledAnchor>
+        {actualSuffix && <span className={suffixWrapper()}>{actualSuffix}</span>}
+      </a>
     )
   },
-)
-
-const StyledAnchor = styled.a<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color } = themes
-    return css`
-      text-decoration: none;
-      box-shadow: 0 1px 0 0;
-      color: ${color.TEXT_LINK};
-
-      &:not([href]) {
-        box-shadow: none;
-      }
-    `
-  }}
-`
-const PrefixWrapper = styled.span<{ themes: Theme }>(
-  ({ themes: { spacingByChar } }) => css`
-    margin-right: ${spacingByChar(0.25)};
-    vertical-align: middle;
-  `,
-)
-const SuffixWrapper = styled.span<{ themes: Theme }>(
-  ({ themes: { spacingByChar } }) => css`
-    margin-left: ${spacingByChar(0.25)};
-    vertical-align: middle;
-  `,
 )

--- a/src/components/TextLink/TextLink.tsx
+++ b/src/components/TextLink/TextLink.tsx
@@ -1,10 +1,10 @@
 import React, { AnchorHTMLAttributes, ReactNode, forwardRef, useMemo } from 'react'
-import { VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { FaExternalLinkAltIcon } from '../Icon'
 
 type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof Props>
-type Props = VariantProps<typeof textLink> & {
+type Props = {
   /** リンクをクリックした時に発火するコールバック関数 */
   onClick?: (e: React.MouseEvent) => void
   /** テキストの前に表示するアイコン */

--- a/src/themes/createShadow.ts
+++ b/src/themes/createShadow.ts
@@ -20,7 +20,7 @@ export type ShadowProperty = {
   LAYER4?: string
   OUTLINE?: string
   OUTLINE_MARGIN?: string
-  LINK_UNDERLINE?: string
+  UNDERLINE?: string
 }
 
 export type CreatedShadowTheme = {
@@ -39,7 +39,7 @@ export type CreatedShadowTheme = {
   LAYER4?: string
   OUTLINE: string
   OUTLINE_MARGIN: string
-  LINK_UNDERLINE: string
+  UNDERLINE: string
   focusIndicatorStyles: FlattenSimpleInterpolation
 }
 
@@ -64,7 +64,7 @@ export const defaultShadow = {
   LAYER4: createLayerShadow(4),
   OUTLINE: defaultOutline,
   OUTLINE_MARGIN: defaultOutlineMargin,
-  LINK_UNDERLINE: '0 1px 0 0'
+  UNDERLINE: '0 1px 0 0'
 }
 
 const createFocusIndicatorStyles = (outline: string) => css`

--- a/src/themes/createShadow.ts
+++ b/src/themes/createShadow.ts
@@ -20,6 +20,7 @@ export type ShadowProperty = {
   LAYER4?: string
   OUTLINE?: string
   OUTLINE_MARGIN?: string
+  LINK_UNDERLINE?: string
 }
 
 export type CreatedShadowTheme = {
@@ -38,6 +39,7 @@ export type CreatedShadowTheme = {
   LAYER4?: string
   OUTLINE: string
   OUTLINE_MARGIN: string
+  LINK_UNDERLINE: string
   focusIndicatorStyles: FlattenSimpleInterpolation
 }
 
@@ -62,6 +64,7 @@ export const defaultShadow = {
   LAYER4: createLayerShadow(4),
   OUTLINE: defaultOutline,
   OUTLINE_MARGIN: defaultOutlineMargin,
+  LINK_UNDERLINE: '0 1px 0 0'
 }
 
 const createFocusIndicatorStyles = (outline: string) => css`


### PR DESCRIPTION
## Related URL
[Link](https://smarthr.atlassian.net/jira/software/projects/SHRUI/boards/99/backlog?selectedIssue=SHRUI-777&text=textlink)

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- TextLinkコンポーネントをTailwindで書き換え
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
1. TextLinkコンポーネントを対象に、Tailwindを利用した書き換えを実装
2. boxShadowのpresetにunderlineのスタイルを追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
