### PR TITLE
fix: Center を styled-components で装飾することができない欠陥を修正

### DIFF
--- a/src/components/Layout/Center/Center.tsx
+++ b/src/components/Layout/Center/Center.tsx
@@ -55,17 +55,18 @@ export const Center: React.FC<Props & ElementProps> = ({
   padding,
   verticalCentering,
   as: Component = 'div',
+  className,
   ...props
 }) => {
   const styleProps = useMemo(
     () => ({
-      className: center({ padding, verticalCentering }),
+      className: center({ padding, verticalCentering, className }),
       style: {
         minHeight: minHeight ?? undefined,
         maxWidth: maxWidth ?? undefined,
       },
     }),
-    [minHeight, maxWidth, padding, verticalCentering],
+    [padding, verticalCentering, className, minHeight, maxWidth],
   )
 
   return <Component {...props} {...styleProps} />


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Center に className が渡っていなかったため styled-components が使えていなかった欠陥を修正

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
