### PR TITLE
fix: RadioButton, CheckBox の装飾用spanがスクリーンリーダーで読み上げられてしまう場合がある問題を修正

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -138,7 +138,7 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
             ref={inputRef}
             aria-invalid={error || undefined}
           />
-          <span className={boxStyle} />
+          <span className={boxStyle} aria-hidden="true" />
           <span className={iconWrapStyle}>
             {mixed ? <FaMinusIcon className={iconStyle} /> : <FaCheckIcon className={iconStyle} />}
           </span>

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -85,7 +85,7 @@ export const RadioButton = forwardRef<HTMLInputElement, Props>(
             className={inputStyle}
             ref={ref}
           />
-          <span className={boxStyle} />
+          <span className={boxStyle} aria-hidden="true" />
         </span>
 
         {children && (


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
