### PR TITLE
fix: Tableの一括操作領域のborderがスクロール時にちらついてしまう場合があるためstyleを調整する

### DIFF
--- a/src/components/Table/BulkActionRow.tsx
+++ b/src/components/Table/BulkActionRow.tsx
@@ -6,7 +6,7 @@ import { useTableHeadCellCount } from './useTableHeadCellCount'
 const bulkActionRow = tv({
   slots: {
     wrapper: 'smarthr-ui-BulkActionRow',
-    cell: 'shr-border-t-shorthand shr-bg-action-background shr-p-1 shr-text-base',
+    cell: 'shr-bg-action-background shr-p-1 shr-text-base',
   },
 })
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

### 修正前
<img width="920" alt="スクリーンショット 2024-04-23 8 21 04" src="https://github.com/kufu/smarthr-ui/assets/773467/b08e2649-e8c9-48a0-b579-85dce0122441">

### 修正後
<img width="919" alt="スクリーンショット 2024-04-23 8 19 55" src="https://github.com/kufu/smarthr-ui/assets/773467/35c6c91f-3cb0-4d5c-9a20-6a80ee0daff0">
