### PR TITLE
fix!: headingコンポーネントのtag属性にspan, legendを指定不可能にする

### DIFF
--- a/src/components/FieldSet/FieldSet.tsx
+++ b/src/components/FieldSet/FieldSet.tsx
@@ -3,11 +3,12 @@ import styled, { css } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
 import { Theme, useTheme } from '../../hooks/useTheme'
-import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
+import { HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
 import { Input } from '../Input'
 import { Stack } from '../Layout/Stack'
 import { StatusLabel } from '../StatusLabel'
+import { Text } from '../Text'
 
 import { useClassNames } from './useClassNames'
 
@@ -16,8 +17,6 @@ type Props = Omit<React.ComponentProps<typeof Input>, 'error'> & {
   label: ReactNode
   /** ラベルのタイプ */
   labelType?: HeadingTypes
-  /** ラベル名の HTML 要素のタイプ */
-  labelTagType?: HeadingTagTypes
   /** input 要素の下に表示するエラーメッセージ */
   errorMessage?: ReactNode | ReactNode[]
   /** input 要素の下に表示するヘルプメッセージ */
@@ -35,7 +34,6 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 export const FieldSet: FC<Props & ElementProps> = ({
   label,
   labelType = 'subBlockTitle',
-  labelTagType = 'span',
   errorMessage,
   helpMessage,
   className = '',
@@ -55,11 +53,9 @@ export const FieldSet: FC<Props & ElementProps> = ({
       aria-describedby={helpMessage ? helpId : undefined}
     >
       <Title themes={theme} className={classNames.title}>
-        {/* TODO: レベル自動計算に任せるならtagのデフォルト値をspanにする必要はないかもしれない。検討する */}
-        {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
-        <LabelHeading type={labelType} tag={labelTagType} className={classNames.titleText}>
+        <LabelText styleType={labelType} className={classNames.titleText}>
           {label}
-        </LabelHeading>
+        </LabelText>
 
         {props.required && (
           <StatusLabel type="red" className={classNames.label}>
@@ -113,7 +109,7 @@ const Title = styled.div<{ themes: Theme }>`
     }
   `}
 `
-const LabelHeading = styled(Heading)`
+const LabelText = styled(Text)`
   display: inline-block;
 `
 

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -14,7 +14,7 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { MultiComboBox, SingleComboBox } from '../ComboBox'
 import { DatePicker } from '../DatePicker'
 import { DropZone } from '../DropZone'
-import { Heading, HeadingTypes } from '../Heading'
+import { HeadingTypes } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
 import { CurrencyInput, Input } from '../Input'
 import { InputFile } from '../InputFile'
@@ -111,7 +111,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
         className={`${classNames.label}`}
         as={isRoleGroup ? 'legend' : 'label'}
       >
-        <GroupLabel type={titleType}>{title}</GroupLabel>
+        <GroupLabel styleType={titleType}>{title}</GroupLabel>
         {statusLabelList.length > 0 && (
           <Cluster gap={0.25} as="span">
             {statusLabelList.map((statusLabelProp, index) => (
@@ -259,7 +259,7 @@ const FormLabel = styled(Cluster).attrs({ align: 'center' })`
   align-self: start;
 `
 
-const GroupLabel = styled(Heading).attrs({ tag: 'span' })``
+const GroupLabel = styled(Text).attrs({ as: 'span' })``
 
 const ErrorMessage = styled.p<{ themes: Theme }>`
   ${({ themes: { color } }) => css`

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes, ReactNode, VFC, useContext, useMemo } from 'reac
 import styled from 'styled-components'
 
 import { LevelContext } from '../SectioningContent'
-import { Text, TextProps } from '../Text'
+import { MAPPER_SIZE_AND_WEIGHT, Text, TextProps } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { useClassNames } from './useClassNames'
@@ -22,14 +22,9 @@ export type Props = {
   visuallyHidden?: boolean
 }
 
-export type HeadingTypes =
-  | 'screenTitle'
-  | 'sectionTitle'
-  | 'blockTitle'
-  | 'subBlockTitle'
-  | 'subSubBlockTitle'
+export type HeadingTypes = TextProps['styleType']
 
-export type HeadingTagTypes = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span' | 'legend'
+export type HeadingTagTypes = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
 type ElementProps = Omit<
   HTMLAttributes<HTMLElement>,
@@ -48,33 +43,10 @@ const generateTagProps = (level: number, tag?: HeadingTagTypes, visuallyHidden?:
 
   return {
     [visuallyHidden ? 'as' : 'forwardedAs']:
-      tag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes),
+      tag || ((level <= 6 ? `h${level}` : 'span') as (HeadingTagTypes | 'span')),
     role,
     'aria-level': ariaLevel,
   }
-}
-
-const MAPPER_SIZE_AND_WEIGHT: { [key in HeadingTypes]: TextProps } = {
-  screenTitle: {
-    size: 'XL',
-  },
-  sectionTitle: {
-    size: 'L',
-  },
-  blockTitle: {
-    size: 'M',
-    weight: 'bold',
-  },
-  subBlockTitle: {
-    size: 'M',
-    weight: 'bold',
-    color: 'TEXT_GREY',
-  },
-  subSubBlockTitle: {
-    size: 'S',
-    weight: 'bold',
-    color: 'TEXT_GREY',
-  },
 }
 
 export const Heading: VFC<Props & ElementProps> = ({

--- a/src/components/RadioButtonPanel/RadioButtonPanel.stories.tsx
+++ b/src/components/RadioButtonPanel/RadioButtonPanel.stories.tsx
@@ -60,9 +60,9 @@ export const All: Story = () => {
             >
               <Stack gap={0.25} as="span">
                 <Cluster align="center" as="span">
-                  <Heading tag="span" type="blockTitle">
+                  <Text as="span" size="M" weight="bold">
                     エンゲージメントサーベイ
-                  </Heading>
+                  </Text>
                   <StatusLabel>組織改善</StatusLabel>
                 </Cluster>
                 <Text>

--- a/src/components/RightFixedNote/RightFixedNote.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.tsx
@@ -7,6 +7,7 @@ import { Theme, useTheme } from '../../hooks/useTheme'
 import { Button } from '../Button'
 import { Heading } from '../Heading'
 import { Section } from '../SectioningContent'
+import { Text } from '../Text'
 import { Textarea } from '../Textarea'
 
 import { ItemProps, OnClickEdit, RightFixedNoteItem } from './RightFixedNoteItem'
@@ -136,10 +137,9 @@ const SectionHeading = styled(Heading).attrs(() => ({
     `}
 `
 
-// eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content
-const TextareaLabelText = styled(Heading).attrs(() => ({
+const TextareaLabelText = styled(Text).attrs(() => ({
   tag: 'span',
-  type: 'subBlockTitle',
+  styleType: 'subBlockTitle',
 }))<{ themes: Theme }>`
   display: inline-block;
   margin-bottom: ${({ themes }) => themes.spacingByChar(1)};

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,6 +1,36 @@
 import React, { ComponentProps, PropsWithChildren, useMemo } from 'react'
 import { VariantProps, tv } from 'tailwind-variants'
 
+export const MAPPER_SIZE_AND_WEIGHT: { [key in StyleTypes]: TextProps } = {
+  screenTitle: {
+    size: 'XL',
+  },
+  sectionTitle: {
+    size: 'L',
+  },
+  blockTitle: {
+    size: 'M',
+    weight: 'bold',
+  },
+  subBlockTitle: {
+    size: 'M',
+    weight: 'bold',
+    color: 'TEXT_GREY',
+  },
+  subSubBlockTitle: {
+    size: 'S',
+    weight: 'bold',
+    color: 'TEXT_GREY',
+  },
+}
+
+type StyleTypes =
+  | 'screenTitle'
+  | 'sectionTitle'
+  | 'blockTitle'
+  | 'subBlockTitle'
+  | 'subSubBlockTitle'
+
 const text = tv({
   variants: {
     size: {
@@ -48,18 +78,27 @@ export type TextProps = VariantProps<typeof text> & {
   as?: string | React.ComponentType<any> | undefined
   /** 強調するかどうかの真偽値。指定すると em 要素になる */
   emphasis?: boolean
+  styleType?: StyleTypes
 }
 
 export const Text: React.FC<PropsWithChildren<TextProps & ComponentProps<'span'>>> = ({
   emphasis,
+  styleType,
   weight = emphasis ? 'bold' : undefined,
   as: Component = emphasis ? 'em' : 'span',
   ...props
 }) => {
   const { size, italic, color, leading, whiteSpace, className, ...others } = props
+  const styleTypeValues = styleType ? MAPPER_SIZE_AND_WEIGHT[styleType] : null
+
   const styles = useMemo(
-    () => text({ size, weight, italic, color, leading, whiteSpace, className }),
-    [size, weight, italic, color, leading, whiteSpace, className],
+    () => text({
+      size: size || styleTypeValues?.size,
+      weight: weight || styleTypeValues?.weight,
+      color: color || styleTypeValues?.color ,
+      italic, leading, whiteSpace, className
+    }),
+    [size, weight, italic, color, leading, whiteSpace, className, styleTypeValues],
   )
 
   return <Component {...others} className={styles} />

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,2 +1,2 @@
-export { Text } from './Text'
+export { Text, MAPPER_SIZE_AND_WEIGHT } from './Text'
 export type { TextProps } from './Text'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- smarthr-ui/Headingは見出しを表現するためのコンポーネントであり、見出し出ない場合はTextコンポーネントで表現するべき、という思想
- Headingは内部的にはTextコンポーネントのaliasなので置き換えも簡単...と思っていたが、想像以上にtag="span"が利用されており、意図しない状態になっている
- a11y系チェックの誤検知なども引き起こしてしまう可能性があるため、Headingコンポーネントのtag属性にはspan, legendを設定出来ないようにしたい

## Capture

<!--
Please attach a capture if it looks different.
-->
