### PR TITLE
chore: InputのVRT用Storyを追加

### DIFF
--- a/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
+++ b/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
@@ -43,6 +43,19 @@ const playHover = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
 }
 VRTHoverSearchInput.play = playHover
 
+export const VRTFocusSearchInput: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      focusしてツールチップを表示した状態で表示されます
+    </VRTInformationPanel>
+    <SearchInputStory />
+  </>
+)
+VRTFocusSearchInput.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  await canvas.getAllByRole('textbox')[0].focus()
+}
+
 export const VRTHoverSearchInputForcedColors: StoryFn = () => (
   <>
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>

--- a/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
+++ b/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
@@ -1,0 +1,66 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+
+import { InformationPanel } from '../../InformationPanel'
+import { Stack } from '../../Layout'
+
+import { SearchInput } from './SearchInput'
+
+export default {
+  title: 'Forms（フォーム）/Input',
+  component: SearchInput,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+const SearchInputStory: StoryFn = () => (
+  <Container>
+    <div>
+      <p>主に入力欄に対する説明をレイアウト上配置できない場合の利用を想定しています。</p>
+      <SearchInput
+        name="default"
+        tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+      />
+    </div>
+  </Container>
+)
+
+export const VRTHoverSearchInput: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hoverしてツールチップを表示した状態で表示されます
+    </VRTInformationPanel>
+    <SearchInputStory />
+  </>
+)
+const playHover = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const input = canvas.getAllByRole('textbox')
+  await userEvent.hover(input[0])
+}
+VRTHoverSearchInput.play = playHover
+
+export const VRTHoverSearchInputForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <SearchInputStory />
+  </>
+)
+VRTHoverSearchInputForcedColors.play = playHover
+VRTHoverSearchInputForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Container = styled(Stack)`
+  ${({ theme: { space } }) => css`
+    padding: ${space(2)};
+  `}
+`
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`

--- a/src/components/Input/VRTInput.stories.tsx
+++ b/src/components/Input/VRTInput.stories.tsx
@@ -15,6 +15,21 @@ export default {
   },
 }
 
+export const VRTFocus: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      focus した状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocus.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    focusWithin: ['span:has(> input)'],
+  },
+}
+
 export const VRTForcedColors: StoryFn = () => (
   <>
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>

--- a/src/components/Input/VRTInput.stories.tsx
+++ b/src/components/Input/VRTInput.stories.tsx
@@ -1,0 +1,32 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Input } from './Input'
+import { All } from './Input.stories'
+
+export default {
+  title: 'Forms（フォーム）/Input',
+  component: Input,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

InputコンポーネントにVRT用のStoryを追加しました。

## What I did

- Forced Colors
  - InputのAllに対してforcedColors: 'active' を適用した状態
- Hover Search Input
  - Search Input をホバーしてツールチップを表示した状態
- Hover Search Input Forced Colors
  - Hover Search Inputに対してforcedColors: 'active' を適用した状態

他に必要そうなストーリーがあればご指摘ください。

## Capture

### Focus
<img width="668" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/2d1452b1-fee1-4d8c-9771-0ebaef84db0e">

### Forced Colors
<img width="480" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/5892afd4-8fd3-4005-9523-37b39d59f737">

### Hover Search Input
<img width="754" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/48d1ff5c-e628-4dc0-a5e8-d0f078c6a708">

### Focus Search Input
<img width="668" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/053d2df7-61e5-4727-b3d9-0050fbe45a11">

### Hover Search Input Forced Colors
<img width="1220" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/4e0d19dd-d945-4df2-adbd-bbc67433fdf8">
