### PR TITLE
feat: Combobox のスタイリングを見直し

### DIFF
--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -13,5 +13,6 @@ export default {
 export const All: StoryFn = () => (
   <Cluster>
     <Chip>ラベル</Chip>
+    <Chip disabled>ラベル[disabled]</Chip>
   </Cluster>
 )

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -17,10 +17,14 @@ const chip = tv({
     size: {
       s: ['shr-text-sm', 'shr-px-0.5', 'shr-py-0.25'],
     },
+    disabled: {
+      true: 'shr-bg-white/50 shr-text-disabled',
+      false: 'shr-bg-white shr-text-black',
+    },
   },
 })
 
-export const Chip: FC<Props> = ({ className, size = 's', ...props }) => {
-  const styles = useMemo(() => chip({ size, className }), [size, className])
+export const Chip: FC<Props> = ({ className, size = 's', disabled, ...props }) => {
+  const styles = useMemo(() => chip({ size, disabled, className }), [size, disabled, className])
   return <span {...props} className={styles} />
 }

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -98,7 +98,7 @@ export const Single: StoryFn = () => {
   )
 
   return (
-    <List>
+    <ListStack>
       <Stack>
         <dt>デフォルト</dt>
         <dd>
@@ -316,7 +316,7 @@ export const Single: StoryFn = () => {
           </form>
         </dd>
       </Stack>
-    </List>
+    </ListStack>
   )
 }
 
@@ -380,7 +380,7 @@ export const Multi: StoryFn = () => {
   )
 
   return (
-    <List gap={2}>
+    <ListStack>
       <Stack>
         <dt>デフォルト</dt>
         <dd>
@@ -599,10 +599,10 @@ export const Multi: StoryFn = () => {
           />
         </dd>
       </Stack>
-    </List>
+    </ListStack>
   )
 }
 
-const List = styled(Stack).attrs({ forwardedAs: 'dl', gap: 2 })`
+const ListStack = styled(Stack).attrs({ forwardedAs: 'dl', gap: 2 })`
   margin: 1rem 1.5rem;
 `

--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 import React, { ReactNode, useCallback, useState } from 'react'
 import styled from 'styled-components'
 
@@ -70,7 +70,7 @@ const manyItems = Array.from({ length: 2000 }).map((_, i) => ({
 
 type Item = { label: ReactNode; value: string; disabled?: boolean; data?: any }
 
-export const Single: Story = () => {
+export const Single: StoryFn = () => {
   const [items, setItems] = useState<Item[]>(defaultItems)
   const [selectedItem, setSelectedItem] = useState<Item | null>(null)
   const [seq, setSeq] = useState(0)
@@ -99,219 +99,223 @@ export const Single: Story = () => {
 
   return (
     <List>
-      <dt>デフォルト</dt>
-      <dd>
-        <SingleComboBox
-          name="default"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-          onChangeSelected={(item) => {
-            action('onChangeSelected')(item)
-            setSelectedItem(item)
-          }}
-          onFocus={action('onFocus')}
-          onBlur={action('onBlur')}
-          data-test="single-combobox-default"
-        />
-      </dd>
-      <dt>アイテム追加可能</dt>
-      <dd>
-        <SingleComboBox
-          name="onAdd"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="新しいアイテムを追加できます。"
-          creatable
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-          onAdd={handleAddItem}
-          data-test="single-combobox-creatable"
-        />
-      </dd>
-      <dt>Disabled</dt>
-      <dd>
-        <SingleComboBox
-          name="disabled"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="Disabled なコンボボックス"
-          disabled
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-          data-test="single-combobox-disabled"
-        />
-      </dd>
-      <dt>必須</dt>
-      <dd>
-        <SingleComboBox
-          name="required"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="Required なコンボボックス"
-          required
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-          data-test="single-combobox-disabled"
-        />
-      </dd>
-      <dt>その他属性</dt>
-      <dd>
-        <SingleComboBox
-          name="inputAttributes"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          inputAttributes={{
-            'aria-label': 'inputAttributes',
-          }}
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-          data-test="single-combobox-disabled"
-        />
-      </dd>
-      <dt>エラー表示</dt>
-      <dd>
-        <SingleComboBox
-          name="error"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          error
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-        />
-      </dd>
-      <dt>読込中</dt>
-      <dd>
-        <SingleComboBox
-          name="isLoading"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          isLoading
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-        />
-      </dd>
-      <dt>文言変更</dt>
-      <dd>
-        <SingleComboBox
-          name="decorator"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-          decorators={{
-            noResultText: (text) => `no result.(${text})`,
-            destroyButtonIconAlt: (text) => `destroy.(${text})`,
-          }}
-        />
-      </dd>
-      <dt>100%幅</dt>
-      <dd>
-        <SingleComboBox
-          name="width100Par"
-          items={items}
-          selectedItem={selectedItem}
-          width="100%"
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-        />
-      </dd>
-      <dt>ドロップダウンリストの幅を絶対指定(600px)</dt>
-      <dd>
-        <SingleComboBox
-          name="dropdownWidth600px"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownWidth={600}
-          dropdownHelpMessage="入力でフィルタリングできます。（ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト）"
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-        />
-      </dd>
-      <dt>ドロップダウンリストの幅を相対指定（Inputの200%幅）</dt>
-      <dd>
-        <SingleComboBox
-          name="dropdownWidth200Par"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownWidth="200%"
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={handleSelectItem}
-          onClear={handleClear}
-        />
-      </dd>
-      <dt>アイテム数が多い時</dt>
-      <dd>
-        <SingleComboBox
-          name="manyItems"
-          items={manyItems}
-          selectedItem={null}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={action('onSelect')}
-        />
-      </dd>
-      <dt>クリアボタンクリック時のデフォルトの挙動を無効化</dt>
-      <dd>
-        <SingleComboBox
-          name="onClearClick"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={handleSelectItem}
-          onClearClick={(e) => {
-            e.preventDefault()
-            handleClear()
-          }}
-          onChangeSelected={(item) => {
-            action('onChangeSelected')(item)
-            setSelectedItem(item)
-          }}
-          data-test="single-combobox-default"
-        />
-      </dd>
-      <dt>デフォルトの選択肢あり</dt>
-      <dd>
-        <SingleWithDefaultItem />
-      </dd>
-      <dt>form要素でラップした場合、選択肢をキーボードで選択してもformをsubmitしない</dt>
-      <form
-        onSubmit={() => {
-          throw new Error('このsubmitは発火しません')
-        }}
-      >
-        <SingleComboBox
-          name="inForm"
-          items={items}
-          selectedItem={selectedItem}
-          width={400}
-          dropdownHelpMessage="キーボードで選択肢を選んでもformはsubmitされません"
-          onSelect={handleSelectItem}
-          onChangeSelected={(item) => {
-            action('onChangeSelected')(item)
-            setSelectedItem(item)
-          }}
-          data-test="single-combobox-no-form-submit"
-        />
-      </form>
-      <dd></dd>
+      <Stack>
+        <dt>デフォルト</dt>
+        <dd>
+          <SingleComboBox
+            name="default"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+            onChangeSelected={(item) => {
+              action('onChangeSelected')(item)
+              setSelectedItem(item)
+            }}
+            onFocus={action('onFocus')}
+            onBlur={action('onBlur')}
+            data-test="single-combobox-default"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>アイテム追加可能</dt>
+        <dd>
+          <SingleComboBox
+            name="onAdd"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="新しいアイテムを追加できます。"
+            creatable
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+            onAdd={handleAddItem}
+            data-test="single-combobox-creatable"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>Disabled</dt>
+        <dd>
+          <SingleComboBox
+            name="disabled"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="Disabled なコンボボックス"
+            disabled
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+            data-test="single-combobox-disabled"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>必須</dt>
+        <dd>
+          <SingleComboBox
+            name="required"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="Required なコンボボックス"
+            required
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+            data-test="single-combobox-disabled"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>その他属性</dt>
+        <dd>
+          <SingleComboBox
+            name="inputAttributes"
+            items={items}
+            selectedItem={selectedItem}
+            inputAttributes={{
+              'aria-label': 'inputAttributes',
+            }}
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+            data-test="single-combobox-disabled"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>エラー表示</dt>
+        <dd>
+          <SingleComboBox
+            name="error"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            error
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>読込中</dt>
+        <dd>
+          <SingleComboBox
+            name="isLoading"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            isLoading
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>文言変更</dt>
+        <dd>
+          <SingleComboBox
+            name="decorator"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+            decorators={{
+              noResultText: (text) => `no result.(${text})`,
+              destroyButtonIconAlt: (text) => `destroy.(${text})`,
+            }}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>100%幅</dt>
+        <dd>
+          <SingleComboBox
+            name="widthFull"
+            items={items}
+            selectedItem={selectedItem}
+            width="100%"
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>ドロップダウンリストの幅を指定(38文字)</dt>
+        <dd>
+          <SingleComboBox
+            name="dropdownWidth38em"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownWidth="38em"
+            dropdownHelpMessage="入力でフィルタリングできます。（ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト）"
+            onSelect={handleSelectItem}
+            onClear={handleClear}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>アイテム数が多い時</dt>
+        <dd>
+          <SingleComboBox
+            name="manyItems"
+            items={manyItems}
+            selectedItem={null}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onSelect={action('onSelect')}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>クリアボタンクリック時のデフォルトの挙動を無効化</dt>
+        <dd>
+          <SingleComboBox
+            name="onClearClick"
+            items={items}
+            selectedItem={selectedItem}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onSelect={handleSelectItem}
+            onClearClick={(e) => {
+              e.preventDefault()
+              handleClear()
+            }}
+            onChangeSelected={(item) => {
+              action('onChangeSelected')(item)
+              setSelectedItem(item)
+            }}
+            data-test="single-combobox-default"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>デフォルトの選択肢あり</dt>
+        <dd>
+          <SingleWithDefaultItem />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>form要素でラップした場合、選択肢をキーボードで選択してもformをsubmitしない</dt>
+        <dd>
+          <form
+            onSubmit={() => {
+              throw new Error('このsubmitは発火しません')
+            }}
+          >
+            <SingleComboBox
+              name="inForm"
+              items={items}
+              selectedItem={selectedItem}
+              dropdownHelpMessage="キーボードで選択肢を選んでもformはsubmitされません"
+              onSelect={handleSelectItem}
+              onChangeSelected={(item) => {
+                action('onChangeSelected')(item)
+                setSelectedItem(item)
+              }}
+              data-test="single-combobox-no-form-submit"
+            />
+          </form>
+        </dd>
+      </Stack>
     </List>
   )
 }
@@ -335,14 +339,13 @@ const SingleWithDefaultItem: React.VFC = () => {
       items={items}
       selectedItem={selectedItem}
       defaultItem={items[0]}
-      width={400}
       onSelect={handleSelectItem}
       onClear={handleClear}
     />
   )
 }
 
-export const Multi: Story = () => {
+export const Multi: StoryFn = () => {
   const [items, setItems] = useState<Item[]>(defaultItems)
   const [selectedItems, setSelectedItems] = useState<Item[]>([])
   const [seq, setSeq] = useState(0)
@@ -377,243 +380,229 @@ export const Multi: Story = () => {
   )
 
   return (
-    <List>
-      <dt>デフォルト</dt>
-      <dd>
-        <MultiComboBox
-          name="default"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          onChangeSelected={(selected) => {
-            action('onChangeSelected')(selected)
-            setSelectedItems(selected)
-          }}
-          onFocus={action('onFocus')}
-          onBlur={action('onBlur')}
-          data-test="multi-combobox-default"
-        />
-      </dd>
-      <dt>アイテム追加可能</dt>
-      <dd>
-        <MultiComboBox
-          name="onAdd"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="新しいアイテムを追加できます。"
-          creatable
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          onAdd={handleAddItem}
-          data-test="multi-combobox-creatable"
-        />
-      </dd>
-      <dt>Disabled</dt>
-      <dd>
-        <MultiComboBox
-          name="disabled"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="Disabled なコンボボックス"
-          disabled
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          data-test="multi-combobox-disabled"
-        />
-      </dd>
-      <dt>必須</dt>
-      <dd>
-        <MultiComboBox
-          name="required"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="Required なコンボボックス"
-          required
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          data-test="multi-combobox-disabled"
-        />
-      </dd>
-      <dt>その他属性</dt>
-      <dd>
-        <MultiComboBox
-          name="inputAttributes"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          inputAttributes={{
-            'aria-label': 'inputAttributes',
-          }}
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          data-test="multi-combobox-disabled"
-        />
-      </dd>
-      <dt>エラー表示</dt>
-      <dd>
-        <MultiComboBox
-          name="error"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          error
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>選択済みアイテムを省略表示 + ツールチップ</dt>
-      <dd>
-        <MultiComboBox
-          name="selectedItemEllipsis"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          selectedItemEllipsis
-        />
-      </dd>
-      <dt>読込中</dt>
-      <dd>
-        <MultiComboBox
-          name="isLoading"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          isLoading
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>文言変更</dt>
-      <dd>
-        <MultiComboBox
-          name="decorator"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          decorators={{
-            noResultText: (text) => `no result.(${text})`,
-            destroyButtonIconAlt: (text) => `destroy.(${text})`,
-            selectedListAriaLabel: (text) => `selected item list.(${text})`,
-          }}
-        />
-      </dd>
-      <dt>選択解除ボタンを非表示</dt>
-      <dd>
-        <MultiComboBox
-          name="invisible_unselected_button"
-          items={items}
-          selectedItems={selectedItems.map((item) => ({ ...item, deletable: false }))}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>テキストボックスの挙動を制御</dt>
-      <dd>
-        <MultiComboBox
-          name="textbox_controllable"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-          onChangeSelected={(selected) => {
-            action('onChangeSelected')(selected)
-            setSelectedItems(selected)
-          }}
-          inputValue={controlledInputValue}
-          onChangeInput={(e) => {
-            setControlledInputValue(e.target.value)
-          }}
-          onBlur={() => setControlledInputValue('')}
-        />
-      </dd>
-      <dt>100%幅</dt>
-      <dd>
-        <MultiComboBox
-          name="width100Par"
-          items={items}
-          selectedItems={selectedItems}
-          width="100%"
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>ドロップダウンリストの幅をアイテムの幅に合わせる</dt>
-      <dd>
-        <MultiComboBox
-          name="dropdownWidthAuto"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownWidth="auto"
-          dropdownHelpMessage="入力でフィルタリングできます。（ダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキストダミーテキスト）"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>ドロップダウンリストの幅を絶対指定(600px)</dt>
-      <dd>
-        <MultiComboBox
-          name="dropdownWidth600px"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownWidth={600}
-          dropdownHelpMessage="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>ドロップダウンリストの幅を相対指定（Inputの200%幅）</dt>
-      <dd>
-        <MultiComboBox
-          name="dropdownWidth200Par"
-          items={items}
-          selectedItems={selectedItems}
-          width={400}
-          dropdownWidth="200%"
-          dropdownHelpMessage="入力でフィルタリングできます"
-          onDelete={handleDelete}
-          onSelect={handleSelectItem}
-        />
-      </dd>
-      <dt>アイテム数が多い時</dt>
-      <dd>
-        <MultiComboBox
-          name="manyItems"
-          items={manyItems}
-          selectedItems={[]}
-          width={400}
-          dropdownHelpMessage="入力でフィルタリングできます。"
-          onSelect={action('onSelect')}
-          data-test="multi-combobox-many"
-        />
-      </dd>
+    <List gap={2}>
+      <Stack>
+        <dt>デフォルト</dt>
+        <dd>
+          <MultiComboBox
+            name="default"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            onChangeSelected={(selected) => {
+              action('onChangeSelected')(selected)
+              setSelectedItems(selected)
+            }}
+            onFocus={action('onFocus')}
+            onBlur={action('onBlur')}
+            data-test="multi-combobox-default"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>アイテム追加可能</dt>
+        <dd>
+          <MultiComboBox
+            name="onAdd"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="新しいアイテムを追加できます。"
+            creatable
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            onAdd={handleAddItem}
+            data-test="multi-combobox-creatable"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>Disabled</dt>
+        <dd>
+          <MultiComboBox
+            name="disabled"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="Disabled なコンボボックス"
+            disabled
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            data-test="multi-combobox-disabled"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>必須</dt>
+        <dd>
+          <MultiComboBox
+            name="required"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="Required なコンボボックス"
+            required
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            data-test="multi-combobox-disabled"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>その他属性</dt>
+        <dd>
+          <MultiComboBox
+            name="inputAttributes"
+            items={items}
+            selectedItems={selectedItems}
+            inputAttributes={{
+              'aria-label': 'inputAttributes',
+            }}
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            data-test="multi-combobox-disabled"
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>エラー表示</dt>
+        <dd>
+          <MultiComboBox
+            name="error"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            error
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>選択済みアイテムを省略表示 + ツールチップ</dt>
+        <dd>
+          <MultiComboBox
+            name="selectedItemEllipsis"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            selectedItemEllipsis
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>読込中</dt>
+        <dd>
+          <MultiComboBox
+            name="isLoading"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            isLoading
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>文言変更</dt>
+        <dd>
+          <MultiComboBox
+            name="decorator"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="入力でフィルタリングできます"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            decorators={{
+              noResultText: (text) => `no result.(${text})`,
+              destroyButtonIconAlt: (text) => `destroy.(${text})`,
+              selectedListAriaLabel: (text) => `selected item list.(${text})`,
+            }}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>選択解除ボタンを非表示</dt>
+        <dd>
+          <MultiComboBox
+            name="invisible_unselected_button"
+            items={items}
+            selectedItems={selectedItems.map((item) => ({ ...item, deletable: false }))}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>テキストボックスの挙動を制御</dt>
+        <dd>
+          <MultiComboBox
+            name="textbox_controllable"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+            onChangeSelected={(selected) => {
+              action('onChangeSelected')(selected)
+              setSelectedItems(selected)
+            }}
+            inputValue={controlledInputValue}
+            onChangeInput={(e) => {
+              setControlledInputValue(e.target.value)
+            }}
+            onBlur={() => setControlledInputValue('')}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>100%幅</dt>
+        <dd>
+          <MultiComboBox
+            name="widthFull"
+            items={items}
+            selectedItems={selectedItems}
+            width="100%"
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>ドロップダウンリストの幅を指定(38文字)</dt>
+        <dd>
+          <MultiComboBox
+            name="dropdownWidth38em"
+            items={items}
+            selectedItems={selectedItems}
+            dropdownWidth="38em"
+            dropdownHelpMessage="入力でフィルタリングできます"
+            onDelete={handleDelete}
+            onSelect={handleSelectItem}
+          />
+        </dd>
+      </Stack>
+      <Stack>
+        <dt>アイテム数が多い時</dt>
+        <dd>
+          <MultiComboBox
+            name="manyItems"
+            items={manyItems}
+            selectedItems={[]}
+            dropdownHelpMessage="入力でフィルタリングできます。"
+            onSelect={action('onSelect')}
+            data-test="multi-combobox-many"
+          />
+        </dd>
+      </Stack>
     </List>
   )
 }
 
-const List = styled.dl`
+const List = styled(Stack).attrs({ forwardedAs: 'dl', gap: 2 })`
   margin: 1rem 1.5rem;
-  dd {
-    margin: 1rem 0 2rem;
-  }
 `

--- a/src/components/ComboBox/ListBoxItemButton.tsx
+++ b/src/components/ComboBox/ListBoxItemButton.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { FaPlusCircleIcon } from '../Icon'
+import { Text } from '../Text'
 
 import { ComboBoxContext } from './ComboBoxContext'
 import { ComboBoxOption } from './types'
@@ -54,8 +55,10 @@ function ListBoxItemButton<T>({
       className={`${className} ${classNames.addButton}`}
       ref={isActive ? activeRef : undefined}
     >
-      <AddIcon color={theme.color.TEXT_LINK} themes={theme} />
-      <AddText themes={theme}>「{label}」を追加</AddText>
+      <FaPlusCircleIcon
+        color={theme.color.TEXT_LINK}
+        text={<Text color="TEXT_LINK">「{label}」を追加</Text>}
+      />
     </AddButton>
   ) : (
     <SelectButton
@@ -117,25 +120,4 @@ const SelectButton = styled.button<{ themes: Theme }>`
 const AddButton = styled(SelectButton)`
   display: flex;
   align-items: center;
-  min-width: 100%;
-`
-const AddIcon = styled(FaPlusCircleIcon)<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { spacingByChar } = themes
-
-    return css`
-      position: relative;
-      top: -1px;
-      margin-right: ${spacingByChar(0.25)};
-    `
-  }}
-`
-const AddText = styled.span<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { color } = themes
-
-    return css`
-      color: ${color.TEXT_LINK};
-    `
-  }}
 `

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -472,7 +472,6 @@ const Container = styled.div.attrs(
       border: ${border.shorthand};
       background-color: ${color.WHITE};
       padding: ${space(0.25)} ${space(0.5)};
-      color: ${color.TEXT_GREY};
       cursor: text;
       min-width: 20em;
 

--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -464,23 +464,20 @@ const Container = styled.div.attrs(
   },
 )<ContainerType>`
   ${({ themes }) => {
-    const { border, radius, color, spacingByChar } = themes
+    const { border, color, radius, space } = themes
 
     return css`
       display: inline-flex;
-      min-width: calc(62px + 32px + ${spacingByChar(0.5)} * 2);
-      min-height: 40px;
       border-radius: ${radius.m};
       border: ${border.shorthand};
-      box-sizing: border-box;
       background-color: ${color.WHITE};
+      padding: ${space(0.25)} ${space(0.5)};
       color: ${color.TEXT_GREY};
       cursor: text;
+      min-width: 20em;
 
       @media (prefers-contrast: more) {
-        & {
-          border: ${border.highContrast};
-        }
+        border: ${border.highContrast};
       }
     `
   }}
@@ -491,9 +488,6 @@ const InputArea = styled.div<{ themes: Theme }>`
     display: flex;
     flex-wrap: wrap;
     gap: ${spacingByChar(0.5)};
-    min-height: calc(1em + ${spacingByChar(0.5)} * 2);
-    max-height: 300px;
-    margin: ${spacingByChar(0.25)} ${spacingByChar(0.5)};
     overflow-y: auto;
   `}
 `
@@ -522,58 +516,43 @@ const InputWrapper = styled.div.attrs(({ $hidden }: InputWrapperProps) => ({
 `
 const Input = styled.input<{ themes: Theme }>`
   ${({ themes }) => {
-    const { color, fontSize, spacingByChar } = themes
+    const { color, fontSize } = themes
 
     return css`
