### PR TITLE
fix: テキスト付き Icon における左右位置の実装を揃える

### DIFF
--- a/src/components/Icon/generateIcon.tsx
+++ b/src/components/Icon/generateIcon.tsx
@@ -116,7 +116,7 @@ export const createIcon = (SvgIcon: IconType) => {
 
     if (existsText) {
       return (
-        <IconAndTextWrapper gap={iconGap} right={right} className={classNames.withText}>
+        <IconAndTextWrapper gap={iconGap} className={classNames.withText}>
           {alt && <VisuallyHiddenText>{alt}</VisuallyHiddenText>}
           {right && text}
           {svgIcon}
@@ -145,21 +145,16 @@ const WrapIcon = styled.svg`
 `
 
 const IconAndTextWrapper = styled.span<{
-  right: ComponentProps['right']
   gap: ComponentProps['iconGap']
 }>`
-  ${({ right, gap }) => css`
-    ${!right &&
-    css`
-      display: inline-flex;
-      align-items: baseline;
-      ${gap && `column-gap: ${useSpacing(gap)};`}
-    `}
+  ${({ gap }) => css`
+    display: inline-flex;
+    align-items: baseline;
+    ${gap && `column-gap: ${useSpacing(gap)};`}
 
     .smarthr-ui-Icon {
       flex-shrink: 0;
       transform: translateY(0.125em);
-      ${right && gap && `margin-inline-start: ${useSpacing(gap)};`}
     }
   `}
 `


### PR DESCRIPTION
Icon[right] の場合は CSS を使わない実装になっていたが、混乱を生みそうなため左右どちらにアイコンが来ても同じ実装になるよう修正した。

折返しが発生した場合、アイコンの下に文字は回り込まないが、親要素の幅で回避できるためそれで良しとする。
（回り込みが必要な場面の方が少ないと判断した。）