### PR TITLE
fix: AppLauncherのスタイルが上書きされてない箇所の詳細度を修正

### DIFF
--- a/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -36,7 +36,7 @@ const appLauncher = tv({
     appsButton: [
       'shr-border-transparent shr-font-normal shr-text-white [&]:shr-bg-transparent [&]:shr-px-0.25',
       'hover:shr-border-transparent hover:[&]:shr-bg-transparent',
-      'focus-visible:shr-border-transparent focus-visible:shr-bg-transparent',
+      'focus-visible:shr-border-transparent focus-visible:[&]:shr-bg-transparent',
     ],
     contentWrapper: ['smarthr-ui-AppLauncher', 'shr-p-1.5 shr-leading-normal'],
     category: 'smarthr-ui-AppLauncher-category',


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`<AppLauncher>` 上で指定しているスタイルが、`<ButtonWrapper>` のスタイルを上書きできておらず、フォーカス時にボタンの背景色が変化せず、低いコントラスト比となっていた

## What I did

`<AppLauncher>` 上のスタイルの詳細度を上げるように指定

## Capture
Before
<img width="108" alt="スクリーンショット 2024-04-05 14 49 24" src="https://github.com/kufu/smarthr-ui/assets/6724665/6ea853c9-da93-4483-bae3-c19fe4dda2f3">

After
<img width="104" alt="スクリーンショット 2024-04-05 14 48 50" src="https://github.com/kufu/smarthr-ui/assets/6724665/e331f486-f83e-4e11-b56c-045eeadee3a0">
