### PR TITLE
refactor: MultiComboBox の min-width を調整

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -473,7 +473,7 @@ const Container = styled.div.attrs(
       background-color: ${color.WHITE};
       padding: ${space(0.25)} ${space(0.5)};
       cursor: text;
-      min-width: 20em;
+      min-width: 15em;
       box-sizing: border-box;
 
       @media (prefers-contrast: more) {


### PR DESCRIPTION
## Related URL

#4196 

## Overview

#4196 でMultiComboBoxの`min-width`のマジックナンバーを解消するために`20em`に指定が変更されていたが、比較的幅指定が狭い固定長のダイアログ上などで利用している場合に収まりきらず、既存のプロダクトの一部で表示崩れを誘発していた。
元々のマジックナンバー指定の頃と比較すると`20em`は約3倍大きく取っており、最小幅としては少し大きすぎる気もするので再調整をしたい。

## What I did

コアメンバーと協議した結果、`15em`程度であればレイアウト崩れの心配もなさそう（仮に親要素のfont-sizeを8px程度まで小さくしても100px以上の幅は確保できる）なので、それを採用した。

## Capture

<!--
Please attach a capture if it looks different.
-->
