### PR TITLE
fix: change `ElementProps` type

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,7 +41,7 @@ type Props = {
   onTenantSelect?: (id: string) => void
 }
 
-type ElementProps = Omit<ComponentProps<'h1'>, keyof Props>
+type ElementProps = Omit<ComponentProps<'header'>, keyof Props>
 
 export const Header: React.FC<PropsWithChildren<Props> & ElementProps> = ({
   logo = <SmartHRLogo className="shr-p-0.75" />,


### PR DESCRIPTION
## Related URL
## Overview
## What I did
Hi I'm sorry, I'm new here!
Changed ElementProps type from `ComponentProps<'h1'>` to `ComponentProps<'header'>` since Header is rendered as a header element.
## Capture