### PR TITLE
chore: TooltipのVRT用Storyを追加

### DIFF
--- a/src/components/Tooltip/VRTTooltip.stories.tsx
+++ b/src/components/Tooltip/VRTTooltip.stories.tsx
@@ -1,0 +1,38 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent } from '@storybook/testing-library'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Tooltip } from './Tooltip'
+import { RegHover } from './Tooltip.stories'
+
+export default {
+  title: 'Data Display（データ表示）/Tooltip',
+  component: Tooltip,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <RegHover />
+  </>
+)
+
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+VRTForcedColors.play = ({ canvasElement }) => {
+  const tooltips = canvasElement.querySelectorAll('.smarthr-ui-Tooltip')
+  tooltips.forEach((tooltip) => userEvent.hover(tooltip))
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

TooltipコンポーネントにVRT用のStoryを追加しました。

## What I did

### Tooltipコンポーネントに1つのVRT用Storyを追加
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態

VRT用で他に必要そうなストーリーは思いつきませんでした。
必要そうなストーリーがあればご指摘ください。

## Capture

<img width="1188" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/2ab31920-a5ec-45c2-92c4-53bf0b0e42c3">