### PR TITLE
fix: props が DOM element に渡ってしまって warning になっている箇所を修正

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -42,7 +42,7 @@ export const Badge: React.FC<BadgeProps> = ({
   const badgeProps = {
     themes: theme,
     $colorName: definedColors[type],
-    withChildren: !!children,
+    $withChildren: !!children,
   }
 
   // ドット表示でもなく、0値を表示するでもない場合は何も表示しない
@@ -68,9 +68,9 @@ const BadgeWrapper = styled.span`
   position: relative;
   display: inline-flex;
 `
-const badgeBaseStyle = css<{ themes: Theme; $colorName: ColorName; withChildren: boolean }>`
-  ${({ themes: { color, radius }, $colorName, withChildren }) => css`
-    ${withChildren &&
+const badgeBaseStyle = css<{ themes: Theme; $colorName: ColorName; $withChildren: boolean }>`
+  ${({ themes: { color, radius }, $colorName, $withChildren }) => css`
+    ${$withChildren &&
     css`
       position: absolute;
       inset-block-start: 0;
@@ -90,7 +90,7 @@ const badgeBaseStyle = css<{ themes: Theme; $colorName: ColorName; withChildren:
 `
 const PillText = styled(Text).attrs({
   size: 'XS',
-})<{ themes: Theme; $colorName: ColorName; withChildren: boolean }>`
+})<{ themes: Theme; $colorName: ColorName; $withChildren: boolean }>`
   ${({ themes: { color }, $colorName }) => css`
     ${badgeBaseStyle}
 
@@ -101,7 +101,7 @@ const PillText = styled(Text).attrs({
     height: 1.75em;
   `}
 `
-const Dot = styled.span<{ themes: Theme; $colorName: ColorName; withChildren: boolean }>`
+const Dot = styled.span<{ themes: Theme; $colorName: ColorName; $withChildren: boolean }>`
   ${badgeBaseStyle}
 
   width: 0.625em;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -41,7 +41,7 @@ export const Badge: React.FC<BadgeProps> = ({
   const actualCount = count && count > 0 ? count : showZero ? 0 : undefined
   const badgeProps = {
     themes: theme,
-    colorName: definedColors[type],
+    $colorName: definedColors[type],
     withChildren: !!children,
   }
 
@@ -68,8 +68,8 @@ const BadgeWrapper = styled.span`
   position: relative;
   display: inline-flex;
 `
-const badgeBaseStyle = css<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
-  ${({ themes: { color, radius }, colorName, withChildren }) => css`
+const badgeBaseStyle = css<{ themes: Theme; $colorName: ColorName; withChildren: boolean }>`
+  ${({ themes: { color, radius }, $colorName, withChildren }) => css`
     ${withChildren &&
     css`
       position: absolute;
@@ -83,25 +83,25 @@ const badgeBaseStyle = css<{ themes: Theme; colorName: ColorName; withChildren: 
     align-items: center;
     justify-content: center;
 
-    box-shadow: 0 0 0 1px ${colorName === 'WARNING_YELLOW' ? color.TEXT_BLACK : color.WHITE};
+    box-shadow: 0 0 0 1px ${$colorName === 'WARNING_YELLOW' ? color.TEXT_BLACK : color.WHITE};
     border-radius: ${radius.full};
-    background-color: ${color[colorName]};
+    background-color: ${color[$colorName]};
   `}
 `
 const PillText = styled(Text).attrs({
   size: 'XS',
-})<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
-  ${({ themes: { color }, colorName }) => css`
+})<{ themes: Theme; $colorName: ColorName; withChildren: boolean }>`
+  ${({ themes: { color }, $colorName }) => css`
     ${badgeBaseStyle}
 
     padding-inline: 0.5em;
     font-variant-numeric: tabular-nums;
-    color: ${colorName === 'WARNING_YELLOW' ? color.TEXT_BLACK : color.WHITE};
+    color: ${$colorName === 'WARNING_YELLOW' ? color.TEXT_BLACK : color.WHITE};
     min-width: 1.75em;
     height: 1.75em;
   `}
 `
-const Dot = styled.span<{ themes: Theme; colorName: ColorName; withChildren: boolean }>`
+const Dot = styled.span<{ themes: Theme; $colorName: ColorName; withChildren: boolean }>`
   ${badgeBaseStyle}
 
   width: 0.625em;

--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -56,7 +56,7 @@ export function ButtonWrapper({
   }, [$loading, className, size, square, variant, wide])
 
   if (props.isAnchor) {
-    const { anchorRef, ...others } = props
+    const { anchorRef, isAnchor: _, ...others } = props
     // eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute, jsx-a11y/anchor-has-content
     return <a {...others} className={anchorStyle} ref={anchorRef} />
   } else {

--- a/src/components/InformationPanel/InformationPanel.tsx
+++ b/src/components/InformationPanel/InformationPanel.tsx
@@ -78,7 +78,7 @@ export const InformationPanel: FC<Props & Omit<BaseElementProps, keyof Props>> =
       {/* HINT: Wrapperをsectionにしているため余計なタグを出力しないようSectioningFragmentを利用する */}
       <SectioningFragment>
         <Stack gap={1.25}>
-          <Header themes={theme} togglable={togglable}>
+          <Header themes={theme} $togglable={togglable}>
             {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
             <Heading type="blockTitle" tag={titleTag} id={titleId} className={classNames.title}>
               <ResponseMessage type={type} iconGap={0.5}>
@@ -126,8 +126,8 @@ const Wrapper = styled(Base).attrs(() => ({
 const Header = styled(Cluster).attrs({
   align: 'center',
   justify: 'space-between',
-})<{ themes: Theme; togglable: boolean }>`
-  ${({ themes: { border, fontSize, leading, space }, togglable }) => {
+})<{ themes: Theme; $togglable: boolean }>`
+  ${({ themes: { border, fontSize, leading, space }, $togglable }) => {
     // (Button(1rem + padding-block + border) - Heading(1rem * 1.25) / 2)
     const adjust = `calc((
         (${fontSize.S} + ${space(1)} + ${border.lineWidth} * 2)
@@ -135,7 +135,7 @@ const Header = styled(Cluster).attrs({
       ) / -2)
     `
     return css`
-      ${togglable &&
+      ${$togglable &&
       css`
         &&& {
           margin-block: ${adjust};

--- a/src/components/NotificationBar/NotificationBar.tsx
+++ b/src/components/NotificationBar/NotificationBar.tsx
@@ -128,7 +128,7 @@ export const NotificationBar: React.FC<Props & ElementProps & BaseProps> = ({
         className={`${type} ${classNames.wrapper}${className && ` ${className}`}`}
         role={role}
         themes={theme}
-        colorSet={colorSet}
+        $colorSet={colorSet}
         onBase={base === 'base'}
       >
         <Inner>
@@ -151,7 +151,7 @@ export const NotificationBar: React.FC<Props & ElementProps & BaseProps> = ({
         {onClose && (
           <CloseButton
             variant="text"
-            colorSet={colorSet}
+            $colorSet={colorSet}
             themes={theme}
             onClick={onClose}
             className={classNames.closeButton}
@@ -169,13 +169,13 @@ const Base = styled(shrBase).attrs({ overflow: 'hidden' })``
 
 const Wrapper = styled.div<{
   themes: Theme
-  colorSet: { fgColor?: string; bgColor?: string }
+  $colorSet: { fgColor?: string; bgColor?: string }
   onBase: boolean
   animate?: boolean
 }>(
   ({
     themes: { color, fontSize, leading, space },
-    colorSet: { fgColor = color.TEXT_BLACK, bgColor = color.WHITE },
+    $colorSet: { fgColor = color.TEXT_BLACK, bgColor = color.WHITE },
     onBase,
     animate,
   }) => css`
@@ -248,12 +248,12 @@ const ActionWrapper = styled(Cluster)<{
   `,
 )
 const CloseButton = styled(Button)<{
-  colorSet: { fgColor?: string; bgColor?: string }
+  $colorSet: { fgColor?: string; bgColor?: string }
   themes: Theme
 }>(
   ({
     themes: { color, spacingByChar },
-    colorSet: { fgColor = color.TEXT_BLACK, bgColor = color.WHITE },
+    $colorSet: { fgColor = color.TEXT_BLACK, bgColor = color.WHITE },
   }) => css`
     flex-shrink: 0;
 

--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -128,7 +128,7 @@ export const TooltipPortal: FC<Props> = ({
       <StyledBalloon
         horizontal={actualHorizontal || 'left'}
         vertical={actualVertical || 'bottom'}
-        isMultiLine={isMultiLine}
+        $isMultiLine={isMultiLine}
       >
         <StyledBalloonText themes={theme}>{message}</StyledBalloonText>
       </StyledBalloon>
@@ -166,9 +166,9 @@ const Container = styled.div<{
     }
   `}
 `
-const StyledBalloon = styled(Balloon)<{ isMultiLine?: boolean }>(
-  ({ isMultiLine }) =>
-    isMultiLine &&
+const StyledBalloon = styled(Balloon)<{ $isMultiLine?: boolean }>(
+  ({ $isMultiLine }) =>
+    $isMultiLine &&
     css`
       max-width: 100%;
       white-space: normal;


### PR DESCRIPTION
## Related URL

🍐 

## Overview

いつからか SmartHR UI を読み込むと添付したキャプチャのような warning が多発するようになった。

<img width="1282" alt="Warning: React does not recognize the `withChildren` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `withchildren` instead. If you accidentally passed it from a parent component, remove it from the DOM element." src="https://github.com/kufu/smarthr-ui/assets/11153463/8e25b3c9-ea5c-4a43-8395-fe50babef68c">


これは、element に本来存在しない名前の props がそのまま DOM element に渡されてしまっているために warning になっているので、そういうのは渡されないようにしたい。

## What I did

- styled-components の機能を使って、`$` をつけることで DOM に渡らないようにする
- ButtonWrapper の isAnchor に関しては styled-components じゃなかったのでスプレッド構文で渡しているところを isAnchor だけ取り出している

動作確認としては、

- この変更では UI は変わらないので、意図しない差分が出ていないこと
- 直したコンポーネントで warning が出ないようになっていること

とかを見てもらえると良さそうです。

## Capture

🍐 
