### PR TITLE
chore: tailwind用presetをpublishするようにした

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src/**/*", "smarthr-ui-preset.ts"],
   "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx", "src/**/__tests__"],
 }


### PR DESCRIPTION
## Overview
- 他のプロジェクトでpresetを再利用したい

## What I did
- npm packageとして公開するときのbuild対象ファイルとして `smarthr-ui-preset` を追加した


## Capture
### Preparation
`npm publish --dry-run` するのはアカウント作らないとで手間だったので下記で確認しました

(1) smarthr-ui-presetがpackされてることを確認する
```sh
$ yarn prepublishOnly  && yarn pack && tar xvzf smarthr-ui-v37.0.0.tgz   
$ ls package/lib/
smarthr-ui-preset.d.ts    smarthr-ui-preset.js      smarthr-ui-preset.js.map  src/
```

(2) 他のプロジェクトでpackしたファイルを`dependencies` に入れる

```sh
$ pnpm add ../smarthr-ui/package 
$ git diff package.json
```

```diff
diff --git a/package.json b/package.json
index 0c41809..6988029 100644
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "^13.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "smarthr-ui": "link:../smarthr-ui/package",
     "swagger-ui-react": "^5.9.0"
   },
   "devDependencies": {
```

(3) presetを読み込む

```sh
$ cat tailwind.config.js
```
```js
/** @type {import('tailwindcss').Config} */

const config = {
  content: ['./src/**/*.{js,jsx,ts,tsx}'],
  presets: [require('smarthr-ui/lib/smarthr-ui-preset')],
  plugins: [],
}

export default config
```

### Result

```tsx
const Page: FC = () =>  <p className="shr-bg-danger shr-p-8 shr-text-white shr-font-bold">hi</p>
```

<img width="1791" alt="image" src="https://github.com/kufu/smarthr-ui/assets/2612082/a6dbddad-fa7f-43e2-b84d-d7308a99619c">
