### PR TITLE
feat: Action / FormDialog のフッター左端に操作領域を追加

### DIFF
--- a/src/components/Dialog/ActionDialog/ActionDialog.tsx
+++ b/src/components/Dialog/ActionDialog/ActionDialog.tsx
@@ -23,6 +23,7 @@ export const ActionDialog: React.FC<Props & ElementProps> = ({
   responseMessage,
   actionDisabled = false,
   closeDisabled,
+  subActionArea,
   className = '',
   portalParent,
   decorators,
@@ -64,6 +65,7 @@ export const ActionDialog: React.FC<Props & ElementProps> = ({
         closeDisabled={closeDisabled}
         onClickClose={handleClickClose}
         onClickAction={handleClickAction}
+        subActionArea={subActionArea}
         responseMessage={responseMessage}
         decorators={decorators}
       >

--- a/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -47,6 +47,8 @@ export type BaseProps = PropsWithChildren<{
    * 閉じるボタンを無効にするかどうか
    */
   closeDisabled?: boolean
+  /** ダイアログフッターの左端操作領域 */
+  subActionArea?: ReactNode
   /**
    * コンポーネントに適用するクラス名
    */
@@ -76,6 +78,7 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
   responseMessage,
   actionDisabled = false,
   closeDisabled,
+  subActionArea,
   decorators,
 }) => {
   const classNames = useClassNames().dialog
@@ -106,24 +109,27 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
         {children}
       </Body>
       <ActionAreaStack $themes={theme} ref={bottomRef} className={classNames.actionArea}>
-        <ButtonArea className={classNames.buttonArea}>
-          <Button
-            onClick={onClickClose}
-            disabled={closeDisabled || isRequestProcessing}
-            className={classNames.closeButton}
-          >
-            {decorators?.closeButtonLabel?.(CLOSE_BUTTON_LABEL) || CLOSE_BUTTON_LABEL}
-          </Button>
-          <Button
-            variant={actionTheme}
-            onClick={handleClickAction}
-            disabled={actionDisabled}
-            loading={isRequestProcessing}
-            className={classNames.actionButton}
-          >
-            {actionText}
-          </Button>
-        </ButtonArea>
+        <Cluster justify="space-between">
+          <div>{subActionArea}</div>
+          <ButtonArea className={classNames.buttonArea}>
+            <Button
+              onClick={onClickClose}
+              disabled={closeDisabled || isRequestProcessing}
+              className={classNames.closeButton}
+            >
+              {decorators?.closeButtonLabel?.(CLOSE_BUTTON_LABEL) || CLOSE_BUTTON_LABEL}
+            </Button>
+            <Button
+              variant={actionTheme}
+              onClick={handleClickAction}
+              disabled={actionDisabled}
+              loading={isRequestProcessing}
+              className={classNames.actionButton}
+            >
+              {actionText}
+            </Button>
+          </ButtonArea>
+        </Cluster>
         {(responseMessage?.status === 'success' || responseMessage?.status === 'error') && (
           <Message>
             <ResponseMessage type={responseMessage.status} role="alert">

--- a/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -110,7 +110,7 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
       </Body>
       <ActionAreaStack $themes={theme} ref={bottomRef} className={classNames.actionArea}>
         <Cluster justify="space-between">
-          <div>{subActionArea}</div>
+          {subActionArea}
           <ButtonArea className={classNames.buttonArea}>
             <Button
               onClick={onClickClose}
@@ -164,7 +164,9 @@ const ActionAreaStack = styled(Stack).attrs({ gap: 0.5 })<{ $themes: Theme }>`
     padding: ${space(1)} ${space(1.5)};
   `}
 `
-const ButtonArea = styled(Cluster).attrs({ gap: { row: 0.5, column: 1 }, justify: 'flex-end' })``
+const ButtonArea = styled(Cluster).attrs({ gap: { row: 0.5, column: 1 }, justify: 'flex-end' })`
+  margin-inline-start: auto;
+`
 const Message = styled.div`
   text-align: right;
 `

--- a/src/components/Dialog/FormDialog/FormDialog.tsx
+++ b/src/components/Dialog/FormDialog/FormDialog.tsx
@@ -23,6 +23,7 @@ export const FormDialog: React.FC<Props & ElementProps> = ({
   responseMessage,
   actionDisabled = false,
   closeDisabled,
+  subActionArea,
   className = '',
   portalParent,
   decorators,
@@ -64,6 +65,7 @@ export const FormDialog: React.FC<Props & ElementProps> = ({
         actionTheme={actionTheme}
         actionDisabled={actionDisabled}
         closeDisabled={closeDisabled}
+        subActionArea={subActionArea}
         onClickClose={handleClickClose}
         onSubmit={handleSubmitAction}
         responseMessage={responseMessage}

--- a/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -118,7 +118,7 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
         </Body>
         <ActionAreaStack themes={theme} ref={bottomRef} className={classNames.actionArea}>
           <Cluster justify="space-between">
-            <div>{subActionArea}</div>
+            {subActionArea}
             <ButtonArea className={classNames.buttonArea}>
               <Button
                 onClick={onClickClose}
@@ -173,7 +173,9 @@ const ActionAreaStack = styled(Stack).attrs({ gap: 0.5 })<{ themes: Theme }>`
     padding: ${space(1)} ${space(1.5)};
   `}
 `
-const ButtonArea = styled(Cluster).attrs({ gap: { row: 0.5, column: 1 }, justify: 'flex-end' })``
+const ButtonArea = styled(Cluster).attrs({ gap: { row: 0.5, column: 1 }, justify: 'flex-end' })`
+  margin-inline-start: auto;
+`
 const Message = styled.div`
   text-align: right;
 `

--- a/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -47,6 +47,8 @@ export type BaseProps = PropsWithChildren<{
    * 閉じるボタンを無効にするかどうか
    */
   closeDisabled?: boolean
+  /** ダイアログフッターの左端操作領域 */
+  subActionArea?: ReactNode
   /**
    * コンポーネントに適用するクラス名
    */
@@ -76,6 +78,7 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   responseMessage,
   actionDisabled = false,
   closeDisabled,
+  subActionArea,
   decorators,
 }) => {
   const classNames = useClassNames().dialog
@@ -114,24 +117,27 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
           {children}
         </Body>
         <ActionAreaStack themes={theme} ref={bottomRef} className={classNames.actionArea}>
-          <ButtonArea className={classNames.buttonArea}>
-            <Button
-              onClick={onClickClose}
-              disabled={closeDisabled || isRequestProcessing}
-              className={classNames.closeButton}
-            >
-              {decorators?.closeButtonLabel?.(CLOSE_BUTTON_LABEL) || CLOSE_BUTTON_LABEL}
-            </Button>
-            <Button
-              type="submit"
-              variant={actionTheme}
-              disabled={actionDisabled}
-              loading={isRequestProcessing}
-              className={classNames.actionButton}
-            >
-              {actionText}
-            </Button>
-          </ButtonArea>
+          <Cluster justify="space-between">
+            <div>{subActionArea}</div>
+            <ButtonArea className={classNames.buttonArea}>
+              <Button
+                onClick={onClickClose}
+                disabled={closeDisabled || isRequestProcessing}
+                className={classNames.closeButton}
+              >
+                {decorators?.closeButtonLabel?.(CLOSE_BUTTON_LABEL) || CLOSE_BUTTON_LABEL}
+              </Button>
+              <Button
+                type="submit"
+                variant={actionTheme}
+                disabled={actionDisabled}
+                loading={isRequestProcessing}
+                className={classNames.actionButton}
+              >
+                {actionText}
+              </Button>
+            </ButtonArea>
+          </Cluster>
           {(responseMessage?.status === 'success' || responseMessage?.status === 'error') && (
             <Message>
               <ResponseMessage type={responseMessage.status} role="alert">


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-872

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

![image](https://github.com/kufu/smarthr-ui/assets/19403400/cda73f0d-0a21-4eb0-973a-97611e431c1d)

任意のボタンなどを埋め込むことができます。
やや実験的な側面がありそうなので、裏メニュー的な取り扱いとして Story には追加していません。

手元の Story を修正するなどして動作確認していただけると嬉しいです。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
