### PR TITLE
chore: ButtonのVRT用Storyに説明など追加

### DIFF
--- a/src/components/Button/VRTButton.stories.tsx
+++ b/src/components/Button/VRTButton.stories.tsx
@@ -1,7 +1,9 @@
 import { action } from '@storybook/addon-actions'
 import { StoryFn } from '@storybook/react'
 import React from 'react'
+import styled from 'styled-components'
 
+import { InformationPanel } from '../InformationPanel'
 import { Cluster, Stack } from '../Layout'
 
 import { _Button, _ButtonAnchor } from './Button.stories'
@@ -17,127 +19,132 @@ export default {
 }
 
 export const _VRTButtonState: StoryFn = () => (
-  <dl>
-    <dt>hover</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <Button id="hover-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="hover-secondary" variant="secondary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="hover-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="hover-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <UnstyledButton id="hover-unstyled" onClick={action('clicked')}>
-            ボタン
-          </UnstyledButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
-            <Button id="hover-skeleton" variant="skeleton" onClick={action('clicked')}>
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hover, activeなどの状態で表示されます
+    </VRTInformationPanel>
+    <dl>
+      <dt>hover</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <Button id="hover-primary" variant="primary" onClick={action('clicked')}>
               ボタン
             </Button>
+            <Button id="hover-secondary" variant="secondary" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="hover-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="hover-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <UnstyledButton id="hover-unstyled" onClick={action('clicked')}>
+              ボタン
+            </UnstyledButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <Button id="hover-skeleton" variant="skeleton" onClick={action('clicked')}>
+                ボタン
+              </Button>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
 
-    <dt>focus</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <Button id="focus-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="focus-secondary" variant="secondary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="focus-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="focus-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <UnstyledButton id="focus-unstyled" onClick={action('clicked')}>
-            ボタン
-          </UnstyledButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
-            <Button id="focus-skeleton" variant="skeleton" onClick={action('clicked')}>
+      <dt>focus</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <Button id="focus-primary" variant="primary" onClick={action('clicked')}>
               ボタン
             </Button>
+            <Button id="focus-secondary" variant="secondary" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="focus-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="focus-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <UnstyledButton id="focus-unstyled" onClick={action('clicked')}>
+              ボタン
+            </UnstyledButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <Button id="focus-skeleton" variant="skeleton" onClick={action('clicked')}>
+                ボタン
+              </Button>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
 
-    <dt>focus-visible</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <Button id="focus-visible-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="focus-visible-secondary" variant="secondary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="focus-visible-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="focus-visible-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <UnstyledButton id="focus-visible-unstyled" onClick={action('clicked')}>
-            ボタン
-          </UnstyledButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
-            <Button id="focus-visible-skeleton" variant="skeleton" onClick={action('clicked')}>
+      <dt>focus-visible</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <Button id="focus-visible-primary" variant="primary" onClick={action('clicked')}>
               ボタン
             </Button>
+            <Button id="focus-visible-secondary" variant="secondary" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="focus-visible-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="focus-visible-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <UnstyledButton id="focus-visible-unstyled" onClick={action('clicked')}>
+              ボタン
+            </UnstyledButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <Button id="focus-visible-skeleton" variant="skeleton" onClick={action('clicked')}>
+                ボタン
+              </Button>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
 
-    <dt>active</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <Button id="active-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="active-secondary" variant="secondary" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="active-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <Button id="active-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </Button>
-          <UnstyledButton id="active-unstyled" onClick={action('clicked')}>
-            ボタン
-          </UnstyledButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
-            <Button id="active-skeleton" variant="skeleton" onClick={action('clicked')}>
+      <dt>active</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <Button id="active-primary" variant="primary" onClick={action('clicked')}>
               ボタン
             </Button>
+            <Button id="active-secondary" variant="secondary" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="active-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <Button id="active-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </Button>
+            <UnstyledButton id="active-unstyled" onClick={action('clicked')}>
+              ボタン
+            </UnstyledButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
-  </dl>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <Button id="active-skeleton" variant="skeleton" onClick={action('clicked')}>
+                ボタン
+              </Button>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
+    </dl>
+  </>
 )
 
 _VRTButtonState.parameters = {
@@ -179,165 +186,170 @@ _VRTButtonState.parameters = {
 }
 
 export const _VRTButtonAnchorState: StoryFn = () => (
-  <dl>
-    <dt>hover</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <AnchorButton href="#" id="hover-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton
-            href="#"
-            id="hover-secondary"
-            variant="secondary"
-            onClick={action('clicked')}
-          >
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="hover-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="hover-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hover, activeなどの状態で表示されます
+    </VRTInformationPanel>
+    <dl>
+      <dt>hover</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <AnchorButton href="#" id="hover-primary" variant="primary" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
             <AnchorButton
               href="#"
-              id="hover-skeleton"
-              variant="skeleton"
+              id="hover-secondary"
+              variant="secondary"
               onClick={action('clicked')}
             >
               ボタン
             </AnchorButton>
+            <AnchorButton href="#" id="hover-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton href="#" id="hover-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <AnchorButton
+                href="#"
+                id="hover-skeleton"
+                variant="skeleton"
+                onClick={action('clicked')}
+              >
+                ボタン
+              </AnchorButton>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
 
-    <dt>focus</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <AnchorButton href="#" id="focus-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton
-            href="#"
-            id="focus-secondary"
-            variant="secondary"
-            onClick={action('clicked')}
-          >
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="focus-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="focus-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
+      <dt>focus</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <AnchorButton href="#" id="focus-primary" variant="primary" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
             <AnchorButton
               href="#"
-              id="focus-skeleton"
-              variant="skeleton"
+              id="focus-secondary"
+              variant="secondary"
               onClick={action('clicked')}
             >
               ボタン
             </AnchorButton>
+            <AnchorButton href="#" id="focus-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton href="#" id="focus-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <AnchorButton
+                href="#"
+                id="focus-skeleton"
+                variant="skeleton"
+                onClick={action('clicked')}
+              >
+                ボタン
+              </AnchorButton>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
 
-    <dt>focus-visible</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <AnchorButton
-            href="#"
-            id="focus-visible-primary"
-            variant="primary"
-            onClick={action('clicked')}
-          >
-            ボタン
-          </AnchorButton>
-          <AnchorButton
-            href="#"
-            id="focus-visible-secondary"
-            variant="secondary"
-            onClick={action('clicked')}
-          >
-            ボタン
-          </AnchorButton>
-          <AnchorButton
-            href="#"
-            id="focus-visible-danger"
-            variant="danger"
-            onClick={action('clicked')}
-          >
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="focus-visible-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
+      <dt>focus-visible</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
             <AnchorButton
               href="#"
-              id="focus-visible-skeleton"
-              variant="skeleton"
+              id="focus-visible-primary"
+              variant="primary"
               onClick={action('clicked')}
             >
               ボタン
             </AnchorButton>
+            <AnchorButton
+              href="#"
+              id="focus-visible-secondary"
+              variant="secondary"
+              onClick={action('clicked')}
+            >
+              ボタン
+            </AnchorButton>
+            <AnchorButton
+              href="#"
+              id="focus-visible-danger"
+              variant="danger"
+              onClick={action('clicked')}
+            >
+              ボタン
+            </AnchorButton>
+            <AnchorButton href="#" id="focus-visible-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <AnchorButton
+                href="#"
+                id="focus-visible-skeleton"
+                variant="skeleton"
+                onClick={action('clicked')}
+              >
+                ボタン
+              </AnchorButton>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
 
-    <dt>active</dt>
-    <dd style={{ padding: '10px' }}>
-      <Stack>
-        <Cluster gap={1}>
-          <AnchorButton href="#" id="active-primary" variant="primary" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton
-            href="#"
-            id="active-secondary"
-            variant="secondary"
-            onClick={action('clicked')}
-          >
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="active-danger" variant="danger" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-          <AnchorButton href="#" id="active-text" variant="text" onClick={action('clicked')}>
-            ボタン
-          </AnchorButton>
-        </Cluster>
-        <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
-          <Cluster>
+      <dt>active</dt>
+      <dd style={{ padding: '10px' }}>
+        <Stack>
+          <Cluster gap={1}>
+            <AnchorButton href="#" id="active-primary" variant="primary" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
             <AnchorButton
               href="#"
-              id="active-skeleton"
-              variant="skeleton"
+              id="active-secondary"
+              variant="secondary"
               onClick={action('clicked')}
             >
               ボタン
             </AnchorButton>
+            <AnchorButton href="#" id="active-danger" variant="danger" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
+            <AnchorButton href="#" id="active-text" variant="text" onClick={action('clicked')}>
+              ボタン
+            </AnchorButton>
           </Cluster>
-        </div>
-      </Stack>
-    </dd>
-  </dl>
+          <div style={{ padding: '1rem', backgroundColor: '#5c5c5c', color: '#fff' }}>
+            <Cluster>
+              <AnchorButton
+                href="#"
+                id="active-skeleton"
+                variant="skeleton"
+                onClick={action('clicked')}
+              >
+                ボタン
+              </AnchorButton>
+            </Cluster>
+          </div>
+        </Stack>
+      </dd>
+    </dl>
+  </>
 )
 
 _VRTButtonAnchorState.parameters = {
@@ -374,11 +386,32 @@ _VRTButtonAnchorState.parameters = {
   },
 }
 
-export const _VRTButtonForceColor = _Button.bind({})
-_VRTButtonForceColor.parameters = {
+const ButtonTemplate = _Button.bind({})
+export const _VRTButtonForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <ButtonTemplate />
+  </>
+)
+_VRTButtonForcedColors.parameters = {
   chromatic: { forcedColors: 'active' },
 }
-export const _VRTButtonAnchorForceColor = _ButtonAnchor.bind({})
-_VRTButtonAnchorForceColor.parameters = {
+
+const ButtonAnchorTemplate = _ButtonAnchor.bind({})
+export const _VRTButtonAnchorForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <ButtonAnchorTemplate />
+  </>
+)
+_VRTButtonAnchorForcedColors.parameters = {
   chromatic: { forcedColors: 'active' },
 }
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Related URL
#3751 

## Overview
ButtonコンポーネントのVRT用のStoryに、VRT用である旨の表示を追加しました。また、Story名に入っていた"Force Color"を"Forced Colors"に変更して他のコンポーネントと統一しました。

## What I did
### ButtonコンポーネントのVRT用の4つのStoryを変更しています。
- VRT Button State
- VRT Button Anchor State
- VRT Button Forced Colors
- VRT Button Anchor Forced Colors

説明文用のInformationPanelの追加に伴い、インデントがずれたので、git上はコードの差分が多く発生していますが、メインのButtonコンポーネント群に関するところは変更していません。

## Capture
![capture](https://github.com/kufu/smarthr-ui/assets/7822534/e9773e73-97fd-4784-b1de-d2449b6ad8af)