### PR TITLE
fix: DatePicker の VRT 用 story の日付を固定

### DIFF
--- a/src/components/DatePicker/VRTDatePicker.stories.tsx
+++ b/src/components/DatePicker/VRTDatePicker.stories.tsx
@@ -20,7 +20,12 @@ const NormalDatePicker = ({ name }: { name: string }) => (
   <List>
     <dt>DatePicker</dt>
     <dd>
-      <DatePicker name={name} onChangeDate={action('change')} data-test="datepicker-1" />
+      <DatePicker
+        name={name}
+        value="2020/01/01"
+        onChangeDate={action('change')}
+        data-test="datepicker-1"
+      />
     </dd>
   </List>
 )
@@ -91,7 +96,11 @@ export const VRTBottomExpanded: StoryFn = () => (
     <List>
       <dt className="bottom">Place on the page bottom</dt>
       <dd>
-        <DatePicker name="place_on_the_page_bottom" onChangeDate={action('change')} />
+        <DatePicker
+          name="place_on_the_page_bottom"
+          value="2020/01/01"
+          onChangeDate={action('change')}
+        />
       </dd>
     </List>
   </WrapperList>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

日付が固定されていないと Chromatic 上で DatePicker の VRT 用 story に毎日差分が発生してしまうので、日付を固定しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
