### PR TITLE
chore: husky v9 対応

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "testcafe": "testcafe",
     "e2e": "ts-node scripts/e2e.ts",
     "e2e:dev": "testcafe chrome --host localhost --skip-js-errors",
-    "prepare": "husky install",
+    "prepare": "husky",
     "chromatic": "chromatic",
     "write:ui-props": "ts-node scripts/exportUIProps.ts",
     "export:ui-props": "run-s build:lib write:ui-props"


### PR DESCRIPTION
## Related URL

- [Release v9\.0\.1 · typicode/husky](https://github.com/typicode/husky/releases/tag/v9.0.1)

> Removed husky install. Use husky or husky some/dir for the same functionality (deprecation notice to be added).

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Husky のメジャーバージョンアップにより、警告が出る状態になっている。これを解消したい。

```
% pnpm install
Lockfile is up to date, resolution step is skipped
Already up to date

> smarthr-ui@41.3.0 prepare /home/f440/go/src/github.com/f440/smarthr-ui
> husky install

install command is deprecated
Done in 1.6s
```

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- [Release v9\.0\.1 · typicode/husky](https://github.com/typicode/husky/releases/tag/v9.0.1) の 「How to Migrate」を参考にスクリプトを修正

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

N/A

<!--
Please attach a capture if it looks different.
-->
