### PR TITLE
chore: SideNavのVRT用Storyを追加

### DIFF
--- a/src/components/SideNav/VRTSideNav.stories.tsx
+++ b/src/components/SideNav/VRTSideNav.stories.tsx
@@ -1,0 +1,62 @@
+import { StoryFn } from '@storybook/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { InformationPanel } from '../InformationPanel'
+
+import { SideNav } from './SideNav'
+import { All } from './SideNav.stories'
+
+export default {
+  title: 'Navigation（ナビゲーション）/SideNav',
+  component: SideNav,
+  parameters: {
+    withTheming: true,
+  },
+}
+
+export const VRTHover: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      hoverされた状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTHover.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    hover: ['li'],
+  },
+}
+
+export const VRTFocus: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      focusされた状態で表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTFocus.parameters = {
+  controls: { hideNoControlsWarning: true },
+  pseudo: {
+    focusVisible: ['button'],
+  },
+}
+
+export const VRTForcedColors: StoryFn = () => (
+  <>
+    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      Chromatic 上では強制カラーモードで表示されます
+    </VRTInformationPanel>
+    <All />
+  </>
+)
+VRTForcedColors.parameters = {
+  chromatic: { forcedColors: 'active' },
+}
+
+const VRTInformationPanel = styled(InformationPanel)`
+  margin-bottom: 24px;
+`


### PR DESCRIPTION
## Overview

SideNavコンポーネントにVRT用のStoryを追加しました。

## What I did

### VRT用Storyを追加
- VRT Hover
  - hoverされた状態で表示されます
- VRT Focus
  - focusされた状態で表示されます
- VRT Panel Forced Colors
  - forcedColors: 'active' を適用した状態

他に必要なストーリーがあればご指摘ください。

## Capture

### VRT Hover
<img width="382" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/477478a1-20a1-410a-ade4-d11d3dc5c37a">

### VRT Focus
<img width="382" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/bca3a646-c577-4bb0-bb3b-496f8f41b925">

### VRT Panel Forced Colors

<img width="420" alt="image" src="https://github.com/kufu/smarthr-ui/assets/1369376/a038accd-88f8-4aff-ab56-03413be53a2c">
