### PR TITLE
chore: cleanコマンドに `./esm` , `./smarthr-ui.css` を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "build:css": "tailwindcss -i ./src/styles/index.css -o ./smarthr-ui.css",
     "build-storybook": "storybook build --quiet -s ./public",
     "build-stylesheet": "ttsc -p tsconfig.stylesheet.json; node scripts/build-stylesheet.ts",
-    "clean": "rimraf ./lib",
+    "clean": "rimraf ./lib ./esm ./smarthr-ui.css",
     "format": "eslint --fix './**/*.ts{,x}'",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint './**/*.ts{,x}'",


### PR DESCRIPTION
## Related URL
[Slack](https://kufuinc.slack.com/archives/CGC58MW01/p1698130887852489?thread_ts=1698125678.289769&cid=CGC58MW01)

- 削除してから生成しないと、意図していない状態を生成する事象が発生したため
- 提案レベルで出しておりますので、もし対応不要等とのことがあればCloseします！
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- 生成されたディレクトリやファイルを一旦削除してから生成し直すようにコマンドを変更
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- package.jsonのコマンドを編集
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
`yarn clean`  を実行した際に、`./lib`, `./esm`, `./smarthr-ui.css` が削除されていることを確認済み