### PR TITLE
test: @testing-library/react-hooks から @testing-library/react に移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@storybook/theming": "^7.5.3",
     "@swc/core": "^1.3.96",
     "@swc/jest": "^0.2.29",
-    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.8",
     "@types/lodash.merge": "^4.6.9",
     "@types/lodash.range": "^3.2.9",

--- a/src/components/ComboBox/__tests__/useActiveOption.test.ts
+++ b/src/components/ComboBox/__tests__/useActiveOption.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react'
 
 import { useActiveOption } from '../useActiveOption'
 

--- a/src/components/ComboBox/__tests__/useOptions.test.tsx
+++ b/src/components/ComboBox/__tests__/useOptions.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import React from 'react'
 
 import { useOptions } from '../useOptions'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,12 +3378,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+"@testing-library/react@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.1.2.tgz#a2b9e9ee87721ec9ed2d7cfc51cc04e474537c32"
+  integrity sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
+    "@testing-library/dom" "^9.0.0"
+    "@types/react-dom" "^18.0.0"
 
 "@testing-library/user-event@^14.4.0":
   version "14.5.1"
@@ -3729,7 +3731,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^18.2.15":
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.15":
   version "18.2.15"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.15.tgz#921af67f9ee023ac37ea84b1bc0cc40b898ea522"
   integrity sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==
@@ -11078,12 +11080,6 @@ react-element-to-jsx-string@^15.0.0:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "18.1.0"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-icons@^4.12.0:
   version "4.12.0"


### PR DESCRIPTION
## Related URL

- [testing\-library/react\-hooks\-testing\-library](https://github.com/testing-library/react-hooks-testing-library)

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

テストで利用しているライブラリ `@testing-library/react-hooks` の peerDependencies に React 18 は含まれておらず、`@testing-library/react-hooks` の README でも React 18 を使う際は `@testing-library/react` に移行するよう促されています。

[A Note about React 18 Support](https://github.com/testing-library/react-hooks-testing-library#a-note-about-react-18-support)

指示に従いライブラリの変更を行いました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- package.json の変更
- テスト内での読み込み元ライブラリの変更

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->