### PR TITLE
fix: Input等がStyled-Componentでラップされている際にFormControlを使用してもラベルのid等が紐づかない問題を修正

### DIFF
--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -6,7 +6,7 @@ import React, {
   ReactNode,
   useMemo,
 } from 'react'
-import styled, { css } from 'styled-components'
+import styled, { css, isStyledComponent } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
 import { useSpacing } from '../../hooks/useSpacing'
@@ -202,16 +202,20 @@ const addIdToFirstInput = (children: ReactNode, managedHtmlFor: string, describe
  * @param type
  * @returns
  */
-const isInputElement = (type: string | React.JSXElementConstructor<any>) =>
-  type === Input ||
-  type === CurrencyInput ||
-  type === Textarea ||
-  type === DatePicker ||
-  type === Select ||
-  type === SingleComboBox ||
-  type === MultiComboBox ||
-  type === InputFile ||
-  type === DropZone
+const isInputElement = (type: string | React.JSXElementConstructor<any>) => {
+  const _type = isStyledComponent(type) ? type.target : type
+  return (
+    _type === Input ||
+    _type === CurrencyInput ||
+    _type === Textarea ||
+    _type === DatePicker ||
+    _type === Select ||
+    _type === SingleComboBox ||
+    _type === MultiComboBox ||
+    _type === InputFile ||
+    _type === DropZone
+  )
+}
 
 const Wrapper = styled(Stack).attrs({
   // 基本的にはすべて 0.5 幅、グルーピングしたフォームコントロール群との余白は ChildrenWrapper で調整する


### PR DESCRIPTION


## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://smarthr.atlassian.net/browse/KAT-999
https://kufuinc.slack.com/archives/CGC58MW01/p1699923068678449

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- FormControl内のDatePickerをStyled-Componentとしてラップした際に、FormControl側で作成されたlabelのidやaria-describedbyがinputに紐づかない問題を解決したい

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- 対象のコンポーネントがStyled-Componentだった場合に、Styled-Componentのターゲットに対して判定をかけるようにした

## Capture

<!--
Please attach a capture if it looks different.
-->
