### PR TITLE
feat: FormDialogのonSubmitの第二引数にFormEventを渡すように修正

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -348,8 +348,9 @@ export const Form_Dialog: StoryFn = () => {
         subtitle="副題"
         actionText="保存"
         decorators={{ closeButtonLabel: (txt) => `cancel.(${txt})` }}
-        onSubmit={(closeDialog) => {
+        onSubmit={(closeDialog, e) => {
           action('executed')()
+          console.log('event', e)
           setResponseMessage(undefined)
           closeDialog()
         }}

--- a/src/components/Dialog/FormDialog/FormDialog.tsx
+++ b/src/components/Dialog/FormDialog/FormDialog.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, useCallback } from 'react'
+import React, { ComponentProps, FormEvent, useCallback } from 'react'
 
 import { useId } from '../../../hooks/useId'
 import { DialogContentInner } from '../DialogContentInner'
@@ -40,13 +40,16 @@ export const FormDialog: React.FC<Props & ElementProps> = ({
     onClickClose()
   }, [onClickClose, props.isOpen])
 
-  const handleSubmitAction = useCallback(() => {
-    if (!props.isOpen) {
-      return
-    }
+  const handleSubmitAction = useCallback(
+    (close: () => void, e: FormEvent<HTMLFormElement>) => {
+      if (!props.isOpen) {
+        return
+      }
 
-    onSubmit(onClickClose)
-  }, [onSubmit, onClickClose, props.isOpen])
+      onSubmit(close, e)
+    },
+    [onSubmit, props.isOpen],
+  )
 
   return createPortal(
     <DialogContentInner

--- a/src/components/Dialog/FormDialog/FormDialogContent.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContent.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, useCallback, useContext } from 'react'
+import React, { FormEvent, HTMLAttributes, useCallback, useContext } from 'react'
 
 import { useId } from '../../../hooks/useId'
 import { DialogContentInner } from '../DialogContentInner'
@@ -33,12 +33,16 @@ export const FormDialogContent: React.FC<Props & ElementProps> = ({
     onClickClose()
   }, [active, onClickClose])
 
-  const handleSubmitAction = useCallback(() => {
-    if (!active) {
-      return
-    }
-    onSubmit(onClickClose)
-  }, [active, onSubmit, onClickClose])
+  const handleSubmitAction = useCallback(
+    (close: () => void, e: FormEvent<HTMLFormElement>) => {
+      if (!active) {
+        return
+      }
+
+      onSubmit(close, e)
+    },
+    [active, onSubmit],
+  )
 
   const titleId = useId()
 

--- a/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, ReactNode, useCallback } from 'react'
+import React, { FC, FormEvent, PropsWithChildren, ReactNode, useCallback } from 'react'
 
 import { Button } from '../../Button'
 import { Heading, HeadingTagTypes } from '../../Heading'
@@ -36,7 +36,7 @@ export type BaseProps = PropsWithChildren<{
    * アクションボタンをクリックした時に発火するコールバック関数
    * @param closeDialog - ダイアログを閉じる関数
    */
-  onSubmit: (closeDialog: () => void) => void
+  onSubmit: (closeDialog: () => void, e: FormEvent<HTMLFormElement>) => void
   /**
    * アクションボタンを無効にするかどうか
    */
@@ -76,12 +76,12 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   decorators,
 }) => {
   const handleSubmitAction = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
+    (e: FormEvent<HTMLFormElement>) => {
       e.preventDefault()
       // HINT: React Potals などで擬似的にformがネストしている場合など、stopPropagationを実行しないと
       // 親formが意図せずsubmitされてしまう場合がある
       e.stopPropagation()
-      onSubmit(onClickClose)
+      onSubmit(onClickClose, e)
     },
     [onSubmit, onClickClose],
   )


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- react-hook-formなど、FormEventを受け取りたいモジュールが存在するため、onSubmit経由でFormEventを引き渡せるように修正します

## Capture

<!--
Please attach a capture if it looks different.
-->
