### PR TITLE
fix: CompactInformationPanelをdeprecatedにする

### DIFF
--- a/src/components/CompactInformationPanel/CompactInformationPanel.stories.tsx
+++ b/src/components/CompactInformationPanel/CompactInformationPanel.stories.tsx
@@ -6,7 +6,7 @@ import { Stack } from '../Layout'
 import { CompactInformationPanel } from '.'
 
 export default {
-  title: 'Data Display（データ表示）/CompactInformationPanel',
+  title: 'Data Display（データ表示）/CompactInformationPanel（非推奨）',
   component: CompactInformationPanel,
 }
 

--- a/src/components/CompactInformationPanel/CompactInformationPanel.tsx
+++ b/src/components/CompactInformationPanel/CompactInformationPanel.tsx
@@ -13,6 +13,9 @@ const compactInformationPanel = tv({
   base: ['smarthr-ui-CompactInformationPanel', 'shr-flex shr-p-1 shr-shadow-layer-3'],
 })
 
+/**
+ * @deprecated `CompactInformationPanel` は非推奨です。`NotificationBar[base="base"]` を使用してください。
+ */
 export const CompactInformationPanel: FC<Props & BaseElementProps> = ({
   type = 'info',
   className,


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`NotificationBar[base="base"]`で代替可能になったので、`CompactInformationPanel`を非推奨にします。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

`CompactInformationPanel`をdeprecatedにしました。

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
