### PR TITLE
chore: ButtonWrapper 内で `shr-` prefix の漏れを修正

### DIFF
--- a/src/components/Button/ButtonWrapper.tsx
+++ b/src/components/Button/ButtonWrapper.tsx
@@ -209,7 +209,7 @@ const button = tv({
         'shr-bg-white',
         'shr-text-black',
         'focus-visible:shr-border-darken',
-        'focus-visible:bg-white-darken',
+        'focus-visible:shr-bg-white-darken',
         'focus-visible:constrast-more:shr-border-high-contrast',
         'hover:shr-border-darken',
         'hover:shr-bg-white-darken',


### PR DESCRIPTION
## Related URL
#4073 の作業を進めている際に見つけたので修正。
軽微だったため #4073 に混ぜようとしたがChromaticのVRTで対象のコンポーネント以外に差分が出ていたため、原因を分けるためにPRを分けた。
[Chromatic](https://www.chromatic.com/build?appId=63d0ccabb5d2dd29825524ab&number=4701)

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
