### PR TITLE
fix: WarningIcon を Fontawesome v6 に追従

### DIFF
--- a/src/components/Icon/WarningIcon.tsx
+++ b/src/components/Icon/WarningIcon.tsx
@@ -4,16 +4,14 @@ import { IconBase } from 'react-icons'
 import { generateIcon } from './generateIcon'
 
 export const WarningIcon = /*#__PURE__*/ generateIcon((props) => (
-  <IconBase {...props} viewBox="0 0 14 13">
+  <IconBase {...props} viewBox="0 0 16 16">
     <path
-      d="M13.536 10.308v-.002L8.145.944C7.65.088 6.354.05 5.85.944l-.001.001-5.387 9.36c-.503.867.141 1.969 1.16 1.969h10.753a1.318 1.318 0 0 0 1.161-1.967Z"
-      className="shr-fill-warning-yellow shr-stroke-black shr-stroke-1"
+      d="m8.863 1.745 6.75 11.5a.998.998 0 0 1-.862 1.505H1.25c-.358 0-.69-.193-.868-.502a1.005 1.005 0 0 1 .005-1.003l6.75-11.5a.998.998 0 0 1 1.725 0Z"
+      className="shr-fill-warning-yellow shr-stroke-black shr-stroke-0.5"
     />
     <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M7.82 7.827c-.019.128-.097.212-.199.238a.285.285 0 0 1-.07.009h-1.1a.286.286 0 0 1-.064-.007c-.105-.024-.187-.108-.206-.24l-.157-3.054c-.023-.157.112-.292.27-.292h1.413c.158 0 .292.135.27.292L7.82 7.827Zm-.306.785a1.03 1.03 0 0 0-1.535.899c0 .583.449 1.032 1.032 1.032a1.03 1.03 0 0 0 .503-1.931Z"
       className="shr-fill-black"
+      d="M8 5a.748.748 0 0 0-.75.75v3.5c0 .416.334.75.75.75s.75-.334.75-.75v-3.5A.748.748 0 0 0 8 5Zm1 7a1 1 0 1 0-2 0 1 1 0 0 0 2 0Z"
     />
   </IconBase>
 ))

--- a/src/smarthr-ui-preset.ts
+++ b/src/smarthr-ui-preset.ts
@@ -169,6 +169,9 @@ export default {
         darken: darkenColor(theme('colors.grey.20')),
         'high-contrast': theme('colors.grey.100'),
       }),
+      strokeWidth: {
+        '0.5': '0.5',
+      },
       keyframes: ({ theme }) => ({
         'loader-line-full-unfill-rotate': {
           '12.5%': {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

WarningIcon を Fontawesome v6 対応しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
