### PR TITLE
chore: github actions の workflow を更新

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: release-candidate
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
           version: 8
       - uses: actions/setup-node@v4
@@ -62,8 +62,18 @@ jobs:
         run: |
           git checkout master
           git cherry-pick $NEW_TAG
-      - name: craete pull request
+      - name: create pull request
         uses: peter-evans/create-pull-request@v6
         with:
           title: 'chore(release): ${{ env.NEW_TAG }}'
           branch: 'merge-release-${{ env.NEW_TAG }}'
+          labels: release candidate
+      - name: Send message to Slack
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "npm publish が完了しました。Release Pull Request を手動でマージしたらリリース完了です。"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -9,6 +9,8 @@ on:
       manual_preparation:
         type: boolean
         description: '前リリースタグとの合流を手動で行う'
+  repository_dispatch:
+    types: [remote_dispatch]
 
 jobs:
   start_release:
@@ -21,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
           version: 8
       - uses: actions/setup-node@v4
@@ -66,3 +68,11 @@ jobs:
           title: Release candidate
           content-filepath: ${{ env.RESULT_PATH }}
           labels: ${{ env.ISSUE_LABELS }}
+      - name: Send GitHub Action trigger data to Slack
+        if: ${{ github.event.client_payload.channel_id != null }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: ${{ github.event.client_payload.channel_id }}
+          payload: ${{ github.event.client_payload.say }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-784

## Overview

SmartHR UI のリリースをこれまでは GitHub Actions ポチポチでやっていたが、よりリリースのハードルを下げるために Slack bot からリリースができるようにしたい。

そのための準備として、外からのトリガーで workflow が動くようにしたい。

## What I did

- startRelease
  - repository_dispatch の設定を追加して外部から workflow を実行できるようにした
  - workflow の最後に Slack bot からリリースを実行するかを確認する投稿をさせる
    - 投稿の内容自体は API を叩く際に payload に入れているので、この workflow 自体からではわからない
- publishRelease
  - リリース後の package.json 更新の PR にラベルをつけて、Slack に通知がいくようにした
    - slack 側には label filter をつけて、特定の PR, Issue のみ通知がいくようにしている
  - workflow の最後に Slack bot からリリース完了の投稿をさせる
- [共通] pnpm/action-setup を v3 に更新
  - ついでにやっただけ
- GitHub の secrets に値を追加
  - Slack bot の SLACK_WEBHOOK_URL と SLACK_BOT_TOKEN を追加しました

### 詳しく

- startRelease は外部から GitHub Actions を実行する API を叩いて起動させます
- publishRelease は外部から PR にラベルを付ける API を叩いて起動させます

## Capture

🍐 
