### PR TITLE
chore: BottomFixedAreaのVRT用Storyを追加

### DIFF
--- a/src/components/BottomFixedArea/VRTBottomFixedArea.stories.tsx
+++ b/src/components/BottomFixedArea/VRTBottomFixedArea.stories.tsx
@@ -1,0 +1,103 @@
+import { StoryFn } from '@storybook/react'
+import { within } from '@storybook/testing-library'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { BottomFixedArea } from './BottomFixedArea'
+import { _BottomFixedArea as All } from './BottomFixedArea.stories'
+
+export default {
+  title: 'Navigation（ナビゲーション）/BottomFixedArea',
+  component: BottomFixedArea,
+  parameters: {
+    withTheming: true,
+    layout: 'fullscreen',
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: '500px',
+      },
+    },
+  },
+}
+
+export const VRTHover: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      通常のボタン、アンカー風のボタンすべてがhoverされた状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTHover.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['button'],
+  },
+}
+
+export const VRTFocusVisibleButton: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      通常のボタンがfocusされた状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocusVisibleButton.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    focusVisible: ['button'],
+  },
+}
+
+export const VRTFocusVisibleAnchor: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      アンカー風のボタンの1つ目がfocusされた状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocusVisibleAnchor.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const button = await canvas.findByRole('button', { name: 'Tertiary_1' })
+  await button.focus()
+}
+
+export const VRTNarrow: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      画面幅が狭い状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTNarrow.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin: 1rem 1rem 24px;
+`


### PR DESCRIPTION
## Overview

BottomFixedAreaコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- VRT Hover
  - 通常のボタン、アンカー風のボタンすべてがhoverされた状態で表示されます
- VRTFocusVisibleButton
  - 通常のボタンがfocusされた状態で表示されます
- VRTFocusVisibleAnchor
  - アンカー風のボタンの1つ目がfocusされた状態で表示されます
- VRTNarrow
  - 画面幅が狭い状態で表示されます
- VRT Panel Forced Colors
  - forcedColors: 'active' を適用した状態

BottomFixedAreaには通常のボタンとアンカー風のボタンがあり、storybook-addon-pseudo-statesによるHoverはどちらにも適用できたので一つのStoryで済ませました。
アンカー風のボタンのフォーカスの状態はstorybook-addon-pseudo-statesで再現できないため、ユーザー操作のシミュレートによってフォーカスを当てています。

また、幅が狭い場合に意図したとおりに折り返すかの確認のため、画面幅の狭いStoryも用意しました。
他に必要なストーリーがあればご指摘ください。

## Capture

### VRT Hover

<img width="518" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/bee82d75-a680-4aa0-b755-8ddc56c50dd1">

### VRTFocusVisibleButton

<img width="518" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/37f0122e-e80e-4906-8c2e-b7c60fa150a3">

### VRTFocusVisibleAnchor

<img width="518" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/81c7ff4b-f766-4e67-a9bc-20b137a60261">

### VRTNarrow

<img width="518" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/cdfc842b-5c64-46fe-aa90-3a3753315573">

### VRT Panel Forced Colors

<img width="532" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/5742587c-619d-40f4-bf08-1e1d98705dbe">
