### PR TITLE
fix: VRT にてスクリーンショットに要素が収まりきっていないストーリーを修正

### DIFF
--- a/src/components/DatePicker/VRTDatePicker.stories.tsx
+++ b/src/components/DatePicker/VRTDatePicker.stories.tsx
@@ -108,6 +108,7 @@ VRTBottomExpanded.play = async ({ canvasElement }: { canvasElement: HTMLElement 
 }
 
 const WrapperList = styled.ul`
+  min-height: 600px;
   padding: 0 24px;
   list-style: none;
   & > li {


### PR DESCRIPTION
## Related URL

N/A

## Overview

- https://github.com/kufu/smarthr-ui/pull/4563

の VRT 差分を確認した際に、`DatePicker` の VRT 結果スクリーンショットにカレンダーUIが表示されていなくて困ったのを解消する

## What I did

スクリーンショットにカレンダーUIが収まるようにサイズを明示する

## Capture

VRT 結果参照
https://www.chromatic.com/build?appId=63d0ccabb5d2dd29825524ab&number=7293