### PR TITLE
fix: AccordionPanel の max-height に余計なスタイルがあたっていたため削除

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelContent.tsx
+++ b/src/components/AccordionPanel/AccordionPanelContent.tsx
@@ -26,7 +26,7 @@ const accordionPanelContent = tv({
     'shr-ease-in-out',
     'shr-invisible',
     'shr-opacity-0',
-    '[&.entered]:shr-max-h-screen',
+    '[&.entered]:shr-max-h-[revert]',
     '[&.entered]:shr-visible',
     '[&.entered]:shr-opacity-100',
   ],


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

tailwindcss 化の際にアニメーション用スタイルを見直したが、不用意に `max-height: 100vh` があたっていたため削除した。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `max-height: revert;` 相当となるスタイルを充てる
- ローカルでアニメーションに問題ないことを確認

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
