### PR TITLE
fix: Heading のスタイリングが reset css に依存していたので修正

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps, FC, PropsWithChildren, useContext, useMemo } fro
 import { tv } from 'tailwind-variants'
 
 import { LevelContext } from '../SectioningContent'
-import { MAPPER_SIZE_AND_WEIGHT, Text, TextProps } from '../Text'
+import { Text, TextProps } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 export type Props = PropsWithChildren<{
@@ -16,7 +16,12 @@ export type Props = PropsWithChildren<{
   visuallyHidden?: boolean
 }>
 
-export type HeadingTypes = TextProps['styleType']
+export type HeadingTypes =
+  | 'screenTitle'
+  | 'sectionTitle'
+  | 'blockTitle'
+  | 'subBlockTitle'
+  | 'subSubBlockTitle'
 
 export type HeadingTagTypes = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 
@@ -24,6 +29,31 @@ type ElementProps = Omit<
   ComponentProps<'h1'>,
   keyof Props | keyof TextProps | 'role' | 'aria-level'
 >
+
+export const MAPPER_SIZE_AND_WEIGHT: { [key in HeadingTypes]: TextProps } = {
+  screenTitle: {
+    size: 'XL',
+    weight: 'normal',
+  },
+  sectionTitle: {
+    size: 'L',
+    weight: 'normal',
+  },
+  blockTitle: {
+    size: 'M',
+    weight: 'bold',
+  },
+  subBlockTitle: {
+    size: 'M',
+    weight: 'bold',
+    color: 'TEXT_GREY',
+  },
+  subSubBlockTitle: {
+    size: 'S',
+    weight: 'bold',
+    color: 'TEXT_GREY',
+  },
+}
 
 const generateTagProps = (level: number, tag?: HeadingTagTypes) => {
   let role = undefined

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,35 +1,7 @@
 import React, { ComponentProps, PropsWithChildren, useMemo } from 'react'
 import { VariantProps, tv } from 'tailwind-variants'
 
-export const MAPPER_SIZE_AND_WEIGHT: { [key in StyleTypes]: TextProps } = {
-  screenTitle: {
-    size: 'XL',
-  },
-  sectionTitle: {
-    size: 'L',
-  },
-  blockTitle: {
-    size: 'M',
-    weight: 'bold',
-  },
-  subBlockTitle: {
-    size: 'M',
-    weight: 'bold',
-    color: 'TEXT_GREY',
-  },
-  subSubBlockTitle: {
-    size: 'S',
-    weight: 'bold',
-    color: 'TEXT_GREY',
-  },
-}
-
-type StyleTypes =
-  | 'screenTitle'
-  | 'sectionTitle'
-  | 'blockTitle'
-  | 'subBlockTitle'
-  | 'subSubBlockTitle'
+import { HeadingTypes, MAPPER_SIZE_AND_WEIGHT } from '../Heading/Heading'
 
 const text = tv({
   variants: {
@@ -43,6 +15,7 @@ const text = tv({
       XXL: 'shr-text-2xl',
     },
     weight: {
+      normal: 'shr-font-normal',
       bold: 'shr-font-bold',
     },
     italic: {
@@ -78,7 +51,8 @@ export type TextProps = VariantProps<typeof text> & {
   as?: string | React.ComponentType<any> | undefined
   /** 強調するかどうかの真偽値。指定すると em 要素になる */
   emphasis?: boolean
-  styleType?: StyleTypes
+  /** 見た目の種類。Heading の種類と同じ */
+  styleType?: HeadingTypes
 }
 
 export const Text: React.FC<PropsWithChildren<TextProps & ComponentProps<'span'>>> = ({

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,2 +1,2 @@
-export { Text, MAPPER_SIZE_AND_WEIGHT } from './Text'
+export { Text } from './Text'
 export type { TextProps } from './Text'


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

reset css があたっていない場合に、予期せず UA スタイルの `font-weight: 700` があたってしまうのを防ぎたい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- bold ではない Heading には明示的に `font-weight: 400` が当たるように修正
- Text に Heading の情報を持っているのはおかしいため、Heading で持つように修正
  - スタイリングの情報
  - 見出しの種類

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
