### PR TITLE
chore: taiwind用presetのビルドをtsconfigごと分けた

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "build": "run-p build:*",
     "build:lib": "tsc -p tsconfig.build.json",
     "build:esm": "tsc -p tsconfig.esm.build.json",
+    "build:preset": "tsc -p tsconfig.preset.build.json",
     "build:css": "tailwindcss -i ./src/styles/index.css -o ./smarthr-ui.css",
     "build-storybook": "storybook build --quiet -s ./public",
     "build-stylesheet": "ttsc -p tsconfig.stylesheet.json; node scripts/build-stylesheet.ts",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,11 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*"],
-  "exclude": [
-    "node_modules",
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.stories.tsx",
-    "src/**/__tests__"
-  ]
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx", "src/**/__tests__"],
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "smarthr-ui-preset.ts"],
-  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx", "src/**/__tests__"],
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.tsx",
+    "src/**/__tests__"
+  ]
 }

--- a/tsconfig.preset.build.json
+++ b/tsconfig.preset.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["smarthr-ui-preset.ts"]
+}


### PR DESCRIPTION
## Related URL
https://github.com/kufu/smarthr-ui/pull/3847

## Overview
- `tsconfig.build.json` の1ファイル内で `include` を複数設定すると、その階層が反映された状態でビルドされてしまう
- そのため、今までのビルドでは `src/` 以下が `lib/` 以下にビルドされていたのに、前回の対応で `lib/src/` 以下にビルドされるようになってしまっていた
- その結果、エントリポイントとして指定されている `lib/index.js` が存在しないことになってしまい、コンポーネント群がimportできなくなってしまった


## What I did
- tsconfigを別ファイルに分けることで、`lib/` 以下にフラットな階層としてビルドを出力できるようにした

## Capture
前回と同様、 `yarn pack` したtarballを解凍し、解凍結果のディレクトリを別プロジェクトでlinkして検証した

**package.json**

```json:
"dependencies": {
  ..
  "smarthr-ui": "link:../smarthr-ui/package",
  ..
}
```

**tailwind.config.js**
```js
const config = {
  content: ['./src/**/*.{js,jsx,ts,tsx}'],
  presets: [require('smarthr-ui/lib/smarthr-ui-preset')],
  plugins: [],
}
```

**component**

```tsx
'use client'
import { FC } from 'react'
import { Text } from 'smarthr-ui'

const Page: FC = () => (
  <>
    <Text size="XXL">API</Text>
    <p className="shr-bg-danger shr-p-8 shr-text-white shr-font-bold">hi</p>
  </>
)
```
### Capture
<img width="1229" alt="image" src="https://github.com/kufu/smarthr-ui/assets/2612082/f3d69033-0946-439e-839f-0b979ad140d8">

✅ SmartHR UIコンポーネントの利用（前回こちらを検証し忘れていた）と、presetが利用できていることを確認