### PR TITLE
fix: 画面幅が狭い時の NotificationBar の見た目を調整

### DIFF
--- a/src/components/NotificationBar/NotificationBar.stories.tsx
+++ b/src/components/NotificationBar/NotificationBar.stories.tsx
@@ -5,7 +5,6 @@ import styled, { css } from 'styled-components'
 import { Button } from '../Button'
 import { CheckBox } from '../CheckBox'
 import { Cluster, Stack } from '../Layout'
-import { LineClamp } from '../LineClamp'
 import { RadioButton } from '../RadioButton'
 import { Text } from '../Text'
 import { TextLink as shrTextLink } from '../TextLink'
@@ -112,16 +111,6 @@ export const All: StoryFn = () => {
             <Actions />
           </NotificationBar>
           <NotificationBar type="warning" message="onClose を省略すると、閉じるボタンが消えます" />
-          <NotificationBar
-            type="success"
-            message={
-              <LineClamp maxLines={1} withTooltip>
-                非推奨ですが、LineClamp
-                を使用して省略もできます。そのでっかい領域によるヘッダー（のナビゲーション）へのアクセス性の低下をフォローするために多くのウェブサイトはヘッダーを固定しちゃうわけなんだけど、それでは同時にコンテンツの閲覧性に影響を与えてしまう。
-              </LineClamp>
-            }
-            onClose={onClose}
-          />
         </Stack>
       </Stack>
     </Wrapper>

--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -13,7 +13,6 @@ import {
   WarningIcon,
 } from '../Icon'
 import { Cluster } from '../Layout'
-import { Text } from '../Text'
 
 import { useClassNames } from './useClassNames'
 
@@ -132,36 +131,35 @@ export const NotificationBar: React.FC<Props & ElementProps & BaseProps> = ({
         colorSet={colorSet}
         onBase={base === 'base'}
       >
-        <MessageArea themes={theme} className={classNames.messageArea}>
-          <IconLayout>
-            <Icon color={iconColor} />
-          </IconLayout>
-          <StyledText leading="TIGHT">{message}</StyledText>
-        </MessageArea>
-        <ActionArea themes={theme} className={classNames.actionArea}>
+        <Inner>
+          <MessageArea themes={theme} className={classNames.messageArea}>
+            <Icon text={message} color={iconColor} iconGap={0.5} />
+          </MessageArea>
           {children && (
-            <ActionWrapper
-              themes={theme}
-              className={classNames.actions}
-              align="center"
-              justify="flex-end"
-            >
-              {children}
-            </ActionWrapper>
+            <ActionArea themes={theme} className={classNames.actionArea}>
+              <ActionWrapper
+                themes={theme}
+                className={classNames.actions}
+                align="center"
+                justify="flex-end"
+              >
+                {children}
+              </ActionWrapper>
+            </ActionArea>
           )}
-          {onClose && (
-            <CloseButton
-              variant="text"
-              colorSet={colorSet}
-              themes={theme}
-              onClick={onClose}
-              className={classNames.closeButton}
-              size="s"
-            >
-              <FaTimesIcon alt="閉じる" />
-            </CloseButton>
-          )}
-        </ActionArea>
+        </Inner>
+        {onClose && (
+          <CloseButton
+            variant="text"
+            colorSet={colorSet}
+            themes={theme}
+            onClick={onClose}
+            className={classNames.closeButton}
+            size="s"
+          >
+            <FaTimesIcon alt="閉じる" />
+          </CloseButton>
+        )}
       </Wrapper>
     </WrapBase>
   )
@@ -182,8 +180,9 @@ const Wrapper = styled.div<{
     animate,
   }) => css`
     display: flex;
-    gap: ${space(1)};
-    align-items: center;
+    gap: ${space(0.5)};
+    align-items: baseline;
+    justify-content: space-between;
     background-color: ${bgColor};
     padding: ${space(0.75)};
     ${onBase &&
@@ -200,6 +199,13 @@ const Wrapper = styled.div<{
     `}
   `,
 )
+const Inner = styled(Cluster).attrs({
+  gap: 1,
+  align: 'center',
+  justify: 'flex-end',
+})`
+  flex-grow: 1;
+`
 const slideIn = (translateLength: string) => keyframes`
   from {
     opacity: 0;
@@ -213,24 +219,17 @@ const slideIn = (translateLength: string) => keyframes`
 const MessageArea = styled.div<{
   themes: Theme
 }>(
-  ({ themes: { spacingByChar } }) => css`
+  ({ themes: { leading, spacingByChar } }) => css`
     display: flex;
     gap: ${spacingByChar(0.5)};
     align-items: center;
     flex-grow: 1;
 
-    /* flexbox で ellipsis するために min-width をつけて幅の計算を発生させている */
-    min-width: 0;
+    .smarthr-ui-Icon-withText {
+      line-height: ${leading.TIGHT};
+    }
   `,
 )
-const IconLayout = styled.div`
-  /* 子のアイコンの line-height を打ち消すために指定 */
-  display: flex;
-`
-const StyledText = styled(Text)`
-  /* flexbox で ellipsis するために min-width をつけて幅の計算を発生させている */
-  min-width: 0;
-`
 const ActionArea = styled.div<{
   themes: Theme
 }>(
@@ -245,8 +244,7 @@ const ActionWrapper = styled(Cluster)<{
   themes: Theme
 }>(
   ({ themes: { spacingByChar } }) => css`
-    margin-top: ${spacingByChar(-0.5)};
-    margin-bottom: ${spacingByChar(-0.5)};
+    margin-block: ${spacingByChar(-0.5)};
   `,
 )
 const CloseButton = styled(Button)<{


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

どこかのタイミングでデグレっていた。

- テキストに折り返しが発生した時、アイコンや閉じるボタンは baseline で揃える
- 操作群が横1列に収まらない時、テキストの右下にボタンは収まる

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->


before | after
--- | ---
<img width="376" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/76af46b1-5789-4499-8e4f-fa523834e6d9"> | <img width="375" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/b452e8f0-5728-4295-bead-a8c86a738606">
<img width="377" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/1f9e215d-8ff5-43c2-87b9-447148de1d1a"> | <img width="377" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/77321900-3071-4c36-adad-b75407c185f7">