### PR TITLE
chore: turbosnapを有効にして無駄なスナップショットを減らす

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@ commands:
   run-chromatic:
     steps:
       - checkout
-      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
+      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes --only-changed
   run-chromatic-master:
     steps:
       - checkout
-      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes
+      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes --only-changed
   install-noto-sans-cjk-jp:
     steps:
       - run:


### PR DESCRIPTION
## Related URL

フロントのSlackで共有した件です。
Chromaticの利用料削減のため、turbosnapを有効にし、gitのコミットの差分に依存しないコンポーネントのスナップショットは取得しないように修正します。

詳細は以下のドキュメントをご確認ください。
https://www.chromatic.com/docs/turbosnap/#turbosnap-beta

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
