### PR TITLE
chore: DefinitionListのVRT用Storyを追加

### DIFF
--- a/src/components/DefinitionList/VRTDefinitionList.stories.tsx
+++ b/src/components/DefinitionList/VRTDefinitionList.stories.tsx
@@ -1,0 +1,52 @@
+import { StoryFn } from '@storybook/react'
+import * as React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { All } from './DefinitionList.stories'
+
+import { DefinitionList } from '.'
+
+export default {
+  title: 'Data Display（データ表示）/DefinitionList',
+  component: DefinitionList,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTNarrow: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

DefinitionListコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- VRT Narrow
  - 画面幅の狭い状態
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態

DefinitionListのストーリーに対してVRT用のストーリーを追加しました。

## Capture

### VRT Narrow

<img width="410" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/3be99f5a-fe96-4b40-b8ed-f50cb33a8b0f">

### VRT Forced Colors

<img width="1160" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/e1a89abf-7a93-443e-bf5d-f42e74c90ad7">