-      min-width: 80px;
+      min-width: 5em;
       width: 100%;
-      min-height: calc(1em + ${spacingByChar(0.5)} * 2);
       border: none;
       font-size: ${fontSize.M};
       color: ${color.TEXT_BLACK};
-      box-sizing: border-box;
       outline: none;
-      &[disabled] {
+
+      :disabled {
         display: none;
       }
     `
   }}
 `
 const Placeholder = styled.p<{ themes: Theme }>`
-  ${({ themes }) => {
-    const { fontSize } = themes
-
-    return css`
-      margin: 0;
-      align-self: center;
-      font-size: ${fontSize.M};
-    `
-  }}
+  margin-block: 0;
+  align-self: center;
 `
 const Suffix = styled.div<{ themes: Theme; $disabled: boolean }>`
-  ${({ themes: { color, spacingByChar }, $disabled }) => {
-    const space = spacingByChar(0.5)
+  ${({ themes: { border, space }, $disabled }) => css`
+    position: relative;
+    margin-inline: ${space(0.5)} ${space(-0.5)};
+    padding: ${space(0.5)};
+    cursor: ${$disabled ? 'not-allowed' : 'pointer'};
 
-    return css`
-      position: relative;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: ${space};
-      padding-left: calc(${space} + 1px);
-      box-sizing: border-box;
-      cursor: ${$disabled ? 'not-allowed' : 'pointer'};
+    &::before {
+      content: '';
+      position: absolute;
+      inset: ${space(0.25)} 0;
+      width: 0;
+      border-left: ${border.shorthand};
+    }
 
-      &::before {
-        content: '';
-        position: absolute;
-        top: ${space};
-        left: 0;
-        display: block;
-        width: 1px;
-        background-color: ${color.BORDER};
-        height: calc(100% - ${space} * 2);
-      }
-    `
-  }}
+    .smarthr-ui-Icon {
+      display: block;
+    }
+  `}
 `

