### PR TITLE
test: a11y-testのリソースクラスをmedium+へ上げた

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
   a11y-test:
     executor: node-active-lts-browsers
     working_directory: ~/repo
+    resource_class: medium+
     steps:
       - install-noto-sans-cjk-jp
       - run-a11y-test


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

#4291 でメモリが不足してCIが落ちていたので、a11y-testのリソースクラスをmedium+へ上げました。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
