### PR TITLE
fix: MultiComboboxのwidth:100%が正常に動作しない不具合修正

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -474,6 +474,7 @@ const Container = styled.div.attrs(
       padding: ${space(0.25)} ${space(0.5)};
       cursor: text;
       min-width: 20em;
+      box-sizing: border-box;
 
       @media (prefers-contrast: more) {
         border: ${border.highContrast};


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

smarthr-uiのv41.1.0の更新時に表示崩れが発生したので直したい。
MultiComboboxにwidth: 100%を指定した場合に、親要素からはみ出るようになってしまいました。

参考: 発生した差分
https://www.chromatic.com/test?appId=652e2197db1cfed7fd55f831&id=65af72585b6d37d60f8ace6d

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

下記対応で削除された`box-sizing: border-box;`を復活させました。

- https://github.com/kufu/smarthr-ui/pull/4196/files#diff-99591a6bd0570c02c5bf0202f232fa3976be1bb4d82ee52eea61c3f0fc5275c9L475


<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
