### PR TITLE
fix: forced-colors: active時のCalendarの表示を改善

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -27,7 +27,7 @@ type ElementProps = Omit<ComponentProps<'section'>, keyof Props>
 const calendar = tv({
   slots: {
     container:
-      'smarthr-ui-Calendar shr-inline-block shr-overflow-hidden shr-rounded-m shr-bg-white shr-text-black shr-shadow-layer-3',
+      'smarthr-ui-Calendar shr-inline-block shr-overflow-hidden shr-rounded-m shr-bg-white shr-text-black shr-shadow-layer-3 forced-colors:shr-border-shorthand forced-colors:shr-shadow-none',
     header: 'smarthr-ui-Calendar-header shr-border-b-shorthand shr-flex shr-items-center shr-p-1',
     yearMonth: 'smarthr-ui-Calendar-yearMonth shr-me-0.5 shr-text-base shr-font-bold',
     monthButtons: 'smarthr-ui-Calendar-monthButtons shr-ms-auto shr-flex',


### PR DESCRIPTION
## Related URL

**SmartHR UI　DatePicker「all」　カレンダーが展開されていることがわからない　NVDA、PC-Talker　VoiceOver**
https://app.asana.com/0/1205448161364688/1206305498133149/f

## Overview

Calendarは `box-shadow` によってコンポーネントの内部と外部に視覚的な境界を作っていますが、CSS Color Adjustment Module Level 1によると、強制カラーモード下では `none`に上書きされると定義されています。

> `box-shadow` and `text-shadow` compute to `none`
> [3.1. Properties Affected by Forced Colors Mode - CSS Color Adjustment Module Level 1](https://drafts.csswg.org/css-color-adjust-1/#forced-colors-properties)

また、Windowsのハイコントラストモードでも同様の振る舞いをします。

> To take a common example, `box-shadow` is a versatile property which web developers can use to achieve various different glow and nested border effects. However, this property is reverted in forced color modes.
> [Styling for Windows high contrast with new standards for forced colors - Microsoft Edge Blog](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/)

これにより、カレンダーの内側の外側の境界がわかりづらくなっています。

## What I did

`forced-colors: active` メディアクエリが有効なときに、Calendarに `border: 1px solid black` 相当のクラスを付けています。カラースキームが上書きされた場合は色が反転します。`ButtonBorder` などの system color を使うことも検討しましたが、ウィジェットの境界を示すのにちょうどいいキーワードがなかったので、~~決め打ちでblackにしています。~~ `shr-border-shorthand` にしています。

## Capture

| メディアクエリ | 表示 |
| :--- | :--- |
| `forced-color: active` + <br/> `prefers-color-scheme: light` | <img width="200" alt="" src="https://github.com/kufu/smarthr-ui/assets/19276905/f8adb304-3ebb-4cde-a973-c69bc0b7de4b"> |
| `forced-color: active` + <br/> `prefers-color-scheme: dark` | <img width="200" alt="" src="https://github.com/kufu/smarthr-ui/assets/19276905/f992f196-df61-4967-90c6-b74118492fb9"> |

