### PR TITLE
fix: 角丸のデザイントークンが rem ベースになっていたので修正

### DIFF
--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -45,9 +45,9 @@ export default {
     }),
     borderRadius: {
       none: '0',
-      s: '0.25rem',
-      m: '0.375rem',
-      l: '0.5rem',
+      s: '4px',
+      m: '6px',
+      l: '8px',
       em: '1em',
       full: '9999px',
     },


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

radius が rem ベースだと、開発環境に依って `html: { font-size: 10px; }` などとしている環境で想定しない大きさになってしまうため修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
