### PR TITLE
fix: Buttonのロード時のlive regionを読み上げるよう修正

### DIFF
--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -124,6 +124,7 @@ export const Loader: FC<Props & ElementProps> = ({
   alt = '処理中',
   text,
   type = 'primary',
+  role = 'status',
   className,
   ...props
 }) => {
@@ -137,7 +138,7 @@ export const Loader: FC<Props & ElementProps> = ({
   const textStyle = useMemo(() => textSlot(), [textSlot])
 
   return (
-    <span {...props} className={wrapperStyle} role="status">
+    <span {...props} className={wrapperStyle} role={role}>
       <span className={spinnerStyle}>
         {[...Array(4)].map((_, index) => (
           <span className={line({ lineNum: (index + 1) as 1 | 2 | 3 | 4 })} key={index}>


### PR DESCRIPTION
## Related URL

**SmartHR UI　「Button」With Loading　読み込み中と読み上げない　NVDA**
https://app.asana.com/0/1205448161364688/1206247075014349/f

## Overview

WAI-ARIAのLive Regionは、ある要素の**コンテンツ**に変更があった際にその変更をユーザーエージェントに通知する機能ですが、コンテンツではなく**要素自体**が動的に追加または削除されたとき、どのように振る舞うべきかは仕様中で言及されていないようです。

したがって、`role="status"`のような属性値を持った要素（今回の場合では `Loader`）が動的に追加されると、ユーザーエージェントの組み合わせによってはこの変更を検出できず、無視してしまいます。最初からLive Regionをもった要素を挿入しておいて、あとからその子要素を変更する、というほうが想定されている使い方のようです。

> The aria-live attribute provides a way for developers to announce such changes to AT based on event triggers set by the developer rather than by user initiated actions so they are made aware that **the content** has changed.
> [aria-live - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live#description)

> What I have found is that aria-live works fantastic when I'm not dynamically adding that attribute.
> [javascript - aria-live="polite" not reading roles of elements it is associated with - Stack Overflow](https://stackoverflow.com/a/68492641)

加えて、WAI-ARIAによると `role="button"` をもつ要素は全ての子要素が *presentational children* として解釈されることになっていますが、ここで `Loader` は `role="status"` です。これもやはりユーザーエージェントの組み合わせによってはローダーの存在を無視しうることを示唆しています。

> To deal with this limitation, browsers, automatically apply role [presentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) to all descendant elements of any button element as it is **a role that does not support semantic children.**
> [ARIA: button role - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#all_descendants_are_presentational)

## What I did

`Button`コンポーネント全体をFragmentにし、Live Regionはbuttonに隣接する子要素になるように変更しました。これによってアクセシビリティツリーには最初からLive Regionが存在し、ロードが始まるとその子要素のみが変更されるようになりました。

また、これによってボタン内の`Loader`にセマンティクスを与える必要がなくなったので、`aria-hidden`属性を追加しました。

この方法はAdrian Roselli氏のブログでも紹介されていました。

**Multi-Function Button — Adrian Roselli**
https://adrianroselli.com/2021/01/multi-function-button.html

## Capture

| 状態 | アクセシビリティツリー |
| :--- | :--- |
| 読み込み前 | <img width="327" alt="" src="https://github.com/kufu/smarthr-ui/assets/19276905/499b80ed-ee83-43d5-b38c-50f72d5db66e"> |
| 読み込み中 |  <img width="327" alt="" src="https://github.com/kufu/smarthr-ui/assets/19276905/94435dbd-cc2d-4ef1-bf34-09fc00387907"> |

