### PR TITLE
feat: tailwindcss 環境向けの ThemeProvider を追加

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,8 +8,11 @@ import { Preview } from '@storybook/react'
 import { createTheme, CreatedTheme } from '../src/themes/createTheme'
 import { ThemeProvider as ShrThemeProvider } from '../src/themes/ThemeProvider'
 import { ThemeProvider as SCThemeProvider, createGlobalStyle } from 'styled-components'
+import { ThemeProvider as TailwindProvider } from '../src/themes/tailwind/TailwindThemeProvider'
 import CssBaseLine from 'smarthr-normalize-css'
 import { defaultLeading, defaultColor } from '../src/'
+
+import tailwindConfig from '../tailwind.config'
 
 import '../src/styles/index.css'
 
@@ -98,8 +101,10 @@ const preview: Preview = {
       return (
         <ThemeProvider>
           <ShrThemeProvider theme={theme}>
-            {resetStyle}
-            <Story />
+            <TailwindProvider config={tailwindConfig}>
+              {resetStyle}
+              <Story />
+            </TailwindProvider>
           </ShrThemeProvider>
         </ThemeProvider>
       )

--- a/src/components/Dropdown/DropdownContentInner.tsx
+++ b/src/components/Dropdown/DropdownContentInner.tsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { theme } from '../../themes'
+import { useTheme } from '../../hooks/useTailwindTheme'
 
 import { DropdownCloser } from './DropdownCloser'
 import { ContentBoxStyle, Rect, getContentBoxStyle } from './dropdownHelper'
@@ -58,7 +58,7 @@ export const DropdownContentInner: FC<Props & ElementProps> = ({
   controllable,
   ...props
 }) => {
-  const { spacing } = theme
+  const { spacing } = useTheme()
   const [isActive, setIsActive] = useState(false)
   const [contentBox, setContentBox] = useState<ContentBoxStyle>({
     top: 'auto',

--- a/src/hooks/useTailwindTheme.ts
+++ b/src/hooks/useTailwindTheme.ts
@@ -1,0 +1,13 @@
+import { useContext, useMemo } from 'react'
+import resolveConfig from 'tailwindcss/resolveConfig'
+
+import { ThemeContext } from '../themes/tailwind/TailwindThemeProvider'
+
+export const useTheme = () => {
+  const { config } = useContext(ThemeContext)
+
+  return useMemo(() => {
+    const { theme } = resolveConfig(config)
+    return theme
+  }, [config])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,8 +131,10 @@ export { Center, Cluster, LineUp, Reel, Stack, Sidebar } from './components/Layo
 
 // hooks
 export { useTheme } from './hooks/useTheme'
+export { useTheme as useTailwindTheme } from './hooks/useTailwindTheme'
 
 // themes
+export * from './themes'
 export { createTheme } from './themes/createTheme'
 export { ThemeProvider } from './themes/ThemeProvider'
 export { defaultPalette } from './themes/createPalette'

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,1 +1,1 @@
-export { theme } from './tailwindTheme'
+export * from './tailwind'

--- a/src/themes/tailwind/TailwindThemeProvider.tsx
+++ b/src/themes/tailwind/TailwindThemeProvider.tsx
@@ -1,0 +1,14 @@
+import React, { PropsWithChildren, createContext } from 'react'
+
+import presetConfig from '../../../smarthr-ui-preset'
+
+type PresetConfig = typeof presetConfig
+
+type Props = PropsWithChildren<{
+  config?: PresetConfig
+}>
+
+export const ThemeContext = createContext<{ config: PresetConfig }>({ config: presetConfig })
+export const ThemeProvider: React.FC<Props> = ({ config = presetConfig, children }) => (
+  <ThemeContext.Provider value={{ config }}>{children}</ThemeContext.Provider>
+)

--- a/src/themes/tailwind/index.ts
+++ b/src/themes/tailwind/index.ts
@@ -1,0 +1,1 @@
+export { ThemeProvider } from './TailwindThemeProvider'

--- a/src/themes/tailwindTheme.ts
+++ b/src/themes/tailwindTheme.ts
@@ -1,7 +1,0 @@
-import resolveConfig from 'tailwindcss/resolveConfig'
-
-import presetConfig from '../../smarthr-ui-preset'
-
-const { theme } = resolveConfig(presetConfig)
-
-export { theme }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,7 @@ import preset from './smarthr-ui-preset'
 
 import type { Config } from 'tailwindcss'
 
-module.exports = {
+export default {
   presets: [preset],
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
 } satisfies Config


### PR DESCRIPTION
## Overview

内部的に JavaScript から動的に theme 値を参照したい場合に、現状では利用者が設定した tailwindConfig の値を参照できていなかった。
Context を挟んでもらうことにより、利用者が実際に使っている tailwindConfig を参照できるようにした。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- tailwindcss 用の ThemeProvider を作成
- tailwindConfig を呼び出し、theme を返す hooks を作成
- smarthr-ui 自体に適用
- ローカルで tailwind.config.js を書き換えて動作確認
  ```jsx
  export default {
    ...
    theme: {
      extend: {
        spacing: {
          '0.5': '10em',
        },
      },
    },
  }
  ```

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
