### PR TITLE
chore: DialogコンポーネントにVRT用のStoryを追加 

### DIFF
--- a/src/components/Dialog/VRTDialog.stories.tsx
+++ b/src/components/Dialog/VRTDialog.stories.tsx
@@ -1,0 +1,93 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Default } from './Dialog.stories'
+
+import {
+  ActionDialog,
+  ActionDialogContent,
+  Dialog,
+  DialogCloser,
+  DialogContent,
+  DialogTrigger,
+  DialogWrapper,
+  MessageDialog,
+  MessageDialogContent,
+  ModelessDialog,
+} from '.'
+
+export default {
+  title: 'Dialog（ダイアログ）/Dialog',
+  component: Dialog,
+  subcomponents: {
+    DialogContent,
+    DialogWrapper,
+    DialogTrigger,
+    DialogCloser,
+    MessageDialog,
+    MessageDialogContent,
+    ActionDialog,
+    ActionDialogContent,
+    ModelessDialog,
+  },
+  parameters: {
+    withTheming: true,
+  },
+}
+export const VRTOpenDialogNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭く、ダイアログを開いた状態で表示されます
+    </VRTInformationPanel>
+    <Default />
+  </Wrapper>
+)
+
+export const VRTDialogForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false} >
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <Default />
+  </Wrapper>
+)
+
+VRTOpenDialogNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' }
+    },
+  },
+}
+VRTOpenDialogNarrow.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const buttons = await canvas.findAllByRole('button')
+  userEvent.click(buttons[0])
+}
+
+VRTDialogForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+VRTDialogForcedColors.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const buttons = await canvas.findAllByRole('button')
+  userEvent.click(buttons[0])
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview
DialogコンポーネントにVRT用のStoryを追加しました。

## What I did
### Dialogコンポーネントに2つのVRT用Storyを追加
- VRT Open Dialog Narrow
  - スマートフォン環境を想定した、ウィンドウ幅の狭い状態でダイアログを開いた状態
- VRT Dialog Forced Colors
  - `forcedColors: 'active'` を適用した状態

## Capture
### 幅が狭い状態
<img src="https://github.com/kufu/smarthr-ui/assets/7822534/c5d66a45-d7d8-4eca-8a6d-f89497aa9db8" width="400" alt="viewportがモバイルを想定した状態のStorybookの画面">

#### Chromaticのスナップショット範囲
[ドキュメント](https://www.chromatic.com/docs/snapshots/#3-take-a-screenshot-and-crop-it-to-the-dimensions-of-the-ui)によるとChromaticは`#storybook-root`要素の範囲でスナップショットを撮るのですが、開いたダイアログはこの要素の外側に作られるため、画面幅が狭い状態ではダイアログの幅は`#storybook-root`より広くなり、Chromaticのスナップショットでは両側が欠けた状態になってしまいます。

これを回避するには、`.storybook/preview.ts`で、`body`の`padding`を`0`にする（そうすると`#storybook-root`が画面幅いっぱいまで広がるはずです）などの対応が必要そうですが、他のStoryにも影響するため、現時点では何もしていません。

Chromatic上のスナップショットは以下です↓
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=652cd9a4c187d7a433a24719

### ForcedColors
こちらもChromatic上のスナップショットは以下です↓
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=652cd9a4c187d7a433a2471a