### PR TITLE
chore: NotificationBarのVRT用Storyを追加

### DIFF
--- a/src/components/NotificationBar/VRTNotificationBar.stories.tsx
+++ b/src/components/NotificationBar/VRTNotificationBar.stories.tsx
@@ -1,0 +1,95 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { NotificationBar } from './NotificationBar'
+import { All, Demo } from './NotificationBar.stories'
+
+export default {
+  title: 'States（状態）/NotificationBar',
+  component: NotificationBar,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTNotificationBarNarrow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTNotificationBarShow: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      NotificationBarを表示した状態で表示されます
+    </VRTInformationPanel>
+    <Demo />
+  </Wrapper>
+)
+
+export const VRTNotificationBarFocus: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      それぞれ1番目のNotificationBarの閉じるボタンにフォーカスした状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+export const VRTNotificationBarForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTNotificationBarShow.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const buttons = await canvas.findAllByRole('button')
+  await userEvent.click(buttons[0])
+}
+
+VRTNotificationBarNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+VRTNotificationBarShow.parameters = {
+  chromatic: { pauseAnimationAtEnd: true },
+}
+
+VRTNotificationBarFocus.parameters = {
+  pseudo: {
+    focusVisible: ['dd > div:first-child .smarthr-ui-NotificationBar-closeButton'],
+  },
+}
+
+VRTNotificationBarForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview
NotificationBarコンポーネントにVRT用のStoryを追加しました。

## What I did
以下の4つを追加しました

- 画面幅が狭いとき
- DemoでNotificationBarが表示された状態（アニメーション終了時点）
- 閉じるボタンにフォーカスした状態
- `forcedColors: 'active'` を適用した状態

## Capture

Chromaticでのキャプチャ
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=6556f539b8a3275b227ffbc1
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=6556f539b8a3275b227ffbc2
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=6556f539b8a3275b227ffbc3
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=6556f539b8a3275b227ffbc4