### PR TITLE
fix: 強制カラーモードの時、チェックマークが二重で表示されていたのでブラウザ標準UIのみを表示するようにした

### DIFF
--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -177,6 +177,11 @@ const IconWrap = styled.span<{ themes: Theme }>`
       & > svg {
         vertical-align: top;
       }
+
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      @media (forced-colors: active) {
+        display: none;
+      }
     `
   }}
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
強制カラーモードの時、チェックマークが二重で表示されていた

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
`forced-colors: active` メディアクエリを利用し、カラーがOSなどによって矯正されている場合は、smarthr-ui 側で表示しているチェックアイコンを非表示にした。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
Google Chromeの開発者ツールで、forced-colors: activeをEmulateしたときのキャプチャ

### Before
![image](https://github.com/kufu/smarthr-ui/assets/13652153/c47fceb5-0840-40f7-b5aa-9787cf0f08a3)

### After
![image](https://github.com/kufu/smarthr-ui/assets/13652153/0820b2af-e0a5-42a4-aea0-c0c38381d4c5)

<!--
Please attach a capture if it looks different.
-->
