### PR TITLE
chore: PageCounterのVRT用Storyを追加

### DIFF
--- a/src/components/PageCounter/VRTPageCounter.stories.tsx
+++ b/src/components/PageCounter/VRTPageCounter.stories.tsx
@@ -1,0 +1,32 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { PageCounter } from './PageCounter'
+import { All } from './PageCounter.stories'
+
+export default {
+  title: 'Data Display（データ表示）/PageCounter',
+  component: PageCounter,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

PageCounterコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加

- VRT Forced Colors
  - forcedColors: 'active' を適用した状態。
  
PageCounterに関しては表示内容が単純なテキストだけのため、 VRT Forced Colorsのストーリーも不要ではと迷いましたが念のため追加しました。不要であれば、このPRをリジェクトいただければと思います。

## Capture

### VRT Panel Forced Colors

<img width="477" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/49843e7a-6394-46ed-87f8-3631db9264be">
