### PR TITLE
fix: 開発用E2Eテストコマンドのオプションを正しく指定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "test-storybook:ci": "wait-on tcp:6006 && pnpm test-storybook --maxWorkers=2 --junit",
     "testcafe": "testcafe",
     "e2e": "ts-node scripts/e2e.ts",
-    "e2e:dev": "testcafe chrome --host localhost --skip-js-errors",
+    "e2e:dev": "testcafe chrome --hostname localhost --skip-js-errors --live",
     "prepare": "husky",
     "chromatic": "chromatic",
     "write:ui-props": "ts-node scripts/exportUIProps.ts",


### PR DESCRIPTION
## Related URL

N/A

## Overview

`pnpm e2e:dev` コマンドでエラーが発生することがある問題を修正する

## What I did

- `--host` という存在しないオプションを指定していたので、`--hostname` に差し替える
- 開発用なので1回きりの実行よりも監視モードにしたほうが良いと思ったので `--live` オプションを付与する

`pnpm e2e:dev [filename]` で E2E テストをローカルで動かせることを確認。