### PR TITLE
chore: LineClampのVRT用Storyを追加

### DIFF
--- a/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -25,59 +25,6 @@ the release of Letraset sheets containing Lorem Ipsum passages, and more recentl
 with desktop publishing software like Aldus PageMaker including versions of Lorem
 Ipsum.`
 
-export const VRTState: StoryFn = () => (
-  <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
-      hover, activeなどの状態で表示されます
-    </VRTInformationPanel>
-    <Wrapper>
-      <List>
-        <dt>hover</dt>
-        <dd id="hover">
-          <Text>
-            <LineClamp maxLines={1} withTooltip>
-              {longText}
-            </LineClamp>
-          </Text>
-        </dd>
-        <dt>focus</dt>
-        <dd id="focus">
-          <Text>
-            <LineClamp maxLines={1} withTooltip>
-              {longText}
-            </LineClamp>
-          </Text>
-        </dd>
-        <dt>focusVisible</dt>
-        <dd id="focus-visible">
-          <Text>
-            <LineClamp maxLines={1} withTooltip>
-              {longText}
-            </LineClamp>
-          </Text>
-        </dd>
-        <dt>active</dt>
-        <dd id="active">
-          <Text>
-            <LineClamp maxLines={1} withTooltip>
-              {longText}
-            </LineClamp>
-          </Text>
-        </dd>
-      </List>
-    </Wrapper>
-  </>
-)
-VRTState.parameters = {
-  controls: { hideNoControlsWarning: true },
-  pseudo: {
-    hover: ['#hover p'],
-    focus: ['#focus p'],
-    focusVisible: ['#focus-visible p'],
-    active: ['#active p'],
-  },
-}
-
 export const VRTUserHover: StoryFn = () => (
   <>
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>

--- a/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -98,6 +98,7 @@ export const VRTUserHover: StoryFn = () => (
   </>
 )
 VRTUserHover.play = async ({ canvasElement }) => {
+  await new Promise((resolve) => setTimeout(resolve, 500))
   const canvas = await within(canvasElement)
   const target = await canvas.getByTestId('user-hover')
   await userEvent.hover(target)
@@ -123,6 +124,7 @@ export const VRTUserFocus: StoryFn = () => (
   </>
 )
 VRTUserFocus.play = async ({ canvasElement }) => {
+  await new Promise((resolve) => setTimeout(resolve, 500))
   const canvas = await within(canvasElement)
   const target = await canvas.getByTestId('user-focus').parentElement! // tabIndexがあるのは親要素
   await target.focus()
@@ -148,6 +150,7 @@ export const VRTForcedColors: StoryFn = () => (
   </>
 )
 VRTForcedColors.play = async ({ canvasElement }) => {
+  await new Promise((resolve) => setTimeout(resolve, 500))
   const canvas = await within(canvasElement)
   const target = await canvas.getByTestId('user-focus').parentElement! // tabIndexがあるのは親要素
   await target.focus()

--- a/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -98,7 +98,7 @@ export const VRTUserHover: StoryFn = () => (
   </>
 )
 VRTUserHover.play = async ({ canvasElement }) => {
-  await new Promise((resolve) => setTimeout(resolve, 500))
+  await new Promise((resolve) => setTimeout(resolve, 500)) // スナップショット時にツールチップを確実に表示させるため
   const canvas = await within(canvasElement)
   const target = await canvas.getByTestId('user-hover')
   await userEvent.hover(target)
@@ -124,7 +124,7 @@ export const VRTUserFocus: StoryFn = () => (
   </>
 )
 VRTUserFocus.play = async ({ canvasElement }) => {
-  await new Promise((resolve) => setTimeout(resolve, 500))
+  await new Promise((resolve) => setTimeout(resolve, 500)) // スナップショット時にツールチップを確実に表示させるため
   const canvas = await within(canvasElement)
   const target = await canvas.getByTestId('user-focus').parentElement! // tabIndexがあるのは親要素
   await target.focus()
@@ -150,7 +150,7 @@ export const VRTForcedColors: StoryFn = () => (
   </>
 )
 VRTForcedColors.play = async ({ canvasElement }) => {
-  await new Promise((resolve) => setTimeout(resolve, 500))
+  await new Promise((resolve) => setTimeout(resolve, 500)) // スナップショット時にツールチップを確実に表示させるため
   const canvas = await within(canvasElement)
   const target = await canvas.getByTestId('user-focus').parentElement! // tabIndexがあるのは親要素
   await target.focus()
@@ -163,6 +163,7 @@ const VRTInformationPanel = styled(InformationPanel)`
   margin-bottom: 24px;
 `
 
+// min-heightで高さを確保しているのは、スナップショット時にツールチップが表示されるようにするため
 const Wrapper = styled.div`
   padding: 24px;
   min-height: 400px;

