### PR TITLE
chore: CompactInformationPanelのVRT用Storyを追加

### DIFF
--- a/src/components/CompactInformationPanel/VRTCompactInformationPanel.stories.tsx
+++ b/src/components/CompactInformationPanel/VRTCompactInformationPanel.stories.tsx
@@ -1,0 +1,52 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Type } from './CompactInformationPanel.stories'
+
+import { CompactInformationPanel } from '.'
+
+export default {
+  title: 'Data Display（データ表示）/CompactInformationPanel',
+  component: CompactInformationPanel,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTNarrow: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <Type />
+  </>
+)
+VRTNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <Type />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

CompactInformationPanelコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- VRT Narrow
  - 画面幅の狭い状態
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態

CompactInformationPanelのストーリーに対してVRT用のストーリーを追加しました。
DefaultとTypeがありましたが、TypeがDefaultのケースも含め網羅的にコンポーネントの状態を用意していましたので、そちらを流用してVRT用のストーリーを作成しました。

## Capture

### VRT Narrow

<img width="414" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/84a3b915-8433-4877-b0c3-108f17f3599c">

### VRT Forced Colors
<img width="520" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/bade9086-955f-441f-8e3c-23180c266963">
