### PR TITLE
fix: ModelessDialog ヘッダを hover した時の装飾を修正

### DIFF
--- a/src/components/Dialog/ModelessDialog.tsx
+++ b/src/components/Dialog/ModelessDialog.tsx
@@ -359,10 +359,12 @@ const Box = styled(Base).attrs({ radius: 'm', layer: 3 })<{
   }}
 `
 const Header = styled.div<{ themes: Theme }>`
-  ${({ themes: { color, border, spacingByChar } }) => css`
+  ${({ themes: { color, border, radius, spacingByChar } }) => css`
     position: relative;
     display: flex;
     align-items: center;
+    border-top-right-radius: ${radius.l};
+    border-top-left-radius: ${radius.l};
     padding-left: ${spacingByChar(1.5)};
     padding-right: ${spacingByChar(1)};
     border-bottom: ${border.shorthand};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

hover 時にはみ出ていたので修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
