### PR TITLE
fix: RadioButtonPanel の装飾を見直し

### DIFF
--- a/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -35,7 +35,10 @@ export const RadioButtonPanel: React.FC<Props> = ({ onClick, as, className, ...p
 }
 
 const Wrapper = styled(Base).attrs({ padding: 1 })<{ themes: Theme }>`
-  ${({ themes: { shadow, space } }) => css`
+  ${({ themes: { border, shadow, space } }) => css`
+    box-shadow: none;
+    border: ${border.shorthand};
+
     :not(:has([disabled])) {
       cursor: pointer;
     }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

smarthr-ui では押せる UI に box-shadow を使っていないため、border に変更。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
