### PR TITLE
fix: FormDialogのsubmit時、portal等で擬似的にネストしている親formをsubmitしてしまうためstopPropagationを追加する

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -77,7 +77,7 @@ const dialogContentInner = tv({
   slots: {
     layout: 'smarthr-ui-Dialog-wrapper shr-fixed shr-inset-0',
     inner:
-      'smarthr-ui-Dialog shr-absolute shr-rounded-m shr-bg-white shr-shadow-layer-3 contrast-more:shr-border contrast-more:shr-border-solid contrast-more:shr-border-highContrast',
+      'smarthr-ui-Dialog contrast-more:shr-border-highContrast shr-absolute shr-rounded-m shr-bg-white shr-shadow-layer-3 contrast-more:shr-border contrast-more:shr-border-solid',
     background: 'smarthr-ui-Dialog-background shr-fixed shr-inset-0 shr-bg-scrim',
   },
 })

--- a/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -83,6 +83,9 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   const handleSubmitAction = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault()
+      // HINT: React Potals などで擬似的にformがネストしている場合など、stopPropagationを実行しないと
+      // 親formが意図せずsubmitされてしまう場合がある
+      e.stopPropagation()
       onSubmit(onClickClose)
     },
     [onSubmit, onClickClose],


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- portalなどで擬似的にform in form している場合でもsubmitイベントが親に到達してしまうため、stopPropagationを追加します

## Capture

<!--
Please attach a capture if it looks different.
-->
