### PR TITLE
chore: TextのVRT用Storyを追加

### DIFF
--- a/src/components/Text/VRTText.stories.tsx
+++ b/src/components/Text/VRTText.stories.tsx
@@ -1,0 +1,29 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Text } from './Text'
+import { Default } from './Text.stories'
+
+export default {
+  title: 'Text（テキスト）/Text',
+  component: Text,
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <Default />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

TextコンポーネントにVRT用のStoryを追加しました。

## What I did

- Forced Colors
  - forcedColors: 'active' を適用した状態

これもHeading同様に単純にテキストだけなのでForced ColorsでさえもVRTが必要か悩ましかったので、不要であればリジェクトでも構いません！🙏
他に必要そうなストーリーがあればご指摘ください。

## Capture

### Forced Colors

<img width="648" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/6446298f-d2f3-47b3-bf23-c6d9a517fa58">
