### PR TITLE
fix: AppNaviDropdown が current の時に押せなくなる不具合を修正

### DIFF
--- a/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/src/components/AppNavi/AppNaviDropdown.tsx
@@ -28,6 +28,11 @@ const appNaviDropdown = tv({
         ],
       },
     },
+    active: {
+      true: {
+        wrapper: 'shr-cursor-pointer',
+      },
+    },
   },
 })
 
@@ -49,11 +54,7 @@ export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
   return (
     <Dropdown>
       <DropdownTrigger>
-        <UnstyledButton
-          aria-current={current ? 'page' : undefined}
-          disabled={current}
-          className={wrapperStyle}
-        >
+        <UnstyledButton aria-current={current ? 'page' : undefined} className={wrapperStyle}>
           {Icon && <Icon className={iconStyle} />}
           {children}
           {displayCaret && <FaCaretDownIcon />}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

AppNaviDrodpdown が current の場合に、ドロップダウンが開けない不具合を修正しました。
`isCurrentUnclickable` を消した影響ですが、ドロップダウンについては押せないと遷移できないリンクやボタンが発生するため `disabled` にはしません。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
