### PR TITLE
fix: DefinitionListのstyleがsmarthr-normalize-cssを利用していないプロダクトで崩れてしまう問題に対応する

### DIFF
--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -316,21 +316,25 @@ export default {
           borderColor: theme('borderColor.default'),
         },
         '.border-t-shorthand': {
+          borderWidth: '0',
           borderTopWidth: theme('borderWidth.DEFAULT'),
           borderTopStyle: 'solid',
           borderTopColor: theme('borderColor.default'),
         },
         '.border-r-shorthand': {
+          borderWidth: '0',
           borderRightWidth: theme('borderWidth.DEFAULT'),
           borderRightStyle: 'solid',
           borderRightColor: theme('borderColor.default'),
         },
         '.border-b-shorthand': {
+          borderWidth: '0',
           borderBottomWidth: theme('borderWidth.DEFAULT'),
           borderBottomStyle: 'solid',
           borderBottomColor: theme('borderColor.default'),
         },
         '.border-l-shorthand': {
+          borderWidth: '0',
           borderLeftWidth: theme('borderWidth.DEFAULT'),
           borderLeftStyle: 'solid',
           borderLeftColor: theme('borderColor.default'),


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- smarthr-normalize-cssが利用されていない場合、dottedのstyleを指定した時点で全方向にborderが設定されてしまう
- styleで基本のwidthを0にすることでnormalize cssを未使用でも表示崩れが起きない状態にしたい

## Capture

<!--
Please attach a capture if it looks different.
-->
