### PR TITLE
fix: MultiComboBox の story でランダムに差分が出てしまう問題の解消

### DIFF
--- a/src/components/ComboBox/VRTComboBox.stories.tsx
+++ b/src/components/ComboBox/VRTComboBox.stories.tsx
@@ -44,6 +44,13 @@ export const VRTMulti: StoryFn = () => (
     <Multi />
   </WrapperList>
 )
+
+const waitForRAF = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      resolve()
+    })
+  })
 const playMulti = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const canvas = within(canvasElement)
   const comboboxes = await canvas.findAllByRole('combobox')
@@ -51,8 +58,10 @@ const playMulti = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const body = canvasElement.ownerDocument.body
   const option1 = await within(body).findByText('option 1')
   await userEvent.click(option1)
+  await waitForRAF()
   const option2 = await within(body).findByText('option 2')
   await userEvent.click(option2)
+  await waitForRAF()
 }
 VRTMulti.play = playMulti
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

MultiComboBox の Chromatic の挙動が不安定だったので直しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

### 原因

MultiComboBox でアイテムが選択されたときのコールバック内では requestAnimationFrame が使用されていて、処理の実行がブラウザの次の描画タイミングまで遅延される実装になっています。 👉 https://github.com/kufu/smarthr-ui/blob/f25c4fc568bd507bec25b97a326b1600b87d996b/src/components/ComboBox/MultiComboBox.tsx#L237
storybook の play function 内ではこの遅延された処理の完了を待たずに後続の処理が走ってしまうので、ブラウザの表示が意図した状態になる前に chromatic のスナップショットが取られてしまう場合があり、ランダムに差分が発生してしまっていると思われます。

### 対応

play function 内に、アイテムクリック後に 1 フレーム分待つ処理を入れました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

Chromatic で、すべてのキャプチャで option1 と option2 が正しく選択されている状態になっていることを確認してください 🙏 

<!--
Please attach a capture if it looks different.
-->
