### PR TITLE
feat: Base,BaseColumnのas属性にsection,aside,article,navを設定した場合、SectioningContent同様に見出しレベル自動計算を行うように修正

### DIFF
--- a/src/components/Base/Base.stories.tsx
+++ b/src/components/Base/Base.stories.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { useTheme } from '../../hooks/useTheme'
+import { Heading } from '../Heading'
+import { Section } from '../SectioningContent'
 import { Table, Td, Th } from '../Table'
 import { Text } from '../Text'
 
@@ -90,6 +92,21 @@ export const BaseStory: StoryFn = () => {
               </Base>
             </li>
           ))}
+        </List>
+      </dd>
+      <dt>SectioningContentをasに指定した場合の見出しレベル自動計算</dt>
+      <dd>
+        <List>
+          <li>
+            <Section>
+              <Heading>親見出し</Heading>
+              <Base as="section">
+                {/* FIXME: Baseに対するチェックは eslint-plugin-smarthr@v0.5.9以降で修正されるため下記コメントは削除する */}
+                {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
+                <Heading>子見出し</Heading>
+              </Base>
+            </Section>
+          </li>
         </List>
       </dd>
     </DescriptionList>

--- a/src/components/Base/Base.tsx
+++ b/src/components/Base/Base.tsx
@@ -1,6 +1,8 @@
 import React, { ComponentPropsWithRef, PropsWithChildren, forwardRef, useMemo } from 'react'
 import { VariantProps, tv } from 'tailwind-variants'
 
+import { useSectionWrapper } from '../SectioningContent/useSectioningWrapper'
+
 import type { Gap } from '../../types'
 
 const base = tv({
@@ -137,6 +139,12 @@ export const Base = forwardRef<HTMLDivElement, Props & ElementProps>(
       })
     }, [className, layer, overflow, padding, radius])
 
-    return <Component {...props} className={styles} ref={ref} />
+    const Wrapper = useSectionWrapper(Component)
+
+    return (
+      <Wrapper>
+        <Component {...props} ref={ref} className={styles} />
+      </Wrapper>
+    )
   },
 )

--- a/src/components/Base/BaseColumn/BaseColumn.stories.tsx
+++ b/src/components/Base/BaseColumn/BaseColumn.stories.tsx
@@ -1,7 +1,9 @@
 import { StoryFn } from '@storybook/react'
 import React from 'react'
 
+import { Heading } from '../../Heading'
 import { Stack } from '../../Layout'
+import { Section } from '../../SectioningContent'
 
 import { BaseColumn } from './BaseColumn'
 
@@ -22,6 +24,16 @@ export const All: StoryFn = () => (
       <BaseColumn padding={1.5} bgColor="ACTION_BACKGROUND">
         padding を1.5文字分に、背景を ACTION_BACKGROUND に変更。
       </BaseColumn>
+    </li>
+    <li>
+      <Section>
+        <Heading>見出しレベルの自動計算の確認</Heading>
+        <BaseColumn as="section">
+          {/* FIXME: BaseColumnに対するチェックは eslint-plugin-smarthr@v0.5.9以降で修正されるため下記コメントは削除する */}
+          {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
+          <Heading type="blockTitle">小見出し</Heading>
+        </BaseColumn>
+      </Section>
     </li>
   </Stack>
 )


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- Base, BaseColumnもas, forwardedAsでSectioningContentを指定した場合、見出しレベル自動計算を行うように修正します。

## Capture

<!--
Please attach a capture if it looks different.
-->
