### PR TITLE
fix: 無効なCSSアニメーションを修正

### DIFF
--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -267,11 +267,11 @@ export default {
           },
         },
         'loader-left-spin': {
-          '0% 100%': { transform: 'rotate(130deg)' },
+          '0%, 100%': { transform: 'rotate(130deg)' },
           '50%': { transform: 'rotate(-5deg)' },
         },
         'loader-right-spin': {
-          '0% 100%': { transform: 'rotate(-130deg)' },
+          '0%, 100%': { transform: 'rotate(-130deg)' },
           '50%': { transform: 'rotate(5deg)' },
         },
         'notification-bar-slide-in': {


### PR DESCRIPTION
## Related URL

なし

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview


SmartHR UI を導入したプロジェクトをビルドしたところ以下のようなエラーが発生しました。

```
warnings when minifying css:
▲ [WARNING] Expected "," but found "100%" [css-syntax-error]

    <stdin>:690:5:
      690 │   0% 100% {
          │      ~~~~
          ╵      ,


▲ [WARNING] Expected "," but found "100%" [css-syntax-error]

    <stdin>:948:5:
      948 │   0% 100% {
          │      ~~~~
          ╵      ,

```

CSSの指定が間違っているようです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

Loaderコンポーネントの回転にあたっていたCSSが間違っていたので修正しました。

これにより今まで無効だった指定が効くようになったのですが、変化は体感できませんでした。


<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
