### PR TITLE
fix: BodyScrollSuppressor を styled-components に依存しない形で実装

### DIFF
--- a/src/components/Dialog/DialogContentInner.tsx
+++ b/src/components/Dialog/DialogContentInner.tsx
@@ -12,10 +12,10 @@ import { tv } from 'tailwind-variants'
 import { useHandleEscape } from '../../hooks/useHandleEscape'
 import { useTheme } from '../../hooks/useTailwindTheme'
 
-import { BodyScrollSuppressor } from './BodyScrollSuppressor'
 import { DialogOverlap } from './DialogOverlap'
 import { DialogPositionProvider } from './DialogPositionProvider'
 import { FocusTrap } from './FocusTrap'
+import { useBodyScrollLock } from './useBodyScrollLock'
 
 export type DialogContentInnerProps = PropsWithChildren<{
   /**
@@ -148,6 +148,8 @@ export const DialogContentInner: FC<DialogContentInnerProps & ElementProps> = ({
     onClickOverlay && onClickOverlay()
   }, [isOpen, onClickOverlay])
 
+  useBodyScrollLock()
+
   return (
     <DialogPositionProvider top={top} bottom={bottom}>
       <DialogOverlap isOpen={isOpen}>
@@ -165,8 +167,6 @@ export const DialogContentInner: FC<DialogContentInnerProps & ElementProps> = ({
           >
             <FocusTrap firstFocusTarget={firstFocusTarget}>{children}</FocusTrap>
           </div>
-          {/* Suppresses scrolling of body while modal is displayed */}
-          <BodyScrollSuppressor />
         </div>
       </DialogOverlap>
     </DialogPositionProvider>

--- a/src/components/Dialog/useBodyScrollLock.tsx
+++ b/src/components/Dialog/useBodyScrollLock.tsx
@@ -1,7 +1,6 @@
-import React, { FC, useEffect, useState } from 'react'
-import { createGlobalStyle, css } from 'styled-components'
+import { useEffect, useState } from 'react'
 
-export const BodyScrollSuppressor: FC = () => {
+export const useBodyScrollLock = () => {
   const [scrollBarWidth, setScrollBarWidth] = useState<number | null>(null)
   const [paddingRight, setPaddingRight] = useState<number | null>(null)
 
@@ -17,21 +16,15 @@ export const BodyScrollSuppressor: FC = () => {
     setPaddingRight(scrollBarWidth + parseInt(originalPaddingRight, 10))
   }, [scrollBarWidth])
 
-  if (scrollBarWidth === null) {
-    return null
-  }
-  return <ScrollSuppressing paddingRight={paddingRight} />
-}
+  useEffect(() => {
+    if (paddingRight !== null) {
+      document.body.style.paddingInlineEnd = `${paddingRight}px`
+    }
+    document.body.style.overflow = 'hidden'
 
-const ScrollSuppressing = createGlobalStyle<{
-  paddingRight: number | null
-}>`
-  body {
-    overflow: hidden;
-    ${({ paddingRight }) =>
-      paddingRight &&
-      css`
-        padding-right: ${paddingRight}px !important;
-      `}
-  }
-`
+    return () => {
+      document.body.style.paddingInlineEnd = ''
+      document.body.style.overflow = ''
+    }
+  }, [paddingRight])
+}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

モーダルダイアログを開いた時、`overflow: hidden` でスクロールを不可にする影響で幅がガタつくのを防ぐ機構が styled-copmonents に依存していたので書き換え。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
