### PR TITLE
chore: TextareaのVRT用Storyを追加

### DIFF
--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -67,6 +67,17 @@ const Template: Story = () => {
       </li>
       <li>
         <Label>
+          最大文字数 (value)
+          <Textarea
+            name="max_length_with_value_over"
+            maxLength={4}
+            value={value}
+            onChange={onChangeValue}
+          />
+        </Label>
+      </li>
+      <li>
+        <Label>
           最大文字数 (decorators)
           <Textarea
             name="max_length_with_value_and_decorators"

--- a/src/components/Textarea/VRTTextarea.stories.tsx
+++ b/src/components/Textarea/VRTTextarea.stories.tsx
@@ -1,0 +1,47 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Textarea } from './Textarea'
+import { All } from './Textarea.stories'
+
+export default {
+  title: 'Forms（フォーム）/Textarea',
+  component: Textarea,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTFocus: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      focus した状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocus.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    focusVisible: ['textarea'],
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

TextareaコンポーネントにVRT用のStoryを追加しました。

## What I did

- State
  - focus した状態
- Forced Colors
  - InputのAllに対してforcedColors: 'active' を適用した状態

他に必要そうなストーリーがあればご指摘ください。

## Capture

### State

<img width="991" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/a22a8908-6c2c-4a3b-a6ae-e9275c2b3b53">

### Forced Colors

<img width="835" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/13e2a221-84bb-4d1a-8e8e-1feb85ac1671">
