### PR TITLE
fix: PageCounterの-がスクリーンリーダーで読み上げられない問題を修正

### DIFF
--- a/src/components/PageCounter/PageCounter.tsx
+++ b/src/components/PageCounter/PageCounter.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { ReactNode, useMemo } from 'react'
 
 import { Cluster } from '../Layout'
 import { Text } from '../Text'
@@ -9,14 +9,29 @@ type Props = {
   start: number
   end: number
   total?: number
-  decorators?: DecoratorsType<'unitForTotal' | 'unit'>
+  decorators?: DecoratorsType<'unitForTotal' | 'unit'> & {
+    rangeSeparator?: string
+  }
 }
 
-const executeDecorator = (defaultText: string, decorator: DecoratorType | undefined) =>
-  decorator?.(defaultText) || defaultText
+type ExecuteDecoratorReturn<T extends DecoratorType | string | undefined> = T extends DecoratorType
+  ? ReactNode
+  : string
+
+const executeDecorator = <T extends DecoratorType | string | undefined>(
+  defaultText: string,
+  decorator: T,
+): ExecuteDecoratorReturn<T> => {
+  if (decorator === undefined) return defaultText
+
+  if (typeof decorator === 'string') return decorator
+
+  return decorator(defaultText) as ExecuteDecoratorReturn<T>
+}
 
 const UNIT_TOTAL_TEXT = '件中'
 const UNIT_TEXT = '件'
+const RANGE_SEPARATOR = 'から'
 
 export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators }) => {
   const unitTotalText = useMemo(
@@ -24,6 +39,10 @@ export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators
     [decorators?.unitForTotal],
   )
   const unitText = useMemo(() => executeDecorator(UNIT_TEXT, decorators?.unit), [decorators?.unit])
+  const rangeSeparator = useMemo(
+    () => executeDecorator(RANGE_SEPARATOR, decorators?.rangeSeparator),
+    [decorators?.rangeSeparator],
+  )
 
   return (
     <Cluster inline align="baseline" className="shr-text-base">
@@ -39,7 +58,7 @@ export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators
         <Text weight="bold" as="b">
           {start.toLocaleString()}
         </Text>
-        <span role="img" aria-label="から">
+        <span role="img" aria-label={rangeSeparator}>
           –
         </span>
         <Text weight="bold" as="b">

--- a/src/components/PageCounter/PageCounter.tsx
+++ b/src/components/PageCounter/PageCounter.tsx
@@ -39,7 +39,9 @@ export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators
         <Text weight="bold" as="b">
           {start.toLocaleString()}
         </Text>
-        –
+        <span role="img" aria-label="から">
+          –
+        </span>
         <Text weight="bold" as="b">
           {end.toLocaleString()}
         </Text>

--- a/src/components/PageCounter/PageCounter.tsx
+++ b/src/components/PageCounter/PageCounter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { Cluster } from '../Layout'
 import { Text } from '../Text'
@@ -15,20 +15,8 @@ type Props = {
   }
 }
 
-type ExecuteDecoratorReturn<T extends DecoratorType | string | undefined> = T extends DecoratorType
-  ? ReactNode
-  : string
-
-const executeDecorator = <T extends DecoratorType | string | undefined>(
-  defaultText: string,
-  decorator: T,
-): ExecuteDecoratorReturn<T> => {
-  if (decorator === undefined) return defaultText
-
-  if (typeof decorator === 'string') return decorator
-
-  return decorator(defaultText) as ExecuteDecoratorReturn<T>
-}
+const executeDecorator = (defaultText: string, decorator: DecoratorType | undefined) =>
+  decorator?.(defaultText) || defaultText
 
 const UNIT_TOTAL_TEXT = '件中'
 const UNIT_TEXT = '件'
@@ -40,10 +28,7 @@ export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators
     [decorators?.unitForTotal],
   )
   const unitText = useMemo(() => executeDecorator(UNIT_TEXT, decorators?.unit), [decorators?.unit])
-  const rangeSeparator = useMemo(
-    () => executeDecorator(RANGE_SEPARATOR, decorators?.rangeSeparator),
-    [decorators?.rangeSeparator],
-  )
+  const rangeSeparator = decorators?.rangeSeparator ?? RANGE_SEPARATOR
 
   return (
     <Cluster inline align="baseline" className="shr-text-base">

--- a/src/components/PageCounter/PageCounter.tsx
+++ b/src/components/PageCounter/PageCounter.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useMemo } from 'react'
 
 import { Cluster } from '../Layout'
 import { Text } from '../Text'
+import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import type { DecoratorType, DecoratorsType } from '../../types'
 
@@ -58,9 +59,8 @@ export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators
         <Text weight="bold" as="b">
           {start.toLocaleString()}
         </Text>
-        <span title={rangeSeparator}>
-          –
-        </span>
+        <VisuallyHiddenText>{rangeSeparator}</VisuallyHiddenText>
+        <span aria-hidden="true">–</span>
         <Text weight="bold" as="b">
           {end.toLocaleString()}
         </Text>

--- a/src/components/PageCounter/PageCounter.tsx
+++ b/src/components/PageCounter/PageCounter.tsx
@@ -58,7 +58,7 @@ export const PageCounter: React.FC<Props> = ({ start, end, total = 0, decorators
         <Text weight="bold" as="b">
           {start.toLocaleString()}
         </Text>
-        <span role="img" aria-label={rangeSeparator}>
+        <span title={rangeSeparator}>
           –
         </span>
         <Text weight="bold" as="b">


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
NVDAで「–」が読み上げられないため、修正したいです。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
「–」に`role="img"`, `aria-label="から"`を付与しました。
`aria-label`を付与したい関係上なんらかの`role`を付与する必要があり、検討した結果`role="img"`に落ち着きました。
他には`role="paragraph"`なども候補にあがりましたが、`paragraph`は`aria-label`を付けることができないroleだったため候補から外しました。

[Accessible Rich Internet Applications (WAI-ARIA) 1.3](https://w3c.github.io/aria/#aria-label)
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
