### PR TITLE
chore: RadioButtonのVRT用Storyを追加

### DIFF
--- a/src/components/RadioButton/VRTRadioButton.stories.tsx
+++ b/src/components/RadioButton/VRTRadioButton.stories.tsx
@@ -1,0 +1,161 @@
+import { StoryFn } from '@storybook/react'
+import React, { ChangeEvent, useState } from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { All } from './RadioButton.stories'
+
+import { RadioButton } from '.'
+
+export default {
+  title: 'Forms（フォーム）/RadioButton',
+  component: RadioButton,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTState: StoryFn = () => {
+  const [checkedName, setCheckedName] = useState<string | null>(null)
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => setCheckedName(e.currentTarget.name)
+
+  return (
+    <WrapperList>
+      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+        hover, activeなどの状態で表示されます
+      </VRTInformationPanel>
+      <li>
+        <Title>hover</Title>
+        <InnerList id="list-hover">
+          <li>
+            <RadioButton name="1" checked={checkedName === '1'} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="2" checked={true} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="3" checked={checkedName === '3'} disabled onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="4" checked={true} disabled onChange={handleChange} />
+          </li>
+        </InnerList>
+      </li>
+
+      <li>
+        <Title>focus</Title>
+        <InnerList id="list-focus">
+          <li>
+            <RadioButton name="5" checked={checkedName === '5'} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="6" checked={true} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="7" checked={checkedName === '7'} disabled onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="8" checked={true} disabled onChange={handleChange} />
+          </li>
+        </InnerList>
+      </li>
+
+      <li>
+        <Title>focus-visible</Title>
+        <InnerList id="list-focus-visible">
+          <li>
+            <RadioButton name="9" checked={checkedName === '9'} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="10" checked={true} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton
+              name="11"
+              checked={checkedName === '11'}
+              disabled
+              onChange={handleChange}
+            />
+          </li>
+          <li>
+            <RadioButton name="12" checked={true} disabled onChange={handleChange} />
+          </li>
+        </InnerList>
+      </li>
+
+      <li>
+        <Title>active</Title>
+        <InnerList id="list-active">
+          <li>
+            <RadioButton name="13" checked={checkedName === '13'} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton name="14" checked={true} onChange={handleChange} />
+          </li>
+          <li>
+            <RadioButton
+              name="15"
+              checked={checkedName === '15'}
+              disabled
+              onChange={handleChange}
+            />
+          </li>
+          <li>
+            <RadioButton name="16" checked={true} disabled onChange={handleChange} />
+          </li>
+        </InnerList>
+      </li>
+    </WrapperList>
+  )
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+
+VRTState.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['#list-hover input'],
+    focus: ['#list-focus input'],
+    focusVisible: ['#list-focus-visible input'],
+    active: ['#list-active input'],
+  },
+}
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const WrapperList = styled.ul`
+  padding: 0 24px;
+  list-style: none;
+  & > li {
+    padding: 16px;
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+  }
+`
+const InnerList = styled.ul`
+  padding: 0;
+  list-style: none;
+  & > li {
+    display: inline-block;
+    &:not(:first-child) {
+      margin-left: 16px;
+    }
+  }
+`
+const Title = styled.p`
+  margin: 0 0 16px;
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

RadioButtonコンポーネントにVRT用のStoryを追加しました。

## What I did

### 2つのVRT用Storyを追加
- VRT State
  - hoverやfocusなどを適用した状態
  - チェックされたラジオボタンも含む
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態

VRT用で他に必要そうなストーリーは思いつきませんでした。
必要そうなストーリーがあればご指摘ください。

## Capture

### VRT State

<img width="449" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/dbb59a0e-eb67-4793-9953-5c8f5a8a9013">

### VRT Forced Colors

<img width="609" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/1937e964-ab6c-443b-81ab-b7b001e30beb">
