### PR TITLE
chore: LayoutのVRT用Storyを追加

### DIFF
--- a/src/components/Layout/Center/VRTCenter.stories.tsx
+++ b/src/components/Layout/Center/VRTCenter.stories.tsx
@@ -1,0 +1,60 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Center } from '../../..'
+import { InformationPanel } from '../../InformationPanel'
+
+import { All } from './Center.stories'
+
+export default {
+  title: 'Layouts（レイアウト）/Center',
+  component: Center,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTCenterNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTCenterForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTCenterNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+VRTCenterForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`

--- a/src/components/Layout/Cluster/VRTCluster.stories.tsx
+++ b/src/components/Layout/Cluster/VRTCluster.stories.tsx
@@ -1,0 +1,60 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Cluster } from '../../..'
+import { InformationPanel } from '../../InformationPanel'
+
+import { All } from './Cluster.stories'
+
+export default {
+  title: 'Layouts（レイアウト）/Cluster',
+  component: Cluster,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTClusterNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTClusterForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTClusterNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+VRTClusterForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`

--- a/src/components/Layout/LineUp/VRTLineUp.stories.tsx
+++ b/src/components/Layout/LineUp/VRTLineUp.stories.tsx
@@ -1,0 +1,60 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { LineUp } from '../../..'
+import { InformationPanel } from '../../InformationPanel'
+
+import { All } from './LineUp.stories'
+
+export default {
+  title: 'Layouts（レイアウト）/LineUp（非推奨）',
+  component: LineUp,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTLineUpNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTLineUpForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTLineUpNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+VRTLineUpForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`

--- a/src/components/Layout/Reel/VRTReel.stories.tsx
+++ b/src/components/Layout/Reel/VRTReel.stories.tsx
@@ -1,0 +1,40 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Reel } from '../../..'
+import { InformationPanel } from '../../InformationPanel'
+
+import { All } from './Reel.stories'
+
+export default {
+  title: 'Layouts（レイアウト）/Reel',
+  component: Reel,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTReelForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTReelForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`

--- a/src/components/Layout/Sidebar/VRTSidebar.stories.tsx
+++ b/src/components/Layout/Sidebar/VRTSidebar.stories.tsx
@@ -1,0 +1,60 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Sidebar } from '../../..'
+import { InformationPanel } from '../../InformationPanel'
+
+import { All } from './Sidebar.stories'
+
+export default {
+  title: 'Layouts（レイアウト）/Sidebar',
+  component: Sidebar,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTSidebarNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTSidebarForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTSidebarNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+VRTSidebarForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`

--- a/src/components/Layout/Stack/VRTStack.stories.tsx
+++ b/src/components/Layout/Stack/VRTStack.stories.tsx
@@ -1,0 +1,60 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { Stack } from '../../..'
+import { InformationPanel } from '../../InformationPanel'
+
+import { All } from './Stack.stories'
+
+export default {
+  title: 'Layouts（レイアウト）/Stack',
+  component: Stack,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTStackNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTStackForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTStackNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+VRTStackForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview
Layout以下の各コンポーネントにVRT用のStoryを追加しました。

## What I did
Layout以下の各コンポーネントに2つのVRT用Storyを追加

- スマートフォン環境を想定した、ウィンドウ幅の狭い状態でパネルを開いた状態
- forcedColors: 'active' を適用した状態

ただし、Reelに関しては、元から幅の狭い状態のStoryが存在しているため、forcedColorsのみ追加しました。

## Capture

Chromaticでのキャプチャ

Center
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c1b
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c1c

Cluster
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c1e
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c1f

LineUp
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c21
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c22

Reel
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c24

Sidebar
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c26
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c27

Stack
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c29
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65530cf30b9752267eee2c2a