### PR TITLE
chore: メモリー不足解消のため、Chromatic の実行インスタンスを medium+ に変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,11 +105,13 @@ jobs:
       - run-a11y-test
   chromatic-deployment:
     executor: node-active-lts
+    resource_class: medium+
     steps:
       - setup-for-test
       - run-chromatic
   chromatic-deployment-master:
     executor: node-active-lts
+    resource_class: medium+
     steps:
       - setup-for-test
       - run-chromatic-master


### PR DESCRIPTION
## Related URL

N/A

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

pnpm化以降、Chromatic へのデプロイのビルドに失敗するようになっています。これを解消したい。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- 管理画面を見た限りOOMが濃厚なので、より強力なインスタンスサイズに変更します。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

N/A

<!--
Please attach a capture if it looks different.
-->
