### PR TITLE
fix: smarthr-normalize-css への依存を剥がすための下準備

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -15,7 +15,7 @@ export default {
 }
 
 export const All: StoryFn = () => (
-  <Stack as="dl" gap={3}>
+  <Stack as="dl" gap={3} className="shr-my-[unset] [&_dd]:shr-ms-[unset]">
     <Stack>
       <DtText>種類</DtText>
       <dd>

--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -98,8 +98,13 @@ export const BaseStory: StoryFn = () => {
 BaseStory.storyName = 'Base'
 
 const DescriptionList = styled.dl`
+  margin-block-start: unset;
   padding: 24px;
   background-color: #eee;
+
+  dd {
+    margin-inline-start: unset;
+  }
 `
 
 const List = styled.ul`

--- a/src/components/Base/BaseColumn/BaseColumn.stories.tsx
+++ b/src/components/Base/BaseColumn/BaseColumn.stories.tsx
@@ -11,7 +11,7 @@ export default {
 }
 
 export const All: StoryFn = () => (
-  <Stack as="ul">
+  <Stack as="ul" className="shr-my-[unset] shr-list-none shr-ps-[unset]">
     <li>
       <p>padding / bgColor で余白と背景色を変えることもできます</p>
     </li>

--- a/src/components/Button/VRTButton.stories.tsx
+++ b/src/components/Button/VRTButton.stories.tsx
@@ -23,7 +23,7 @@ export const _VRTButtonState: StoryFn = () => (
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
-    <dl>
+    <dl className="*:shr-ms-0">
       <dt>hover</dt>
       <dd style={{ padding: '10px' }}>
         <Stack>
@@ -190,7 +190,7 @@ export const _VRTButtonAnchorState: StoryFn = () => (
     <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
-    <dl>
+    <dl className="*:shr-ms-0">
       <dt>hover</dt>
       <dd style={{ padding: '10px' }}>
         <Stack>

--- a/src/components/ComboBox/VRTComboBox.stories.tsx
+++ b/src/components/ComboBox/VRTComboBox.stories.tsx
@@ -83,6 +83,7 @@ VRTMultiForcedColors.parameters = {
 }
 
 const WrapperList = styled.ul`
+  margin-block: unset;
   padding: 0 24px;
   list-style: none;
   & > li {

--- a/src/components/FormControl/FormControl.stories.tsx
+++ b/src/components/FormControl/FormControl.stories.tsx
@@ -13,7 +13,7 @@ export default {
 }
 
 export const All: StoryFn = () => (
-  <Stack gap={2} as="dl">
+  <Stack gap={2} as="dl" className="shr-my-[unset] [&_dd]:shr-ms-[unset]">
     <Stack>
       <Text italic color="TEXT_GREY" as="dt">
         基本

--- a/src/components/FormGroup/FormGroup.stories.tsx
+++ b/src/components/FormGroup/FormGroup.stories.tsx
@@ -2,6 +2,7 @@ import { StoryFn } from '@storybook/react'
 import React from 'react'
 
 import { CompactInformationPanel } from '../CompactInformationPanel'
+import { TextLink } from '../TextLink'
 
 import { FormGroup } from './FormGroup'
 
@@ -13,8 +14,8 @@ export default {
 export const All: StoryFn = () => (
   <CompactInformationPanel type="warning">
     FormGroupコンポーネントは非推奨です。
-    <a href="/?path=/docs/forms（フォーム）-formcontrol--docs">FormControl</a>か
-    <a href="/?path=/docs/forms（フォーム）-fieldset--docs">Fieldset</a>
+    <TextLink href="/?path=/docs/forms（フォーム）-formcontrol--docs">FormControl</TextLink>か
+    <TextLink href="/?path=/docs/forms（フォーム）-fieldset--docs">Fieldset</TextLink>
     コンポーネントを使用してください。
   </CompactInformationPanel>
 )

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -56,6 +56,7 @@ const StyledPageHeading = styled(PageHeading)`
 `
 
 const List = styled.ul`
+  margin-block: unset;
   padding: 0 2.4rem;
   list-style: none;
 

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -55,7 +55,7 @@ export const AltText: StoryFn = () => (
     <p>
       <span id="text">連絡帳</span>
     </p>
-    <dl>
+    <dl className="shr-my-[unset] [&_dd]:shr-ms-[unset]">
       <dt>visually hidden text</dt>
       <dd>
         <FaAddressBookIcon alt="連絡帳" />
@@ -167,5 +167,9 @@ const ItemWrapper = styled(BaseColumn)`
     flex-direction: column;
     align-items: center;
     gap: ${space(0.5)};
+
+    dd {
+      margin-inline-start: unset;
+    }
   `}
 `

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -128,7 +128,11 @@ export const Currency: StoryFn = () => {
 }
 Currency.storyName = 'CurrencyInput'
 
-const ListStack = styled(Stack).attrs({ forwardedAs: 'ul' })``
+const ListStack = styled(Stack).attrs({ forwardedAs: 'ul' })`
+  margin-block: unset;
+  padding-inline-start: unset;
+  list-style-type: none;
+`
 const StyledInput = styled(Input)`
   width: 50%;
 `

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -68,11 +68,11 @@ export const RegFocus = Template.bind({})
 RegFocus.play = () => userEvent.tab()
 
 const List = styled.ul`
+  list-style-type: none;
+  margin-block: unset;
   padding: 0 20px;
 
   & > li {
-    list-style: none;
-
     &:not(:first-child) {
       margin-top: 20px;
     }

--- a/src/components/SpreadsheetTable/SpreadsheetTable.stories.tsx
+++ b/src/components/SpreadsheetTable/SpreadsheetTable.stories.tsx
@@ -38,7 +38,7 @@ export const All: StoryFn = () => {
   ]
 
   return (
-    <Stack gap={2} as="dl">
+    <Stack gap={2} as="dl" className="shr-my-[unset] [&_dd]:shr-ms-[unset]">
       <Stack>
         <Text italic color="TEXT_GREY" as="dt">
           基本

--- a/src/components/TabBar/TabBar.stories.tsx
+++ b/src/components/TabBar/TabBar.stories.tsx
@@ -15,7 +15,7 @@ export default {
 }
 
 export const All: StoryFn = () => (
-  <Stack as="ul" className="shr-list-none">
+  <Stack as="ul" className="shr-my-[unset] shr-list-none shr-ps-[unset]">
     <li>
       <p>標準</p>
       <Template subid={1} />

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -56,6 +56,7 @@ const Wrapper = styled.ul(
   ({ theme: { spacingByChar } }) => css`
     list-style: none;
     margin: ${spacingByChar(1.5)};
+    padding-inline-start: unset;
 
     li + li {
       margin-top: ${spacingByChar(1)};

--- a/src/components/TextLink/VRTTextLink.stories.tsx
+++ b/src/components/TextLink/VRTTextLink.stories.tsx
@@ -100,6 +100,7 @@ const Wrapper = styled.ul(
   ({ theme: { spacingByChar } }) => css`
     list-style: none;
     margin: ${spacingByChar(1.5)};
+    padding-inline-start: unset;
 
     li + li {
       margin-top: ${spacingByChar(1)};

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -285,6 +285,7 @@ const List = styled.dl`
     }
     dd {
       margin-top: 5px;
+      margin-inline-start: unset;
 
       &.limit {
         width: 200px;

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -347,6 +347,9 @@ export default {
           lineHeight: theme('lineHeight.normal'),
           color: theme('colors.black'),
         },
+        p: {
+          marginBlock: 'unset',
+        },
       })
       addVariant('forced-colors', '@media (forced-colors: active)')
     }),

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -299,7 +299,7 @@ export default {
     textDecorationColor: false,
   },
   plugins: [
-    plugin(({ addComponents, addVariant, theme }) => {
+    plugin(({ addComponents, addBase, addVariant, theme }) => {
       addComponents({
         /**
          * box-shadow や ring を使った仕組みでは Firefox で欠陥があるため、独自定義している
@@ -338,6 +338,14 @@ export default {
           borderLeftWidth: theme('borderWidth.DEFAULT'),
           borderLeftStyle: 'solid',
           borderLeftColor: theme('borderColor.default'),
+        },
+      })
+      addBase({
+        body: {
+          overflowWrap: 'break-word',
+          fontFamily: 'system-ui, sans-serif',
+          lineHeight: theme('lineHeight.normal'),
+          color: theme('colors.black'),
         },
       })
       addVariant('forced-colors', '@media (forced-colors: active)')


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

smarthr-normalize-css がなくても機能する smarthr-ui を作りにいくための下準備です。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- smarthr-normalize-css で最低限必要な global css を Tailwind CSS の base layer として定義します
- Chroamtic で差分を洗い出すために smarthr-normalize-css を Story に当てている箇所を消します
  - これは差分を洗い出し終わったら消します

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
