### PR TITLE
fix: FormGroupのGroupLabelTextでforwardedAsを使うように修正

### DIFF
--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -264,7 +264,7 @@ const FormLabel = styled(Cluster).attrs({ align: 'center' })`
   align-self: start;
 `
 
-const GroupLabelText = styled(Text).attrs({ as: 'span' })``
+const GroupLabelText = styled(Text).attrs({ forwardedAs: 'span' })``
 
 const ErrorMessage = styled.p<{ themes: Theme }>`
   ${({ themes: { color } }) => css`


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- https://github.com/kufu/smarthr-ui/pull/3908 の変更で、FormControl(FormGroup)のGroupLabelTextに `as` が 使われるようになったのですが、`styled(Text)` なので `forwardedAs` でないと正しく渡されないため修正しました

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- as を forwardedAs に変更

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
- FormControlのstory
  - before: labelにstyleが当たっていない
  - after: labelにstyleが当たっている

| before | after |
| --- | --- |
| <img width="350" alt="image" src="https://github.com/kufu/smarthr-ui/assets/16136015/4ad77b75-2794-48f1-ae63-fdafcba8ab41"> | <img width="474" alt="image" src="https://github.com/kufu/smarthr-ui/assets/16136015/b018df94-815b-42ca-af79-8500d5875f0c"> |


<!--
Please attach a capture if it looks different.
-->
