### PR TITLE
fix: ハイコントラストモード時、AppNaviのAnchorに下線を表示する

### DIFF
--- a/src/components/AppNavi/AppNaviAnchor.tsx
+++ b/src/components/AppNavi/AppNaviAnchor.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, VFC } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { useTheme } from '../../hooks/useTheme'
 import { ComponentProps as IconProps } from '../Icon'
@@ -47,4 +47,12 @@ export const AppNaviAnchor: VFC<InnerProps> = ({
   )
 }
 
-const Anchor = styled.a<ItemStyleProps>((props) => getItemStyle(props))
+const Anchor = styled.a<ItemStyleProps>(
+  (props) => css`
+    ${getItemStyle(props)}
+
+    @media (forced-colors: active) {
+      text-decoration: underline;
+    }
+  `,
+)


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
AppNaviのAnchorについて、ハイコントラストモード利用時に下線が表示されないため、リンクであることがわかりづらい問題を解決したいです。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
CSSを修正して、強制カラーモード時にunderlineを表示するように修正しました。
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
| before | after |
| --- | --- |
| <img width="1020" alt="image" src="https://github.com/kufu/smarthr-ui/assets/60545096/00f54046-951e-4270-8e76-12a812e37385"> | <img width="1019" alt="image" src="https://github.com/kufu/smarthr-ui/assets/60545096/34157d0e-f295-4db9-8a98-49dde12a61d3"> |
<!--
Please attach a capture if it looks different.
-->
