### PR TITLE
chore: SelectのVRT用Storyを追加

### DIFF
--- a/src/components/Select/VRTSelect.stories.tsx
+++ b/src/components/Select/VRTSelect.stories.tsx
@@ -25,106 +25,108 @@ const options = [
 ]
 
 export const VRTState: StoryFn = () => (
-  <WrapperList>
+  <>
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
-    <li>
-      <Title>hover</Title>
-      <InnerList id="list-hover">
-        <li>
-          <Text>
-            <span>標準</span>
-            <Select name="default" options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>エラー状態</span>
-            <Select name="error" error options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>disabled 状態</span>
-            <Select name="disabled" disabled options={options} />
-          </Text>
-        </li>
-      </InnerList>
-    </li>
+    <WrapperList>
+      <li>
+        <Title>hover</Title>
+        <InnerList id="list-hover">
+          <li>
+            <Text>
+              <span>標準</span>
+              <Select name="default" options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>エラー状態</span>
+              <Select name="error" error options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>disabled 状態</span>
+              <Select name="disabled" disabled options={options} />
+            </Text>
+          </li>
+        </InnerList>
+      </li>
 
-    <li>
-      <Title>focus</Title>
-      <InnerList id="list-focus">
-        <li>
-          <Text>
-            <span>標準</span>
-            <Select name="default" options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>エラー状態</span>
-            <Select name="error" error options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>disabled 状態</span>
-            <Select name="disabled" disabled options={options} />
-          </Text>
-        </li>
-      </InnerList>
-    </li>
+      <li>
+        <Title>focus</Title>
+        <InnerList id="list-focus">
+          <li>
+            <Text>
+              <span>標準</span>
+              <Select name="default" options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>エラー状態</span>
+              <Select name="error" error options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>disabled 状態</span>
+              <Select name="disabled" disabled options={options} />
+            </Text>
+          </li>
+        </InnerList>
+      </li>
 
-    <li>
-      <Title>focus-visible</Title>
-      <InnerList id="list-focus-visible">
-        <li>
-          <Text>
-            <span>標準</span>
-            <Select name="default" options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>エラー状態</span>
-            <Select name="error" error options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>disabled 状態</span>
-            <Select name="disabled" disabled options={options} />
-          </Text>
-        </li>
-      </InnerList>
-    </li>
+      <li>
+        <Title>focus-visible</Title>
+        <InnerList id="list-focus-visible">
+          <li>
+            <Text>
+              <span>標準</span>
+              <Select name="default" options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>エラー状態</span>
+              <Select name="error" error options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>disabled 状態</span>
+              <Select name="disabled" disabled options={options} />
+            </Text>
+          </li>
+        </InnerList>
+      </li>
 
-    <li>
-      <Title>active</Title>
-      <InnerList id="list-active">
-        <li>
-          <Text>
-            <span>標準</span>
-            <Select name="default" options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>エラー状態</span>
-            <Select name="error" error options={options} />
-          </Text>
-        </li>
-        <li>
-          <Text>
-            <span>disabled 状態</span>
-            <Select name="disabled" disabled options={options} />
-          </Text>
-        </li>
-      </InnerList>
-    </li>
-  </WrapperList>
+      <li>
+        <Title>active</Title>
+        <InnerList id="list-active">
+          <li>
+            <Text>
+              <span>標準</span>
+              <Select name="default" options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>エラー状態</span>
+              <Select name="error" error options={options} />
+            </Text>
+          </li>
+          <li>
+            <Text>
+              <span>disabled 状態</span>
+              <Select name="disabled" disabled options={options} />
+            </Text>
+          </li>
+        </InnerList>
+      </li>
+    </WrapperList>
+  </>
 )
 
 export const VRTForcedColors: StoryFn = () => (

--- a/src/components/Select/VRTSelect.stories.tsx
+++ b/src/components/Select/VRTSelect.stories.tsx
@@ -1,0 +1,178 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+import { Stack } from '../Layout'
+
+import { All } from './Select.stories'
+
+import { Select } from '.'
+
+export default {
+  title: 'Forms（フォーム）/Select',
+  component: Select,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+const options = [
+  { label: '高齢任意加入被保険者', value: 'apple' },
+  { label: 'Orange', value: 'orange' },
+  { label: '評価業務担当者', value: 'banana' },
+  { label: '書類に記載する従業員・扶養家族', value: 'melon', disabled: true },
+]
+
+export const VRTState: StoryFn = () => (
+  <WrapperList>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hover, activeなどの状態で表示されます
+    </VRTInformationPanel>
+    <li>
+      <Title>hover</Title>
+      <InnerList id="list-hover">
+        <li>
+          <Text>
+            <span>標準</span>
+            <Select name="default" options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>エラー状態</span>
+            <Select name="error" error options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>disabled 状態</span>
+            <Select name="disabled" disabled options={options} />
+          </Text>
+        </li>
+      </InnerList>
+    </li>
+
+    <li>
+      <Title>focus</Title>
+      <InnerList id="list-focus">
+        <li>
+          <Text>
+            <span>標準</span>
+            <Select name="default" options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>エラー状態</span>
+            <Select name="error" error options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>disabled 状態</span>
+            <Select name="disabled" disabled options={options} />
+          </Text>
+        </li>
+      </InnerList>
+    </li>
+
+    <li>
+      <Title>focus-visible</Title>
+      <InnerList id="list-focus-visible">
+        <li>
+          <Text>
+            <span>標準</span>
+            <Select name="default" options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>エラー状態</span>
+            <Select name="error" error options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>disabled 状態</span>
+            <Select name="disabled" disabled options={options} />
+          </Text>
+        </li>
+      </InnerList>
+    </li>
+
+    <li>
+      <Title>active</Title>
+      <InnerList id="list-active">
+        <li>
+          <Text>
+            <span>標準</span>
+            <Select name="default" options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>エラー状態</span>
+            <Select name="error" error options={options} />
+          </Text>
+        </li>
+        <li>
+          <Text>
+            <span>disabled 状態</span>
+            <Select name="disabled" disabled options={options} />
+          </Text>
+        </li>
+      </InnerList>
+    </li>
+  </WrapperList>
+)
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+
+VRTState.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['#list-hover select'],
+    focus: ['#list-focus select'],
+    focusVisible: ['#list-focus-visible select'],
+    active: ['#list-active select'],
+  },
+}
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const WrapperList = styled.ul`
+  padding: 0 24px;
+  list-style: none;
+  & > li {
+    padding: 16px;
+    &:not(:first-child) {
+      margin-top: 8px;
+    }
+  }
+`
+const InnerList = styled.ul`
+  padding: 0;
+  list-style: none;
+  & > li {
+    display: inline-block;
+    &:not(:first-child) {
+      margin-left: 16px;
+    }
+  }
+`
+const Title = styled.p`
+  margin: 0 0 16px;
+`
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`
+const Text = styled(Stack).attrs({ as: 'label', gap: 0.5 })``


### PR DESCRIPTION
## Overview

RadioButtonコンポーネントにVRT用のStoryを追加しました。

## What I did

### 2つのVRT用Storyを追加
- VRT State
  - hoverやfocusなどを適用した状態
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態

このSelectコンポーネントをクリックしたい際に表示されるリストはブラウザデフォルトのものであるため、そのリストのVRTテストは不要と判断しました。VRT用で他に必要そうなストーリーは思いつきませんでした。
必要そうなストーリーがあればご指摘ください。

## Capture

### VRT State

<img width="966" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/0f6fc6ff-3480-4519-a4e6-508fc520ee87">

### VRT Forced Colors

<img width="1170" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/0d792fe8-3b19-451b-b73f-e8e35160bf2a">
