### PR TITLE
fix: button と input, textarea, select の font-family を normalize

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,7 +19,7 @@ import '../src/styles/index.css'
 const preview: Preview = {
   globalTypes: {
     reset: {
-      defaultValue: null,
+      defaultValue: 'smarthr-normalize',
       toolbar: {
         title: 'CSS Reset',
         items: [

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,7 +19,7 @@ import '../src/styles/index.css'
 const preview: Preview = {
   globalTypes: {
     reset: {
-      defaultValue: 'smarthr-normalize',
+      defaultValue: null,
       toolbar: {
         title: 'CSS Reset',
         items: [

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -350,6 +350,9 @@ export default {
         p: {
           marginBlock: 'unset',
         },
+        'button, input, textarea, select': {
+          fontFamily: 'inherit',
+        },
       })
       addVariant('forced-colors', '@media (forced-colors: active)')
     }),


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-876

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

AccordionPanel に差分がでていて気がついた。
button に UA style の `button { font-family: Arial; }` があたっていたため、`inherit` に変更。
input や textarea なども同様と考えられるため修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
