### PR TITLE
feat: RightFixedNoteのeditボタンの表示/非表示を切り替えられるようにする

### DIFF
--- a/src/components/RightFixedNote/RightFixedNote.stories.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.stories.tsx
@@ -3,6 +3,7 @@ import { Story } from '@storybook/react'
 import * as React from 'react'
 
 import { RightFixedNote } from './RightFixedNote'
+import { ItemProps } from './RightFixedNoteItem'
 
 export default {
   title: 'Data Display（データ表示）/RightFixedNote',
@@ -17,7 +18,7 @@ export default {
   },
 }
 
-const sampleItems = [
+const sampleItems: ItemProps[] = [
   {
     id: 'id-1',
     text: 'コメントテキストテキストテキストテキストテキストテキスト',
@@ -32,9 +33,10 @@ const sampleItems = [
   },
   {
     id: 'id-3',
-    text: 'コメントテキストテキストテキストテキストテキストテキスト',
+    text: '編集できないコメントテキストテキストテキストテキストテキストテキスト',
     date: '2020/4/15 16:20:00',
     author: 'test@smarthr.co.jp',
+    isEditable: false,
   },
 ]
 

--- a/src/components/RightFixedNote/RightFixedNote.stories.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import * as React from 'react'
 
 import { RightFixedNote } from './RightFixedNote'
@@ -40,7 +40,7 @@ const sampleItems: ItemProps[] = [
   },
 ]
 
-export const All: Story = () => (
+export const All: StoryFn = () => (
   <RightFixedNote
     title="RightFixedNote"
     items={sampleItems}
@@ -51,7 +51,7 @@ export const All: Story = () => (
 )
 All.storyName = 'all'
 
-export const WithoutTextareaLabel: Story = () => (
+export const WithoutTextareaLabel: StoryFn = () => (
   <RightFixedNote
     title="RightFixedNote"
     items={sampleItems}
@@ -61,7 +61,7 @@ export const WithoutTextareaLabel: Story = () => (
 )
 WithoutTextareaLabel.storyName = 'without textarea label'
 
-export const WithoutItems: Story = () => (
+export const WithoutItems: StoryFn = () => (
   <RightFixedNote
     title="RightFixedNote"
     onSubmit={action('submit!')}
@@ -71,7 +71,7 @@ export const WithoutItems: Story = () => (
 )
 WithoutItems.storyName = 'without items'
 
-export const WithoutItemsAndTextareaLabel: Story = () => (
+export const WithoutItemsAndTextareaLabel: StoryFn = () => (
   <RightFixedNote
     title="RightFixedNote"
     onSubmit={action('submit!')}

--- a/src/components/RightFixedNote/RightFixedNote.stories.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.stories.tsx
@@ -36,7 +36,7 @@ const sampleItems: ItemProps[] = [
     text: '編集できないコメントテキストテキストテキストテキストテキストテキスト',
     date: '2020/4/15 16:20:00',
     author: 'test@smarthr.co.jp',
-    isEditable: false,
+    editable: false,
   },
 ]
 

--- a/src/components/RightFixedNote/RightFixedNoteItem.tsx
+++ b/src/components/RightFixedNote/RightFixedNoteItem.tsx
@@ -18,7 +18,7 @@ export type ItemProps = {
   /** このアイテムの著者 */
   author?: ReactNode
   /** edit ボタンを表示するかどうか */
-  isEditable?: boolean
+  editable?: boolean
   /** edit ボタンの aria-label */
   editLabel?: string
   /** このコンポーネントに適用するクラス名 */
@@ -37,7 +37,7 @@ export const RightFixedNoteItem: VFC<Props> = ({
   date,
   author,
   onClickEdit,
-  isEditable = true,
+  editable = true,
   editLabel = '編集',
   className = '',
 }) => {
@@ -47,7 +47,7 @@ export const RightFixedNoteItem: VFC<Props> = ({
   return (
     <Wrapper themes={theme} className={`${className} ${classNames.item}`}>
       <TextBase themes={theme}>
-        {isEditable && (
+        {editable && (
           <EditButton
             size="s"
             onClick={(e) => onClickEdit(e, id)}

--- a/src/components/RightFixedNote/RightFixedNoteItem.tsx
+++ b/src/components/RightFixedNote/RightFixedNoteItem.tsx
@@ -17,6 +17,8 @@ export type ItemProps = {
   date?: ReactNode
   /** このアイテムの著者 */
   author?: ReactNode
+  /** edit ボタンを表示するかどうか */
+  isEditable?: boolean
   /** edit ボタンの aria-label */
   editLabel?: string
   /** このコンポーネントに適用するクラス名 */
@@ -35,6 +37,7 @@ export const RightFixedNoteItem: VFC<Props> = ({
   date,
   author,
   onClickEdit,
+  isEditable = true,
   editLabel = '編集',
   className = '',
 }) => {
@@ -44,15 +47,17 @@ export const RightFixedNoteItem: VFC<Props> = ({
   return (
     <Wrapper themes={theme} className={`${className} ${classNames.item}`}>
       <TextBase themes={theme}>
-        <EditButton
-          size="s"
-          onClick={(e) => onClickEdit(e, id)}
-          square
-          aria-label={editLabel}
-          className={classNames.itemEditButton}
-        >
-          <FaPenIcon />
-        </EditButton>
+        {isEditable && (
+          <EditButton
+            size="s"
+            onClick={(e) => onClickEdit(e, id)}
+            square
+            aria-label={editLabel}
+            className={classNames.itemEditButton}
+          >
+            <FaPenIcon />
+          </EditButton>
+        )}
         <Text themes={theme} className={classNames.itemText}>
           {text}
         </Text>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

RightFixedNoteのeditボタンは常に非表示になっているが、プロダクトや権限によってはコメントが編集不可の場合もあるため、editボタンの表示/非表示をpropsで制御したい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

itemの`isEditable`でボタンの表示/非表示を切り替えられるようにしました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

Chromaticから確認してください。

<!--
Please attach a capture if it looks different.
-->
