### PR TITLE
fix: FormControl コンポーネントの props が DOM に表出しないようにする

### DIFF
--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -109,7 +109,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
   return (
     <WrapperStack
       {...props}
-      innerMargin={innerMargin}
+      $innerMargin={innerMargin}
       disabled={disabled}
       aria-labelledby={isRoleGroup ? managedLabelId : undefined}
       aria-describedby={isRoleGroup && describedbyIds ? describedbyIds : undefined}
@@ -165,7 +165,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
         </Stack>
       )}
 
-      <ChildrenWrapper innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
+      <ChildrenWrapper $innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
         {addIdToFirstInput(children, managedHtmlFor, describedbyIds)}
       </ChildrenWrapper>
 
@@ -233,10 +233,10 @@ const isInputElement = (type: string | React.JSXElementConstructor<any>) => {
 }
 
 const WrapperStack = styled(Stack).attrs<{
-  innerMargin: Props['innerMargin']
-}>(({ innerMargin }) => ({
+  $innerMargin: Props['innerMargin']
+}>(({ $innerMargin }) => ({
   // 基本的にはすべて 0.5 幅、グルーピングしたフォームコントロール群との余白は 1
-  gap: innerMargin ?? 0.5,
+  gap: $innerMargin ?? 0.5,
 }))<{
   $themes: Theme
 }>`
@@ -297,12 +297,12 @@ const ErrorMessage = styled.p<{ themes: Theme }>`
   `}
 `
 
-const ChildrenWrapper = styled.div<{ isRoleGroup: boolean } & Pick<Props, 'innerMargin'>>`
-  ${({ innerMargin, isRoleGroup }) => css`
-    ${(innerMargin || isRoleGroup) &&
+const ChildrenWrapper = styled.div<{ isRoleGroup: boolean; $innerMargin: Props['innerMargin'] }>`
+  ${({ $innerMargin, isRoleGroup }) => css`
+    ${($innerMargin || isRoleGroup) &&
     css`
       &&& {
-        margin-block-start: ${useSpacing(innerMargin || (isRoleGroup ? 1 : 0.5))};
+        margin-block-start: ${useSpacing($innerMargin || (isRoleGroup ? 1 : 0.5))};
       }
     `}
   `}

--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -122,7 +122,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
         id={managedLabelId}
         className={`${classNames.label}`}
         forwardedAs={isRoleGroup ? 'legend' : 'label'}
-        dangerouslyTitleHidden={dangerouslyTitleHidden}
+        $dangerouslyTitleHidden={dangerouslyTitleHidden}
         // Stack 対象にしないための hidden
         hidden={dangerouslyTitleHidden || undefined}
       >
@@ -278,11 +278,14 @@ const WrapperStack = styled(Stack).attrs<{
   `}
 `
 
-type FormLabelProps = Pick<Props, 'className' | 'dangerouslyTitleHidden'>
+type FormLabelProps = {
+  className: Props['className']
+  $dangerouslyTitleHidden: Props['dangerouslyTitleHidden']
+}
 const TitleCluster = styled(Cluster).attrs(
-  ({ className, dangerouslyTitleHidden }: FormLabelProps) => ({
+  ({ className, $dangerouslyTitleHidden }: FormLabelProps) => ({
     align: 'center',
-    className: dangerouslyTitleHidden ? visuallyHiddenText({ className }) : className,
+    className: $dangerouslyTitleHidden ? visuallyHiddenText({ className }) : className,
   }),
 )<FormLabelProps>`
   /* flex-item が stretch してクリッカブル領域が広がりすぎないようにする */


### PR DESCRIPTION
## Related URL

🍐 

## Overview

FormControl コンポーネントの innerMargin と dangerouslyTitleHidden prop が styled-components を通して DOM に表出しており、React の warning が出てしまっているので出ないようにしたい

## What I did

styled-components にわたす際に props 名に $ をつけて回避
参考: [transient props](https://styled-components.com/docs/api#transient-props)

## Capture

🍐 
