### PR TITLE
chore: react-docgen-typescriptをpackage.jsonに追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "prettier-plugin-tailwindcss": "^0.5.11",
     "puppeteer": "^22.1.0",
     "react": "^18.2.0",
+    "react-docgen-typescript": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "smarthr-normalize-css": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ devDependencies:
   react:
     specifier: ^18.2.0
     version: 18.2.0
+  react-docgen-typescript:
+    specifier: ^2.2.2
+    version: 2.2.2(typescript@5.3.3)
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://kufuinc.slack.com/archives/CGC58MW01/p1708387625302639

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- yarn の頃は dependencies / peerDependencies でインストールしたmoduleを使っても問題なかった
- pnpm になったら厳格になってちゃんと package.json に書いてないとエラーになるようになったため、package.jsonに明記します

## Capture

<!--
Please attach a capture if it looks different.
-->
