### PR TITLE
fix: AppNaviで子要素の要素がnavを上回った場合の表示不具合を修正

### DIFF
--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -86,6 +86,15 @@ export const WithChildren: StoryFn = () => (
 )
 WithChildren.storyName = 'with children'
 
+export const WithOverHeightChildren: StoryFn = () => (
+  <Wrapper>
+    <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret>
+      <OverHeightChild>子コンポーネントの高さがnavの高さを上回る場合</OverHeightChild>
+    </AppNavi>
+  </Wrapper>
+)
+WithChildren.storyName = 'with children'
+
 export const WithoutChildren: StoryFn = () => (
   <Wrapper>
     <AppNavi label="機能名" buttons={withoutIconButtons} displayDropdownCaret />
@@ -148,6 +157,12 @@ const OverflowWrapper = styled(Wrapper)`
 `
 const Child = styled.p`
   margin: 0 0 0 auto;
+`
+const OverHeightChild = styled.p`
+  display: flex;
+  align-items: center;
+  margin: 0 0 0 auto;
+  height: 50px;
 `
 const InnerWrapper = styled.div`
   margin-bottom: 40px;

--- a/src/components/AppNavi/AppNavi.stories.tsx
+++ b/src/components/AppNavi/AppNavi.stories.tsx
@@ -93,7 +93,7 @@ export const WithOverHeightChildren: StoryFn = () => (
     </AppNavi>
   </Wrapper>
 )
-WithChildren.storyName = 'with children'
+WithChildren.storyName = 'with over height children'
 
 export const WithoutChildren: StoryFn = () => (
   <Wrapper>

--- a/src/components/AppNavi/AppNaviAnchor.tsx
+++ b/src/components/AppNavi/AppNaviAnchor.tsx
@@ -17,7 +17,11 @@ export type AppNaviAnchorProps = PropsWithChildren<{
 const appNaviAnchor = tv({
   extend: appNaviItemStyle,
   slots: {
-    wrapper: ['smarthr-ui-AppNavi-anchor', 'forced-colors:shr-underline'],
+    wrapper: [
+      'smarthr-ui-AppNavi-anchor',
+      'forced-colors:shr-underline',
+      'shr-box-border shr-h-full shr-items-center',
+    ],
   },
 })
 

--- a/src/components/AppNavi/AppNaviButton.tsx
+++ b/src/components/AppNavi/AppNaviButton.tsx
@@ -18,7 +18,10 @@ export type AppNaviButtonProps = PropsWithChildren<{
 const appNaviButton = tv({
   extend: appNaviItemStyle,
   slots: {
-    wrapper: 'smarthr-ui-AppNavi-button',
+    wrapper: [
+      'smarthr-ui-AppNavi-button',
+      'shr-h-full [&&&]:shr-box-border [&&&]:shr-items-center',
+    ],
   },
 })
 

--- a/src/components/AppNavi/AppNaviCustomTag.tsx
+++ b/src/components/AppNavi/AppNaviCustomTag.tsx
@@ -17,7 +17,7 @@ export type AppNaviCustomTagProps = PropsWithChildren<{
 const appNaviCustomTag = tv({
   extend: appNaviItemStyle,
   slots: {
-    wrapper: 'smarthr-ui-AppNavi-customTag',
+    wrapper: ['smarthr-ui-AppNavi-customTag', 'shr-box-border shr-h-full shr-items-center'],
   },
 })
 

--- a/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/src/components/AppNavi/AppNaviDropdown.tsx
@@ -25,6 +25,7 @@ const appNaviDropdown = tv({
         wrapper: [
           'smarthr-ui-AppNavi-dropdown',
           '[&[aria-expanded="true"]_.smarthr-ui-Icon:last-child]:shr-rotate-180',
+          '[&&&]:shr-box-border [&&&]:shr-h-full [&&&]:shr-items-center',
         ],
       },
     },
@@ -53,7 +54,7 @@ export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
 
   return (
     <Dropdown>
-      <DropdownTrigger>
+      <DropdownTrigger className="shr-h-full">
         <UnstyledButton aria-current={current ? 'page' : undefined} className={wrapperStyle}>
           {Icon && <Icon className={iconStyle} />}
           {children}


### PR DESCRIPTION
## Related URL
担当しているプロダクトで以下のようなリグレッションが発生しておりまして、原因はv43.2.0で入った変更の影響によるものだと考えられます。
AppNaviにnavのheightを超えるコンテンツを入れても高さが調整されていなかった。（height:100%が削除されてしまっていた。）
AppNaviの子要素にheight: 100%を適用することで、高さが変わっても正常に表示されるように修正したいです。
![image](https://github.com/kufu/smarthr-ui/assets/25091548/efa6286b-1c77-4c78-82e3-163d2f7d7ee4)

原因となっている変更：
- https://github.com/kufu/smarthr-ui/compare/v43.1.0...v43.2.0#diff-b43b079f47f72365f6016d9ef81213846a9e2c2be19e96a9e899ac7b96ff6759L61
- https://github.com/kufu/smarthr-ui/compare/v43.1.0...v43.2.0#diff-23c69fd343a6f2ead0811189c5f3077af941f0fb8943f2f56370bc2fb0df1b69L47

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
fix: AppNaviで子要素の要素がnavを上回った場合の表示を修正
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- スタイルの調整
- テストの追加
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
![image](https://github.com/kufu/smarthr-ui/assets/25091548/9078b630-fa75-4fee-a5ad-2302209f8ea9)
