### PR TITLE
fix: 強制カラーモードの時、borderのスタイルが適用されるようにした

### DIFF
--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -4,7 +4,7 @@ import { VariantProps, tv } from 'tailwind-variants'
 import type { Gap } from '../../types'
 
 const base = tv({
-  base: 'smarthr-ui-Base shr-bg-white contrast-more:shr-border-high-contrast',
+  base: 'smarthr-ui-Base shr-bg-white forced-colors:shr-border-shorthand contrast-more:shr-border-high-contrast',
   variants: {
     paddingBlock: {
       0: 'shr-py-0',


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

強制カラーモードの時、Baseコンポーネントの枠が表示されなくなっていた。（強制カラーモードでは box-shadow が none に強制されるため、見えなくなっていた。）

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

強制カラーモードの場合、borderが表示されるように対応した。
CSSで表すと以下のようになる。
```
@media (forced-colors: active) {
  border: 1px solid ButtonBorder;
}
```

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
Google Chromeの開発者ツールで、forced-colors: activeをEmulateしたときのキャプチャ

### 強制カラーモードではない場合
![image](https://github.com/kufu/smarthr-ui/assets/13652153/f421e5e8-6959-409b-8c01-1b7bfd7429be)

### 強制カラーモードの場合
#### [Before]
![image](https://github.com/kufu/smarthr-ui/assets/13652153/24ddb017-963a-4cb2-a1d5-40c0d552baff)


#### [After]
![image](https://github.com/kufu/smarthr-ui/assets/13652153/96134825-20fa-4410-ab09-11530a993649)

<!--
Please attach a capture if it looks different.
-->
