### PR TITLE
feat: Button を Tailwind CSS 化

### DIFF
--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -1,11 +1,15 @@
-import React, { AnchorHTMLAttributes, forwardRef } from 'react'
+import React, { AnchorHTMLAttributes, forwardRef, useMemo } from 'react'
+import { tv } from 'tailwind-variants'
 
 import { ButtonInner } from './ButtonInner'
 import { ButtonWrapper } from './ButtonWrapper'
 import { BaseProps } from './types'
-import { useClassNames } from './useClassNames'
 
 type ElementProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
+
+const anchorButton = tv({
+  base: 'smarthr-ui-AnchorButton',
+})
 
 export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementProps>(
   (
@@ -16,13 +20,13 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementPro
       suffix,
       wide = false,
       variant = 'secondary',
-      className = '',
+      className,
       children,
       ...props
     },
     ref,
   ) => {
-    const classNames = useClassNames().anchorButton
+    const styles = useMemo(() => anchorButton({ className }), [className])
 
     return (
       <ButtonWrapper
@@ -31,7 +35,7 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementPro
         square={square}
         wide={wide}
         variant={variant}
-        className={`${className} ${classNames.wrapper}`}
+        className={styles}
         isAnchor
         anchorRef={ref}
       >

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React, { useState } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -19,7 +19,7 @@ export default {
 type ButtonProps = React.ComponentProps<typeof Button>
 type AnchorButtonProps = React.ComponentProps<typeof AnchorButton>
 
-export const _Button: Story = () => (
+export const _Button: StoryFn = () => (
   <List>
     <dt>Default</dt>
     <dd>
@@ -188,7 +188,7 @@ _Button.parameters = {
   controls: { hideNoControlsWarning: true },
 }
 
-export const _ButtonControl: Story = (args: ButtonProps) => (
+export const _ButtonControl: StoryFn = (args: ButtonProps) => (
   <Wrapper>
     <Button {...args} onClick={action('clicked')}>
       {args.children}
@@ -199,7 +199,7 @@ _ButtonControl.args = {
   children: 'ボタン',
 }
 
-export const _ButtonAnchor: Story = () => (
+export const _ButtonAnchor: StoryFn = () => (
   <List>
     <dt>Default</dt>
     <dd>
@@ -334,7 +334,7 @@ _ButtonAnchor.parameters = {
   controls: { hideNoControlsWarning: true },
 }
 
-export const _ButtonAnchorControl: Story = (args: AnchorButtonProps) => (
+export const _ButtonAnchorControl: StoryFn = (args: AnchorButtonProps) => (
   <Wrapper>
     <AnchorButton {...args} href="#" onClick={action('clicked')}>
       {args.children}
@@ -345,7 +345,7 @@ _ButtonAnchorControl.args = {
   children: 'ボタン',
 }
 
-export const WithLoading: Story = (args: ButtonProps) => {
+export const WithLoading: StoryFn = (args: ButtonProps) => {
   const [loading, setLoading] = useState(false)
   const handleClick = () => {
     setLoading(true)

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -51,7 +51,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
       variant = 'secondary',
       disabled,
       disabledDetail,
-      className = '',
+      className,
       children,
       loading = false,
       ...props

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,18 +1,43 @@
-import React, { ButtonHTMLAttributes, forwardRef } from 'react'
-import styled, { css } from 'styled-components'
+import React, { ButtonHTMLAttributes, forwardRef, useMemo } from 'react'
+import { tv } from 'tailwind-variants'
 
-import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaInfoCircleIcon } from '../Icon'
 import { Cluster } from '../Layout'
-import { Loader as shrLoader } from '../Loader'
+import { Loader } from '../Loader'
 import { Tooltip } from '../Tooltip'
 
 import { ButtonInner } from './ButtonInner'
 import { ButtonWrapper } from './ButtonWrapper'
-import { BaseProps, Variant } from './types'
-import { useClassNames } from './useClassNames'
+import { BaseProps } from './types'
 
 type ElementProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
+
+const buttonStyle = tv({
+  slots: {
+    wrapper: 'smarthr-ui-Button',
+    loader: 'shr-align-bottom [&&&_.s]:shr-h-em [&&&_.s]:shr-w-em',
+    disabledWrapper: 'smarthr-ui-Button-disabledWrapper',
+    disabledTooltip: [
+      '[&&&]:shr-overflow-y-unset',
+      /* Tooltip との距離を変えずに反応範囲を広げるために negative space を使う */
+      '[&_.smarthr-ui-Icon]:-shr-m-0.25',
+      /* global styleなどでborder-boxが適用されている場合表示崩れを起こす為、content-boxを指定する */
+      '[&_.smarthr-ui-Icon]:shr-box-content',
+      '[&_.smarthr-ui-Icon]:shr-p-0.25',
+      '[&_.smarthr-ui-Icon]:shr-text-grey',
+    ],
+  },
+  variants: {
+    isSecondary: {
+      true: {
+        loader: '[&&&_.light]:shr-border-disabled',
+      },
+      false: {
+        loader: '[&&&_.light]:shr-border-white/50',
+      },
+    },
+  },
+})
 
 export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
   (
@@ -33,12 +58,14 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
     },
     ref,
   ) => {
-    const theme = useTheme()
-    const classNames = useClassNames().button
-
-    const loader = (
-      <Loader size="s" type="light" variant={variant} forwardedAs="span" themes={theme} />
+    const { wrapper, loader: loaderSlot, disabledWrapper, disabledTooltip } = buttonStyle()
+    const wrapperStyle = useMemo(() => wrapper({ className }), [className, wrapper])
+    const loaderStyle = useMemo(
+      () => loaderSlot({ isSecondary: variant === 'secondary' }),
+      [loaderSlot, variant],
     )
+
+    const loader = <Loader size="s" type="light" as="span" className={loaderStyle} />
     const actualPrefix = !loading && prefix
     const actualSuffix = loading && !square ? loader : suffix
     const disabledOnLoading = loading || disabled
@@ -52,7 +79,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         square={square}
         wide={wide}
         variant={variant}
-        className={`${className} ${classNames.wrapper}`}
+        className={wrapperStyle}
         buttonRef={ref}
         disabled={disabledOnLoading}
         $loading={loading}
@@ -67,17 +94,18 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
       const DisabledDetailIcon = disabledDetail.icon || FaInfoCircleIcon
 
       return (
-        <DisabledDetailWrapper themes={theme} className={classNames.disabledWrapper}>
+        <Cluster inline align="center" gap={0.25} className={disabledWrapper()}>
           {button}
           <Tooltip
             message={disabledDetail.message}
             triggerType="icon"
             horizontal="auto"
             vertical="auto"
+            className={disabledTooltip()}
           >
             <DisabledDetailIcon />
           </Tooltip>
-        </DisabledDetailWrapper>
+        </Cluster>
       )
     }
 
@@ -86,44 +114,3 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
 )
 // BottomFixedArea での判定に用いるために displayName を明示的に設定する
 Button.displayName = 'Button'
-
-const Loader = styled(shrLoader)<{ variant: Variant; themes: Theme }>`
-  ${({ variant, themes: { color } }) => css`
-    vertical-align: bottom;
-
-    &&& {
-      .s {
-        width: 1em;
-        height: 1em;
-      }
-    }
-
-    .light {
-      border-color: ${variant === 'secondary'
-        ? color.TEXT_DISABLED
-        : color.disableColor(color.TEXT_WHITE)};
-    }
-  `}
-`
-
-const DisabledDetailWrapper = styled(Cluster).attrs({
-  inline: true,
-  align: 'center',
-  gap: 0.25,
-})<{ themes: Theme }>`
-  ${({ themes: { color, space } }) => css`
-    > .smarthr-ui-Tooltip {
-      overflow-y: unset;
-
-      .smarthr-ui-Icon {
-        /* Tooltip との距離を変えずに反応範囲を広げるために negative space を使う */
-        margin: ${space(-0.25)};
-        padding: ${space(0.25)};
-
-        /* global styleなどでborder-boxが適用されている場合表示崩れを起こす為、content-boxを指定する */
-        box-sizing: content-box;
-        color: ${color.TEXT_GREY};
-      }
-    }
-  `}
-`

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -1,26 +1,22 @@
-import React, { VFC } from 'react'
-import styled from 'styled-components'
+import React, { FC, PropsWithChildren } from 'react'
+import { tv } from 'tailwind-variants'
 
-export type Props = {
+export type Props = PropsWithChildren<{
   prefix?: React.ReactNode
   suffix?: React.ReactNode
-  children?: React.ReactNode
-}
+}>
 
-export const ButtonInner: VFC<Props> = ({ prefix, suffix, children }) => (
-    <>
-      {prefix}
-      <TextLabel>{children}</TextLabel>
-      {suffix}
-    </>
-  )
+const buttonInner = tv({
+  base: [
+    /* LineClamp を併用する場合に、幅を計算してもらうために指定 */
+    'shr-min-w-0',
+  ],
+})
 
-const TextLabel = styled.span`
-  /* LineClamp を併用する場合に、幅を計算してもらうために指定 */
-  min-width: 0;
-
-  .s & {
-    /* FIXME! SVG とテキストコンテンツの縦位置が揃わないので暫定対応 */
-    line-height: 0;
-  }
-`
+export const ButtonInner: FC<Props> = ({ prefix, suffix, ...props }) => (
+  <>
+    {prefix}
+    <span {...props} className={buttonInner()} />
+    {suffix}
+  </>
+)

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -5,9 +5,7 @@ import React, {
   ReactNode,
   useMemo,
 } from 'react'
-import styled, { css } from 'styled-components'
-
-import { Theme, useTheme } from '../../hooks/useTheme'
+import { tv } from 'tailwind-variants'
 
 import { Variant } from './types'
 
@@ -33,209 +31,273 @@ type Props =
   | (ButtonProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonProps>)
   | (AnchorProps & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof AnchorProps>)
 
-type StyleProps = Pick<Props, 'wide' | 'variant' | '$loading'> & { themes: Theme }
-
-export function ButtonWrapper({ size, square, className, ...props }: Props) {
-  const theme = useTheme()
+export function ButtonWrapper({
+  variant,
+  size,
+  square,
+  wide = false,
+  $loading,
+  className,
+  ...props
+}: Props) {
+  const { default: defaultButton, anchor } = useMemo(
+    () =>
+      button({
+        variant,
+        loading: $loading,
+        wide,
+      }),
+    [$loading, variant, wide],
+  )
   const buttonClassName = useMemo(
     () => `${size} ${className} ${square ? 'square' : ''}`,
     [className, size, square],
   )
-  return props.isAnchor ? (
-    // eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute
-    <Anchor {...props} className={buttonClassName} ref={props.anchorRef} themes={theme} />
-  ) : (
-    <Button {...props} className={buttonClassName} ref={props.buttonRef} themes={theme} />
-  )
-}
 
-const baseStyles = css<StyleProps>(({ wide, $loading, themes }) => {
-  const { border, fontSize, leading, radius, shadow, spacingByChar } = themes
-
-  return css`
-    box-sizing: border-box;
-    cursor: pointer;
-    display: inline-flex;
-    ${$loading && `flex-direction: row-reverse;`}
-    justify-content: center;
-    align-items: center;
-    gap: ${spacingByChar(0.5)};
-    text-align: center;
-    white-space: nowrap;
-    border-radius: ${radius.m};
-
-    /* ボタンの高さを合わせるために指定 */
-    border: ${border.lineWidth} ${border.lineStyle} transparent;
-    padding: ${spacingByChar(0.75)} ${spacingByChar(1)};
-    font-family: inherit;
-    font-size: ${fontSize.M};
-    font-weight: bold;
-    line-height: ${leading.NONE};
-    ${wide && 'width: 100%;'}
-
-    &.square {
-      padding: ${spacingByChar(0.75)};
-    }
-
-    &.s {
-      padding: ${spacingByChar(0.5)};
-      font-size: ${fontSize.S};
-
-      /* ボタンラベルの line-height を 0 にしたため、高さを担保する */
-      min-height: calc(${fontSize.S} + ${spacingByChar(1)} + (${border.lineWidth} * 2));
-    }
-
-    &:focus-visible {
-      ${shadow.focusIndicatorStyles}
-    }
-
-    @media (prefers-contrast: more) {
-      & {
-        border: ${border.highContrast};
-      }
-    }
-
-    /* baseline より下の leading などの余白を埋める */
-    .smarthr-ui-Icon,
-    svg {
-      display: block;
-    }
-  `
-})
-
-const Button = styled.button<StyleProps>(({ variant, themes }) => {
-  const styles = variantStyles(variant, themes)
-  return css`
-    ${baseStyles}
-    ${styles.default}
-
-    &:focus-visible,
-    &:hover {
-      ${styles.focus}
-    }
-    &[disabled] {
-      cursor: not-allowed;
-      ${styles.disabled}
-
-      /* alpha color を使用しているので、背景色と干渉させない */
-      background-clip: padding-box;
-    }
-  `
-})
-
-const Anchor = styled.a<StyleProps>(({ variant, themes }) => {
-  const styles = variantStyles(variant, themes)
-  return css`
-    ${baseStyles}
-    ${styles.default}
-    text-decoration: none;
-
-    &:focus-visible,
-    &:hover {
-      ${styles.focus}
-    }
-    &:not([href]) {
-      cursor: not-allowed;
-      ${styles.disabled}
-
-      /* alpha color を使用しているので、背景色と干渉させない */
-      background-clip: padding-box;
-    }
-  `
-})
-
-function variantStyles(variant: Variant, theme: Theme) {
-  const { color } = theme
-  switch (variant) {
-    case 'primary':
-      return {
-        default: css`
-          border-color: ${color.MAIN};
-          background-color: ${color.MAIN};
-          color: ${color.TEXT_WHITE};
-        `,
-        focus: css`
-          border-color: ${color.hoverColor(color.MAIN)};
-          background-color: ${color.hoverColor(color.MAIN)};
-        `,
-        disabled: css`
-          border-color: ${color.disableColor(color.MAIN)};
-          background-color: ${color.disableColor(color.MAIN)};
-          color: ${color.disableColor(color.TEXT_WHITE)};
-        `,
-      }
-    case 'secondary':
-      return {
-        default: css`
-          border-color: ${color.BORDER};
-          background-color: ${color.WHITE};
-          color: ${color.TEXT_BLACK};
-        `,
-        focus: css`
-          border-color: ${color.hoverColor(color.BORDER)};
-          background-color: ${color.hoverColor(color.WHITE)};
-
-          @media (prefers-contrast: more) {
-            & {
-              border-color: ${color.TEXT_BLACK};
-            }
-          }
-        `,
-        disabled: css`
-          border-color: ${color.disableColor(color.BORDER)};
-          background-color: ${color.hoverColor(color.WHITE)};
-          color: ${color.TEXT_DISABLED};
-        `,
-      }
-    case 'danger':
-      return {
-        default: css`
-          border-color: ${color.DANGER};
-          background-color: ${color.DANGER};
-          color: ${color.TEXT_WHITE};
-        `,
-        focus: css`
-          border-color: ${color.hoverColor(color.DANGER)};
-          background-color: ${color.hoverColor(color.DANGER)};
-        `,
-        disabled: css`
-          border-color: ${color.disableColor(color.DANGER)};
-          background-color: ${color.disableColor(color.DANGER)};
-          color: ${color.disableColor(color.TEXT_WHITE)};
-        `,
-      }
-    case 'skeleton':
-      return {
-        default: css`
-          border-color: ${color.WHITE};
-          background-color: transparent;
-          color: ${color.TEXT_WHITE};
-        `,
-        focus: css`
-          border-color: ${color.hoverColor(color.WHITE)};
-          background-color: ${color.OVERLAY};
-          color: ${color.hoverColor(color.TEXT_WHITE)};
-        `,
-        disabled: css`
-          border-color: ${color.disableColor(color.WHITE)};
-          background-color: transparent;
-          color: ${color.disableColor(color.TEXT_WHITE)};
-        `,
-      }
-    case 'text':
-      return {
-        default: css`
-          background-color: transparent;
-          color: ${color.TEXT_BLACK};
-        `,
-        focus: css`
-          background-color: ${color.hoverColor(color.WHITE)};
-        `,
-        disabled: css`
-          border-color: transparent;
-          background-color: transparent;
-          color: ${color.TEXT_DISABLED};
-        `,
-      }
+  if (props.isAnchor) {
+    const { anchorRef, ...others } = props
+    // eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute, jsx-a11y/anchor-has-content
+    return <a {...others} className={anchor({ className: buttonClassName })} ref={anchorRef} />
+  } else {
+    const { buttonRef, ...others } = props
+    return (
+      <button
+        {...others}
+        className={defaultButton({ className: buttonClassName })}
+        ref={buttonRef}
+      />
+    )
   }
 }
+
+const button = tv({
+  slots: {
+    default: [
+      'disabled:shr-cursor-not-allowed',
+      /* alpha color を使用しているので、背景色と干渉させない */
+      'disabled:shr-bg-clip-padding',
+    ],
+    anchor: [
+      'shr-no-underline',
+      '[&:not([href])]:shr-cursor-not-allowed',
+      /* alpha color を使用しているので、背景色と干渉させない */
+      '[&:not([href])]:shr-bg-clip-padding',
+    ],
+  },
+  variants: {
+    variant: {
+      primary: {},
+      secondary: {},
+      danger: {},
+      skeleton: {},
+      text: {},
+    },
+    loading: {
+      true: {
+        default: 'shr-flex-row-reverse',
+        anchor: 'shr-flex-row-reverse',
+      },
+    },
+    wide: {
+      true: {
+        default: 'shr-w-full',
+        anchor: 'shr-w-full',
+      },
+    },
+  },
+  compoundSlots: [
+    {
+      slots: ['default', 'anchor'],
+      className: [
+        'shr-box-border',
+        'shr-cursor-pointer',
+        'shr-inline-flex',
+        'shr-justify-center',
+        'shr-items-center',
+        'shr-gap-0.5',
+        'shr-text-center',
+        'shr-whitespace-nowrap',
+        'shr-rounded-m',
+        /* ボタンの高さを合わせるために指定 */
+        'shr-border',
+        'shr-border-solid',
+        'shr-px-1',
+        'shr-py-0.75',
+        'shr-font-inherit',
+        'shr-text-base',
+        'shr-font-bold',
+        'shr-leading-none',
+        '[&.s]:shr-p-0.5',
+        '[&.s]:shr-text-sm',
+        /* ボタンラベルの line-height を 0 にしたため、高さを担保する */
+        '[&.s]:shr-min-h-[calc(theme(fontSize.sm)+theme(spacing.1)+theme(borderWidth.2))]',
+        '[&.square:not(&.s)]:shr-p-0.75',
+        'focus-visible:shr-focusIndicator',
+        'contrast-more:shr-border-highContrast',
+        /* baseline より下の leading などの余白を埋める */
+        '[&_.smarthr-ui-Icon]:shr-block',
+        /** selector list は使えない
+         * via https://github.com/tailwindlabs/tailwindcss/issues/10576#issuecomment-1440703413
+         */
+        '[&_svg]:shr-block',
+      ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      variant: 'primary',
+      className: [
+        'shr-border-main',
+        'shr-bg-main',
+        'shr-text-white',
+        'focus-visible:shr-border-main-darken',
+        'focus-visible:shr-bg-main-darken',
+        'hover:shr-border-main-darken',
+        'hover:shr-bg-main-darken',
+      ],
+    },
+    {
+      slots: ['default'],
+      variant: 'primary',
+      className: [
+        'disabled:shr-border-main/50',
+        'disabled:shr-bg-main/50',
+        'disabled:shr-text-white/50',
+      ],
+    },
+    {
+      slots: ['anchor'],
+      variant: 'primary',
+      className: [
+        '[&:not([href])]:shr-border-main/50',
+        '[&:not([href])]:shr-bg-main/50',
+        '[&:not([href])]:shr-text-white/50',
+      ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      variant: 'secondary',
+      className: [
+        'shr-border-default',
+        'shr-bg-white',
+        'shr-text-black',
+        'focus-visible:shr-border-darken',
+        'focus-visible:bg-white-darken',
+        'focus-visible:constrast-more:shr-border-highContrast',
+        'hover:shr-border-darken',
+        'hover:shr-bg-white-darken',
+        'hover:constrast-more:shr-border-highContrast',
+      ],
+    },
+    {
+      slots: ['default'],
+      variant: 'secondary',
+      className: [
+        'disabled:shr-border-disabled/50',
+        'disabled:shr-bg-white-darken',
+        'disabled:shr-text-disabled',
+      ],
+    },
+    {
+      slots: ['anchor'],
+      variant: 'secondary',
+      className: [
+        '[&:not([href])]:shr-border-disabled/50',
+        '[&:not([href])]:shr-bg-white-darken',
+        '[&:not([href])]:shr-text-disabled',
+      ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      variant: 'danger',
+      className: [
+        'shr-border-danger',
+        'shr-bg-danger',
+        'shr-text-white',
+        'focus-visible:shr-border-danger-darken',
+        'focus-visible:shr-bg-danger-darken',
+        'hover:shr-border-danger-darken',
+        'hover:shr-bg-danger-darken',
+      ],
+    },
+    {
+      slots: ['default'],
+      variant: 'danger',
+      className: [
+        'disabled:shr-border-danger/50',
+        'disabled:shr-bg-danger/50',
+        'disabled:shr-text-white/50',
+      ],
+    },
+    {
+      slots: ['anchor'],
+      variant: 'danger',
+      className: [
+        '[&:not([href])]:shr-border-danger/50',
+        '[&:not([href])]:shr-bg-danger/50',
+        '[&:not([href])]:shr-text-white/50',
+      ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      variant: 'skeleton',
+      className: [
+        'shr-border-white',
+        'shr-bg-transparent',
+        'shr-text-white',
+        'focus-visible:shr-border-white-darken',
+        'focus-visible:shr-bg-overlay',
+        'focus-visible:shr-text-white-darken',
+        'hover:shr-border-white-darken',
+        'hover:shr-bg-overlay',
+        'hover:shr-text-white-darken',
+      ],
+    },
+    {
+      slots: ['default'],
+      variant: 'skeleton',
+      className: [
+        'disabled:shr-border-white/50',
+        'disabled:shr-bg-transparent',
+        'disabled:shr-text-white/50',
+      ],
+    },
+    {
+      slots: ['anchor'],
+      variant: 'skeleton',
+      className: [
+        '[&:not([href])]:shr-border-white/50',
+        '[&:not([href])]:shr-bg-transparent',
+        '[&:not([href])]:shr-text-white/50',
+      ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      variant: 'text',
+      className: [
+        'shr-border-transparent',
+        'shr-bg-transparent',
+        'shr-text-black',
+        'focus-visible:shr-bg-white-darken',
+        'hover:shr-bg-white-darken',
+      ],
+    },
+    {
+      slots: ['default'],
+      variant: 'text',
+      className: [
+        'disabled:shr-border-transparent',
+        'disabled:shr-bg-transparent',
+        'disabled:shr-text-disabled',
+      ],
+    },
+    {
+      slots: ['anchor'],
+      variant: 'text',
+      className: [
+        '[&:not([href])]:shr-border-transparent',
+        '[&:not([href])]:shr-bg-transparent',
+        '[&:not([href])]:shr-text-disabled',
+      ],
+    },
+  ],
+})

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -40,33 +40,28 @@ export function ButtonWrapper({
   className,
   ...props
 }: Props) {
-  const { default: defaultButton, anchor } = useMemo(
-    () =>
-      button({
-        variant,
-        loading: $loading,
-        wide,
-      }),
-    [$loading, variant, wide],
-  )
-  const buttonClassName = useMemo(
-    () => `${size} ${className} ${square ? 'square' : ''}`,
-    [className, size, square],
-  )
+  const { buttonStyle, anchorStyle } = useMemo(() => {
+    const { default: defaultButton, anchor } = button({
+      variant,
+      size,
+      type: square ? 'square' : 'default',
+      loading: $loading,
+      wide,
+    })
+
+    return {
+      buttonStyle: defaultButton({ className }),
+      anchorStyle: anchor({ className }),
+    }
+  }, [$loading, className, size, square, variant, wide])
 
   if (props.isAnchor) {
     const { anchorRef, ...others } = props
     // eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute, jsx-a11y/anchor-has-content
-    return <a {...others} className={anchor({ className: buttonClassName })} ref={anchorRef} />
+    return <a {...others} className={anchorStyle} ref={anchorRef} />
   } else {
     const { buttonRef, ...others } = props
-    return (
-      <button
-        {...others}
-        className={defaultButton({ className: buttonClassName })}
-        ref={buttonRef}
-      />
-    )
+    return <button {...others} className={buttonStyle} ref={buttonRef} />
   }
 }
 
@@ -91,6 +86,15 @@ const button = tv({
       danger: {},
       skeleton: {},
       text: {},
+    },
+    size: {
+      default: {},
+      s: {},
+    },
+    // FIXME 本来は square の Boolean value を使いたいが、tailwind-variants にバグがありそうなので暫定的に string で対応
+    type: {
+      default: {},
+      square: {},
     },
     loading: {
       true: {
@@ -121,17 +125,9 @@ const button = tv({
         /* ボタンの高さを合わせるために指定 */
         'shr-border',
         'shr-border-solid',
-        'shr-px-1',
-        'shr-py-0.75',
         'shr-font-inherit',
-        'shr-text-base',
         'shr-font-bold',
         'shr-leading-none',
-        '[&.s]:shr-p-0.5',
-        '[&.s]:shr-text-sm',
-        /* ボタンラベルの line-height を 0 にしたため、高さを担保する */
-        '[&.s]:shr-min-h-[calc(theme(fontSize.sm)+theme(spacing.1)+theme(borderWidth.2))]',
-        '[&.square:not(&.s)]:shr-p-0.75',
         'focus-visible:shr-focusIndicator',
         'contrast-more:shr-border-highContrast',
         /* baseline より下の leading などの余白を埋める */
@@ -141,6 +137,33 @@ const button = tv({
          */
         '[&_svg]:shr-block',
       ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      size: 's',
+      className: [
+        'shr-p-0.5',
+        'shr-text-sm',
+        /* ボタンラベルの line-height を 0 にしたため、高さを担保する */
+        'shr-min-h-[calc(theme(fontSize.sm)+theme(spacing.1)+theme(borderWidth.2))]',
+      ],
+    },
+    {
+      slots: ['default', 'anchor'],
+      size: 'default',
+      className: ['shr-text-base'],
+    },
+    {
+      slots: ['default', 'anchor'],
+      size: 'default',
+      type: 'default',
+      className: ['shr-px-1', 'shr-py-0.75'],
+    },
+    {
+      slots: ['default', 'anchor'],
+      size: 'default',
+      type: 'square',
+      className: 'shr-p-0.75',
     },
     {
       slots: ['default', 'anchor'],

--- a/src/components/Button/useClassNames.ts
+++ b/src/components/Button/useClassNames.ts
@@ -8,11 +8,7 @@ import { SecondaryButton, SecondaryButtonAnchor } from './SecondaryButton'
 import { SkeletonButton, SkeletonButtonAnchor } from './SkeletonButton'
 import { TextButton, TextButtonAnchor } from './TextButton'
 
-import { AnchorButton, Button } from '.'
-
 export const useClassNames = () => {
-  const generateButotn = useClassNameGenerator(Button.displayName || 'Button')
-  const generateAnchorButotn = useClassNameGenerator(AnchorButton.displayName || 'AnchorButton')
   const generatePrimaryButton = useClassNameGenerator(PrimaryButton.displayName || 'PrimaryButton')
   const generatePrimaryButtonAnchor = useClassNameGenerator(
     PrimaryButtonAnchor.displayName || 'PrimaryButtonAnchor',
@@ -40,13 +36,6 @@ export const useClassNames = () => {
 
   return useMemo(
     () => ({
-      button: {
-        wrapper: generateButotn(),
-        disabledWrapper: generateButotn('disabledWrapper'),
-      },
-      anchorButton: {
-        wrapper: generateAnchorButotn(),
-      },
       primaryButton: {
         wrapper: generatePrimaryButton(),
       },
@@ -79,8 +68,6 @@ export const useClassNames = () => {
       },
     }),
     [
-      generateAnchorButotn,
-      generateButotn,
       generateDangerButton,
       generateDangerButtonAnchor,
       generatePrimaryButton,

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -28,6 +28,7 @@ type Props = {
   text?: ReactNode
   /** コンポーネントの色調 */
   type?: 'primary' | 'light'
+  as?: string | React.ComponentType<any>
 }
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -1,3 +1,4 @@
+import { darken } from 'polished'
 import plugin from 'tailwindcss/plugin'
 
 import { defaultColor } from './themes/createColor'
@@ -12,15 +13,16 @@ const spacingByChar = createSpacingByChar(defaultHtmlFontSize / 2)
 type Spacing = {
   [key in (typeof spacingSizes)[number]]: string
 }
+const darkenColor = (color: string, amount: number = 0.05) => darken(amount, color)
 
 // この preset を各プロダクトでも読み込んでもらう想定
 export default {
   content: [],
   theme: {
-    backgroundColor: {
+    backgroundColor: ({ theme }) => ({
       black: defaultColor.GREY_100,
       white: defaultColor.WHITE,
-      disabled: defaultColor.GREY_30,
+      'white-darken': theme('colors.white-darken'),
       link: defaultColor.TEXT_LINK,
       background: defaultColor.BACKGROUND,
       column: defaultColor.COLUMN,
@@ -29,24 +31,15 @@ export default {
       head: defaultColor.HEAD,
       'action-background': defaultColor.ACTION_BACKGROUND,
       main: defaultColor.MAIN,
+      'main-darken': theme('colors.main-darken'),
       danger: defaultColor.DANGER,
+      'danger-darken': theme('colors.danger-darken'),
       'warning-yellow': defaultColor.WARNING_YELLOW,
       overlay: defaultColor.OVERLAY,
       scrim: defaultColor.SCRIM,
       inherit: 'inherit',
       transparent: 'transparent',
-    },
-    borderColor: {
-      DEFAULT: defaultColor.BORDER,
-      black: defaultColor.GREY_100,
-      white: defaultColor.WHITE,
-      grey: defaultColor.GREY_65,
-      main: defaultColor.MAIN,
-      danger: defaultColor.DANGER,
-      disabled: defaultColor.GREY_30,
-      inherit: 'inherit',
-      transparent: 'transparent',
-    },
+    }),
     borderRadius: {
       none: '0',
       s: '0.25rem',
@@ -67,8 +60,13 @@ export default {
     colors: {
       black: defaultColor.GREY_100,
       white: defaultColor.WHITE,
+      'white-darken': darkenColor(defaultColor.WHITE),
       main: defaultColor.MAIN,
+      'main-darken': darkenColor(defaultColor.MAIN),
       brand: defaultColor.BRAND,
+      outline: defaultColor.OUTLINE,
+      danger: defaultColor.DANGER,
+      'danger-darken': darkenColor(defaultColor.DANGER),
       grey: {
         DEFAULT: defaultColor.GREY_65,
         5: defaultColor.GREY_5,
@@ -83,6 +81,9 @@ export default {
       inherit: 'inherit',
       transparent: 'transparent',
       current: 'currentColor',
+    },
+    fontFamily: {
+      inherit: 'inherit',
     },
     fontSize: {
       '2xs': defaultFontSize.XXS,
@@ -121,15 +122,16 @@ export default {
     stroke: {
       black: defaultColor.GREY_100,
     },
-    textColor: {
-      black: defaultColor.GREY_100,
-      white: defaultColor.WHITE,
-      disabled: defaultColor.GREY_30,
+    textColor: ({ theme }) => ({
+      black: theme('colors.black'),
+      white: theme('colors.white'),
+      'white-darken': theme('colors.white-darken'),
+      disabled: theme('colors.grey.30'),
       link: defaultColor.TEXT_LINK,
-      grey: defaultColor.GREY_65,
+      grey: theme('colors.grey.65'),
       inherit: 'inherit',
       transparent: 'transparent',
-    },
+    }),
     zIndex: {
       auto: 'auto',
       0: '0',
@@ -138,22 +140,27 @@ export default {
       overlap: `${defaultZIndex.OVERLAP}`,
       'flash-message': `${defaultZIndex.FLASH_MESSAGE}`,
     },
-    // 継承するのはこっち。なんかある?
-    extend: {},
+    extend: {
+      borderColor: ({ theme }) => ({
+        default: theme('colors.grey.20'),
+        disabled: theme('colors.grey.20/50'),
+        darken: darkenColor(theme('colors.grey.20')),
+        highContrast: theme('colors.grey.100'),
+      }),
+    },
   },
   corePlugins: {
     preflight: false,
     boxShadowColor: false,
     caretColor: false,
     divideColor: false,
-    fontFamily: false,
     placeholderColor: false,
     ringColor: false,
     ringOffsetColor: false,
     textDecorationColor: false,
   },
   plugins: [
-    plugin(({ addUtilities }) => {
+    plugin(({ addUtilities, addComponents, theme }) => {
       addUtilities({
         '.overflow-inherit': { overflow: 'inherit' },
         '.overflow-initial': { overflow: 'initial' },
@@ -167,6 +174,17 @@ export default {
         '.overflow-y-revert': { 'overflow-y': 'revert' },
         '.overflow-x-unset': { 'overflow-x': 'unset' },
         '.overflow-y-unset': { 'overflow-y': 'unset' },
+      })
+      addComponents({
+        /**
+         * box-shadow や ring を使った仕組みでは Firefoxx で欠陥があるため、独自定義している
+         * via https://github.com/tailwindlabs/tailwindcss/issues/10226
+         */
+        '.focusIndicator': {
+          outline: 'none',
+          isolation: 'isolate',
+          boxShadow: `0 0 0 2px ${theme('colors.white')}, 0 0 0 4px ${theme('colors.outline')}`,
+        },
       })
     }),
   ],

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -1,3 +1,5 @@
+import plugin from 'tailwindcss/plugin'
+
 import { defaultColor } from './themes/createColor'
 import { defaultFontSize, defaultHtmlFontSize } from './themes/createFontSize'
 import { defaultShadow } from './themes/createShadow'
@@ -109,6 +111,7 @@ export default {
     },
     spacing: {
       px: '1px',
+      em: '1em',
       ...(spacingSizes
         .map((size) => ({
           [size]: spacingByChar(size),
@@ -149,6 +152,23 @@ export default {
     ringOffsetColor: false,
     textDecorationColor: false,
   },
-  plugins: [],
+  plugins: [
+    plugin(({ addUtilities }) => {
+      addUtilities({
+        '.overflow-inherit': { overflow: 'inherit' },
+        '.overflow-initial': { overflow: 'initial' },
+        '.overflow-revert': { overflow: 'revert' },
+        '.overflow-unset': { overflow: 'unset' },
+        '.overflow-x-inherit': { 'overflow-x': 'inherit' },
+        '.overflow-y-inherit': { 'overflow-y': 'inherit' },
+        '.overflow-x-initial': { 'overflow-x': 'initial' },
+        '.overflow-y-initial': { 'overflow-y': 'initial' },
+        '.overflow-x-revert': { 'overflow-x': 'revert' },
+        '.overflow-y-revert': { 'overflow-y': 'revert' },
+        '.overflow-x-unset': { 'overflow-x': 'unset' },
+        '.overflow-y-unset': { 'overflow-y': 'unset' },
+      })
+    }),
+  ],
   prefix: 'shr-',
 } satisfies Config


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-731

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Button コンポーネントを Tailwind CSS 化します。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- ゴリッと preset を見直しました
  - overflow に `inherit | initial | unset | revert` のグローバル値を生やしました
  - spacing に `em: '1em'` を生やしました
  - ほか
- Button を置き換えました
- ButtonWrapper を置き換えました
- ButtonInner を置き換えました
- クラスセレクタでスタイル指定していた箇所を置き換えました

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
