### PR TITLE
chore: RightFixedNoteのVRT用Storyを追加

### DIFF
--- a/src/components/RightFixedNote/VRTRightFixedNote.stories.tsx
+++ b/src/components/RightFixedNote/VRTRightFixedNote.stories.tsx
@@ -1,0 +1,62 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { RightFixedNote } from './RightFixedNote'
+import { All } from './RightFixedNote.stories'
+
+export default {
+  title: 'Data Display（データ表示）/RightFixedNote',
+  component: RightFixedNote,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTHover: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hoverの状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTHover.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['button'],
+  },
+}
+
+export const VRTFocusVisible: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      focusの状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocusVisible.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    focusVisible: ['button', 'textarea'],
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

RightFixedNoteコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加

- VRT Hover
  - ボタン要素をhover
- VRT Focus Visible
  - ボタン要素とテキストエリアをフォーカス
- VRT Forced Colors
  - forcedColors: 'active' を適用した状態。

他のコンポーネントではhoverとfocusVisibleはVRT Stateというストーリーでひとまとめにしていましたが、このコンポーネントが1画面に1つ配置される特殊なコンポーネントであるため別々のコンポーネントに分けました。

## Capture

### VRT Hover
<img width="665" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/77ba3dd5-1129-48dd-a304-94fa3ab5fc0d">

### VRT Focus Visible
<img width="665" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/a66fd0a8-79fb-48dc-8efc-2d1fbc343b6d">

### VRT Panel Forced Colors
<img width="1183" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/e661d6ff-1d25-42e9-a222-19d432438b8b">
