### PR TITLE
fix: AccodionPanel[iconPosition="right"] の開閉アイコン向きを調整

### DIFF
--- a/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -10,7 +10,7 @@ import { tv } from 'tailwind-variants'
 
 import { getIsInclude, mapToKeyArray } from '../../libs/map'
 import { Heading, HeadingTagTypes, HeadingTypes } from '../Heading'
-import { FaCaretRightIcon, FaCaretUpIcon } from '../Icon'
+import { FaCaretDownIcon, FaCaretRightIcon } from '../Icon'
 import { Cluster } from '../Layout'
 
 import { AccordionPanelContext } from './AccordionPanel'
@@ -46,13 +46,13 @@ const accordionPanelTrigger = tv({
       'hover:shr-shadow-none',
       'focus-visible:shr-focusIndicator',
     ],
-    leftIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:shr-rotate-90',
-    rightIcon: 'group-aria-expanded:shrink-0 group-aria-expanded:-shr-rotate-180',
+    leftIcon: 'shr-transition-transform shr-duration-100 group-aria-expanded:shr-rotate-90',
+    rightIcon: 'group-aria-expanded:-shr-rotate-180',
   },
   compoundSlots: [
     {
       slots: ['leftIcon', 'rightIcon'],
-      className: ['shr-transition-transform', 'shr-duration-150'],
+      className: 'group-aria-expanded:shrink-0',
     },
   ],
 })
@@ -114,7 +114,9 @@ export const AccordionPanelTrigger: FC<Props & ElementProps> = ({
         <Cluster className="shr-flex-nowrap" align="center" as="span">
           {displayIcon && iconPosition === 'left' && <FaCaretRightIcon className={leftIconStyle} />}
           <span className={titleStyle}>{children}</span>
-          {displayIcon && iconPosition === 'right' && <FaCaretUpIcon className={rightIconStyle} />}
+          {displayIcon && iconPosition === 'right' && (
+            <FaCaretDownIcon className={rightIconStyle} />
+          )}
         </Cluster>
       </button>
     </Heading>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

右アイコンの AccordionPanel の開閉動作を見直しました。 
thx! @shinog

Before | After
--- | ---
<img width="455" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/3cbe483b-515e-4fe6-a438-ae5fd83f632d"> | <img width="455" alt="image" src="https://github.com/kufu/smarthr-ui/assets/19403400/624b984d-d89c-42a8-a104-1321e8bacb27">

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
