### PR TITLE
chore: devDependenciesのnon-major updateを一つのグループにまとめる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "extends": ["github>kufu/renovate-config"],
   "npm": {
     "postUpdateOptions": ["pnpmDedupe"]
-  }
+  },
+  "packageRules": [
+    {
+      "groupName": "devDependencies (non-major)",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"], 
+      "matchCurrentVersion": "!/^0/",
+      "schedule": ["after 8am and before 5pm on Monday"]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"], 
       "matchCurrentVersion": "!/^0/",
-      "schedule": ["after 8am and before 5pm on Monday"]
+      "schedule": ["after 8am and before 5pm on Monday"],
+      "autoMerge": false
     }
   ]
 }


### PR DESCRIPTION
## Related URL
[提案スレ](https://kufuinc.slack.com/archives/CGC58MW01/p1712219406755239)
CIの実行回数を減らし、Storybookのsnapshot数を減らすのが目的。
minor, patchバージョンに関するPRの数を週に1度に限定して、手動でマージしていくことを想定している。

このPRで目指す状態
```
dependencies: 単体PR / 随時
devDependencies: 
1. majorは単体PR / 随時
2. minor || patch は おまとめ1PR/week
```
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- renovate.jsonの更新
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- renovate.jsonの更新
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->