### PR TITLE
fix: Fieldset で innerMargin={0} が作用しないのを修正

### DIFF
--- a/src/components/FormGroup/FormGroup.tsx
+++ b/src/components/FormGroup/FormGroup.tsx
@@ -165,9 +165,7 @@ export const FormGroup: React.FC<Props & ElementProps> = ({
         </Stack>
       )}
 
-      <ChildrenWrapper $innerMargin={innerMargin} isRoleGroup={isRoleGroup}>
-        {addIdToFirstInput(children, managedHtmlFor, describedbyIds)}
-      </ChildrenWrapper>
+      <div>{addIdToFirstInput(children, managedHtmlFor, describedbyIds)}</div>
 
       {supplementaryMessage && (
         <Text
@@ -297,16 +295,5 @@ const ErrorMessage = styled.p<{ themes: Theme }>`
     .smarthr-ui-FormGroup-errorMessage {
       color: ${color.DANGER};
     }
-  `}
-`
-
-const ChildrenWrapper = styled.div<{ isRoleGroup: boolean; $innerMargin: Props['innerMargin'] }>`
-  ${({ $innerMargin, isRoleGroup }) => css`
-    ${($innerMargin || isRoleGroup) &&
-    css`
-      &&& {
-        margin-block-start: ${useSpacing($innerMargin || (isRoleGroup ? 1 : 0.5))};
-      }
-    `}
   `}
 `


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- Fieldset の innerMargin に 0を渡しても作用しないのを修正しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- 原因は ChildrenWrapper 内の `margin-block-start: ${useSpacing($innerMargin || (isRoleGroup ? 1 : 0.5))};` において `||` で分岐していて 0 が falsy になるからだったのですが、そもそも、innerMargin は WrapperStack のgapに渡されていてChildrenWrapperがなくともmargin が確保されるようなので、ChildrenWrapper ごと削除しました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

innerMargin 0 の場合

| Before | After |
| --- | --- |
| <img width="652" alt="image" src="https://github.com/kufu/smarthr-ui/assets/16136015/20c36b44-3725-4e92-bb09-f1423a71f881"> |<img width="755" alt="image" src="https://github.com/kufu/smarthr-ui/assets/16136015/31009dbd-d277-41bd-ba6e-2b3feda87b22">  |

<!--
Please attach a capture if it looks different.
-->
