### PR TITLE
chore: IconのVRT用Storyを追加

### DIFF
--- a/src/components/Icon/VRTIcon.stories.tsx
+++ b/src/components/Icon/VRTIcon.stories.tsx
@@ -1,0 +1,45 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import * as Icons from './Icon'
+import { All, Color } from './Icon.stories'
+
+const { FaAddressBookIcon } = Icons
+
+export default {
+  title: 'Media（メディア）/Icon',
+  component: FaAddressBookIcon,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <Title>Color</Title>
+    <VRTColorWrapper>
+      <Color />
+    </VRTColorWrapper>
+    <Title>All</Title>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`
+const Title = styled.p`
+  margin: 0 0 16px;
+`
+const VRTColorWrapper = styled.div`
+  padding: 0 16px 16px 0;
+`


### PR DESCRIPTION
## Overview

IconコンポーネントにVRT用のStoryを追加しました。

## What I did

- Forced Colors
  - ColorとAllのStoryに対してforcedColors: 'active' を適用した状態

もともと、Size、Text、WithTextなどのストーリーがあり十分そうに思えたので、ForcedColorsだけ追加しました。
forcedColors: 'active' を適用した状態でVRTしたほうが良さそうなものはColorとAllの2つで十分と判断しました。
他に必要そうなストーリーがあればご指摘ください。

## Capture

### Forced Colors

<img width="1069" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/5097df13-8e36-489c-8498-9812cc2652a2">
