### PR TITLE
chore: .ideaのディレクトリ配下をgit管理から排除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,5 @@ actual_images
 reg_storybook
 
 smarthr-ui.css
+
+.idea


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- Editorの設定ファイルがgit管理されないように.gitignoreを更新する
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- .gitignoreを更新
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
