### PR TITLE
chore: set storybook-base-dir for Chromatic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,11 @@ commands:
   run-chromatic:
     steps:
       - checkout
-      - run: pnpm ui run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes --only-changed
+      - run: pnpm ui run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes --only-changed --storybook-base-dir=packages/smarthr-ui
   run-chromatic-master:
     steps:
       - checkout
-      - run: STORYBOOK_NODE_ENV="production" pnpm ui run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes --only-changed
+      - run: STORYBOOK_NODE_ENV="production" pnpm ui run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --auto-accept-changes --only-changed --storybook-base-dir=packages/smarthr-ui
   install-noto-sans-cjk-jp:
     steps:
       - run:


### PR DESCRIPTION
## Related URL

- [monorepo build fails due to storybookBaseDir check in v11.3.1 · Issue #975 · chromaui/chromatic-cli](https://github.com/chromaui/chromatic-cli/issues/975)
- [Chromatic + TurboSnap cannot find the base directory · Issue #971 · chromaui/chromatic-cli](https://github.com/chromaui/chromatic-cli/issues/971)

## Overview

モノレポ構成だと、storybookのbase directoryを設定する必要が出てきたので設定

[CLI • Chromatic docs](https://www.chromatic.com/docs/cli/#configuration-options)

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