--- a/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -11,7 +11,6 @@ export default {
   title: 'Data Display（データ表示）/LineClamp',
   component: LineClamp,
   parameters: {
-    layout: 'fullscreen',
     withTheming: true,
   },
 }
@@ -166,6 +165,7 @@ const VRTInformationPanel = styled(InformationPanel)`
 
 const Wrapper = styled.div`
   padding: 24px;
+  min-height: 400px;
 `
 const Text = styled.p`
   width: 400px;

--- a/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -1,0 +1,176 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { LineClamp } from './LineClamp'
+
+export default {
+  title: 'Data Display（データ表示）/LineClamp',
+  component: LineClamp,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+const longText = `
+Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
+Ipsum has been the industry's standard dummy text ever since the 1500s, when an
+unknown printer took a galley of type and scrambled it to make a type specimen
+book. It has survived not only five centuries, but also the leap into electronic
+typesetting, remaining essentially unchanged. It was popularised in the 1960s with
+the release of Letraset sheets containing Lorem Ipsum passages, and more recently
+with desktop publishing software like Aldus PageMaker including versions of Lorem
+Ipsum.`
+
+export const VRTState: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hover, activeなどの状態で表示されます
+    </VRTInformationPanel>
+    <Wrapper>
+      <List>
+        <dt>hover</dt>
+        <dd id="hover">
+          <Text>
+            <LineClamp maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+        <dt>focus</dt>
+        <dd id="focus">
+          <Text>
+            <LineClamp maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+        <dt>focusVisible</dt>
+        <dd id="focus-visible">
+          <Text>
+            <LineClamp maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+        <dt>active</dt>
+        <dd id="active">
+          <Text>
+            <LineClamp maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+      </List>
+    </Wrapper>
+  </>
+)
+VRTState.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['#hover p'],
+    focus: ['#focus p'],
+    focusVisible: ['#focus-visible p'],
+    active: ['#active p'],
+  },
+}
+
+export const VRTUserHover: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      ユーザー操作のhoverをシミュレートしてツールチップを表示します
+    </VRTInformationPanel>
+    <Wrapper>
+      <List>
+        <dt>hover</dt>
+        <dd>
+          <Text>
+            <LineClamp data-testid="user-hover" maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+      </List>
+    </Wrapper>
+  </>
+)
+VRTUserHover.play = async ({ canvasElement }) => {
+  const canvas = await within(canvasElement)
+  const target = await canvas.getByTestId('user-hover')
+  await userEvent.hover(target)
+}
+
+export const VRTUserFocus: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      ユーザー操作のfocusをシミュレートしてツールチップを表示します
+    </VRTInformationPanel>
+    <Wrapper>
+      <List>
+        <dt>focus</dt>
+        <dd>
+          <Text>
+            <LineClamp data-testid="user-focus" maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+      </List>
+    </Wrapper>
+  </>
+)
+VRTUserFocus.play = async ({ canvasElement }) => {
+  const canvas = await within(canvasElement)
+  const target = await canvas.getByTestId('user-focus').parentElement! // tabIndexがあるのは親要素
+  await target.focus()
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <Wrapper>
+      <List>
+        <dt>focus</dt>
+        <dd>
+          <Text>
+            <LineClamp data-testid="user-focus" maxLines={1} withTooltip>
+              {longText}
+            </LineClamp>
+          </Text>
+        </dd>
+      </List>
+    </Wrapper>
+  </>
+)
+VRTForcedColors.play = async ({ canvasElement }) => {
+  const canvas = await within(canvasElement)
+  const target = await canvas.getByTestId('user-focus').parentElement! // tabIndexがあるのは親要素
+  await target.focus()
+}
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`
+
+const Wrapper = styled.div`
+  padding: 24px;
+`
+const Text = styled.p`
+  width: 400px;
+  margin: 0 0 16px;
+  font-size: 16px;
+`
+const List = styled.dl`
+  margin: 1rem;
+  & > dd {
+    margin: 16px 0 40px;
+  }
+`

--- a/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -11,6 +11,7 @@ export default {
   title: 'Data Display（データ表示）/LineClamp',
   component: LineClamp,
   parameters: {
+    layout: 'fullscreen',
     withTheming: true,
   },
 }


### PR DESCRIPTION
## Overview

LineClampコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- ~~VRT State~~
  - ~~hover、activeを擬似的に指定した状態（その状態もスタイルによる装飾がないようなので、変化はありません）~~
- VRTUserHover
  - ユーザー操作のhoverをシミュレートしてツールチップを表示した状態
- VRTUserFocus
  - ユーザー操作のfocusをシミュレートしてツールチップを表示した状態
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態。ツールチップが出ている状態が良いと考え、フォーカスしてツールチップが表示されている状態を対象にしています

LineClampのストーリーに対してVRT用のストーリーを追加しました。
他に必要なストーリーがあればご指摘ください。