### PR TITLE
fix: Revert "tailwind用presetをpublishするようにした" (#3847)

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "smarthr-ui-preset.ts"],
   "exclude": ["node_modules", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx", "src/**/__tests__"],
 }


### PR DESCRIPTION
## Related URL
https://github.com/kufu/smarthr-ui/pull/3847

## Overview
- `tsconfig.build.json` の1ファイル内で `include` を複数設定すると、その階層が反映された状態でビルドされてしまう
- そのため、今までのビルドでは `src/` 以下が `lib/` 以下にビルドされていたのに、前回の対応で `lib/src/` 以下にビルドされるようになってしまっていた
- その結果、エントリポイントとして指定されている `lib/index.js` が存在しないことになってしまい、コンポーネント群がimportできなくなってしまった


## What I did
Reverts kufu/smarthr-ui#3847

## Capture
nothing