### PR TITLE
fix: FieldSetとFormControlのinnerMarginを揃える

### DIFF
--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -23,7 +23,7 @@ export const All: StoryFn = () => (
         基本
       </Text>
       <Stack as="dd">
-        <Fieldset title="就業形態" innerMargin={0.5}>
+        <Fieldset title="就業形態">
           <Cluster gap={1.25}>
             <RadioButton name="employment" defaultChecked={true}>
               正社員
@@ -34,7 +34,7 @@ export const All: StoryFn = () => (
             <RadioButton name="employment">その他</RadioButton>
           </Cluster>
         </Fieldset>
-        <Fieldset title="その他の設定" innerMargin={0.5}>
+        <Fieldset title="その他の設定">
           <CheckBox name="includeBoardMembers">役員を含める</CheckBox>
         </Fieldset>
       </Stack>
@@ -50,7 +50,7 @@ export const All: StoryFn = () => (
           errorMessages="入力されていない項目があります。"
         >
           <Stack>
-            <Fieldset title="設定の有無" titleType="subBlockTitle" innerMargin={0.5}>
+            <Fieldset title="設定の有無" titleType="subBlockTitle">
               <Cluster gap={1.25}>
                 <RadioButton name="existsConfig" defaultChecked={true}>
                   あり
@@ -90,7 +90,7 @@ export const All: StoryFn = () => (
           disabled
         >
           <Stack>
-            <Fieldset title="就業形態" innerMargin={0.5}>
+            <Fieldset title="就業形態">
               <Cluster gap={1.25}>
                 <RadioButton name="employment2">正社員</RadioButton>
                 <RadioButton name="employment2">契約社員</RadioButton>
@@ -99,7 +99,7 @@ export const All: StoryFn = () => (
                 <RadioButton name="employment2">その他</RadioButton>
               </Cluster>
             </Fieldset>
-            <Fieldset title="その他の設定" innerMargin={0.5}>
+            <Fieldset title="その他の設定">
               <CheckBox name="includeBoardMembers">役員を含める</CheckBox>
             </Fieldset>
             <Cluster gap={1}>
@@ -139,7 +139,6 @@ export const All: StoryFn = () => (
               }
             />
           }
-          innerMargin={0.5}
           dangerouslyTitleHidden
         >
           <Cluster gap={1.25}>

--- a/src/components/FormControl/FormControl.tsx
+++ b/src/components/FormControl/FormControl.tsx
@@ -112,7 +112,7 @@ const childrenWrapper = tv({
     {
       innerMargin: undefined,
       isRoleGroup: true,
-      className: '[:not([hidden])_~_&&&]:shr-mt-1',
+      className: '[:not([hidden])_~_&&&]:shr-mt-0.5',
     },
     {
       innerMargin: undefined,


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`FormControl`と`FieldSet`で children の wrapper につく `margin-top` の値が異なるためなんとかしたい。

同じフォーム内で`FormControl`と`FieldSet`が混在している場合、タイトルと入力要素間のmarginがまちまちになってしまうのでつらい

### FormControl

children の wrapper に `mt-0.5` がついている

![スクリーンショット 2024-04-24 9 43 16](https://github.com/kufu/smarthr-ui/assets/32166731/510a75cb-7a21-46c4-9f9a-01caa35a79bb)

### Fieldset

children の wrapper に `mt-1` がついている

![スクリーンショット 2024-04-24 9 42 57](https://github.com/kufu/smarthr-ui/assets/32166731/942994d7-144d-43a7-98b0-c946a01193c3)

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- children の wrapper につく `margin-top` の値を揃えた

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
