### PR TITLE
fix: ComboBox のストーリーブック内で文字が表示できていない問題を修正

### DIFF
--- a/src/components/ComboBox/ComboBox.stories.tsx
+++ b/src/components/ComboBox/ComboBox.stories.tsx
@@ -213,7 +213,7 @@ export const Single: StoryFn = () => {
           onClear={handleClear}
         />
       </FormControl>
-      <FormControl title="�ロップダウンリストの幅を指定(38文字)">
+      <FormControl title="ドロップダウンリストの幅を指定(38文字)">
         <SingleComboBox
           name="dropdownWidth38em"
           items={items}


### PR DESCRIPTION
## Related URL

N/A

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<img width="471" alt="image" src="https://github.com/kufu/smarthr-ui/assets/9423/ca82034d-af6f-45ee-8aeb-47080e9a58db">

ストーリーブック内の文字が壊れているので解消したい。


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- 文字の置き換え

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<img width="393" alt="image" src="https://github.com/kufu/smarthr-ui/assets/9423/68ea2d36-0f41-4664-9d10-3b26717c65ba">


<!--
Please attach a capture if it looks different.
-->
