### PR TITLE
chore: ComboboxのVRT用Storyを追加

### DIFF
--- a/src/components/ComboBox/VRTComboBox.stories.tsx
+++ b/src/components/ComboBox/VRTComboBox.stories.tsx
@@ -1,0 +1,98 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Multi, Single } from './ComboBox.stories'
+
+import { MultiComboBox, SingleComboBox } from '.'
+
+export default {
+  title: 'Forms（フォーム）/ComboBox',
+  component: SingleComboBox,
+  subcomponents: { MultiComboBox },
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTSingle: StoryFn = () => (
+  <WrapperList>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Singleコンボボックスのリストを展開して1つ目の項目をホバーした状態で表示されます
+    </VRTInformationPanel>
+    <Single />
+  </WrapperList>
+)
+const playSingle = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const textboxes = await canvas.findAllByRole('textbox')
+  await textboxes[0].focus()
+  const body = canvasElement.ownerDocument.body
+  const option = await within(body).findByText('option 1')
+  await userEvent.hover(option)
+}
+VRTSingle.play = playSingle
+
+export const VRTMulti: StoryFn = () => (
+  <WrapperList>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Multiコンボボックスのリストを展開して1つ目と2つ目の項目を選択した状態で表示されます
+    </VRTInformationPanel>
+    <Multi />
+  </WrapperList>
+)
+const playMulti = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const comboboxes = await canvas.findAllByRole('combobox')
+  comboboxes[0].focus()
+  const body = canvasElement.ownerDocument.body
+  const option1 = await within(body).findByText('option 1')
+  await userEvent.click(option1)
+  const option2 = await within(body).findByText('option 2')
+  await userEvent.click(option2)
+}
+VRTMulti.play = playMulti
+
+export const VRTSingleForcedColors: StoryFn = () => (
+  <WrapperList>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます{' '}
+    </VRTInformationPanel>
+    <Single />
+  </WrapperList>
+)
+VRTSingleForcedColors.play = playSingle
+VRTSingleForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+export const VRTMultiForcedColors: StoryFn = () => (
+  <WrapperList>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます{' '}
+    </VRTInformationPanel>
+    <Multi />
+  </WrapperList>
+)
+VRTMultiForcedColors.play = playMulti
+VRTMultiForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const WrapperList = styled.ul`
+  padding: 0 24px;
+  list-style: none;
+  & > li {
+    padding: 16px;
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+  }
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

ComboboxコンポーネントにVRT用のStoryを追加しました。

## What I did

### Tooltipコンポーネントに2つのVRT用Storyを追加
- VRT Single
  - Singleコンボボックスのリストを展開し、１つ目の項目をホバーした状態
- VRT Multi
  - Multiコンボボックスのリストを展開した後に、１つ目と2つ目の項目を選択した状態
- VRT Single Forced Colors
  - VRT Singleに、forcedColors: 'active' を適用した状態
- VRT Multi Forced Colors
  - VRT MultiにforcedColors: 'active' を適用した状態

完全に網羅しようとするとあまりにも冗長になると判断し、リストを展開していくつかの操作をした状態をVRT用テストとして追加しました。他に必要なテストがありそうでしたらご指摘ください。

## Capture
### VRT Single
<img width="715" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/7f48f950-2d8c-4fdb-9a5b-8d775fa3002d">

### VRT Multi
<img width="715" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/75dd8793-8ea5-4eda-965c-cc92bf083234">


### VRT Single Forced Colors
<img width="596" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/719fee20-1e93-48ac-b6ca-ae3557592a02">

### VRT Multi Forced Colors
<img width="596" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/358c6145-cfa7-4226-a718-17c3d3a5a9e1">