### PR TITLE
fix: Revert "RadioButtonをTailwindCSS化"

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,60 +1,17 @@
-import React, {
-  ChangeEventHandler,
-  ComponentPropsWithRef,
-  PropsWithChildren,
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-} from 'react'
+import React, { ComponentProps, PropsWithChildren, forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useId } from '../../hooks/useId'
-import { FaCheckIcon, FaMinusIcon } from '../Icon'
 
-export type Props = PropsWithChildren<
-  ComponentPropsWithRef<'input'> & {
-    /** `true` のとき、チェック状態を `mixed` にする */
-    mixed?: boolean
-    /** チェックボックスにエラーがあるかどうか */
-    error?: boolean
-  }
->
+import { CheckBoxInput } from './CheckBoxInput'
+
+export type Props = PropsWithChildren<ComponentProps<typeof CheckBoxInput>>
 
 const checkbox = tv({
   slots: {
     wrapper: 'smarthr-ui-CheckBox shr-inline-flex shr-items-baseline',
-    box: [
-      'shr-pointer-events-none shr-absolute shr-box-border shr-h-full shr-w-full shr-rounded-s shr-border shr-border-solid shr-bg-white',
-      'contrast-more:shr-border-high-contrast',
-      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
-      'forced-colors:shr-hidden',
-      'peer-checked:shr-border-main peer-checked:shr-bg-main contrast-more:peer-checked:shr-border-high-contrast',
-      'peer-indeterminate:shr-border-main peer-indeterminate:shr-bg-main contrast-more:peer-indeterminate:shr-border-high-contrast',
-      'peer-disabled:shr-border-disabled peer-disabled:shr-bg-white-darken',
-      'peer-disabled:peer-checked:shr-border-default peer-disabled:peer-checked:shr-bg-border',
-      'peer-disabled:peer-indeterminate:shr-border-default peer-disabled:peer-indeterminate:shr-bg-border',
-      'peer-focus-visible:shr-focus-indicator',
-      'peer-hover:shr-shadow-input-hover',
-    ],
-    input: [
-      'smarthr-ui-CheckBox-checkBox shr-peer shr-absolute shr-left-0 shr-top-0 shr-m-0 shr-h-full shr-w-full shr-cursor-pointer shr-opacity-0 disabled:shr-pointer-events-none',
-      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
-      'forced-colors:shr-static forced-colors:shr-opacity-100',
-    ],
-    icon: 'shr-fill-current',
-    iconWrap: [
-      'shr-pointer-events-none shr-absolute shr-left-1/2 shr-top-1/2 shr-inline-block shr-h-[theme(fontSize.2xs)] shr-w-[theme(fontSize.2xs)] -shr-translate-x-1/2 -shr-translate-y-1/2 shr-text-2xs',
-      'shr-text-transparent peer-checked:shr-text-white peer-indeterminate:shr-text-white',
-      'peer-disabled:peer-indeteminate:shr-text-white-darken peer-disabled:peer-checked:shr-text-white-darken',
-      'forced-colors:shr-hidden',
-    ],
-    innerWrapper:
-      'shr-relative shr-box-border shr-inline-block shr-h-[theme(fontSize.base)] shr-w-[theme(fontSize.base)] shr-shrink-0 shr-translate-y-[0.125em] shr-leading-none',
     label: [
-      'smarthr-ui-CheckBox-label shr-ms-0.5 shr-cursor-pointer shr-text-base shr-leading-tight',
+      'smarthr-ui-CheckBox-label shr-ms-0.5 shr-cursor-pointer shr-text-base shr-leading-tight shr-text-black',
     ],
   },
   variants: {
@@ -62,87 +19,26 @@ const checkbox = tv({
       true: {
         label: 'shr-pointer-events-none shr-cursor-not-allowed shr-text-disabled',
       },
-      false: {
-        label: 'shr-text-black',
-      },
     },
-    error: {
-      true: {
-        box: 'shr-border-danger',
-      },
-      false: {
-        box: 'shr-border-default',
-      },
-    },
-  },
-  defaultVariants: {
-    error: false,
   },
 })
 
 export const CheckBox = forwardRef<HTMLInputElement, Props>(
-  ({ checked, mixed = false, error, onChange, className, children, ...props }, ref) => {
-    const {
-      wrapperStyle,
-      innerWrapperStyle,
-      boxStyle,
-      inputStyle,
-      iconWrapStyle,
-      iconStyle,
-      labelStyle,
-    } = useMemo(() => {
-      const { wrapper, innerWrapper, box, input, iconWrap, icon, label } = checkbox()
+  ({ className, children, ...props }, ref) => {
+    const { wrapperStyle, labelStyle } = useMemo(() => {
+      const { wrapper, label } = checkbox()
       return {
         wrapperStyle: wrapper({ className }),
-        innerWrapperStyle: innerWrapper(),
-        boxStyle: box({ error }),
-        inputStyle: input(),
-        iconWrapStyle: iconWrap(),
-        iconStyle: icon(),
         labelStyle: label({ disabled: props.disabled }),
       }
-    }, [className, error, props.disabled])
-
-    const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
-      (e) => {
-        if (onChange) onChange(e)
-      },
-      [onChange],
-    )
-
-    const inputRef = useRef<HTMLInputElement>(null)
-    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-      ref,
-      () => inputRef.current,
-    )
-
-    useEffect(() => {
-      if (inputRef.current) {
-        inputRef.current.indeterminate = !!(checked && mixed)
-      }
-    }, [checked, mixed])
+    }, [className, props.disabled])
 
     const checkBoxId = useId(props.id)
 
     return (
       <span className={wrapperStyle}>
-        <span className={innerWrapperStyle}>
-          {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
-          <input
-            {...props}
-            type="checkbox"
-            id={checkBoxId}
-            checked={checked}
-            onChange={handleChange}
-            className={inputStyle}
-            ref={inputRef}
-            aria-invalid={error || undefined}
-          />
-          <span className={boxStyle} />
-          <span className={iconWrapStyle}>
-            {mixed ? <FaMinusIcon className={iconStyle} /> : <FaCheckIcon className={iconStyle} />}
-          </span>
-        </span>
+        {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
+        <CheckBoxInput {...props} ref={ref} id={checkBoxId} />
 
         {children && (
           <label className={labelStyle} htmlFor={checkBoxId}>

--- a/src/components/CheckBox/CheckBoxInput.tsx
+++ b/src/components/CheckBox/CheckBoxInput.tsx
@@ -1,0 +1,117 @@
+import React, {
+  ComponentPropsWithRef,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react'
+import { tv } from 'tailwind-variants'
+
+import { FaCheckIcon, FaMinusIcon } from '../Icon'
+
+type Props = ComponentPropsWithRef<'input'> & {
+  /** `true` のとき、チェック状態を `mixed` にする */
+  mixed?: boolean
+  /** チェックボックスにエラーがあるかどうか */
+  error?: boolean
+}
+
+const checkboxInput = tv({
+  slots: {
+    box: [
+      'shr-pointer-events-none shr-absolute shr-box-border shr-h-full shr-w-full shr-rounded-s shr-border shr-border-solid shr-bg-white',
+      'contrast-more:shr-border-high-contrast',
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      'forced-colors:shr-hidden',
+      'peer-checked:shr-border-main peer-checked:shr-bg-main contrast-more:peer-checked:shr-border-high-contrast',
+      'peer-indeterminate:shr-border-main peer-indeterminate:shr-bg-main contrast-more:peer-indeterminate:shr-border-high-contrast',
+      'peer-disabled:shr-border-disabled peer-disabled:shr-bg-white-darken',
+      'peer-disabled:peer-checked:shr-border-default peer-disabled:peer-checked:shr-bg-border',
+      'peer-disabled:peer-indeterminate:shr-border-default peer-disabled:peer-indeterminate:shr-bg-border',
+      'peer-focus-visible:shr-focus-indicator',
+      'peer-hover:shr-shadow-input-hover',
+    ],
+    input: [
+      'smarthr-ui-CheckBox-checkBox shr-peer shr-absolute shr-left-0 shr-top-0 shr-m-0 shr-h-full shr-w-full shr-cursor-pointer shr-opacity-0 disabled:shr-pointer-events-none',
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      'forced-colors:shr-static forced-colors:shr-opacity-100',
+    ],
+    icon: 'shr-fill-current',
+    iconWrap: [
+      'shr-pointer-events-none shr-absolute shr-left-1/2 shr-top-1/2 shr-inline-block shr-h-[theme(fontSize.2xs)] shr-w-[theme(fontSize.2xs)] -shr-translate-x-1/2 -shr-translate-y-1/2 shr-text-2xs',
+      'shr-text-transparent peer-checked:shr-text-white peer-indeterminate:shr-text-white',
+      'peer-disabled:peer-indeteminate:shr-text-white-darken peer-disabled:peer-checked:shr-text-white-darken',
+      'forced-colors:shr-hidden',
+    ],
+    wrapper:
+      'shr-relative shr-box-border shr-inline-block shr-h-[theme(fontSize.base)] shr-w-[theme(fontSize.base)] shr-shrink-0 shr-translate-y-[0.125em] shr-leading-none',
+  },
+  variants: {
+    error: {
+      true: {
+        box: 'shr-border-danger',
+      },
+      false: {
+        box: 'shr-border-default',
+      },
+    },
+  },
+  defaultVariants: {
+    error: false,
+  },
+})
+
+export const CheckBoxInput = forwardRef<HTMLInputElement, Props>(
+  ({ checked, mixed = false, error, onChange, ...props }, ref) => {
+    const { wrapperStyle, boxStyle, inputStyle, iconWrapStyle, iconStyle } = useMemo(() => {
+      const { wrapper, box, input, iconWrap, icon } = checkboxInput()
+      return {
+        wrapperStyle: wrapper(),
+        boxStyle: box({ error }),
+        inputStyle: input(),
+        iconWrapStyle: iconWrap(),
+        iconStyle: icon(),
+      }
+    }, [error])
+
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (onChange) onChange(e)
+      },
+      [onChange],
+    )
+
+    const inputRef = useRef<HTMLInputElement>(null)
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current,
+    )
+
+    useEffect(() => {
+      if (inputRef.current) {
+        inputRef.current.indeterminate = !!(checked && mixed)
+      }
+    }, [checked, mixed])
+
+    return (
+      <span className={wrapperStyle}>
+        {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
+        <input
+          {...props}
+          type="checkbox"
+          checked={checked}
+          onChange={handleChange}
+          className={inputStyle}
+          ref={inputRef}
+          aria-invalid={error || undefined}
+        />
+        <span className={boxStyle} />
+        <span className={iconWrapStyle}>
+          {mixed ? <FaMinusIcon className={iconStyle} /> : <FaCheckIcon className={iconStyle} />}
+        </span>
+      </span>
+    )
+  },
+)

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,4 +1,4 @@
-import { StoryFn } from '@storybook/react'
+import { Story } from '@storybook/react'
 import React, { ChangeEvent, useState } from 'react'
 import styled from 'styled-components'
 
@@ -9,7 +9,7 @@ export default {
   component: RadioButton,
 }
 
-export const All: StoryFn = () => {
+export const All: Story = () => {
   const [checkedName, setCheckedName] = useState<string | null>(null)
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => setCheckedName(e.currentTarget.name)
 

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,100 +1,82 @@
-import React, {
-  ChangeEventHandler,
-  ComponentPropsWithRef,
-  PropsWithChildren,
-  forwardRef,
-  useCallback,
-  useMemo,
-} from 'react'
-import { tv } from 'tailwind-variants'
+import React, { ReactNode, forwardRef } from 'react'
+import styled, { css } from 'styled-components'
 
 import { useId } from '../../hooks/useId'
+import { Theme, useTheme } from '../../hooks/useTheme'
 
-type Props = PropsWithChildren<ComponentPropsWithRef<'input'>>
+import { RadioButtonInput, Props as RadioButtonInputProps } from './RadioButtonInput'
+import { useClassNames } from './useClassNames'
 
-const radioButton = tv({
-  slots: {
-    wrapper: 'smarthr-ui-RadioButton shr-inline-flex shr-items-baseline',
-    label:
-      'smarthr-ui-RadioButton-label shr-ms-0.5 shr-cursor-pointer shr-text-base shr-leading-tight',
-    innerWrapper:
-      'shr-relative shr-inline-block shr-h-em shr-w-em shr-shrink-0 shr-translate-y-[0.125em] shr-leading-none',
-    box: [
-      'shr-pointer-events-none',
-      'shr-box-border shr-block shr-h-full shr-w-full shr-rounded-full shr-border shr-border-solid shr-border-default shr-bg-white',
-      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
-      'forced-colors:shr-hidden',
-      'contrast-more:shr-border-high-contrast',
-      'peer-checked:shr-border-main peer-checked:shr-bg-main contrast-more:peer-checked:shr-border-high-contrast',
-      'peer-checked:before:shr-pointer-events-none peer-checked:before:shr-absolute peer-checked:before:shr-left-1/2 peer-checked:before:shr-top-1/2 peer-checked:before:shr-h-[0.375em] peer-checked:before:shr-w-[0.375em] peer-checked:before:-shr-translate-x-1/2 peer-checked:before:-shr-translate-y-1/2 peer-checked:before:shr-rounded-full peer-checked:before:shr-bg-white peer-checked:before:shr-content-[""]',
-      'peer-disabled:shr-cursor-not-allowed peer-disabled:shr-border-default/50 peer-disabled:shr-bg-white-darken',
-      'peer-disabled:peer-checked:shr-border-default peer-disabled:peer-checked:shr-bg-border peer-disabled:peer-checked:before:shr-bg-white-darken',
-      'peer-focus-visible:shr-focus-indicator',
-    ],
-    input: [
-      'smarthr-ui-RadioButton-radioButton shr-peer',
-      'shr-absolute shr-left-0 shr-top-0 shr-m-0 shr-h-full shr-w-full shr-cursor-pointer shr-opacity-0',
-      'disabled:shr-pointer-events-none',
-      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
-      'forced-colors:shr-static forced-colors:shr-opacity-100',
-    ],
-  },
-  variants: {
-    disabled: {
-      true: {
-        label: 'shr-cursor-not-allowed shr-text-disabled',
-      },
-      false: {
-        label: 'shr-text-black',
-        box: 'peer-hover:shr-shadow-input-hover',
-      },
-    },
-  },
-})
+type Props = {
+  /** ラベルの行高 */
+  lineHeight?: number
+  /** ラジオボタンのラベル */
+  children?: ReactNode
+} & RadioButtonInputProps
 
 export const RadioButton = forwardRef<HTMLInputElement, Props>(
-  ({ onChange, children, className, ...props }, ref) => {
-    const { wrapperStyle, innerWrapperStyle, boxStyle, inputStyle, labelStyle } = useMemo(() => {
-      const { wrapper, innerWrapper, box, input, label } = radioButton()
-      return {
-        wrapperStyle: wrapper({ className }),
-        innerWrapperStyle: innerWrapper(),
-        boxStyle: box({ disabled: !!props.disabled }),
-        inputStyle: input(),
-        labelStyle: label({ disabled: props.disabled }),
-      }
-    }, [className, props.disabled])
-
-    const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
-      (e) => {
-        if (onChange) onChange(e)
-      },
-      [onChange],
-    )
-
+  ({ lineHeight = 1.5, children, className = '', ...props }, ref) => {
+    const theme = useTheme()
+    const classNames = useClassNames()
     const radioButtonId = useId(props.id)
 
-    return (
-      <span className={wrapperStyle}>
-        <span className={innerWrapperStyle}>
+    if (!children) {
+      return (
+        <Wrapper className={`${className} ${classNames.wrapper}`} themes={theme}>
           {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
-          <input
-            {...props}
-            type="radio"
-            id={radioButtonId}
-            onChange={handleChange}
-            className={inputStyle}
-            ref={ref}
-          />
-          <span className={boxStyle} />
-        </span>
+          <RadioButtonInput {...props} ref={ref} className={classNames.radioButton} />
+        </Wrapper>
+      )
+    }
 
-        {children && (
-          <label htmlFor={radioButtonId} className={labelStyle}>
-            {children}
-          </label>
-        )}
-      </span>
+    return (
+      <Wrapper className={`${className} ${classNames.wrapper}`} themes={theme}>
+        <ButtonLayout $height={`${lineHeight}em`}>
+          {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
+          <RadioButtonInput {...props} ref={ref} id={radioButtonId} />
+        </ButtonLayout>
+
+        <Label
+          htmlFor={radioButtonId}
+          className={`${props.disabled ? 'disabled' : ''} ${classNames.label}`}
+          $lineHeight={lineHeight}
+          themes={theme}
+        >
+          {children}
+        </Label>
+      </Wrapper>
     )
   },
 )
+
+const Wrapper = styled.div<{ themes: Theme }>`
+  ${({ themes: { fontSize } }) => css`
+    display: inline-flex;
+    align-items: start;
+    font-size: ${fontSize.M};
+  `}
+`
+const ButtonLayout = styled.div<{ $height: string }>`
+  ${({ $height }) => css`
+    display: flex;
+    align-items: center;
+    height: ${$height};
+  `}
+`
+const Label = styled.label<{ themes: Theme; $lineHeight: number }>`
+  ${({ themes, $lineHeight }) => {
+    const { spacingByChar, color } = themes
+
+    return css`
+      margin-left: ${spacingByChar(0.5)};
+      color: ${color.TEXT_BLACK};
+      line-height: ${$lineHeight};
+      cursor: pointer;
+
+      &.disabled {
+        color: ${color.TEXT_DISABLED};
+        cursor: not-allowed;
+      }
+    `
+  }}
+`

--- a/src/components/RadioButton/RadioButtonInput.tsx
+++ b/src/components/RadioButton/RadioButtonInput.tsx
@@ -1,0 +1,147 @@
+import { transparentize } from 'polished'
+import React, { ChangeEvent, InputHTMLAttributes, forwardRef, useCallback } from 'react'
+import styled, { css } from 'styled-components'
+
+import { Theme, useTheme } from '../../hooks/useTheme'
+
+import { useClassNames } from './useClassNames'
+
+export type Props = InputHTMLAttributes<HTMLInputElement>
+
+export const RadioButtonInput = forwardRef<HTMLInputElement, Props>(
+  ({ onChange, ...props }, ref) => {
+    const theme = useTheme()
+    const handleChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        if (onChange) onChange(e)
+      },
+      [onChange],
+    )
+    const classNames = useClassNames()
+
+    return (
+      <Wrapper themes={theme}>
+        {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute */}
+        <Input
+          {...props}
+          type="radio"
+          onChange={handleChange}
+          className={classNames.radioButton}
+          themes={theme}
+          ref={ref}
+        />
+        <Box themes={theme} />
+      </Wrapper>
+    )
+  },
+)
+
+const Wrapper = styled.span<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { leading } = themes
+
+    return css`
+      position: relative;
+      display: inline-block;
+      flex-shrink: 0;
+      width: 1em;
+      height: 1em;
+      line-height: ${leading.NONE};
+    `
+  }}
+`
+const Box = styled.span<{ themes: Theme }>`
+  ${({ themes }) => {
+    const { border, color } = themes
+
+    return css`
+      display: block;
+      width: 100%;
+      height: 100%;
+      border-radius: 50%;
+      border: ${border.shorthand};
+      background-color: ${color.WHITE};
+      box-sizing: border-box;
+
+      /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+      @media (forced-colors: active) {
+        display: none;
+      }
+
+      @media (prefers-contrast: more) {
+        & {
+          border: ${border.highContrast};
+        }
+      }
+
+      /* FIXME: なぜか static classname になってしまうため & を重ねている */
+      input:checked + && {
+        border-color: ${color.MAIN};
+        background-color: ${color.MAIN};
+
+        @media (prefers-contrast: more) {
+          & {
+            border: ${border.highContrast};
+          }
+        }
+
+        &::before {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          width: 0.375em;
+          height: 0.375em;
+          border-radius: 50%;
+          background-color: ${color.WHITE};
+          transform: translate(-50%, -50%);
+          content: '';
+          pointer-events: none;
+        }
+      }
+
+      /* FIXME: なぜか static classname になってしまうため & を重ねている */
+      input:disabled + && {
+        border-color: ${color.disableColor(color.BORDER)};
+        background-color: ${color.hoverColor(color.WHITE)};
+        cursor: not-allowed;
+      }
+
+      input:disabled:checked + && {
+        border-color: ${color.BORDER};
+        background-color: ${color.BORDER};
+
+        &::before {
+          background-color: ${color.hoverColor(color.WHITE)};
+        }
+      }
+    `
+  }}
+`
+const Input = styled.input<{ themes: Theme }>`
+  ${({ themes: { color, shadow } }) => css`
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    cursor: pointer;
+
+    &[disabled] {
+      pointer-events: none;
+    }
+    &:hover:not([disabled]) + span {
+      box-shadow: 0 0 0 2px ${transparentize(0.78, color.MAIN)};
+    }
+    &:focus-visible + span {
+      box-shadow: ${shadow.focusIndicatorStyles};
+    }
+
+    /* 強制カラーモードのときは、ブラウザ標準のUIを表示する */
+    @media (forced-colors: active) {
+      position: initial;
+      opacity: 1;
+    }
+  `}
+`

--- a/src/components/RadioButton/useClassNames.ts
+++ b/src/components/RadioButton/useClassNames.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react'
+
+import { useClassNameGenerator } from '../../hooks/useClassNameGenerator'
+
+import { RadioButton } from './RadioButton'
+
+export function useClassNames() {
+  const generate = useClassNameGenerator(RadioButton.displayName || 'RadioButton')
+
+  return useMemo(
+    () => ({
+      wrapper: generate(),
+      radioButton: generate('radioButton'),
+      label: generate('label'),
+    }),
+    [generate],
+  )
+}


### PR DESCRIPTION
Reverts kufu/smarthr-ui#4122

Input と StatusLabel の背景色が指定されていない問題を先に修正してリリースしたほうが良さそうなので一旦 revert