### PR TITLE
feat: DropdownMenuButton[onlyIconTrigger] は任意のアイコンに差し替えられるようにする

### DIFF
--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.stories.tsx
@@ -3,6 +3,7 @@ import React, { ComponentProps } from 'react'
 
 import { AnchorButton, Button } from '../../Button'
 import { RemoteDialogTrigger, RemoteTriggerActionDialog } from '../../Dialog'
+import { FaGearIcon } from '../../Icon'
 import { Cluster } from '../../Layout'
 
 import { DropdownMenuButton } from './DropdownMenuButton'
@@ -72,7 +73,7 @@ export const Render: React.FC = () => (
     <Template onlyIconTrigger label="その他の操作" />
     <Template triggerSize="s" label="操作" />
     <Template triggerSize="s" label={<span>操作</span>} disabled />
-    <Template triggerSize="s" onlyIconTrigger label="操作" />
+    <Template triggerSize="s" onlyIconTrigger triggerIcon={FaGearIcon} label="操作" />
     <RemoteTriggerActionDialog
       id="hoge"
       title="Triggerのテスト"

--- a/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -1,6 +1,7 @@
 import React, {
   ComponentProps,
   ComponentPropsWithRef,
+  ComponentType,
   FC,
   ReactElement,
   ReactNode,
@@ -14,7 +15,7 @@ import { tv } from 'tailwind-variants'
 import { Dropdown, DropdownContent, DropdownScrollArea, DropdownTrigger } from '..'
 import { AnchorButton, Button, BaseProps as ButtonProps } from '../../Button'
 import { RemoteDialogTrigger } from '../../Dialog'
-import { FaCaretDownIcon, FaEllipsisHIcon } from '../../Icon'
+import { FaCaretDownIcon, FaEllipsisIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 
 type Actions = ActionItem | ActionItem[]
@@ -38,6 +39,8 @@ type Props = {
   triggerSize?: ButtonProps['size']
   /** 引き金となるボタンをアイコンのみとするかどうか */
   onlyIconTrigger?: boolean
+  /** 引き金となるアイコンを差し替えたい場合（onlyIconTrigger=true の場合のみ有効） */
+  triggerIcon?: ComponentType<ComponentProps<typeof FaCaretDownIcon>>
 }
 type ElementProps = Omit<ComponentPropsWithRef<'button'>, keyof Props>
 
@@ -68,20 +71,20 @@ export const DropdownMenuButton: FC<Props & ElementProps> = ({
   children,
   triggerSize,
   onlyIconTrigger = false,
+  triggerIcon: TriggerIcon,
   className,
   ...props
 }) => {
   const containerRef = React.useRef<HTMLDivElement>(null)
 
-  const triggerLabel = useMemo(
-    () =>
-      onlyIconTrigger ? (
-        <FaEllipsisHIcon alt={typeof label === 'string' ? label : innerText(label)} />
-      ) : (
-        label
-      ),
-    [onlyIconTrigger, label],
-  )
+  const triggerLabel = useMemo(() => {
+    const Icon = TriggerIcon || FaEllipsisIcon
+    return onlyIconTrigger ? (
+      <Icon alt={typeof label === 'string' ? label : innerText(label)} />
+    ) : (
+      label
+    )
+  }, [label, TriggerIcon, onlyIconTrigger])
   const triggerSuffix = useMemo(
     // eslint-disable-next-line react/jsx-no-useless-fragment
     () => (onlyIconTrigger ? <></> : <FaCaretDownIcon alt="候補を開く" />),


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

基本的にアイコンのみの DropdownMenuButton の利用を減らしていたためアイコンを絞っていたが、視覚設計の一貫で必要になったため差し替えるための props `triggerIcon` を足しました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
