### PR TITLE
chore: BaseColumnのVRT用Storyを追加

### DIFF
--- a/src/components/Base/BaseColumn/VRTBaseColumn.stories.tsx
+++ b/src/components/Base/BaseColumn/VRTBaseColumn.stories.tsx
@@ -1,0 +1,32 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../../InformationPanel'
+
+import { BaseColumn } from './BaseColumn'
+import { All } from './BaseColumn.stories'
+
+export default {
+  title: 'Data Display（データ表示）/BaseColumn',
+  component: BaseColumn,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTBaseForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTBaseForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

BaseColumnコンポーネントにVRT用のStoryを追加しました。

## What I did

### BaseColumnコンポーネントにVRT用Storyを追加

- Forced Colors
  - forcedColors: 'active' を適用した状態

他に必要そうなストーリーがあればご指摘ください。

## Capture

<img width="564" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/0d5883ab-41c7-4613-89bb-ef51d7e70706">
