### PR TITLE
chore: BalloonのVRT用Storyを追加

### DIFF
--- a/src/components/Balloon/VRTBalloon.stories.tsx
+++ b/src/components/Balloon/VRTBalloon.stories.tsx
@@ -1,0 +1,33 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Balloon } from './Balloon'
+import { All } from './Balloon.stories'
+
+export default {
+  title: 'Data Display（データ表示）/Balloon',
+  component: Balloon,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

BalloonコンポーネントにVRT用のStoryを追加しました。

## What I did

### Balloonコンポーネントに2つのVRT用Storyを追加
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態

VRT用で他に必要そうなストーリーは思いつきませんでした。
必要そうなストーリーがあればご指摘ください。

## Capture

<img width="433" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/5f85a173-cc6a-4b78-a001-4a28102a6006">
