### PR TITLE
feat: CheckBox と RadioButton の disabled 色を見直す

### DIFF
--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -27,7 +27,9 @@ const checkboxInput = tv({
       'forced-colors:shr-hidden',
       'peer-checked:shr-border-main peer-checked:shr-bg-main contrast-more:peer-checked:shr-border-highContrast',
       'peer-indeterminate:shr-border-main peer-indeterminate:shr-bg-main contrast-more:peer-indeterminate:shr-border-highContrast',
-      'peer-disabled:shr-border-default peer-disabled:shr-bg-border',
+      'peer-disabled:shr-border-disabled peer-disabled:shr-bg-white-darken',
+      'peer-disabled:peer-checked:shr-border-default peer-disabled:peer-checked:shr-bg-border',
+      'peer-disabled:peer-indeterminate:shr-border-default peer-disabled:peer-indeterminate:shr-bg-border',
       'peer-focus-visible:shr-focusIndicator',
       'peer-hover:shr-shadow-input-hover',
     ],
@@ -40,6 +42,7 @@ const checkboxInput = tv({
     iconWrap: [
       'shr-pointer-events-none shr-absolute shr-left-1/2 shr-top-1/2 shr-inline-block shr-h-[theme(fontSize.2xs)] shr-w-[theme(fontSize.2xs)] -shr-translate-x-1/2 -shr-translate-y-1/2 shr-text-2xs',
       'shr-text-transparent peer-checked:shr-text-white peer-indeterminate:shr-text-white',
+      'peer-disabled:peer-indeteminate:shr-text-white-darken peer-disabled:peer-checked:shr-text-white-darken',
       'forced-colors:shr-hidden',
     ],
     wrapper:

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -11,8 +11,6 @@ export type Props = InputHTMLAttributes<HTMLInputElement>
 export const RadioButtonInput = forwardRef<HTMLInputElement, Props>(
   ({ onChange, ...props }, ref) => {
     const theme = useTheme()
-    const { checked, disabled } = props
-    const boxClassName = `${checked ? 'active' : ''} ${disabled ? 'disabled' : ''}`
     const handleChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
         if (onChange) onChange(e)
@@ -32,7 +30,7 @@ export const RadioButtonInput = forwardRef<HTMLInputElement, Props>(
           themes={theme}
           ref={ref}
         />
-        <Box className={boxClassName} themes={theme} />
+        <Box themes={theme} />
       </Wrapper>
     )
   },

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -102,17 +102,18 @@ const Box = styled.span<{ themes: Theme }>`
       }
 
       /* FIXME: なぜか static classname になってしまうため & を重ねている */
-      input[disabled] + && {
-        background-color: ${color.BORDER};
-        border-color: ${color.BORDER};
+      input:disabled + && {
+        border-color: ${color.disableColor(color.BORDER)};
+        background-color: ${color.hoverColor(color.WHITE)};
         cursor: not-allowed;
+      }
 
-        &.active {
-          border-color: ${color.BORDER};
+      input:disabled:checked + && {
+        border-color: ${color.BORDER};
+        background-color: ${color.BORDER};
 
-          &::before {
-            background-color: ${color.WHITE};
-          }
+        &::before {
+          background-color: ${color.hoverColor(color.WHITE)};
         }
       }
     `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Close #3991 
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

before | after
--- | ---
<img width="760" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/5e7c77f8-ede1-4988-aa30-e6b941337d1b"> | <img width="754" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/d1776cfd-c667-48f0-9828-66fe393366ef">
<img width="756" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/a7595884-43ab-46c6-aa94-4c9171de636a"> | <img width="758" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/292bb8b8-3721-4b28-9b77-0bf722553b3e">