### PR TITLE
chore: StatusLabelのVRT用Storyを追加

### DIFF
--- a/src/components/StatusLabel/VRTStatusLabel.stories.tsx
+++ b/src/components/StatusLabel/VRTStatusLabel.stories.tsx
@@ -1,0 +1,40 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { StatusLabel } from './StatusLabel'
+import { All } from './StatusLabel.stories'
+
+export default {
+  title: 'States（状態）/StatusLabel',
+  component: StatusLabel,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTStatusLabelForcedColors: StoryFn = () => (
+  <Wrapper>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </Wrapper>
+)
+
+VRTStatusLabelForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const Wrapper = styled.div`
+  height: 100vh;
+  box-sizing: border-box;
+  padding: 24px;
+  color: ${({ theme }) => theme.color.TEXT_BLACK};
+`
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview
StatusLabelコンポーネントにVRT用のStoryを追加しました。

## What I did
画面幅は影響しないコンポーネントで、ボタンを押すなどの動作もないので、forcedColors: 'active' を適用したStoryのみ追加しています。

## Capture

Chromaticでのキャプチャ
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=6556fb89421058594ad2d213