### PR TITLE
feat: add new icons: FaBabyCarriage, FaTruck, and FaTruckLoading

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -22,6 +22,7 @@ import {
   FaArrowsAltH,
   FaArrowsAltV,
   FaAsterisk,
+  FaBabyCarriage,
   FaBan,
   FaBars,
   FaBell,
@@ -276,6 +277,8 @@ import {
   FaTrashAlt,
   FaTrashRestore,
   FaTrashRestoreAlt,
+  FaTruck,
+  FaTruckLoading,
   FaUndo,
   FaUndoAlt,
   FaUnlink,
@@ -334,6 +337,7 @@ export const FaArrowsAltIcon = /*#__PURE__*/ createIcon(FaArrowsAlt)
 export const FaArrowsAltHIcon = /*#__PURE__*/ createIcon(FaArrowsAltH)
 export const FaArrowsAltVIcon = /*#__PURE__*/ createIcon(FaArrowsAltV)
 export const FaAsteriskIcon = /*#__PURE__*/ createIcon(FaAsterisk)
+export const FaBabyCarriageIcon = /*#__PURE__*/ createIcon(FaBabyCarriage)
 export const FaBanIcon = /*#__PURE__*/ createIcon(FaBan)
 export const FaBarsIcon = /*#__PURE__*/ createIcon(FaBars)
 export const FaBellIcon = /*#__PURE__*/ createIcon(FaBell)
@@ -587,6 +591,8 @@ export const FaTrashIcon = /*#__PURE__*/ createIcon(FaTrash)
 export const FaTrashAltIcon = /*#__PURE__*/ createIcon(FaTrashAlt)
 export const FaTrashRestoreIcon = /*#__PURE__*/ createIcon(FaTrashRestore)
 export const FaTrashRestoreAltIcon = /*#__PURE__*/ createIcon(FaTrashRestoreAlt)
+export const FaTruckIcon = /*#__PURE__*/ createIcon(FaTruck)
+export const FaTruckLoadingIcon = /*#__PURE__*/ createIcon(FaTruckLoading)
 export const FaUndoIcon = /*#__PURE__*/ createIcon(FaUndo)
 export const FaUndoAltIcon = /*#__PURE__*/ createIcon(FaUndoAlt)
 export const FaUnlinkIcon = /*#__PURE__*/ createIcon(FaUnlink)


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Icons にアイコンを追加したい

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

以下の3つのアイコンを追加した。

- FaBabyCarriage
- FaTruck
- FaTruckLoading

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<img width="239" alt="image" src="https://github.com/kufu/smarthr-ui/assets/64398878/4c67cafc-35e9-4b9c-9108-8344ffc96f5d">

<img width="444" alt="image" src="https://github.com/kufu/smarthr-ui/assets/64398878/df2cc670-bbcd-4c76-b7a3-dad493ab4dc4">


<!--
Please attach a capture if it looks different.
-->
