### PR TITLE
fix(Icon): Figmaにのみ存在するアイコンを復活

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,5 @@
 import {
+  FaAddressBook,
   FaAddressCard,
   FaAngleDown,
   FaAngleLeft,
@@ -16,11 +17,13 @@ import {
   FaArrowUp19,
   FaArrowUpWideShort,
   FaArrowsRotate,
+  FaAsterisk,
   FaBabyCarriage,
   FaBan,
   FaBars,
   FaBarsStaggered,
   FaBell,
+  FaBellSlash,
   FaBolt,
   FaBook,
   FaBookOpen,
@@ -33,6 +36,7 @@ import {
   FaCalendarDays,
   FaCalendarXmark,
   FaCaretDown,
+  FaCaretLeft,
   FaCaretRight,
   FaCaretUp,
   FaChartArea,
@@ -55,6 +59,7 @@ import {
   FaCircleUser,
   FaCircleXmark,
   FaClipboard,
+  FaClipboardCheck,
   FaClipboardList,
   FaClock,
   FaClockRotateLeft,
@@ -66,6 +71,8 @@ import {
   FaComments,
   FaCompress,
   FaCopy,
+  FaCube,
+  FaCubes,
   FaDatabase,
   FaDoorOpen,
   FaDownLeftAndUpRightToCenter,
@@ -87,6 +94,7 @@ import {
   FaFont,
   FaGauge,
   FaGear,
+  FaGears,
   FaGlobe,
   FaGraduationCap,
   FaGrip,
@@ -95,8 +103,11 @@ import {
   FaGripVertical,
   FaHourglassHalf,
   FaHouse,
+  FaIdBadge,
+  FaIdCard,
   FaImage,
   FaInbox,
+  FaIntercom,
   FaKey,
   FaLeftLong,
   FaLeftRight,
@@ -104,17 +115,22 @@ import {
   FaLink,
   FaList,
   FaListOl,
+  FaListUl,
   FaLock,
+  FaLockOpen,
   FaMagnifyingGlass,
   FaMagnifyingGlassMinus,
   FaMagnifyingGlassPlus,
+  FaMessage,
   FaMinus,
+  FaMoneyCheckDollar,
   FaPaintbrush,
   FaPaperPlane,
   FaPaperclip,
   FaPen,
   FaPenToSquare,
   FaPencil,
+  FaPiggyBank,
   FaPlus,
   FaPowerOff,
   FaPrint,
@@ -129,9 +145,13 @@ import {
   FaRotate,
   FaRotateLeft,
   FaShareNodes,
+  FaShieldHalved,
+  FaSliders,
   FaSort,
   FaSortDown,
   FaSortUp,
+  FaSquareCheck,
+  FaSquareMinus,
   FaSquarePlus,
   FaSquarePollVertical,
   FaStar,
@@ -139,6 +159,7 @@ import {
   FaTable,
   FaTableList,
   FaTag,
+  FaTags,
   FaToolbox,
   FaTrash,
   FaTrashCan,
@@ -152,14 +173,19 @@ import {
   FaUserCheck,
   FaUserClock,
   FaUserLarge,
+  FaUserPen,
   FaUserPlus,
   FaUsers,
+  FaWindowMaximize,
+  FaWindowMinimize,
+  FaWindowRestore,
   FaXmark,
   FaYenSign,
 } from 'react-icons/fa6'
 
 import { createIcon } from './generateIcon'
 
+export const FaAddressBookIcon = /*#__PURE__*/ createIcon(FaAddressBook)
 export const FaAddressCardIcon = /*#__PURE__*/ createIcon(FaAddressCard)
 export const FaAngleDownIcon = /*#__PURE__*/ createIcon(FaAngleDown)
 export const FaAngleLeftIcon = /*#__PURE__*/ createIcon(FaAngleLeft)
@@ -168,20 +194,22 @@ export const FaAngleUpIcon = /*#__PURE__*/ createIcon(FaAngleUp)
 export const FaAnglesLeftIcon = /*#__PURE__*/ createIcon(FaAnglesLeft)
 export const FaAnglesRightIcon = /*#__PURE__*/ createIcon(FaAnglesRight)
 export const FaArrowDownIcon = /*#__PURE__*/ createIcon(FaArrowDown)
+export const FaArrowDownWideShortIcon = /*#__PURE__*/ createIcon(FaArrowDownWideShort)
 export const FaArrowLeftIcon = /*#__PURE__*/ createIcon(FaArrowLeft)
 export const FaArrowRightIcon = /*#__PURE__*/ createIcon(FaArrowRight)
 export const FaArrowRotateLeftIcon = /*#__PURE__*/ createIcon(FaArrowRotateLeft)
 export const FaArrowRotateRightIcon = /*#__PURE__*/ createIcon(FaArrowRotateRight)
 export const FaArrowUp19Icon = /*#__PURE__*/ createIcon(FaArrowUp19)
-export const FaArrowUpWideShortIcon = /*#__PURE__*/ createIcon(FaArrowUpWideShort)
-export const FaArrowDownWideShortIcon = /*#__PURE__*/ createIcon(FaArrowDownWideShort)
 export const FaArrowUpIcon = /*#__PURE__*/ createIcon(FaArrowUp)
+export const FaArrowUpWideShortIcon = /*#__PURE__*/ createIcon(FaArrowUpWideShort)
 export const FaArrowsRotateIcon = /*#__PURE__*/ createIcon(FaArrowsRotate)
+export const FaAsteriskIcon = /*#__PURE__*/ createIcon(FaAsterisk)
 export const FaBabyCarriageIcon = /*#__PURE__*/ createIcon(FaBabyCarriage)
 export const FaBanIcon = /*#__PURE__*/ createIcon(FaBan)
 export const FaBarsIcon = /*#__PURE__*/ createIcon(FaBars)
 export const FaBarsStaggeredIcon = /*#__PURE__*/ createIcon(FaBarsStaggered)
 export const FaBellIcon = /*#__PURE__*/ createIcon(FaBell)
+export const FaBellSlashIcon = /*#__PURE__*/ createIcon(FaBellSlash)
 export const FaBoltIcon = /*#__PURE__*/ createIcon(FaBolt)
 export const FaBookIcon = /*#__PURE__*/ createIcon(FaBook)
 export const FaBookOpenIcon = /*#__PURE__*/ createIcon(FaBookOpen)
@@ -194,6 +222,7 @@ export const FaCalendarCheckIcon = /*#__PURE__*/ createIcon(FaCalendarCheck)
 export const FaCalendarDaysIcon = /*#__PURE__*/ createIcon(FaCalendarDays)
 export const FaCalendarXmarkIcon = /*#__PURE__*/ createIcon(FaCalendarXmark)
 export const FaCaretDownIcon = /*#__PURE__*/ createIcon(FaCaretDown)
+export const FaCaretLeftIcon = /*#__PURE__*/ createIcon(FaCaretLeft)
 export const FaCaretRightIcon = /*#__PURE__*/ createIcon(FaCaretRight)
 export const FaCaretUpIcon = /*#__PURE__*/ createIcon(FaCaretUp)
 export const FaChartAreaIcon = /*#__PURE__*/ createIcon(FaChartArea)
@@ -215,6 +244,7 @@ export const FaCirclePlusIcon = /*#__PURE__*/ createIcon(FaCirclePlus)
 export const FaCircleQuestionIcon = /*#__PURE__*/ createIcon(FaCircleQuestion)
 export const FaCircleUserIcon = /*#__PURE__*/ createIcon(FaCircleUser)
 export const FaCircleXmarkIcon = /*#__PURE__*/ createIcon(FaCircleXmark)
+export const FaClipboardCheckIcon = /*#__PURE__*/ createIcon(FaClipboardCheck)
 export const FaClipboardIcon = /*#__PURE__*/ createIcon(FaClipboard)
 export const FaClipboardListIcon = /*#__PURE__*/ createIcon(FaClipboardList)
 export const FaClockIcon = /*#__PURE__*/ createIcon(FaClock)
@@ -227,6 +257,8 @@ export const FaCommentIcon = /*#__PURE__*/ createIcon(FaComment)
 export const FaCommentsIcon = /*#__PURE__*/ createIcon(FaComments)
 export const FaCompressIcon = /*#__PURE__*/ createIcon(FaCompress)
 export const FaCopyIcon = /*#__PURE__*/ createIcon(FaCopy)
+export const FaCubeIcon = /*#__PURE__*/ createIcon(FaCube)
+export const FaCubesIcon = /*#__PURE__*/ createIcon(FaCubes)
 export const FaDatabaseIcon = /*#__PURE__*/ createIcon(FaDatabase)
 export const FaDoorOpenIcon = /*#__PURE__*/ createIcon(FaDoorOpen)
 export const FaDownLeftAndUpRightToCenterIcon = /*#__PURE__*/ createIcon(
@@ -250,6 +282,7 @@ export const FaFolderPlusIcon = /*#__PURE__*/ createIcon(FaFolderPlus)
 export const FaFontIcon = /*#__PURE__*/ createIcon(FaFont)
 export const FaGaugeIcon = /*#__PURE__*/ createIcon(FaGauge)
 export const FaGearIcon = /*#__PURE__*/ createIcon(FaGear)
+export const FaGearsIcon = /*#__PURE__*/ createIcon(FaGears)
 export const FaGlobeIcon = /*#__PURE__*/ createIcon(FaGlobe)
 export const FaGraduationCapIcon = /*#__PURE__*/ createIcon(FaGraduationCap)
 export const FaGripIcon = /*#__PURE__*/ createIcon(FaGrip)
@@ -258,8 +291,11 @@ export const FaGripLinesVerticalIcon = /*#__PURE__*/ createIcon(FaGripLinesVerti
 export const FaGripVerticalIcon = /*#__PURE__*/ createIcon(FaGripVertical)
 export const FaHourglassHalfIcon = /*#__PURE__*/ createIcon(FaHourglassHalf)
 export const FaHouseIcon = /*#__PURE__*/ createIcon(FaHouse)
+export const FaIdBadgeIcon = /*#__PURE__*/ createIcon(FaIdBadge)
+export const FaIdCardIcon = /*#__PURE__*/ createIcon(FaIdCard)
 export const FaImageIcon = /*#__PURE__*/ createIcon(FaImage)
 export const FaInboxIcon = /*#__PURE__*/ createIcon(FaInbox)
+export const FaIntercomIcon = /*#__PURE__*/ createIcon(FaIntercom)
 export const FaKeyIcon = /*#__PURE__*/ createIcon(FaKey)
 export const FaLeftLongIcon = /*#__PURE__*/ createIcon(FaLeftLong)
 export const FaLeftRightIcon = /*#__PURE__*/ createIcon(FaLeftRight)
@@ -267,17 +303,22 @@ export const FaLightbulbIcon = /*#__PURE__*/ createIcon(FaLightbulb)
 export const FaLinkIcon = /*#__PURE__*/ createIcon(FaLink)
 export const FaListIcon = /*#__PURE__*/ createIcon(FaList)
 export const FaListOlIcon = /*#__PURE__*/ createIcon(FaListOl)
+export const FaListUlIcon = /*#__PURE__*/ createIcon(FaListUl)
 export const FaLockIcon = /*#__PURE__*/ createIcon(FaLock)
+export const FaLockOpenIcon = /*#__PURE__*/ createIcon(FaLockOpen)
 export const FaMagnifyingGlassIcon = /*#__PURE__*/ createIcon(FaMagnifyingGlass)
 export const FaMagnifyingGlassMinusIcon = /*#__PURE__*/ createIcon(FaMagnifyingGlassMinus)
 export const FaMagnifyingGlassPlusIcon = /*#__PURE__*/ createIcon(FaMagnifyingGlassPlus)
+export const FaMessageIcon = /*#__PURE__*/ createIcon(FaMessage)
 export const FaMinusIcon = /*#__PURE__*/ createIcon(FaMinus)
+export const FaMoneyCheckDollarIcon = /*#__PURE__*/ createIcon(FaMoneyCheckDollar)
 export const FaPaintbrushIcon = /*#__PURE__*/ createIcon(FaPaintbrush)
 export const FaPaperPlaneIcon = /*#__PURE__*/ createIcon(FaPaperPlane)
 export const FaPaperclipIcon = /*#__PURE__*/ createIcon(FaPaperclip)
 export const FaPenIcon = /*#__PURE__*/ createIcon(FaPen)
 export const FaPenToSquareIcon = /*#__PURE__*/ createIcon(FaPenToSquare)
 export const FaPencilIcon = /*#__PURE__*/ createIcon(FaPencil)
+export const FaPiggyBankIcon = /*#__PURE__*/ createIcon(FaPiggyBank)
 export const FaPlusIcon = /*#__PURE__*/ createIcon(FaPlus)
 export const FaPowerOffIcon = /*#__PURE__*/ createIcon(FaPowerOff)
 export const FaPrintIcon = /*#__PURE__*/ createIcon(FaPrint)
@@ -292,9 +333,13 @@ export const FaRocketIcon = /*#__PURE__*/ createIcon(FaRocket)
 export const FaRotateIcon = /*#__PURE__*/ createIcon(FaRotate)
 export const FaRotateLeftIcon = /*#__PURE__*/ createIcon(FaRotateLeft)
 export const FaShareNodesIcon = /*#__PURE__*/ createIcon(FaShareNodes)
+export const FaShieldHalvedIcon = /*#__PURE__*/ createIcon(FaShieldHalved)
+export const FaSlidersIcon = /*#__PURE__*/ createIcon(FaSliders)
 export const FaSortDownIcon = /*#__PURE__*/ createIcon(FaSortDown)
 export const FaSortIcon = /*#__PURE__*/ createIcon(FaSort)
 export const FaSortUpIcon = /*#__PURE__*/ createIcon(FaSortUp)
+export const FaSquareCheckIcon = /*#__PURE__*/ createIcon(FaSquareCheck)
+export const FaSquareMinusIcon = /*#__PURE__*/ createIcon(FaSquareMinus)
 export const FaSquarePlusIcon = /*#__PURE__*/ createIcon(FaSquarePlus)
 export const FaSquarePollVerticalIcon = /*#__PURE__*/ createIcon(FaSquarePollVertical)
 export const FaStarIcon = /*#__PURE__*/ createIcon(FaStar)
@@ -302,6 +347,7 @@ export const FaSuitcaseMedicalIcon = /*#__PURE__*/ createIcon(FaSuitcaseMedical)
 export const FaTableIcon = /*#__PURE__*/ createIcon(FaTable)
 export const FaTableListIcon = /*#__PURE__*/ createIcon(FaTableList)
 export const FaTagIcon = /*#__PURE__*/ createIcon(FaTag)
+export const FaTagsIcon = /*#__PURE__*/ createIcon(FaTags)
 export const FaToolboxIcon = /*#__PURE__*/ createIcon(FaToolbox)
 export const FaTrashCanIcon = /*#__PURE__*/ createIcon(FaTrashCan)
 export const FaTrashIcon = /*#__PURE__*/ createIcon(FaTrash)
@@ -317,8 +363,12 @@ export const FaUserCheckIcon = /*#__PURE__*/ createIcon(FaUserCheck)
 export const FaUserClockIcon = /*#__PURE__*/ createIcon(FaUserClock)
 export const FaUserIcon = /*#__PURE__*/ createIcon(FaUser)
 export const FaUserLargeIcon = /*#__PURE__*/ createIcon(FaUserLarge)
+export const FaUserPenIcon = /*#__PURE__*/ createIcon(FaUserPen)
 export const FaUserPlusIcon = /*#__PURE__*/ createIcon(FaUserPlus)
 export const FaUsersIcon = /*#__PURE__*/ createIcon(FaUsers)
+export const FaWindowMaximizeIcon = /*#__PURE__*/ createIcon(FaWindowMaximize)
+export const FaWindowMinimizeIcon = /*#__PURE__*/ createIcon(FaWindowMinimize)
+export const FaWindowRestoreIcon = /*#__PURE__*/ createIcon(FaWindowRestore)
 export const FaXmarkIcon = /*#__PURE__*/ createIcon(FaXmark)
 export const FaYenSignIcon = /*#__PURE__*/ createIcon(FaYenSign)
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://smarthr.atlassian.net/browse/SHRUI-950

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

#4481 で消えてしまったがFigmaにはあるアイコンを復活させる

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- FigmaのIcon群と実装にあるIcon群の集合の差分をとる
  - [Slackに差分の一覧](https://kufuinc.slack.com/archives/CDG1XRPTP/p1713513309888609?thread_ts=1713510005.526079&cid=CDG1XRPTP)があります
- 差分のうち、Figmaにはあるが実装にないものを追加

## Capture

量が多いので[Storybook](https://63d0ccabb5d2dd29825524ab-xdaqjuvfef.chromatic.com/?path=/docs/media%EF%BC%88%E3%83%A1%E3%83%87%E3%82%A3%E3%82%A2%EF%BC%89-icon--docs)で見てください！

観点: 
- エラーなくすべて表示されているか
- [足すべきアイコン](https://kufuinc.slack.com/archives/CDG1XRPTP/p1713513309888609?thread_ts=1713510005.526079&cid=CDG1XRPTP)がすべて足されているか

<!--
Please attach a capture if it looks different.
-->
