### PR TITLE
fix: size="s" の Button でも、アイコンとテキストコンテントの縦位置が揃うようにする

### DIFF
--- a/src/components/Button/AnchorButton.tsx
+++ b/src/components/Button/AnchorButton.tsx
@@ -39,7 +39,7 @@ export const AnchorButton = forwardRef<HTMLAnchorElement, BaseProps & ElementPro
         isAnchor
         anchorRef={ref}
       >
-        <ButtonInner prefix={prefix} suffix={suffix}>
+        <ButtonInner prefix={prefix} suffix={suffix} size={size}>
           {children}
         </ButtonInner>
       </ButtonWrapper>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -85,7 +85,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps>(
         disabled={disabledOnLoading}
         $loading={loading}
       >
-        <ButtonInner prefix={actualPrefix} suffix={actualSuffix}>
+        <ButtonInner prefix={actualPrefix} suffix={actualSuffix} size={size}>
           {actualChildren}
         </ButtonInner>
       </ButtonWrapper>

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -10,6 +10,8 @@ const buttonInner = tv({
   base: [
     /* LineClamp を併用する場合に、幅を計算してもらうために指定 */
     'shr-min-w-0',
+    /* SVG とテキストコンテンツの縦位置を揃えるために指定 */
+    'shr-leading-[0]',
   ],
 })
 

--- a/src/components/Button/ButtonInner.tsx
+++ b/src/components/Button/ButtonInner.tsx
@@ -1,24 +1,35 @@
-import React, { FC, PropsWithChildren } from 'react'
+import React, { FC, PropsWithChildren, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 export type Props = PropsWithChildren<{
   prefix?: React.ReactNode
   suffix?: React.ReactNode
+  size: 'default' | 's'
 }>
 
 const buttonInner = tv({
   base: [
     /* LineClamp を併用する場合に、幅を計算してもらうために指定 */
     'shr-min-w-0',
-    /* SVG とテキストコンテンツの縦位置を揃えるために指定 */
-    'shr-leading-[0]',
   ],
+  variants: {
+    size: {
+      default: '',
+      s: [
+        /* SVG とテキストコンテンツの縦位置を揃えるために指定 */
+        'shr-leading-[0]',
+      ],
+    },
+  },
 })
 
-export const ButtonInner: FC<Props> = ({ prefix, suffix, ...props }) => (
-  <>
-    {prefix}
-    <span {...props} className={buttonInner()} />
-    {suffix}
-  </>
-)
+export const ButtonInner: FC<Props> = ({ prefix, suffix, size, ...props }) => {
+  const styles = useMemo(() => buttonInner({ size }), [size])
+  return (
+    <>
+      {prefix}
+      <span {...props} className={styles} />
+      {suffix}
+    </>
+  )
+}


### PR DESCRIPTION
## Related URL

N/A

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`<Button>` コンポーネントにて、 `size="s"` と `prefix` または `suffix` にアイコンを指定した場合に、アイコンとテキストコンテンツの縦位置が揃わない問題を解消したいです。

`<Button>` の Tailwind 化にて、以下の箇所で `line-height` の設定を削除していますが、 `size="s"` の場合には引き続き必要に見えました。
https://github.com/kufu/smarthr-ui/pull/3899/files#r1375616072

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Tailwind 化前のコードを参考に、 `line-height: 0` が設定されるようにしてみました。

→ その後不備が見つかったため、 @uknmr さんに影響範囲を最小にするようコミットいただいてます

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

|before|after|
|----|----|
|![スクリーンショット 2024-01-12 19 10 13](https://github.com/kufu/smarthr-ui/assets/16274215/fcd5fd94-5e0a-4230-8a94-0f9cba579812)|![スクリーンショット 2024-01-12 19 10 26](https://github.com/kufu/smarthr-ui/assets/16274215/432ce402-a7a3-4f6f-b149-cfdf946f4810)|

