### PR TITLE
refactor: Sidebar を Tailwind CSS 化

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React from 'react'
 import styled, { css } from 'styled-components'
 
@@ -15,7 +15,7 @@ export default {
   },
 }
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <div style={{ margin: '32px' }}>
     <PageHeading>Sidebar</PageHeading>
     <p>

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -140,10 +140,10 @@ export const Sidebar: React.FC<Props> = ({
   const styledChildren = React.Children.map(children, (child, i) => {
     if (React.isValidElement(child)) {
       if (i === 0) {
-        return React.cloneElement(child as ReactElement, { ...firstItemStyleProps })
+        return React.cloneElement(child as ReactElement, { ...firstItemStyleProps, ...child.props })
       }
       if (i === React.Children.count(children) - 1) {
-        return React.cloneElement(child as ReactElement, { ...lastItemStyleProps })
+        return React.cloneElement(child as ReactElement, { ...lastItemStyleProps, ...child.props })
       }
     }
 

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -139,11 +139,18 @@ export const Sidebar: React.FC<Props> = ({
   // tailwindcss で :first-child / :last-child に対して動的な min-height を当てられないため、React で疑似的に処理している
   const styledChildren = React.Children.map(children, (child, i) => {
     if (React.isValidElement(child)) {
+      const childClassName = child.props.className ?? ''
       if (i === 0) {
-        return React.cloneElement(child as ReactElement, { ...firstItemStyleProps, ...child.props })
+        return React.cloneElement(child as ReactElement, {
+          className: `${firstItemStyleProps.className} ${childClassName}`,
+          style: { ...firstItemStyleProps.style, ...child.props.style },
+        })
       }
       if (i === React.Children.count(children) - 1) {
-        return React.cloneElement(child as ReactElement, { ...lastItemStyleProps, ...child.props })
+        return React.cloneElement(child as ReactElement, {
+          className: `${lastItemStyleProps.className} ${childClassName}`,
+          style: { ...lastItemStyleProps.style, ...child.props.style },
+        })
       }
     }
 

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,61 +1,158 @@
-import styled, { css } from 'styled-components'
-
-import { useSpacing } from '../../../hooks/useSpacing'
+import {
+  type CSSProperties,
+  type ComponentProps,
+  type PropsWithChildren,
+  ReactElement,
+  useMemo,
+} from 'react'
+import React from 'react'
+import { VariantProps, tv } from 'tailwind-variants'
 
 import type { Gap, SeparateGap } from '../../../types'
-import type { CSSProperties } from 'react'
 
-type Props = {
-  /** 各領域の縦位置の揃え方（align-items） */
-  align?: CSSProperties['alignItems']
-  /** コンポーネントの `min-width` 値 */
-  contentsMinWidth?: CSSProperties['minWidth']
-  /** 各領域の間隔の指定（gap） */
-  gap?: Gap | SeparateGap
-  /** `true` のとき、サイドコンテンツを右側に表示する */
-  right?: boolean
-}
-
-export const Sidebar = styled.div<Props>(
-  ({ align = 'stretch', contentsMinWidth = '50%', gap = 1, right }) => {
-    const isGapSeparate = gap instanceof Object
-    const gapValue = isGapSeparate
-      ? css`
-          gap: ${useSpacing(gap.row)} ${useSpacing(gap.column)};
-        `
-      : css`
-          gap: ${useSpacing(gap)};
-        `
-    const sidebarValue = css`
-      flex-grow: 1;
-    `
-    const mainContentsValue = css`
-      flex-basis: 0;
-      flex-grow: 999;
-      min-width: ${contentsMinWidth};
-    `
-
-    return css`
-      display: flex;
-      flex-wrap: wrap;
-      align-items: ${align};
-      ${gapValue}
-
-      & > *:last-child {
-        ${right ? sidebarValue : mainContentsValue}
-      }
-
-      & > *:first-child {
-        ${right ? mainContentsValue : sidebarValue}
-      }
-
-      /* 
-      Chromeで空の要素にflex-gapがあると印刷時にレイアウトが崩れるので gap の値を0にする
-      See https://bugs.chromium.org/p/chromium/issues/detail?id=1161709
-      */
-      &:empty {
-        gap: 0;
-      }
-    `
+const sidebar = tv({
+  base: ['shr-flex shr-flex-wrap', 'empty:shr-gap-0'],
+  variants: {
+    align: {
+      start: 'shr-items-start',
+      'flex-start': 'shr-items-start',
+      end: 'shr-items-end',
+      'flex-end': 'shr-items-end',
+      center: 'shr-items-center',
+      baseline: 'shr-items-baseline',
+      stretch: 'shr-items-stretch',
+    },
+    rowGap: {
+      0: 'shr-gap-y-0',
+      0.25: 'shr-gap-y-0.25',
+      0.5: 'shr-gap-y-0.5',
+      0.75: 'shr-gap-y-0.75',
+      1: 'shr-gap-y-1',
+      1.25: 'shr-gap-y-1.25',
+      1.5: 'shr-gap-y-1.5',
+      2: 'shr-gap-y-2',
+      2.5: 'shr-gap-y-2.5',
+      3: 'shr-gap-y-3',
+      3.5: 'shr-gap-y-3.5',
+      4: 'shr-gap-y-4',
+      8: 'shr-gap-y-8',
+      X3S: 'shr-gap-y-0.25',
+      XXS: 'shr-gap-y-0.5',
+      XS: 'shr-gap-y-1',
+      S: 'shr-gap-y-1.5',
+      M: 'shr-gap-y-2',
+      L: 'shr-gap-y-2.5',
+      XL: 'shr-gap-y-3',
+      XXL: 'shr-gap-y-3.5',
+      X3L: 'shr-gap-y-4',
+    } as { [key in Gap]: string },
+    columnGap: {
+      0: 'shr-gap-x-0',
+      0.25: 'shr-gap-x-0.25',
+      0.5: 'shr-gap-x-0.5',
+      0.75: 'shr-gap-x-0.75',
+      1: 'shr-gap-x-1',
+      1.25: 'shr-gap-x-1.25',
+      1.5: 'shr-gap-x-1.5',
+      2: 'shr-gap-x-2',
+      2.5: 'shr-gap-x-2.5',
+      3: 'shr-gap-x-3',
+      3.5: 'shr-gap-x-3.5',
+      4: 'shr-gap-x-4',
+      8: 'shr-gap-x-8',
+      X3S: 'shr-gap-x-0.25',
+      XXS: 'shr-gap-x-0.5',
+      XS: 'shr-gap-x-1',
+      S: 'shr-gap-x-1.5',
+      M: 'shr-gap-x-2',
+      L: 'shr-gap-x-2.5',
+      XL: 'shr-gap-x-3',
+      XXL: 'shr-gap-x-3.5',
+      X3L: 'shr-gap-x-4',
+    } as { [key in Gap]: string },
   },
-)
+})
+const sidebarItem = tv({
+  slots: {
+    firstItem: '',
+    lastItem: '',
+  },
+  variants: {
+    right: {
+      true: {
+        firstItem: 'shr-grow-[999] shr-basis-0',
+        lastItem: 'shr-grow',
+      },
+      false: {
+        firstItem: 'shr-grow',
+        lastItem: 'shr-grow-[999] shr-basis-0',
+      },
+    },
+  },
+})
+
+type Props = Omit<VariantProps<typeof sidebar>, 'rowGap' | 'columnGap'> &
+  VariantProps<typeof sidebarItem> &
+  PropsWithChildren<{
+    as?: string | React.ComponentType<any>
+    /** コンポーネントの `min-width` 値 */
+    contentsMinWidth?: CSSProperties['minWidth']
+    /** 各領域の間隔の指定（gap） */
+    gap?: Gap | SeparateGap
+  }> &
+  ComponentProps<'div'>
+
+export const Sidebar: React.FC<Props> = ({
+  as: Component = 'div',
+  align = 'stretch',
+  contentsMinWidth = '50%',
+  gap = 1,
+  right = false,
+  className,
+  children,
+  ...props
+}) => {
+  const rowGap = gap instanceof Object ? gap.row : gap
+  const columnGap = gap instanceof Object ? gap.column : gap
+
+  const wrapperStyle = useMemo(
+    () => sidebar({ align, rowGap, columnGap, className }),
+    [align, rowGap, columnGap, className],
+  )
+  const { firstItemStyleProps, lastItemStyleProps } = useMemo(() => {
+    const { firstItem, lastItem } = sidebarItem({ right })
+    const styleProps = {
+      minWidth: contentsMinWidth,
+    }
+    return {
+      firstItemStyleProps: {
+        className: firstItem(),
+        style: right ? styleProps : undefined,
+      },
+      lastItemStyleProps: {
+        className: lastItem(),
+        style: right ? undefined : styleProps,
+      },
+    }
+  }, [contentsMinWidth, right])
+
+  // tailwindcss で :first-child / :last-child に対して動的な min-height を当てられないため、React で疑似的に処理している
+  const styledChildren = React.Children.map(children, (child, i) => {
+    if (React.isValidElement(child)) {
+      if (i === 0) {
+        return React.cloneElement(child as ReactElement, { ...firstItemStyleProps })
+      }
+      if (i === React.Children.count(children) - 1) {
+        return React.cloneElement(child as ReactElement, { ...lastItemStyleProps })
+      }
+    }
+
+    return child
+  })
+
+  return (
+    <Component {...props} className={wrapperStyle}>
+      {styledChildren}
+    </Component>
+  )
+}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-765

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

tailwindcss では `* > :first-child` に対して動的な `min-width` を与えられないため、React 側で疑似的に `:first-child` と `:last-child` を再現しています。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