--- a/src/components/ComboBox/MultiSelectedItem.tsx
+++ b/src/components/ComboBox/MultiSelectedItem.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { UnstyledButton } from '../Button'
+import { Chip } from '../Chip'
 import { FaTimesCircleIcon } from '../Icon'
 
 import { MultiSelectedItemTooltip } from './MultiSelectedItemTooltip'
@@ -53,9 +54,11 @@ export function MultiSelectedItem<T>({
 
   return (
     <MultiSelectedItemTooltip needsTooltip={needsTooltip} text={item.label}>
-      <Wrapper themes={theme} disabled={disabled} className={classNames.selectedItem}>
+      <Chip
+        disabled={disabled}
+        className={`${classNames.selectedItem} shr-flex shr-items-center shr-gap-0.75 shr-leading-normal [&]:shr-rounded-em`}
+      >
         <ItemLabel
-          themes={theme}
           enableEllipsis={enableEllipsis}
           className={classNames.selectedItemLabel}
           ref={labelRef}
@@ -83,35 +86,18 @@ export function MultiSelectedItem<T>({
             tabIndex={-1}
           >
             <FaTimesCircleIcon
-              color="inherit"
+              color={disabled ? 'TEXT_DISABLED' : 'inherit'}
               alt={decorators?.destroyButtonIconAlt?.(DESTROY_BUTTON_TEXT) || DESTROY_BUTTON_TEXT}
             />
           </DeleteButton>
         )}
-      </Wrapper>
+      </Chip>
     </MultiSelectedItemTooltip>
   )
 }
 
-const Wrapper = styled.div<{ themes: Theme; disabled?: boolean }>`
-  ${({ themes, disabled }) => {
-    const { border, color, fontSize } = themes
-
-    return css`
-      position: relative;
-      display: flex;
-      border-radius: 1em;
-      border: ${border.shorthand};
-      background-color: ${disabled ? color.disableColor(color.WHITE) : color.WHITE};
-      color: ${disabled ? color.TEXT_DISABLED : color.TEXT_BLACK};
-      font-size: ${fontSize.S};
-    `
-  }}
-`
-const ItemLabel = styled.div<{ enableEllipsis?: boolean; themes: Theme }>`
-  ${({ enableEllipsis, themes: { border, spacingByChar } }) => css`
-    padding: ${spacingByChar(0.25)} calc(${spacingByChar(0.5)} - ${border.lineWidth});
-
+const ItemLabel = styled.span<{ enableEllipsis?: boolean }>`
+  ${({ enableEllipsis }) => css`
     ${enableEllipsis &&
     css`
       white-space: nowrap;
@@ -121,19 +107,20 @@ const ItemLabel = styled.div<{ enableEllipsis?: boolean; themes: Theme }>`
   `}
 `
 const DeleteButton = styled(UnstyledButton)<{ themes: Theme; disabled?: boolean }>`
-  ${({ themes: { border, spacingByChar, shadow }, disabled }) => css`
+  ${({ themes: { color, radius, shadow }, disabled }) => css`
     flex-shrink: 1;
-    padding: calc(${spacingByChar(0.5)} - ${border.lineWidth});
-    border-radius: 50%;
+
+    border-radius: ${radius.full};
     cursor: ${disabled ? 'not-allowed' : 'pointer'};
     line-height: 0;
+    color: ${color.TEXT_BLACK};
 
     &:focus-visible {
       box-shadow: unset;
     }
 
     &:focus-visible > svg {
-      border-radius: 50%;
+      border-radius: ${radius.full};
       ${shadow.focusIndicatorStyles};
     }
   `}

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -389,10 +389,8 @@ function SingleComboBoxComponent<T>(
                   }
                 />
               </ClearButton>
-              <CaretDownButton themes={theme} onClick={onClickInput} type="button">
-                <CaretDownWrapper themes={theme}>
-                  <FaCaretDownIcon color={caretIconColor} />
-                </CaretDownWrapper>
+              <CaretDownButton themes={theme} onClick={onClickInput}>
+                <FaCaretDownIcon color={caretIconColor} />
               </CaretDownButton>
             </>
           }
@@ -425,10 +423,8 @@ export const SingleComboBox = forwardRef(SingleComboBoxComponent) as (<T>(
 }
 
 type ContainerType = { $disabled: boolean; $width: number | string }
-const Container = styled.div.attrs(({ $disabled, $width = 'auto' }: ContainerType) => {
-  const style: React.CSSProperties = {
-    width: typeof $width === 'number' ? `${$width}px` : $width,
-  }
+const Container = styled.div.attrs<ContainerType>(({ style = {}, $disabled, $width }) => {
+  style.width = typeof $width === 'number' ? `${$width}px` : $width
 
   if ($disabled) {
     style.cursor = 'not-allowed'
@@ -442,31 +438,27 @@ const StyledInput = styled(Input)`
   width: 100%;
 `
 const CaretDownButton = styled.button<{ themes: Theme }>(({ themes }) => {
-  const { spacingByChar } = themes
-  const space = spacingByChar(0.5)
-
+  const { border, space } = themes
   return css`
-    height: 100%;
-    box-sizing: border-box;
-    padding: ${space};
-    padding-left: 0;
-    margin-right: -${space};
+    position: relative;
     cursor: pointer;
     background-color: transparent;
     border: none;
     appearance: none;
-  `
-})
-const CaretDownWrapper = styled.span<{ themes: Theme }>(({ themes }) => {
-  const { border, spacingByChar } = themes
-  return css`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    box-sizing: border-box;
-    padding-left: ${spacingByChar(0.5)};
-    border-left: ${border.shorthand};
+    margin-right: ${space(-0.5)};
+    padding: ${space(0.5)};
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: ${space(0.25)} 0;
+      width: 0;
+      border-left: ${border.shorthand};
+    }
+
+    .smarthr-ui-Icon {
+      display: block;
+    }
   `
 })
 
@@ -478,21 +470,21 @@ const ClearButton = styled(UnstyledButton).attrs(({ $hidden }: ClearButtonProps)
   style: $hidden ? { display: 'none' } : undefined,
 }))<ClearButtonProps>`
   ${({ themes }) => {
-    const { shadow, spacingByChar } = themes
+    const { radius, shadow, space } = themes
     return css`
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 100%;
-      padding: 0 ${spacingByChar(0.5)};
       cursor: pointer;
+      margin-inline-end: ${space(0.5)};
+
+      .smarthr-ui-Icon {
+        display: block;
+      }
 
       &:focus-visible {
         box-shadow: unset;
       }
 
       &:focus-visible > svg {
-        border-radius: 50%;
+        border-radius: ${radius.full};
         ${shadow.focusIndicatorStyles};
       }
     `

--- a/src/components/ComboBox/useListBox.tsx
+++ b/src/components/ComboBox/useListBox.tsx
@@ -333,7 +333,7 @@ const Container = styled.div<Rect & { themes: Theme }>(({ left, $width, height, 
     max-width: calc(100vw - ${left}px - ${spacingByChar(0.5)});
     min-width: 100%;
 
-    padding: ${spacingByChar(0.5)} 0;
+    padding-block: ${spacingByChar(0.5)};
     border-radius: ${radius.m};
     box-shadow: ${shadow.LAYER3};
     background-color: ${color.WHITE};
@@ -364,7 +364,7 @@ const NoItems = styled.p<{ themes: Theme }>`
     const { color, fontSize, spacingByChar } = themes
 
     return css`
-      margin: 0;
+      margin-block: 0;
       padding: ${spacingByChar(0.5)} ${spacingByChar(1)};
       background-color: ${color.WHITE};
       font-size: ${fontSize.M};

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -47,6 +47,7 @@ export default {
       s: '0.25rem',
       m: '0.375rem',
       l: '0.5rem',
+      em: '1em',
       full: '9999px',
     },
     boxShadow: {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Tailwind CSS 化の前に複雑なスタイリングを減らしたかったため、見直しました。
見直し自体は `refactor` でしたが、Chip や tailwind-preset に機能追加をしたため `feat` としています。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Multi / Single で微妙にズレていた装飾を合わせました
- MultiCombobox の初期幅がマジックナンバーになっていたため、文字ベースの `20em` に変更しました
- MultiComboBox の選択済みアイテムを Chip に置き換えました
- Chip に disabled 状態を追加しました
- 不要な DOM を削りマークアップを見直しました

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
