### PR TITLE
chore: Heading、PageHeadingのVRT用Storyを追加

### DIFF
--- a/src/components/Heading/VRTHeading.stories.tsx
+++ b/src/components/Heading/VRTHeading.stories.tsx
@@ -1,0 +1,29 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Heading } from './Heading'
+import { All } from './Heading.stories'
+
+export default {
+  title: 'Text（テキスト）/Heading',
+  component: Heading,
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

HeadingコンポーネントにVRT用のStoryを追加しました。

## What I did

- Forced Colors
  - forcedColors: 'active' を適用した状態

単純に見出しだけなのでForced ColorsでさえもVRTが必要か悩ましかったので不要であればリジェクトでも構いません🙏
他に必要そうなストーリーがあればご指摘ください。

## Capture

### Forced Colors

<img width="526" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/d818e82e-9cd3-4ba7-9ba6-172e073c009d">
