### PR TITLE
feat: 一括選択のチェックボックスに可視のラベルを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -44,9 +44,21 @@ export const ThCheckbox = forwardRef<HTMLInputElement, CheckBoxProps & Props>(
       }
     }, [className])
 
-    const checkAllInvisibleLabel =
-      decorators?.checkAllInvisibleLabel?.(CHECK_ALL_INVISIBLE_LABEL) || CHECK_ALL_INVISIBLE_LABEL
-    const checkColumnName = decorators?.checkColumnName?.(CHECK_COLUMN_NAME) || CHECK_COLUMN_NAME
+    const checkAllInvisibleLabel = useMemo(() => {
+      if (decorators && decorators.checkAllInvisibleLabel) {
+        return decorators.checkAllInvisibleLabel(CHECK_ALL_INVISIBLE_LABEL)
+      }
+
+      return CHECK_ALL_INVISIBLE_LABEL
+    }, [decorators])
+
+    const checkColumnName = useMemo(() => {
+      if (decorators && decorators.checkColumnName) {
+        return decorators.checkColumnName(CHECK_COLUMN_NAME)
+      }
+
+      return CHECK_COLUMN_NAME
+    }, [decorators])
 
     return (
       // Th に必要な属性やイベントは不要

--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -10,10 +10,13 @@ import { Th } from './Th'
 import type { DecoratorsType } from '../../types'
 
 type Props = {
-  decorators?: DecoratorsType<'checkAllInvisibleLabel'>
+  decorators?: DecoratorsType<'checkAllInvisibleLabel'> & {
+    checkColumnName?: (text: string) => string
+  }
 }
 
 const CHECK_ALL_INVISIBLE_LABEL = 'すべての項目を選択/解除'
+const CHECK_COLUMN_NAME = '選択'
 
 const thCheckbox = tv({
   slots: {
@@ -43,9 +46,11 @@ export const ThCheckbox = forwardRef<HTMLInputElement, CheckBoxProps & Props>(
 
     const checkAllInvisibleLabel =
       decorators?.checkAllInvisibleLabel?.(CHECK_ALL_INVISIBLE_LABEL) || CHECK_ALL_INVISIBLE_LABEL
+    const checkColumnName = decorators?.checkColumnName?.(CHECK_COLUMN_NAME) || CHECK_COLUMN_NAME
+
     return (
       // Th に必要な属性やイベントは不要
-      <Th className={wrapperStyle}>
+      <Th className={wrapperStyle} aria-label={checkColumnName}>
         <Center as="label" verticalCentering className={innerStyle}>
           <Balloon as="span" horizontal="left" vertical="middle" className={balloonStyle}>
             <span className="shr-p-0.5 shr-block">{checkAllInvisibleLabel}</span>

--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { Balloon } from '../Balloon'
 import { CheckBox, Props as CheckBoxProps } from '../CheckBox'
 import { Center } from '../Layout'
-import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { Th } from './Th'
 
@@ -13,36 +13,44 @@ type Props = {
   decorators?: DecoratorsType<'checkAllInvisibleLabel'>
 }
 
-const CHECK_ALL_INVISIBLE_LABEL = 'すべての行を選択'
+const CHECK_ALL_INVISIBLE_LABEL = 'すべての項目を選択/解除'
 
 const thCheckbox = tv({
   slots: {
-    inner: 'shr-absolute shr-inset-0 [&:not(:has([disabled]))]:shr-cursor-pointer',
+    inner: 'shr-absolute shr-inset-0 [&:not(:has([disabled]))]:shr-cursor-pointer shr-group/label',
     wrapper: 'shr-relative shr-w-[theme(fontSize.base)] [&]:shr-px-0.75',
     checkbox: '[&]:shr-block',
+    balloon: [
+      // 位置はセルの真ん中(50%)+checkboxの幅の半分(8px)+outlineの幅(4px)+Balloonの矢印の幅(5px), sr-onlyで隠す
+      'shr-absolute shr-left-[calc(50%+(theme(fontSize.base)/2)+4px+5px)] shr-sr-only',
+      // labelの中の要素に hover or focus-visible がある時のスタイル。shr-absoluteはshr-not-sr-onlyのpositionをabsoluteに上書きしている
+      'group-has-[:hover,:focus-visible]/label:shr-not-sr-only group-has-[:hover,:focus-visible]/label:shr-absolute group-has-[:hover,:focus-visible]/label:shr-whitespace-nowrap',
+    ],
   },
 })
 
 export const ThCheckbox = forwardRef<HTMLInputElement, CheckBoxProps & Props>(
   ({ decorators, className, ...others }, ref) => {
-    const { wrapperStyle, innerStyle, checkboxStyle } = useMemo(() => {
-      const { wrapper, inner, checkbox } = thCheckbox()
+    const { wrapperStyle, innerStyle, balloonStyle, checkboxStyle } = useMemo(() => {
+      const { wrapper, inner, balloon, checkbox } = thCheckbox()
       return {
         wrapperStyle: wrapper({ className }),
         innerStyle: inner(),
         checkboxStyle: checkbox(),
+        balloonStyle: balloon(),
       }
     }, [className])
 
+    const checkAllInvisibleLabel =
+      decorators?.checkAllInvisibleLabel?.(CHECK_ALL_INVISIBLE_LABEL) || CHECK_ALL_INVISIBLE_LABEL
     return (
       // Th に必要な属性やイベントは不要
       <Th className={wrapperStyle}>
         <Center as="label" verticalCentering className={innerStyle}>
+          <Balloon as="span" horizontal="left" vertical="middle" className={balloonStyle}>
+            <span className="shr-p-0.5 shr-block">{checkAllInvisibleLabel}</span>
+          </Balloon>
           <CheckBox {...others} ref={ref} className={checkboxStyle} />
-          <VisuallyHiddenText>
-            {decorators?.checkAllInvisibleLabel?.(CHECK_ALL_INVISIBLE_LABEL) ||
-              CHECK_ALL_INVISIBLE_LABEL}
-          </VisuallyHiddenText>
         </Center>
       </Th>
     )


### PR DESCRIPTION
## Overview

`<Table>` のヘッダーセルにあるチェックボックスには、マシンリーダブルなラベルはあるが可視のラベルがなかったため追加。

参考: [フォーム: ウェブアクセシビリティ簡易チェックリスト | アクセシビリティ | SmartHR Design System](https://smarthr.design/accessibility/check-list/#h2-6)

関連チケット
https://smarthr.atlassian.net/browse/SHRUI-1066

> 入力する内容や、操作がラベルとして表示されている

## What I did

テキストラベルを表示するスペースがセル内に無いため、マウスポインターがホバーした際、またはフォーカスした際に、「すべての行を選択」のツールチップを出した。

![ツールチップのスクリーンショット。チェックボックスの右側に「すべての行を選択」と書かれた吹き出しが表示されている。](https://github.com/kufu/smarthr-ui/assets/6724665/89d16ba5-9cf5-4885-9585-d9939f03ed4a)

ヘッダーセルを固定した際に、`<Table>` コンポーネントの描画範囲外が描画されなくなるため、ツールチップは右側に出した。（右側の見出しセルが見えなくなるけど。。。）

### その他

`<ThCheckbox>` は `<th>` でレンダリングされ、内包するコンテンツが「すべての行を選択」になるので、チェックボックスがあるカラムの名前が「すべての行を選択」になってしまう。

そのことを回避するために `<th>` に `aria-label` を付与し、内包するコンテンツを無視して「選択」というカラム名に変更した。