### PR TITLE
fix: DropZoneのstoryの文言をデザインシステムに準拠した内容に変更

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.stories.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.stories.tsx
@@ -26,7 +26,7 @@ export const All: StoryFn = () => (
       <Text>With children</Text>
       <DropZone name="with_children" onSelectFiles={onSelectFiles}>
         <DropZoneText>
-          <span>ここにドラッグ&ドロップ</span>
+          <span>ここにドラッグアンドドロップ</span>
           <span>または</span>
         </DropZoneText>
       </DropZone>
@@ -36,7 +36,7 @@ export const All: StoryFn = () => (
       <Text>Button accepting only image files</Text>
       <DropZone name="accept" onSelectFiles={onSelectFiles} accept="image/*">
         <DropZoneText>
-          <span>ここにドラッグ&ドロップ</span>
+          <span>ここにドラッグアンドドロップ</span>
           <span>または</span>
         </DropZoneText>
       </DropZone>


### PR DESCRIPTION
## Related URL

[用字用語：一覧 | 用字用語 | SmartHR Design System](https://smarthr.design/products/contents/idiomatic-usage/data/#%E3%81%9F%E8%A1%8C)
<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
デザインシステムのライティングガイドラインとしては、「ドラッグ＆ドロップ」ではなく「ドラッグアンドドロップ」が推奨されているので、その形に合わせたい。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
該当の文言を修正した。
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
<img width="1032" alt="image" src="https://github.com/kufu/smarthr-ui/assets/60545096/5d320680-f2a8-49b4-bdc9-13e4a0137eb6">

<!--
Please attach a capture if it looks different.
-->
