### PR TITLE
feat: FormControl でも dangerouslyTitleHidden オプションを許容する

### DIFF
--- a/src/components/FormControl/FormControl.stories.tsx
+++ b/src/components/FormControl/FormControl.stories.tsx
@@ -57,6 +57,16 @@ export const All: StoryFn = () => (
     </Stack>
     <Stack>
       <Text italic color="TEXT_GREY" as="dt">
+        項目名非表示
+      </Text>
+      <dd>
+        <FormControl title="氏名" dangerouslyTitleHidden>
+          <Input name="fullname" value="草野栄一郎" readOnly />
+        </FormControl>
+      </dd>
+    </Stack>
+    <Stack>
+      <Text italic color="TEXT_GREY" as="dt">
         各種コントロールが紐づくこと
       </Text>
       <dd>

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps } from 'react'
 
 import { FormGroup } from '../FormGroup'
 
-type Props = Omit<ComponentProps<typeof FormGroup>, 'as' | 'dangerouslyTitleHidden'>
+type Props = Omit<ComponentProps<typeof FormGroup>, 'as'>
 
 export const FormControl: React.FC<Props> = FormGroup
 // 一部スタイリングが内部的に FormGroup という名前に依存しているため置き換え


### PR DESCRIPTION
## Related URL

N/A

## Overview

`FormGroup` や `Fieldset` では提供されている `dangerouslyTitleHidden` オプションを `FormControl` でも使えるようにします。

## What I did

`FormControl` で入力要素の項目ラベルを非表示にするなんて言語道断という背景は理解しているつもりですが、実際に既存画面に対して `FormControl` を用いたアクセシビリティの底上げを狙うと、どうしても「FormControl 使うと可視ラベルが冗長に表示されちゃうから、このケースでは使えないなぁ」という判断になるケースがあります。

既存画面の構成上、可視ラベルは他のもので代用できているけど、アクセシブルネームや `helpMessage` `errorMessages` などの仕組みには乗っかりたいという場面のために、`dangerouslyTitleHidden` を使えるようにしました。