### PR TITLE
chore: typoしているclassNameを削除する

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -44,7 +44,6 @@ const accordionPanelTrigger = tv({
       'shr-text-left',
       'hover:shr-bg-white-darken',
       'hover:shr-shadow-none',
-      'focus-visible:shr-focus-indicator',
     ],
     leftIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:shr-rotate-90',
     rightIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:-shr-rotate-180',

--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -44,6 +44,7 @@ const accordionPanelTrigger = tv({
       'shr-text-left',
       'hover:shr-bg-white-darken',
       'hover:shr-shadow-none',
+      'focus-visible:shr-focus-indicator',
     ],
     leftIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:shr-rotate-90',
     rightIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:-shr-rotate-180',

--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -44,7 +44,7 @@ const accordionPanelTrigger = tv({
       'shr-text-left',
       'hover:shr-bg-white-darken',
       'hover:shr-shadow-none',
-      'focus-visible:shr-focusIndicator',
+      'focus-visible:shr-focus-indicator',
     ],
     leftIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:shr-rotate-90',
     rightIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:-shr-rotate-180',

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -55,7 +55,6 @@ const tooltip = tv({
     /* inline-block に overflow: visible 以外を指定すると、vertical-align が bottom margin edge に揃ってしまう
      * https://ja.stackoverflow.com/questions/2603/ */
     'shr-align-bottom',
-    'focus-visible:shr-focus-indicator',
   ],
   variants: {
     isIcon: {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -55,7 +55,7 @@ const tooltip = tv({
     /* inline-block に overflow: visible 以外を指定すると、vertical-align が bottom margin edge に揃ってしまう
      * https://ja.stackoverflow.com/questions/2603/ */
     'shr-align-bottom',
-    'focus-visible:shr-focusIndicator',
+    'focus-visible:shr-focus-indicator',
   ],
   variants: {
     isIcon: {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -49,12 +49,11 @@ type ElementProps = Omit<ComponentProps<'span'>, keyof Props | 'aria-describedby
 const tooltip = tv({
   base: [
     'smarthr-ui-Tooltip',
-    'shr-inline-block',
-    'shr-max-w-full',
-    'shr-overflow-y-hidden',
+    'shr-inline-block shr-max-w-full shr-overflow-y-hidden',
     /* inline-block に overflow: visible 以外を指定すると、vertical-align が bottom margin edge に揃ってしまう
      * https://ja.stackoverflow.com/questions/2603/ */
     'shr-align-bottom',
+    'focus-visible:shr-focus-indicator',
   ],
   variants: {
     isIcon: {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- 他のアイテムを実装しているときに、classNameのtypoに気づいたので、typoを修正しようとしました。
- ですが、修正したらもともと正常に表示されていそうな部分が表示されなくなったりしたので、classNameごと削除する方針に切り替えました。
- 今のfocus周りの表示が正しい・正しくないの判断がつかなかったのでヘルプほしいです！（chromeとfirefoxで確認しましたが、目立った箇所はわからず...）
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
