### PR TITLE
chore: HeaderのVRT用Storyを追加

### DIFF
--- a/src/components/Header/VRTHeader.stories.tsx
+++ b/src/components/Header/VRTHeader.stories.tsx
@@ -1,0 +1,131 @@
+import { StoryFn } from '@storybook/react'
+import { userEvent, within } from '@storybook/testing-library'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { Header } from './Header'
+import { All } from './Header.stories'
+
+export default {
+  title: 'Navigation（ナビゲーション）/Header',
+  component: Header,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTFocusVisible: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      通常のボタンがfocusされた状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocusVisible.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    focusVisible: ['a', 'button'],
+  },
+}
+
+export const VRTDropDown: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      ドロップダウンを表示した状態で表示されます
+    </VRTInformationPanel>
+    <WrapperForDropdown>
+      <All />
+    </WrapperForDropdown>
+  </>
+)
+VRTDropDown.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const button = await canvas.findByRole('button', { name: /株式会社SmartHR/ })
+  await userEvent.click(button)
+}
+
+export const VRTLauncher: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      ランチャーを表示した状態で表示されます
+    </VRTInformationPanel>
+    <WrapperForLauncher>
+      <All />
+    </WrapperForLauncher>
+  </>
+)
+VRTLauncher.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const button = await canvas.findByRole('button', { name: /アプリ/ })
+  await userEvent.click(button)
+}
+
+export const VRTNarrowTablet: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      タブレットの画面幅で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTNarrowTablet.parameters = {
+  viewport: {
+    defaultViewport: 'vrtTablet',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtTablet' },
+    },
+  },
+}
+
+export const VRTNarrowMobile: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      モバイルの画面幅で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTNarrowMobile.parameters = {
+  viewport: {
+    defaultViewport: 'vrtMobile',
+  },
+  chromatic: {
+    modes: {
+      vrtMobile: { viewport: 'vrtMobile' },
+    },
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <WrapperForLauncher>
+      <All />
+    </WrapperForLauncher>
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+VRTForcedColors.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const button = await canvas.findByRole('button', { name: /アプリ/ })
+  await userEvent.click(button)
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin: 1rem 1rem 24px;
+`
+const WrapperForDropdown = styled.div`
+  margin-bottom: 80px;
+`
+const WrapperForLauncher = styled.div`
+  margin-bottom: 400px;
+`

--- a/src/components/Header/VRTHeader.stories.tsx
+++ b/src/components/Header/VRTHeader.stories.tsx
@@ -127,5 +127,5 @@ const WrapperForDropdown = styled.div`
   margin-bottom: 80px;
 `
 const WrapperForLauncher = styled.div`
-  margin-bottom: 400px;
+  padding-bottom: 400px;
 `


### PR DESCRIPTION
## Overview

HeaderコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- VRT FocusVisibleButton
  - ボタンやリンクがfocusされた状態で表示されます
- VRT DropDown
  - ドロップダウンが表示された状態で表示されます
- VRT Launcher
  - ランチャーが表示された状態で表示されます
- VRT NarrowTablet
  - 画面幅がタブレットサイズで表示されます
- VRT NarrowMobile
  - 画面幅がモバイルサイズで表示されます
- VRT Panel Forced Colors
  - forcedColors: 'active' を適用した状態

他に必要なストーリーがあればご指摘ください。

## Capture

### VRT FocusVisibleButton

<img width="1766" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/cc76cc31-a710-414f-9076-383f67812a6e">

### VRT DropDown

<img width="1766" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/f546b0e9-ec8e-42d3-91b0-7f28f5a8fd74">

### VRT Launcher

<img width="1766" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/f421c039-2ed5-45e0-a3bc-13287c415b02">

### VRT NarrowTablet

<img width="832" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/1f8f38d3-70a5-4fa9-8502-900faa9d225f">

### VRT NarrowMobile

<img width="406" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/c5b49b91-d241-48a0-8f38-bfd2c25be527">

### VRT Panel Forced Colors

<img width="1185" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/db00152c-b9e0-41a2-a02a-43426f6664bb">
