### PR TITLE
chore: TextLinkのVRT用Storyを追加

### DIFF
--- a/src/components/TextLink/VRTTextLink.stories.tsx
+++ b/src/components/TextLink/VRTTextLink.stories.tsx
@@ -1,0 +1,108 @@
+import { StoryFn } from '@storybook/react'
+import { within } from '@storybook/testing-library'
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+
+import { FaFlagIcon } from '../Icon'
+import { InformationPanel } from '../InformationPanel'
+
+import { TextLink } from './TextLink'
+import { All } from './TextLink.stories'
+
+export default {
+  title: 'Text（テキスト）/TextLink',
+  component: TextLink,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTState: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hover, activeなどの状態で表示されます
+    </VRTInformationPanel>
+    <Wrapper>
+      <li id="hover">
+        <p>hover</p>
+        <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">
+          健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+        </TextLink>
+      </li>
+      <li id="focus">
+        <p>focus</p>
+        <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">
+          健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+        </TextLink>
+      </li>
+      <li id="focus-visible">
+        <p>focusVisible</p>
+        <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">
+          健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+        </TextLink>
+      </li>
+      <li id="active">
+        <p>active</p>
+        <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">
+          健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+        </TextLink>
+      </li>
+    </Wrapper>
+  </>
+)
+VRTState.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['#hover a'],
+    focus: ['#focus a'],
+    focusVisible: ['#focus-visible a'],
+    active: ['#active a'],
+  },
+}
+
+export const VRTUserFocus: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      ユーザーのフォーカス操作をシミュレートした状態で表示されます
+    </VRTInformationPanel>
+    <Wrapper>
+      <li id="hover">
+        <p>hover</p>
+        <TextLink href="/?path=/story/textlink--all" prefix={<FaFlagIcon />} target="_blank">
+          健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+        </TextLink>
+      </li>
+    </Wrapper>
+  </>
+)
+VRTUserFocus.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const link = await canvas.findByRole('link')
+  link.focus()
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`
+const Wrapper = styled.ul(
+  ({ theme: { spacingByChar } }) => css`
+    list-style: none;
+    margin: ${spacingByChar(1.5)};
+
+    li + li {
+      margin-top: ${spacingByChar(1)};
+    }
+  `,
+)


### PR DESCRIPTION
## Overview

TextLinkコンポーネントにVRT用のStoryを追加しました。

## What I did
- State
  - hover、focus、focusVisible、activeで変化はないのですが、リンクであるため念のため追加しました
- UserFocus
  - 上記のfocus、focusVisibleでは専用の装飾がないと変化がないため、ユーザー操作によるフォー明かすをシミュレートしてブラウザデフォルトのフォーカスのスタイルを表示しています
- Forced Colors
  - forcedColors: 'active' を適用した状態

State、UserFocusのストーリーが必要か悩ましいところでした。不要ならお伝えください。
他に必要そうなストーリーがあればご指摘ください。

## Capture

### State

<img width="681" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/a3b27616-db97-4e01-99eb-387ee65b56b6">

### UserFocus

<img width="642" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/5686082c-0f4e-4a15-a086-41e96d51196b">

### Forced Colors

<img width="721" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/a8db4cf9-fa38-4051-ada6-680ba91e34bd">

