### PR TITLE
feat: RightFixedNoteにloadingとsubmittingの状態を追加

### DIFF
--- a/src/components/RightFixedNote/RightFixedNote.stories.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.stories.tsx
@@ -51,6 +51,30 @@ export const All: StoryFn = () => (
 )
 All.storyName = 'all'
 
+export const Loading: StoryFn = () => (
+  <RightFixedNote
+    title="RightFixedNote"
+    items={sampleItems}
+    onSubmit={action('submit!')}
+    onClickEdit={action('click edit!!')}
+    textareaLabel="コメント"
+    loading
+  />
+)
+Loading.storyName = 'loading'
+
+export const Submitting: StoryFn = () => (
+  <RightFixedNote
+    title="RightFixedNote"
+    items={sampleItems}
+    onSubmit={action('submit!')}
+    onClickEdit={action('click edit!!')}
+    textareaLabel="コメント"
+    submitting
+  />
+)
+Submitting.storyName = 'submitting'
+
 export const WithoutTextareaLabel: StoryFn = () => (
   <RightFixedNote
     title="RightFixedNote"

--- a/src/components/RightFixedNote/RightFixedNote.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.tsx
@@ -122,9 +122,11 @@ export const RightFixedNote: VFC<Props & ElementProps> = ({
               disabled={submitting}
             />
 
-            <SubmitButton type="submit" className={classNames.submitButton} loading={submitting}>
-              {submitLabel}
-            </SubmitButton>
+            <SubmitButtonWrapper>
+              <Button type="submit" className={classNames.submitButton} loading={submitting}>
+                {submitLabel}
+              </Button>
+            </SubmitButtonWrapper>
           </>
         )}
       </Section>
@@ -178,7 +180,6 @@ const StyledTextarea = styled(Textarea)<{ themes: Theme }>`
   `}
 `
 
-const SubmitButton = styled(Button)`
-  display: block;
+const SubmitButtonWrapper = styled.div`
   float: right;
 `

--- a/src/components/RightFixedNote/RightFixedNote.tsx
+++ b/src/components/RightFixedNote/RightFixedNote.tsx
@@ -6,6 +6,8 @@ import { useId } from '../../hooks/useId'
 import { Theme, useTheme } from '../../hooks/useTheme'
 import { Button } from '../Button'
 import { Heading } from '../Heading'
+import { Center } from '../Layout'
+import { Loader } from '../Loader'
 import { Section } from '../SectioningContent'
 import { Text } from '../Text'
 import { Textarea } from '../Textarea'
@@ -32,6 +34,10 @@ type Props = {
   className?: string
   /** コンポーネント内の文言を変更するための関数を設定 */
   decorators?: DecoratorsType<'submitLabel'>
+  /** 読み込み中かどうか */
+  loading?: boolean
+  /** 送信中かどうか */
+  submitting?: boolean
 }
 type ElementProps = Omit<FormHTMLAttributes<HTMLFormElement>, keyof Props>
 
@@ -47,6 +53,8 @@ export const RightFixedNote: VFC<Props & ElementProps> = ({
   onSubmit,
   className = '',
   decorators,
+  loading = false,
+  submitting = false,
   ...props
 }) => {
   const theme = useTheme()
@@ -84,27 +92,41 @@ export const RightFixedNote: VFC<Props & ElementProps> = ({
           {title}
         </SectionHeading>
 
-        {items &&
-          items.map((item) => (
-            <RightFixedNoteItem {...item} key={item.id} onClickEdit={onClickEdit} />
-          ))}
+        {loading ? (
+          <Center padding={8}>
+            <Loader />
+          </Center>
+        ) : (
+          <>
+            {items &&
+              items.map((item) => (
+                <RightFixedNoteItem
+                  {...item}
+                  key={item.id}
+                  onClickEdit={onClickEdit}
+                  submitting={submitting}
+                />
+              ))}
 
-        {textareaLabel && (
-          <label htmlFor={textareaId}>
-            <TextareaLabelText themes={theme}>{textareaLabel}</TextareaLabelText>
-          </label>
+            {textareaLabel && (
+              <label htmlFor={textareaId}>
+                <TextareaLabelText themes={theme}>{textareaLabel}</TextareaLabelText>
+              </label>
+            )}
+            <StyledTextarea
+              id={textareaId}
+              name={TEXT_AREA_NAME}
+              themes={theme}
+              aria-label={innerText(textareaLabel || title)}
+              className={classNames.textarea}
+              disabled={submitting}
+            />
+
+            <SubmitButton type="submit" className={classNames.submitButton} loading={submitting}>
+              {submitLabel}
+            </SubmitButton>
+          </>
         )}
-        <StyledTextarea
-          id={textareaId}
-          name={TEXT_AREA_NAME}
-          themes={theme}
-          aria-label={innerText(textareaLabel || title)}
-          className={classNames.textarea}
-        />
-
-        <SubmitButton type="submit" className={classNames.submitButton}>
-          {submitLabel}
-        </SubmitButton>
       </Section>
     </WrapperForm>
   )

--- a/src/components/RightFixedNote/RightFixedNoteItem.tsx
+++ b/src/components/RightFixedNote/RightFixedNoteItem.tsx
@@ -23,6 +23,8 @@ export type ItemProps = {
   editLabel?: string
   /** このコンポーネントに適用するクラス名 */
   className?: string
+  /** 送信中かどうか */
+  submitting?: boolean
 }
 
 export type OnClickEdit = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>, id: string) => void
@@ -40,6 +42,7 @@ export const RightFixedNoteItem: VFC<Props> = ({
   editable = true,
   editLabel = '編集',
   className = '',
+  submitting = false,
 }) => {
   const theme = useTheme()
   const classNames = useClassNames()
@@ -54,6 +57,7 @@ export const RightFixedNoteItem: VFC<Props> = ({
             square
             aria-label={editLabel}
             className={classNames.itemEditButton}
+            disabled={submitting}
           >
             <FaPenIcon />
           </EditButton>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

社内プロダクトで`RightFixedNote`を使うにあたり、`loading`(初期読み込み中)と`submitting`(送信中)の状態を追加し、`Loader`を表示するなどしたい

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- Propsに`loading`と`submitting`を追加しました
  - 割りとエイヤで実装したので、実装内容問題無さそうか確認お願いします！

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
