### PR TITLE
fix: Dialog の背景を押した時の挙動をデフォルトで閉じないように揃える

### DIFF
--- a/e2e/components/Dialog/Dialog.test.ts
+++ b/e2e/components/Dialog/Dialog.test.ts
@@ -27,12 +27,8 @@ test('ダイアログが開閉できること', async (t) => {
     .expect(trigger.focused)
     .ok()
 
-  // 背景クリックでダイアログが閉じることを確認
-  await t
-    .click(trigger)
-    .click(background, { offsetX: 0, offsetY: 0 })
-    .expect(content.exists)
-    .notOk()
+  // 背景クリックでダイアログが閉じないことを確認
+  await t.click(trigger).click(background, { offsetX: 0, offsetY: 0 }).expect(content.exists).ok()
 })
 
 test('フォーカストラップが動作すること', async (t) => {

--- a/e2e/components/Dialog/DialogWrapper.test.ts
+++ b/e2e/components/Dialog/DialogWrapper.test.ts
@@ -27,12 +27,8 @@ test('DialogContent が開閉できること', async (t) => {
     .expect(trigger.focused)
     .ok()
 
-  // 背景クリックでダイアログが閉じることを確認
-  await t
-    .click(trigger)
-    .click(background, { offsetX: 0, offsetY: 0 })
-    .expect(content.exists)
-    .notOk()
+  // 背景クリックでダイアログが閉じないことを確認
+  await t.click(trigger).click(background, { offsetX: 0, offsetY: 0 }).expect(content.exists).ok()
 })
 
 test('MessageDialogContent が開閉できること', async (t) => {
@@ -54,12 +50,8 @@ test('MessageDialogContent が開閉できること', async (t) => {
     .expect(trigger.focused)
     .ok()
 
-  // 背景クリックでダイアログが閉じることを確認
-  await t
-    .click(trigger)
-    .click(background, { offsetX: 0, offsetY: 0 })
-    .expect(content.exists)
-    .notOk()
+  // 背景クリックでダイアログが閉じないことを確認
+  await t.click(trigger).click(background, { offsetX: 0, offsetY: 0 }).expect(content.exists).ok()
 })
 
 test('ActionDialogContent が開閉できること', async (t) => {
@@ -81,10 +73,6 @@ test('ActionDialogContent が開閉できること', async (t) => {
     .expect(trigger.focused)
     .ok()
 
-  // 背景クリックでダイアログが閉じることを確認
-  await t
-    .click(trigger)
-    .click(background, { offsetX: 0, offsetY: 0 })
-    .expect(content.exists)
-    .notOk()
+  // 背景クリックでダイアログが閉じないことを確認
+  await t.click(trigger).click(background, { offsetX: 0, offsetY: 0 }).expect(content.exists).ok()
 })

--- a/e2e/components/Dialog/MessageDialog.test.ts
+++ b/e2e/components/Dialog/MessageDialog.test.ts
@@ -27,10 +27,6 @@ test('ダイアログが開閉できること', async (t) => {
     .expect(trigger.focused)
     .ok()
 
-  // 背景クリックでダイアログが閉じることを確認
-  await t
-    .click(trigger)
-    .click(background, { offsetX: 0, offsetY: 0 })
-    .expect(content.exists)
-    .notOk()
+  // 背景クリックでダイアログが閉じないことを確認
+  await t.click(trigger).click(background, { offsetX: 0, offsetY: 0 }).expect(content.exists).ok()
 })

--- a/src/components/Dialog/ActionDialog/ActionDialogContent.tsx
+++ b/src/components/Dialog/ActionDialog/ActionDialogContent.tsx
@@ -11,7 +11,7 @@ import { ActionDialogContentInner, BaseProps } from './ActionDialogContentInner'
 type Props = BaseProps & UncontrolledDialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
+export const ActionDialogContent: React.FC<Props & ElementProps> = ({
   children,
   title,
   actionText,
@@ -45,7 +45,6 @@ export const ActionDialogContent: React.VFC<Props & ElementProps> = ({
   return createPortal(
     <DialogContentInner
       {...props}
-      onClickOverlay={onClickClose}
       onPressEscape={onClickClose}
       isOpen={active}
       ariaLabelledby={titleId}

--- a/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useCallback } from 'react'
+import React, { FC, PropsWithChildren, ReactNode, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
@@ -13,11 +13,7 @@ import { useClassNames } from '../useClassNames'
 
 import type { DecoratorsType, ResponseMessageType } from '../../../types'
 
-export type BaseProps = {
-  /**
-   * ダイアログの内容
-   */
-  children: ReactNode
+export type BaseProps = PropsWithChildren<{
   /**
    * ダイアログのタイトル
    */
@@ -57,7 +53,7 @@ export type BaseProps = {
   className?: string
   /** コンポーネント内の文言を変更するための関数を設定 */
   decorators?: DecoratorsType<'closeButtonLabel'>
-}
+}>
 
 export type ActionDialogContentInnerProps = BaseProps & {
   onClickClose: () => void

--- a/src/components/Dialog/BodyScrollSuppressor.tsx
+++ b/src/components/Dialog/BodyScrollSuppressor.tsx
@@ -1,7 +1,7 @@
-import React, { VFC, useEffect, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 
-export const BodyScrollSuppressor: VFC = () => {
+export const BodyScrollSuppressor: FC = () => {
   const [scrollBarWidth, setScrollBarWidth] = useState<number | null>(null)
   const [paddingRight, setPaddingRight] = useState<number | null>(null)
 

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -81,7 +81,6 @@ export const Default: Story = () => {
         </Button>
         <Dialog
           isOpen={opened === 'default'}
-          onClickOverlay={onClickClose}
           onPressEscape={onClickClose}
           id="dialog-default"
           ariaLabel="Dialog"
@@ -137,7 +136,6 @@ export const Default: Story = () => {
         </Button>
         <Dialog
           isOpen={opened === 'focus'}
-          onClickOverlay={onClickClose}
           onPressEscape={onClickClose}
           firstFocusTarget={inputRef}
           id="dialog-focus"
@@ -202,7 +200,6 @@ export const Message_Dialog: Story = () => {
           </Section>
         }
         onClickClose={onClickClose}
-        onClickOverlay={onClickClose}
         decorators={{ closeButtonLabel: (txt) => `close.(${txt})` }}
         id="dialog-message"
         data-test="dialog-content"
@@ -302,7 +299,6 @@ export const Action_Dialog: Story = () => {
             closeDialog()
           }}
           onClickClose={onClickClose}
-          onClickOverlay={onClickClose}
           decorators={{ closeButtonLabel: (txt) => `close.(${txt})` }}
           firstFocusTarget={openedFocusRef}
           data-test="opened-dialog"
@@ -427,7 +423,6 @@ export const Form_Dialog: Story = () => {
             closeDialog()
           }}
           onClickClose={onClickClose}
-          onClickOverlay={onClickClose}
           decorators={{ closeButtonLabel: (txt) => `close.(${txt})` }}
           firstFocusTarget={openedFocusRef}
           data-test="opened-form-dialog"
@@ -465,226 +460,226 @@ const Buttons = styled.div`
 `
 
 export const Action_Dialog_With_Trigger: Story = () => (
-    <>
-      <ActionDialogWithTrigger
-        trigger={<Button>open.</Button>}
-        title="ActionDialog With Trigger"
-        actionText="保存"
-        onClickAction={(close) => {
-          close()
-        }}
-      >
-        <Description>ActionDialog with Trigger.</Description>
-      </ActionDialogWithTrigger>
+  <>
+    <ActionDialogWithTrigger
+      trigger={<Button>open.</Button>}
+      title="ActionDialog With Trigger"
+      actionText="保存"
+      onClickAction={(close) => {
+        close()
+      }}
+    >
+      <Description>ActionDialog with Trigger.</Description>
+    </ActionDialogWithTrigger>
 
-      <ActionDialogWithTrigger
-        trigger={<Button disabled={true}>open.</Button>}
-        title="Disabled ActionDialog With Trigger"
-        actionText="保存"
-        onClickAction={(close) => {
-          close()
-        }}
-      >
-        <Description>ActionDialog with Trigger.</Description>
-      </ActionDialogWithTrigger>
-    </>
-  )
+    <ActionDialogWithTrigger
+      trigger={<Button disabled={true}>open.</Button>}
+      title="Disabled ActionDialog With Trigger"
+      actionText="保存"
+      onClickAction={(close) => {
+        close()
+      }}
+    >
+      <Description>ActionDialog with Trigger.</Description>
+    </ActionDialogWithTrigger>
+  </>
+)
 
 export const Remote_Trigger_Action_Dialog: Story = () => (
-    <>
-      <div>
-        <p>複数のトリガーに対応</p>
-        <RemoteDialogTrigger targetId="remote_trigger_action_dialog_1">
-          <Button>Trigger 1.</Button>
-        </RemoteDialogTrigger>
-        <RemoteDialogTrigger targetId="remote_trigger_action_dialog_1">
-          <Button>Trigger 2.</Button>
-        </RemoteDialogTrigger>
-        <RemoteTriggerActionDialog
-          id="remote_trigger_action_dialog_1"
-          title="Remote Trigger Action Dialog 1"
-          actionText="保存"
-          onClickAction={(close) => {
-            close()
-          }}
-          onToggle={(isOpen) => {
-            console.log(`isOpen: ${isOpen}`)
-          }}
-          onOpen={() => console.log(`open!`)}
-          onClose={() => console.log(`close!`)}
-        >
-          <Description>Remote Trigger Action Dialog.</Description>
-        </RemoteTriggerActionDialog>
-      </div>
+  <>
+    <div>
+      <p>複数のトリガーに対応</p>
+      <RemoteDialogTrigger targetId="remote_trigger_action_dialog_1">
+        <Button>Trigger 1.</Button>
+      </RemoteDialogTrigger>
+      <RemoteDialogTrigger targetId="remote_trigger_action_dialog_1">
+        <Button>Trigger 2.</Button>
+      </RemoteDialogTrigger>
+      <RemoteTriggerActionDialog
+        id="remote_trigger_action_dialog_1"
+        title="Remote Trigger Action Dialog 1"
+        actionText="保存"
+        onClickAction={(close) => {
+          close()
+        }}
+        onToggle={(isOpen) => {
+          console.log(`isOpen: ${isOpen}`)
+        }}
+        onOpen={() => console.log(`open!`)}
+        onClose={() => console.log(`close!`)}
+      >
+        <Description>Remote Trigger Action Dialog.</Description>
+      </RemoteTriggerActionDialog>
+    </div>
 
-      <div>
-        <p>disabled</p>
-        <RemoteDialogTrigger targetId="remote_trigger_action_dialog_2">
-          <Button disabled={true}>disabled.</Button>
-        </RemoteDialogTrigger>
-        <RemoteTriggerActionDialog
-          id="remote_trigger_action_dialog_2"
-          title="Remote Trigger Action Dialog 2"
-          actionText="保存"
-          onClickAction={(close) => {
-            close()
-          }}
-        >
-          <Description>Remote Trigger Action Dialog.</Description>
-        </RemoteTriggerActionDialog>
-      </div>
-    </>
-  )
+    <div>
+      <p>disabled</p>
+      <RemoteDialogTrigger targetId="remote_trigger_action_dialog_2">
+        <Button disabled={true}>disabled.</Button>
+      </RemoteDialogTrigger>
+      <RemoteTriggerActionDialog
+        id="remote_trigger_action_dialog_2"
+        title="Remote Trigger Action Dialog 2"
+        actionText="保存"
+        onClickAction={(close) => {
+          close()
+        }}
+      >
+        <Description>Remote Trigger Action Dialog.</Description>
+      </RemoteTriggerActionDialog>
+    </div>
+  </>
+)
 
 export const Remote_Trigger_Form_Dialog: Story = () => (
-    <>
-      <div>
-        <p>複数のトリガーに対応</p>
-        <RemoteDialogTrigger targetId="remote_trigger_form_dialog_1">
-          <Button>Trigger 1.</Button>
-        </RemoteDialogTrigger>
-        <RemoteDialogTrigger targetId="remote_trigger_form_dialog_1">
-          <Button>Trigger 2.</Button>
-        </RemoteDialogTrigger>
-        <RemoteTriggerFormDialog
-          id="remote_trigger_form_dialog_1"
-          title="Remote Trigger Form Dialog 1"
-          actionText="保存"
-          onSubmit={(close) => {
-            close()
-          }}
-        >
-          <Description>Remote Trigger Form Dialog.</Description>
-        </RemoteTriggerFormDialog>
-      </div>
+  <>
+    <div>
+      <p>複数のトリガーに対応</p>
+      <RemoteDialogTrigger targetId="remote_trigger_form_dialog_1">
+        <Button>Trigger 1.</Button>
+      </RemoteDialogTrigger>
+      <RemoteDialogTrigger targetId="remote_trigger_form_dialog_1">
+        <Button>Trigger 2.</Button>
+      </RemoteDialogTrigger>
+      <RemoteTriggerFormDialog
+        id="remote_trigger_form_dialog_1"
+        title="Remote Trigger Form Dialog 1"
+        actionText="保存"
+        onSubmit={(close) => {
+          close()
+        }}
+      >
+        <Description>Remote Trigger Form Dialog.</Description>
+      </RemoteTriggerFormDialog>
+    </div>
 
-      <div>
-        <p>disabled</p>
-        <RemoteDialogTrigger targetId="remote_trigger_form_dialog_2">
-          <Button disabled={true}>disabled.</Button>
-        </RemoteDialogTrigger>
-        <RemoteTriggerFormDialog
-          id="remote_trigger_form_dialog_2"
-          title="Remote Trigger Form Dialog 2"
-          actionText="保存"
-          onSubmit={(close) => {
-            close()
-          }}
-        >
-          <Description>Remote Trigger Form Dialog.</Description>
-        </RemoteTriggerFormDialog>
-      </div>
-    </>
-  )
+    <div>
+      <p>disabled</p>
+      <RemoteDialogTrigger targetId="remote_trigger_form_dialog_2">
+        <Button disabled={true}>disabled.</Button>
+      </RemoteDialogTrigger>
+      <RemoteTriggerFormDialog
+        id="remote_trigger_form_dialog_2"
+        title="Remote Trigger Form Dialog 2"
+        actionText="保存"
+        onSubmit={(close) => {
+          close()
+        }}
+      >
+        <Description>Remote Trigger Form Dialog.</Description>
+      </RemoteTriggerFormDialog>
+    </div>
+  </>
+)
 
 export const Remote_Trigger_Message_Dialog: Story = () => (
-    <>
-      <div>
-        <p>複数のトリガーに対応</p>
-        <RemoteDialogTrigger targetId="remote_trigger_message_dialog_1">
-          <Button>Trigger 1.</Button>
-        </RemoteDialogTrigger>
-        <RemoteDialogTrigger targetId="remote_trigger_message_dialog_1">
-          <Button>Trigger 2.</Button>
-        </RemoteDialogTrigger>
-        <RemoteTriggerMessageDialog
-          id="remote_trigger_message_dialog_1"
-          title="Remote Trigger Message Dialog 1"
-          description={<Description>Remote Trigger Message Dialog.</Description>}
-        />
-      </div>
+  <>
+    <div>
+      <p>複数のトリガーに対応</p>
+      <RemoteDialogTrigger targetId="remote_trigger_message_dialog_1">
+        <Button>Trigger 1.</Button>
+      </RemoteDialogTrigger>
+      <RemoteDialogTrigger targetId="remote_trigger_message_dialog_1">
+        <Button>Trigger 2.</Button>
+      </RemoteDialogTrigger>
+      <RemoteTriggerMessageDialog
+        id="remote_trigger_message_dialog_1"
+        title="Remote Trigger Message Dialog 1"
+        description={<Description>Remote Trigger Message Dialog.</Description>}
+      />
+    </div>
 
-      <div>
-        <p>disabled</p>
-        <RemoteDialogTrigger targetId="remote_trigger_message_dialog_2">
-          <Button disabled={true}>disabled.</Button>
-        </RemoteDialogTrigger>
-        <RemoteTriggerMessageDialog
-          id="remote_trigger_message_dialog_2"
-          title="Remote Trigger Message Dialog 2"
-          description={<Description>Remote Trigger Message Dialog.</Description>}
-        />
-      </div>
-    </>
-  )
+    <div>
+      <p>disabled</p>
+      <RemoteDialogTrigger targetId="remote_trigger_message_dialog_2">
+        <Button disabled={true}>disabled.</Button>
+      </RemoteDialogTrigger>
+      <RemoteTriggerMessageDialog
+        id="remote_trigger_message_dialog_2"
+        title="Remote Trigger Message Dialog 2"
+        description={<Description>Remote Trigger Message Dialog.</Description>}
+      />
+    </div>
+  </>
+)
 
 export const Uncontrolled: Story = () => (
-    <TriggerList>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button
-              aria-haspopup="dialog"
-              aria-controls="dialog-uncontrolled"
-              data-test="dialog-trigger"
-            >
-              Dialog
-            </Button>
-          </DialogTrigger>
-          <DialogContent id="dialog-uncontrolled" data-test="dialog-content">
-            <Description>Uncontrolled Dialog.</Description>
-            <Content>
-              <DialogCloser>
-                <Button data-test="dialog-closer">Close</Button>
-              </DialogCloser>
-            </Content>
-          </DialogContent>
-        </DialogWrapper>
-      </li>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button
-              aria-haspopup="dialog"
-              aria-controls="dialog-uncontrolled-message"
-              data-test="message-dialog-trigger"
-            >
-              MessageDialog
-            </Button>
-          </DialogTrigger>
-          <MessageDialogContent
-            title="Uncontrolled Message Dialog"
-            description={<p>{dummyText} </p>}
-            id="dialog-uncontrolled-message"
-            data-test="message-dialog-content"
-          />
-        </DialogWrapper>
-      </li>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button
-              aria-haspopup="dialog"
-              aria-controls="dialog-uncontrolled-action"
-              data-test="action-dialog-trigger"
-            >
-              ActionDialog
-            </Button>
-          </DialogTrigger>
-          <ActionDialogContent
-            title="Uncontrolled Action Dialog"
-            actionText="実行"
-            actionDisabled={false}
-            onClickAction={(closeDialog) => {
-              action('executed')()
-              closeDialog()
-            }}
-            id="dialog-uncontrolled-action"
-            data-test="action-dialog-content"
+  <TriggerList>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button
+            aria-haspopup="dialog"
+            aria-controls="dialog-uncontrolled"
+            data-test="dialog-trigger"
           >
-            <Description>
-              The content of ActionDialogContent is freely implemented by the user as children.
-              <br />
-              So you need to prepare your own style.
-              <br />
-              When action is executed, you can specify when to close dialog. In this story, dialog
-              closes one second after clicking action
-            </Description>
-          </ActionDialogContent>
-        </DialogWrapper>
-      </li>
-    </TriggerList>
-  )
+            Dialog
+          </Button>
+        </DialogTrigger>
+        <DialogContent id="dialog-uncontrolled" data-test="dialog-content">
+          <Description>Uncontrolled Dialog.</Description>
+          <Content>
+            <DialogCloser>
+              <Button data-test="dialog-closer">Close</Button>
+            </DialogCloser>
+          </Content>
+        </DialogContent>
+      </DialogWrapper>
+    </li>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button
+            aria-haspopup="dialog"
+            aria-controls="dialog-uncontrolled-message"
+            data-test="message-dialog-trigger"
+          >
+            MessageDialog
+          </Button>
+        </DialogTrigger>
+        <MessageDialogContent
+          title="Uncontrolled Message Dialog"
+          description={<p>{dummyText} </p>}
+          id="dialog-uncontrolled-message"
+          data-test="message-dialog-content"
+        />
+      </DialogWrapper>
+    </li>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button
+            aria-haspopup="dialog"
+            aria-controls="dialog-uncontrolled-action"
+            data-test="action-dialog-trigger"
+          >
+            ActionDialog
+          </Button>
+        </DialogTrigger>
+        <ActionDialogContent
+          title="Uncontrolled Action Dialog"
+          actionText="実行"
+          actionDisabled={false}
+          onClickAction={(closeDialog) => {
+            action('executed')()
+            closeDialog()
+          }}
+          id="dialog-uncontrolled-action"
+          data-test="action-dialog-content"
+        >
+          <Description>
+            The content of ActionDialogContent is freely implemented by the user as children.
+            <br />
+            So you need to prepare your own style.
+            <br />
+            When action is executed, you can specify when to close dialog. In this story, dialog
+            closes one second after clicking action
+          </Description>
+        </ActionDialogContent>
+      </DialogWrapper>
+    </li>
+  </TriggerList>
+)
 Uncontrolled.parameters = {
   docs: {
     description: {
@@ -695,57 +690,57 @@ Uncontrolled.parameters = {
 }
 
 export const WidthAndPosition: Story = () => (
-    <TriggerList>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button aria-haspopup="dialog" aria-controls="dialog-width-1">
-              幅 400px
-            </Button>
-          </DialogTrigger>
-          <DialogContent width={400} id="dialog-width-1">
-            <Description>幅 400px のダイアログ</Description>
-          </DialogContent>
-        </DialogWrapper>
-      </li>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button aria-haspopup="dialog" aria-controls="dialog-width-2">
-              幅 80%
-            </Button>
-          </DialogTrigger>
-          <DialogContent width="80%" id="dialog-width-2">
-            <Description>幅 80% のダイアログ</Description>
-          </DialogContent>
-        </DialogWrapper>
-      </li>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button aria-haspopup="dialog" aria-controls="dialog-position-1">
-              top-left
-            </Button>
-          </DialogTrigger>
-          <DialogContent top={50} left={200} id="dialog-position-1">
-            <Description>This Dialog is set to `top: 50px, left: 200px`.</Description>
-          </DialogContent>
-        </DialogWrapper>
-      </li>
-      <li>
-        <DialogWrapper>
-          <DialogTrigger>
-            <Button aria-haspopup="dialog" aria-controls="dialog-position-2">
-              bottom-right
-            </Button>
-          </DialogTrigger>
-          <DialogContent right={50} bottom={100} id="dialog-position-2">
-            <Description>This Dialog is set to `right: 50px, bottom: 100px`.</Description>
-          </DialogContent>
-        </DialogWrapper>
-      </li>
-    </TriggerList>
-  )
+  <TriggerList>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button aria-haspopup="dialog" aria-controls="dialog-width-1">
+            幅 400px
+          </Button>
+        </DialogTrigger>
+        <DialogContent width={400} id="dialog-width-1">
+          <Description>幅 400px のダイアログ</Description>
+        </DialogContent>
+      </DialogWrapper>
+    </li>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button aria-haspopup="dialog" aria-controls="dialog-width-2">
+            幅 80%
+          </Button>
+        </DialogTrigger>
+        <DialogContent width="80%" id="dialog-width-2">
+          <Description>幅 80% のダイアログ</Description>
+        </DialogContent>
+      </DialogWrapper>
+    </li>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button aria-haspopup="dialog" aria-controls="dialog-position-1">
+            top-left
+          </Button>
+        </DialogTrigger>
+        <DialogContent top={50} left={200} id="dialog-position-1">
+          <Description>This Dialog is set to `top: 50px, left: 200px`.</Description>
+        </DialogContent>
+      </DialogWrapper>
+    </li>
+    <li>
+      <DialogWrapper>
+        <DialogTrigger>
+          <Button aria-haspopup="dialog" aria-controls="dialog-position-2">
+            bottom-right
+          </Button>
+        </DialogTrigger>
+        <DialogContent right={50} bottom={100} id="dialog-position-2">
+          <Description>This Dialog is set to `right: 50px, bottom: 100px`.</Description>
+        </DialogContent>
+      </DialogWrapper>
+    </li>
+  </TriggerList>
+)
 WidthAndPosition.parameters = {
   docs: {
     description: {
@@ -755,30 +750,30 @@ WidthAndPosition.parameters = {
 }
 
 export const WithScroll: Story = () => (
-    <ScrollWrapper>
-      <BorderedWrapper>
-        We can confirm that there is no change in the width of the wrapper for this text before and
-        after opening a dialog.
-      </BorderedWrapper>
-      <DialogWrapper>
-        <DialogTrigger>
-          <Button aria-haspopup="dialog" aria-controls="dialog-with-scroll-1">
-            Open Dialog
-          </Button>
-        </DialogTrigger>
-        <DialogContent id="dialog-with-scroll-1">
-          <ContentWrapper>
-            <div>
-              The content behind the opened dialog is not scrollable.
-              <br />
-              Of course the content on the opened dialog is scrollable.
-            </div>
+  <ScrollWrapper>
+    <BorderedWrapper>
+      We can confirm that there is no change in the width of the wrapper for this text before and
+      after opening a dialog.
+    </BorderedWrapper>
+    <DialogWrapper>
+      <DialogTrigger>
+        <Button aria-haspopup="dialog" aria-controls="dialog-with-scroll-1">
+          Open Dialog
+        </Button>
+      </DialogTrigger>
+      <DialogContent id="dialog-with-scroll-1">
+        <ContentWrapper>
+          <div>
+            The content behind the opened dialog is not scrollable.
             <br />
-          </ContentWrapper>
-        </DialogContent>
-      </DialogWrapper>
-    </ScrollWrapper>
-  )
+            Of course the content on the opened dialog is scrollable.
+          </div>
+          <br />
+        </ContentWrapper>
+      </DialogContent>
+    </DialogWrapper>
+  </ScrollWrapper>
+)
 WithScroll.parameters = { docs: { disable: true } }
 const ScrollWrapper = styled.div`
   height: 200vh;
@@ -898,78 +893,78 @@ export const Modeless_Dialog: Story = () => {
 }
 
 export const RegDialogOpenedDialog: Story = () => (
-    <Dialog isOpen>
-      <Description>{dummyText}</Description>
-    </Dialog>
-  )
+  <Dialog isOpen>
+    <Description>{dummyText}</Description>
+  </Dialog>
+)
 
 export const RegDialogOpenedDialogWidth: Story = () => (
-    <Dialog isOpen width={500}>
-      <Description>{dummyText}</Description>
-    </Dialog>
-  )
+  <Dialog isOpen width={500}>
+    <Description>{dummyText}</Description>
+  </Dialog>
+)
 
 export const RegDialogOpenedDialogPosition: Story = () => (
-    <Dialog isOpen top={20} right={40} bottom={60} left={80}>
-      <Description>{dummyText}</Description>
-    </Dialog>
-  )
+  <Dialog isOpen top={20} right={40} bottom={60} left={80}>
+    <Description>{dummyText}</Description>
+  </Dialog>
+)
 
 export const RegOpendMessage: Story = () => (
-    <MessageDialog
-      isOpen={true}
-      title="MessageDialog"
-      description={<p>{dummyText}</p>}
-      onClickClose={action('clicked close')}
-    />
-  )
+  <MessageDialog
+    isOpen={true}
+    title="MessageDialog"
+    description={<p>{dummyText}</p>}
+    onClickClose={action('clicked close')}
+  />
+)
 RegOpendMessage.parameters = { docs: { disable: true } }
 
 export const RegOpendAction: Story = () => (
-    <ActionDialog
-      isOpen={true}
-      title="ActionDialog"
-      actionText="保存"
-      onClickAction={action('clicked action')}
-      onClickClose={action('clicked close')}
-    >
-      <Description>
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-      </Description>
-      <Content>
-        <label>
-          <input name="reg_opend_action_checkbox" type="checkbox" />
-          Agree
-        </label>
-      </Content>
-    </ActionDialog>
-  )
+  <ActionDialog
+    isOpen={true}
+    title="ActionDialog"
+    actionText="保存"
+    onClickAction={action('clicked action')}
+    onClickClose={action('clicked close')}
+  >
+    <Description>
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+    </Description>
+    <Content>
+      <label>
+        <input name="reg_opend_action_checkbox" type="checkbox" />
+        Agree
+      </label>
+    </Content>
+  </ActionDialog>
+)
 RegOpendAction.parameters = { docs: { disable: true } }
 
 export const RegOpenedModeless: Story = () => (
-    <ModelessDialog
-      isOpen
-      header={<ModelessHeading>モードレスダイアログ</ModelessHeading>}
-      footer={<ModelessFooter>フッタ</ModelessFooter>}
-      height={500}
-      width={600}
-    >
-      <div style={{ margin: '1rem' }}>
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-        {dummyText}
-      </div>
-    </ModelessDialog>
-  )
+  <ModelessDialog
+    isOpen
+    header={<ModelessHeading>モードレスダイアログ</ModelessHeading>}
+    footer={<ModelessFooter>フッタ</ModelessFooter>}
+    height={500}
+    width={600}
+  >
+    <div style={{ margin: '1rem' }}>
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+      {dummyText}
+    </div>
+  </ModelessDialog>
+)
 
 export const Body以外のPortalParent: Story = () => {
   const [isOpen, setIsOpen] = useState<'deault' | 'actiion' | 'message' | 'modeless'>()
@@ -1013,7 +1008,6 @@ export const Body以外のPortalParent: Story = () => {
 
       <Dialog
         isOpen={isOpen === 'deault'}
-        onClickOverlay={onClickClose}
         onPressEscape={onClickClose}
         id="portal-default"
         ariaLabel="Dialog"
@@ -1053,7 +1047,6 @@ export const Body以外のPortalParent: Story = () => {
         title="MessageDialog"
         description={<p>MessageDialog を近接要素に生成しています</p>}
         onClickClose={onClickClose}
-        onClickOverlay={onClickClose}
         id="portal-message"
         portalParent={portalParentRef}
       />

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -7,18 +7,13 @@ import { useDialogPortal } from './useDialogPortal'
 type Props = DialogProps & DireactChildren
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const Dialog: React.VFC<Props & ElementProps> = ({
-  children,
-  className = '',
+export const Dialog: React.FC<Props & ElementProps> = ({
+  className,
   portalParent,
   id,
   ...props
 }) => {
   const { createPortal } = useDialogPortal(portalParent, id)
 
-  return createPortal(
-    <DialogContentInner {...props} className={className}>
-      {children}
-    </DialogContentInner>,
-  )
+  return createPortal(<DialogContentInner {...props} className={className} />)
 }

--- a/src/components/Dialog/DialogCloser.tsx
+++ b/src/components/Dialog/DialogCloser.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react'
+import React, { PropsWithChildren, useContext } from 'react'
 import styled from 'styled-components'
 
 import { DialogContentContext } from './DialogContent'
 
-export const DialogCloser: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
+export const DialogCloser: React.FC<PropsWithChildren> = (props) => {
   const { onClickClose } = useContext(DialogContentContext)
-  return <Wrapper onClick={onClickClose}>{children}</Wrapper>
+  return <Wrapper {...props} onClick={onClickClose} />
 }
 
 const Wrapper = styled.div`

--- a/src/components/Dialog/DialogContent.tsx
+++ b/src/components/Dialog/DialogContent.tsx
@@ -17,20 +17,13 @@ export const DialogContentContext = createContext<DialogContentContextType>({
 
 type Props = UncontrolledDialogProps & DireactChildren
 
-export const DialogContent: React.VFC<Props> = ({ portalParent, children, ...props }) => {
+export const DialogContent: React.FC<Props> = ({ portalParent, ...props }) => {
   const { onClickClose, active } = useContext(DialogContext)
   const { createPortal } = useDialogPortal(portalParent)
 
   return createPortal(
     <DialogContentContext.Provider value={{ onClickClose }}>
-      <DialogContentInner
-        {...props}
-        isOpen={active}
-        onClickOverlay={onClickClose}
-        onPressEscape={onClickClose}
-      >
-        {children}
-      </DialogContentInner>
+      <DialogContentInner {...props} isOpen={active} onPressEscape={onClickClose} />
     </DialogContentContext.Provider>,
   )
 }

--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactNode, RefObject, VFC, useCallback, useRef } from 'react'
+import React, { ComponentProps, FC, PropsWithChildren, RefObject, useCallback, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
 import { useHandleEscape } from '../../hooks/useHandleEscape'
@@ -10,7 +10,7 @@ import { DialogPositionProvider } from './DialogPositionProvider'
 import { FocusTrap } from './FocusTrap'
 import { useClassNames } from './useClassNames'
 
-export type DialogContentInnerProps = {
+export type DialogContentInnerProps = PropsWithChildren<{
   /**
    * オーバーレイをクリックした時に発火するコールバック関数
    */
@@ -63,12 +63,8 @@ export type DialogContentInnerProps = {
    * コンポーネントに適用するクラス名
    */
   className?: string
-  /**
-   * ダイアログの内容
-   */
-  children: ReactNode
-}
-type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof DialogContentInnerProps>
+}>
+type ElementProps = Omit<ComponentProps<'div'>, keyof DialogContentInnerProps>
 
 type StyleProps = {
   $width?: string | number
@@ -82,7 +78,7 @@ function exist(value: any) {
   return value !== undefined && value !== null
 }
 
-export const DialogContentInner: VFC<DialogContentInnerProps & ElementProps> = ({
+export const DialogContentInner: FC<DialogContentInnerProps & ElementProps> = ({
   onClickOverlay,
   onPressEscape = () => {
     /* noop */
@@ -191,8 +187,8 @@ const Inner = styled.div<StyleProps & { themes: Theme }>`
 `
 const Background = styled.div<{ themes: Theme }>`
   ${({ themes }) => css`
-      position: fixed;
-      inset: 0;
-      background-color: ${themes.color.SCRIM};
-    `}
+    position: fixed;
+    inset: 0;
+    background-color: ${themes.color.SCRIM};
+  `}
 `

--- a/src/components/Dialog/DialogOverlap.tsx
+++ b/src/components/Dialog/DialogOverlap.tsx
@@ -1,17 +1,16 @@
-import React, { ReactNode, VFC, useEffect, useState } from 'react'
+import React, { FC, PropsWithChildren, ReactNode, useEffect, useState } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import styled from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 
-type Props = {
+type Props = PropsWithChildren<{
   isOpen: boolean
-  children: ReactNode
-}
+}>
 
 const transitionClassName = 'shr-dialog-transition'
 
-export const DialogOverlap: VFC<Props> = ({ isOpen, children }) => {
+export const DialogOverlap: FC<Props> = ({ isOpen, children }) => {
   const theme = useTheme()
   const [childrenBuffer, setChildrenBuffer] = useState<ReactNode>(null)
 

--- a/src/components/Dialog/DialogPositionProvider.tsx
+++ b/src/components/Dialog/DialogPositionProvider.tsx
@@ -7,15 +7,15 @@ type PositionContextType = {
 
 export const PositionContext = createContext<PositionContextType>({})
 
-export const DialogPositionProvider: React.VFC<
+export const DialogPositionProvider: React.FC<
   PositionContextType & { children?: React.ReactNode }
 > = ({ top, bottom, children }) => (
-    <PositionContext.Provider
-      value={{
-        top,
-        bottom,
-      }}
-    >
-      {children}
-    </PositionContext.Provider>
-  )
+  <PositionContext.Provider
+    value={{
+      top,
+      bottom,
+    }}
+  >
+    {children}
+  </PositionContext.Provider>
+)

--- a/src/components/Dialog/DialogTrigger.tsx
+++ b/src/components/Dialog/DialogTrigger.tsx
@@ -1,15 +1,11 @@
-import React, { useContext } from 'react'
+import React, { PropsWithChildren, useContext } from 'react'
 import styled from 'styled-components'
 
 import { DialogContext } from './DialogWrapper'
 
-export const DialogTrigger: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
+export const DialogTrigger: React.FC<PropsWithChildren> = (props) => {
   const { onClickTrigger } = useContext(DialogContext)
-  return (
-    <Wrapper onClick={onClickTrigger} aria-haspopup="dialog">
-      {children}
-    </Wrapper>
-  )
+  return <Wrapper {...props} onClick={onClickTrigger} aria-haspopup="dialog" />
 }
 
 const Wrapper = styled.div`

--- a/src/components/Dialog/DialogWrapper.tsx
+++ b/src/components/Dialog/DialogWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react'
+import React, { PropsWithChildren, createContext, useState } from 'react'
 
 type DialogContextType = {
   onClickTrigger: () => void
@@ -16,18 +16,17 @@ export const DialogContext = createContext<DialogContextType>({
   active: false,
 })
 
-export const DialogWrapper: React.VFC<{ children?: React.ReactNode }> = ({ children }) => {
+export const DialogWrapper: React.FC<PropsWithChildren> = (props) => {
   const [active, setActive] = useState(false)
 
   return (
     <DialogContext.Provider
+      {...props}
       value={{
         onClickTrigger: () => setActive(true),
         onClickClose: () => setActive(false),
         active,
       }}
-    >
-      {children}
-    </DialogContext.Provider>
+    />
   )
 }

--- a/src/components/Dialog/FocusTrap.tsx
+++ b/src/components/Dialog/FocusTrap.tsx
@@ -1,13 +1,12 @@
-import React, { ReactNode, RefObject, VFC, useCallback, useEffect, useRef } from 'react'
+import React, { FC, PropsWithChildren, RefObject, useCallback, useEffect, useRef } from 'react'
 
 import { tabbable } from '../../libs/tabbable'
 
-type Props = {
+type Props = PropsWithChildren<{
   firstFocusTarget?: RefObject<HTMLElement>
-  children: ReactNode
-}
+}>
 
-export const FocusTrap: VFC<Props> = ({ firstFocusTarget, children }) => {
+export const FocusTrap: FC<Props> = ({ firstFocusTarget, children }) => {
   const ref = useRef<HTMLDivElement | null>(null)
   const dummyFocusRef = useRef<HTMLDivElement>(null)
 

--- a/src/components/Dialog/FormDialog/FormDialogContent.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContent.tsx
@@ -11,7 +11,7 @@ import { BaseProps, FormDialogContentInner } from './FormDialogContentInner'
 type Props = BaseProps & UncontrolledDialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const FormDialogContent: React.VFC<Props & ElementProps> = ({
+export const FormDialogContent: React.FC<Props & ElementProps> = ({
   children,
   title,
   actionText,
@@ -45,7 +45,6 @@ export const FormDialogContent: React.VFC<Props & ElementProps> = ({
   return createPortal(
     <DialogContentInner
       {...props}
-      onClickOverlay={onClickClose}
       onPressEscape={onClickClose}
       isOpen={active}
       ariaLabelledby={titleId}

--- a/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useCallback } from 'react'
+import React, { FC, PropsWithChildren, ReactNode, useCallback } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
@@ -13,11 +13,7 @@ import { useClassNames } from '../useClassNames'
 
 import type { DecoratorsType, ResponseMessageType } from '../../../types'
 
-export type BaseProps = {
-  /**
-   * ダイアログの内容
-   */
-  children: ReactNode
+export type BaseProps = PropsWithChildren<{
   /**
    * ダイアログのタイトル
    */
@@ -57,7 +53,7 @@ export type BaseProps = {
   className?: string
   /** コンポーネント内の文言を変更するための関数を設定 */
   decorators?: DecoratorsType<'closeButtonLabel'>
-}
+}>
 
 export type FormDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
@@ -84,10 +80,13 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
 }) => {
   const classNames = useClassNames().dialog
   const theme = useTheme()
-  const handleSubmitAction = useCallback((e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    onSubmit(onClickClose)
-  }, [onSubmit, onClickClose])
+  const handleSubmitAction = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      onSubmit(onClickClose)
+    },
+    [onSubmit, onClickClose],
+  )
   const { offsetHeight, titleRef, bottomRef } = useOffsetHeight()
 
   const isRequestProcessing = responseMessage && responseMessage.status === 'processing'

--- a/src/components/Dialog/MessageDialog/MessageDialogContent.tsx
+++ b/src/components/Dialog/MessageDialog/MessageDialogContent.tsx
@@ -11,7 +11,7 @@ import { BaseProps, MessageDialogContentInner } from './MessageDialogContentInne
 type Props = BaseProps & UncontrolledDialogProps
 type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
-export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
+export const MessageDialogContent: React.FC<Props & ElementProps> = ({
   title,
   description,
   portalParent,
@@ -33,7 +33,6 @@ export const MessageDialogContent: React.VFC<Props & ElementProps> = ({
   return createPortal(
     <DialogContentInner
       {...props}
-      onClickOverlay={onClickClose}
       onPressEscape={onClickClose}
       isOpen={active}
       className={className}

--- a/src/components/Dialog/MessageDialog/MessageDialogContentInner.tsx
+++ b/src/components/Dialog/MessageDialog/MessageDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from 'react'
+import React, { FC } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../../hooks/useTheme'
@@ -40,7 +40,7 @@ export type MessageDialogContentInnerProps = BaseProps & {
 
 const CLOSE_BUTTON_LABEL = '閉じる'
 
-export const MessageDialogContentInner: VFC<MessageDialogContentInnerProps> = ({
+export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
   title,
   subtitle,
   titleTag,
@@ -92,12 +92,12 @@ const TitleArea = styled(Stack).attrs(() => ({
 )
 const Description = styled.div<{ themes: Theme; offsetHeight: number }>`
   ${({ themes: { fontSize, spacingByChar }, offsetHeight }) => css`
-      max-height: calc(100vh - ${offsetHeight}px);
-      overflow: auto;
-      padding: 0 ${spacingByChar(1.5)};
-      font-size: ${fontSize.M};
-      line-height: 1.5;
-    `}
+    max-height: calc(100vh - ${offsetHeight}px);
+    overflow: auto;
+    padding: 0 ${spacingByChar(1.5)};
+    font-size: ${fontSize.M};
+    line-height: 1.5;
+  `}
 `
 const Bottom = styled.div<{ themes: Theme }>`
   ${({ themes }) => {

--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -2,6 +2,7 @@ import React, {
   ComponentProps,
   FC,
   MouseEvent,
+  PropsWithChildren,
   ReactNode,
   RefObject,
   useCallback,
@@ -26,15 +27,11 @@ import { useDialogPortal } from './useDialogPortal'
 
 import type { DecoratorsType } from '../../types'
 
-type Props = {
+type Props = PropsWithChildren<{
   /**
    * ダイアログのヘッダ部分の内容
    */
   header: ReactNode
-  /**
-   * ダイアログのコンテンツ部分の内容
-   */
-  children: ReactNode
   /**
    * ダイアログのフッタ部分の内容
    */
@@ -84,7 +81,7 @@ type Props = {
     dialogHandlerAriaLabel?: (txt: string) => string
     dialogHandlerAriaValuetext?: (txt: string, data: DOMRect | undefined) => string
   }
-}
+}>
 
 const DIALOG_HANDLER_ARIA_LABEL = 'ダイアログの位置'
 const CLOSE_BUTTON_ICON_ALT = '閉じる'
@@ -254,9 +251,9 @@ export const ModelessDialog: FC<Props & BaseElementProps> = ({
         onStart={(_, data) => setPosition({ x: data.x, y: data.y })}
         onDrag={(_, data) => {
           setPosition((prev) => ({
-              x: prev.x + data.deltaX,
-              y: prev.y + data.deltaY,
-            }))
+            x: prev.x + data.deltaX,
+            y: prev.y + data.deltaY,
+          }))
         }}
         position={position}
         bounds={draggableBounds}
@@ -347,8 +344,10 @@ const Box = styled(Base).attrs({ radius: 'm', layer: 3 })<{
         css`
           max-width: min(
             calc(
-              100vw - max(${leftMargin}, ${spacingByChar(0.5)}) -
-                max(${rightMargin}, ${spacingByChar(0.5)})
+              100vw - max(${leftMargin}, ${spacingByChar(0.5)}) - max(
+                  ${rightMargin},
+                  ${spacingByChar(0.5)}
+                )
             ),
             800px
           );


### PR DESCRIPTION
## Overview

Dialog の背景を押した時の挙動がまちまちだったため揃えました。
Dialog の背景は予期せずクリックした場合に閉じてしまうのを避けるため、デフォルトで閉じないようにしました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- VFC を FC に置き換え
- `onClickOverlay` の初期値に `onClickClose` を渡している箇所を消去
- children を独自定義しているところを `PropsWithChildren` で置き換え

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
