### PR TITLE
fix: ComboBoxのitemsのdataに関する型を修正し、コンポーネントに対してgenericsを指定した場合は必ず存在するように修正

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -291,6 +291,34 @@ export const Single: Story = () => {
       <dd>
         <SingleWithDefaultItem />
       </dd>
+      <dt>itemsのdataの型を指定</dt>
+      <dd>
+        <SingleComboBox<{ extraText: string }>
+          name="onClearClick"
+          items={[
+            {
+              label: 'option 1',
+              value: 'value-1',
+              data: {
+                extraText: 'extra.',
+              },
+            },
+          ]}
+          selectedItem={selectedItem}
+          width={400}
+          dropdownHelpMessage="入力でフィルタリングできます。"
+          onSelect={handleSelectItem}
+          onClearClick={(e) => {
+            e.preventDefault()
+            handleClear()
+          }}
+          onChangeSelected={(item) => {
+            action('onChangeSelected.item.data')(item.data)
+            setSelectedItem(item)
+          }}
+          data-test="single-combobox-default"
+        />
+      </dd>
     </List>
   )
 }

--- a/src/components/ComboBox/types.ts
+++ b/src/components/ComboBox/types.ts
@@ -1,10 +1,10 @@
 import React, { ChangeEvent, ReactNode } from 'react'
 
-export type ComboBoxItem<T> = {
+export type ComboBoxItem<T = void> = {
   value: string
   label: React.ReactNode
   disabled?: boolean
-  data?: T
+  data: T
 }
 
 export type ComboBoxOption<T> = {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- Combobox系コンポーネントはgenericsでitmesのdata属性に対する型を指定できるようになっている
- しかしこのdata属性にはundefinedも指定されてしまうため、利用する際には常にdataの存在チェックをしなければならず使い勝手が悪い
- 存在する場合、しない場合の分岐は利用者が行いたい & そもそもdataの型を指定する場合、基本的に存在している場合が多い為いい感じにしたい

## Capture

<!--
Please attach a capture if it looks different.
-->
