### PR TITLE
fix: style属性が無意味に指定されるため、widthのデフォルト値である"auto"を削除する

### DIFF
--- a/src/components/ComboBox/MultiComboBox.tsx
+++ b/src/components/ComboBox/MultiComboBox.tsx
@@ -176,7 +176,7 @@ const ActualMultiComboBox = <T,>(
     dropdownHelpMessage,
     isLoading,
     selectedItemEllipsis,
-    width = 'auto',
+    width,
     dropdownWidth = 'auto',
     inputValue: controlledInputValue,
     className,

--- a/src/components/ComboBox/SingleComboBox.tsx
+++ b/src/components/ComboBox/SingleComboBox.tsx
@@ -148,7 +148,7 @@ const ActualSingleComboBox = <T,>(
     placeholder = '',
     dropdownHelpMessage,
     isLoading,
-    width = 'auto',
+    width,
     dropdownWidth = 'auto',
     className,
     onChange,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -92,7 +92,7 @@ const ActualSelect = <T extends string>(
     onChange,
     onChangeValue,
     error = false,
-    width = 'auto',
+    width,
     hasBlank = false,
     decorators,
     size = 'default',


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- width属性のデフォルト値にautoが指定されているため、style属性が必ず出力される状態になっている
- この状態ではstyled-componentsでwidthしてもstyle属性の指定が優先されてしまい、!important等を利用する必要が発生してしまう
- style属性を指定しなくても `width` の初期値はcss的には 'auto' であるため、メリットもほぼなく、初期値を削除することで対応したい

## Capture

<!--
Please attach a capture if it looks different.
-->
