### PR TITLE
fix: Textareaでwidthを指定しない場合、style属性で"width=auto"が指定されないようにする

### DIFF
--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -87,7 +87,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
     {
       autoFocus,
       maxLength,
-      width = 'auto',
+      width,
       className,
       autoResize = false,
       maxRows = Infinity,


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- styled-componentsなどでTextareaに対してwidthを指定する場合、修正前の状態では常にstyle="width: auto;" が指定されてしまい、styled-componentsによるwidth指定が無視されてしまう
- widthの初期値はautoであるため、初期値として指定する意味も無いため調整する

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
