### PR TITLE
chore: BackgroundJobsPanelのVRT用Storyを追加

### DIFF
--- a/src/components/BackgroundJobsPanel/VRTBackgroundJobsPanel.stories.tsx
+++ b/src/components/BackgroundJobsPanel/VRTBackgroundJobsPanel.stories.tsx
@@ -1,4 +1,6 @@
+import { action } from '@storybook/addon-actions'
 import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
 import * as React from 'react'
 import styled from 'styled-components'
 
@@ -19,6 +21,131 @@ export default {
   },
 }
 
+export const VRTPanelState: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hover, activeなどの状態で表示されます
+    </VRTInformationPanel>
+    <List>
+      <dt>hover</dt>
+      <dd id="hover">
+        <BackgroundJobsPanel
+          title="Jobs panel"
+          jobs={[
+            {
+              id: 1,
+              status: 'processing',
+              name: 'Job 1',
+              description: 'Processing',
+              isCancelable: true,
+            },
+          ]}
+          onClickExpansion={action('click expansion')}
+          onClickCancelJob={action('click cancel')}
+          onClickClose={action('click close')}
+          isExpanded
+        />
+      </dd>
+      <dt>focus</dt>
+      <dd id="focus">
+        <BackgroundJobsPanel
+          title="Jobs panel"
+          jobs={[
+            {
+              id: 1,
+              status: 'processing',
+              name: 'Job 1',
+              description: 'Processing',
+              isCancelable: true,
+            },
+          ]}
+          onClickExpansion={action('click expansion')}
+          onClickCancelJob={action('click cancel')}
+          onClickClose={action('click close')}
+          isExpanded
+        />
+      </dd>
+      <dt>focusVisible</dt>
+      <dd id="focus-visible">
+        <BackgroundJobsPanel
+          title="Jobs panel"
+          jobs={[
+            {
+              id: 1,
+              status: 'processing',
+              name: 'Job 1',
+              description: 'Processing',
+              isCancelable: true,
+            },
+          ]}
+          onClickExpansion={action('click expansion')}
+          onClickCancelJob={action('click cancel')}
+          onClickClose={action('click close')}
+          isExpanded
+        />
+      </dd>
+      <dt>active</dt>
+      <dd id="active">
+        <BackgroundJobsPanel
+          title="Jobs panel"
+          jobs={[
+            {
+              id: 1,
+              status: 'processing',
+              name: 'Job 1',
+              description: 'Processing',
+              isCancelable: true,
+            },
+          ]}
+          onClickExpansion={action('click expansion')}
+          onClickCancelJob={action('click cancel')}
+          onClickClose={action('click close')}
+          isExpanded
+        />
+      </dd>
+    </List>
+  </>
+)
+VRTPanelState.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['#hover button'],
+    focus: ['#focus button'],
+    focusVisible: ['#focus-visible button'],
+    active: ['#active button'],
+  },
+}
+
+export const VRTPanelHoverLong: StoryFn = () => (
+  <List>
+    <dt>Hover long text ellipsis</dt>
+    <dd>
+      <BackgroundJobsPanel
+        title="Ellipsis"
+        jobs={[
+          {
+            id: 1,
+            status: 'downloading',
+            name: 'long long long long long long long long long long long long name',
+            description: 'long long long long long long long long long long long long description',
+          },
+        ]}
+        onClickExpansion={action('click expansion')}
+        onClickCancelJob={action('click cancel')}
+        onClickClose={action('click close')}
+      />
+    </dd>
+  </List>
+)
+VRTPanelHoverLong.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const text = await canvas.findByText(
+    'long long long long long long long long long long long long name',
+    { selector: 'span' },
+  )
+  await userEvent.hover(text)
+}
+
 export const VRTPanelForcedColors: StoryFn = () => (
   <>
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
@@ -33,4 +160,16 @@ VRTPanelForcedColors.parameters = {
 
 const VRTInformationPanel = styled(InformationPanel)`
   margin-bottom: 24px;
+`
+const List = styled.dl`
+  list-style: none;
+  margin: 0;
+  padding: 2rem;
+
+  dt {
+    margin-bottom: 1rem;
+  }
+  dd {
+    margin: 0 0 2rem;
+  }
 `

--- a/src/components/BackgroundJobsPanel/VRTBackgroundJobsPanel.stories.tsx
+++ b/src/components/BackgroundJobsPanel/VRTBackgroundJobsPanel.stories.tsx
@@ -1,0 +1,36 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { BackgroundJobsList } from './BackgroundJobsList'
+import { BackgroundJobsPanel } from './BackgroundJobsPanel'
+import { PanelView } from './BackgroundJobsPanel.stories'
+
+export default {
+  title: 'Data Display（データ表示）/BackgroundJobsPanel',
+  component: BackgroundJobsPanel,
+  subcomponents: {
+    BackgroundJobsList,
+  },
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTPanelForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <PanelView />
+  </>
+)
+VRTPanelForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

BackgroundJobsPanelコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- VRT Panel State
  - パネル内のボタンにhoverやfocusなどを適用した状態
- VRT Panel Hover Long
  - 長いテキストにホバーしてツールチップを表示した状態
- VRT Panel Forced Colors
  - forcedColors: 'active' を適用した状態

panelのストーリーに対してVRT用のストーリーを追加しました。
listはJavaScriptによる処理と見受けられましたのでTailwindへの移行のための追加テストは不要と判断しました。

## Capture

### VRT Panel State

<img width="508" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/29a5477f-89b9-4f13-9e1d-b3cecf1ae9bd">

### VRT Panel Hover Long

<img width="637" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/01cc99bf-3013-4180-812a-d98c227ab15d">

### VRT Panel Forced Colors

<img width="522" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/61ed6e74-4ac3-4902-8f24-a81ce8213758">
