### PR TITLE
fix: 強制カラーモード時に Icon の色が強制されない欠陥を修正

### DIFF
--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -71,12 +71,15 @@ const button = tv({
       'disabled:shr-cursor-not-allowed',
       /* alpha color を使用しているので、背景色と干渉させない */
       'disabled:shr-bg-clip-padding',
+      '[&_.smarthr-ui-Icon]:forced-colors:disabled:shr-fill-[GrayText]',
     ],
     anchor: [
       'shr-no-underline',
       '[&:not([href])]:shr-cursor-not-allowed',
       /* alpha color を使用しているので、背景色と干渉させない */
       '[&:not([href])]:shr-bg-clip-padding',
+      '[&_.smarthr-ui-Icon]:forced-colors:shr-fill-[LinkText]',
+      '[&:not([href])_.smarthr-ui-Icon]:forced-colors:shr-fill-[CanvasText]',
     ],
   },
   variants: {

--- a/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -2,14 +2,24 @@
 
 exports[`Icon should be match snapshot 1`] = `
 [
-  <span
+  @media (forced-colors:active) {
+
+}
+
+<span
     id="text"
   >
     連絡帳
   </span>,
-  <svg
+  @media (forced-colors:active) {
+  .c0 {
+    fill: CanvasText;
+  }
+}
+
+<svg
     aria-hidden={true}
-    className=" smarthr-ui-Icon"
+    className="c0  smarthr-ui-Icon"
     fill="currentColor"
     focusable={false}
     height="1em"
@@ -45,14 +55,24 @@ exports[`Icon should be match snapshot 1`] = `
   overflow: hidden;
 }
 
+@media (forced-colors:active) {
+
+}
+
 <span
     className="c0"
   >
     連絡帳
   </span>,
-  <svg
+  @media (forced-colors:active) {
+  .c0 {
+    fill: CanvasText;
+  }
+}
+
+<svg
     aria-hidden={true}
-    className=" smarthr-ui-Icon"
+    className="c0  smarthr-ui-Icon"
     fill="currentColor"
     focusable={false}
     height="1em"
@@ -72,9 +92,15 @@ exports[`Icon should be match snapshot 1`] = `
       d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-228-32c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H118.4C106 384 96 375.4 96 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2z"
     />
   </svg>,
-  <svg
+  @media (forced-colors:active) {
+  .c0 {
+    fill: CanvasText;
+  }
+}
+
+<svg
     aria-label="連絡帳"
-    className=" smarthr-ui-Icon"
+    className="c0  smarthr-ui-Icon"
     fill="currentColor"
     focusable={false}
     height="1em"
@@ -94,9 +120,15 @@ exports[`Icon should be match snapshot 1`] = `
       d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-228-32c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H118.4C106 384 96 375.4 96 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2z"
     />
   </svg>,
-  <svg
+  @media (forced-colors:active) {
+  .c0 {
+    fill: CanvasText;
+  }
+}
+
+<svg
     aria-labelledby="text"
-    className=" smarthr-ui-Icon"
+    className="c0  smarthr-ui-Icon"
     fill="currentColor"
     focusable={false}
     height="1em"

--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -96,8 +96,9 @@ export const createIcon = (SvgIcon: IconType) => {
     const existsText = !!text
     const iconSize = size ? theme.fontSize[size] : '1em' // 指定がない場合は親要素のフォントサイズを継承する
     const svgIcon = (
-      <SvgIcon
+      <WrapIcon
         {...props}
+        as={SvgIcon}
         stroke="currentColor"
         fill="currentColor"
         strokeWidth="0"
@@ -136,6 +137,12 @@ export const createIcon = (SvgIcon: IconType) => {
 
   return Icon
 }
+
+const WrapIcon = styled.svg`
+  @media (forced-colors: active) {
+    fill: CanvasText;
+  }
+`
 
 const IconAndTextWrapper = styled.span<{
   right: ComponentProps['right']

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -129,6 +129,32 @@ const Wrapper = styled.th<{ themes: Theme; fixed: boolean }>`
         }
       }
     `}
+
+    @media (forced-colors: active) {
+      &[aria-sort='none'] {
+        .smarthr-ui-Icon {
+          fill: GrayText;
+        }
+      }
+
+      &[aria-sort='ascending'] {
+        .smarthr-ui-Icon:first-child {
+          fill: CanvasText;
+        }
+        .smarthr-ui-Icon:last-child {
+          fill: GrayText;
+        }
+      }
+
+      &[aria-sort='descending'] {
+        .smarthr-ui-Icon:first-child {
+          fill: GrayText;
+        }
+        .smarthr-ui-Icon:last-child {
+          fill: CanvasText;
+        }
+      }
+    }
   `}
 `
 

--- a/src/components/Table/Th.tsx
+++ b/src/components/Table/Th.tsx
@@ -138,20 +138,24 @@ const Wrapper = styled.th<{ themes: Theme; fixed: boolean }>`
       }
 
       &[aria-sort='ascending'] {
-        .smarthr-ui-Icon:first-child {
-          fill: CanvasText;
-        }
-        .smarthr-ui-Icon:last-child {
-          fill: GrayText;
+        .smarthr-ui-Icon {
+          &:first-child {
+            fill: CanvasText;
+          }
+          &:last-child {
+            fill: GrayText;
+          }
         }
       }
 
       &[aria-sort='descending'] {
-        .smarthr-ui-Icon:first-child {
-          fill: GrayText;
-        }
-        .smarthr-ui-Icon:last-child {
-          fill: CanvasText;
+        .smarthr-ui-Icon {
+          &:first-child {
+            fill: GrayText;
+          }
+          &:last-child {
+            fill: CanvasText;
+          }
         }
       }
     }

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -160,7 +160,7 @@ export default {
     textDecorationColor: false,
   },
   plugins: [
-    plugin(({ addUtilities, addComponents, theme }) => {
+    plugin(({ addUtilities, addComponents, addVariant, theme }) => {
       addUtilities({
         '.overflow-inherit': { overflow: 'inherit' },
         '.overflow-initial': { overflow: 'initial' },
@@ -186,6 +186,7 @@ export default {
           boxShadow: `0 0 0 2px ${theme('colors.white')}, 0 0 0 4px ${theme('colors.outline')}`,
         },
       })
+      addVariant('forced-colors', '@media (forced-colors: active)')
     }),
   ],
   prefix: 'shr-',


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

強制カラーモード時にシステム色を使うように修正しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

normal | forced color mode (light) | forced color mode (dark)
--- | --- | ---
<img width="123" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/82a9a2b9-c054-4d97-a481-b9045f87f946"> | <img width="123" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/baf11385-fd2c-4881-921d-e07b0dc0d74e"> | <img width="123" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/e5d82c24-32e4-4e07-8735-e4da7e2362e5">