### PR TITLE
chore: BadgeのVRT用Storyを追加

### DIFF
--- a/src/components/Badge/VRTBadge.stories.tsx
+++ b/src/components/Badge/VRTBadge.stories.tsx
@@ -1,0 +1,40 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Badge } from './Badge'
+import { All } from './Badge.stories'
+
+export default {
+  title: 'States（状態）/Badge',
+  component: Badge,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTBadgeForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTBadgeForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview
BadgeコンポーネントにVRT用のStoryを追加しました。

## What I did
画面幅は影響しないコンポーネントで、ボタンを押すなどの動作もないので、forcedColors: 'active' を適用したStoryのみ追加しています。

## Capture

Chromaticでのキャプチャ
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=65544fb0dabe0867f26b9233