### PR TITLE
fix: DefinitionListItem が空の場合に高さが潰れる欠陥を修正

### DIFF
--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -115,6 +115,14 @@ export const All: StoryFn = () => (
                 </>
               ),
               description: '標準は subBlockTitle です。blockTitle と subBlockTitle があります。',
+              fullWidth: true,
+            },
+            {
+              term: '空文字の場合も line-height 込みの高さを保ちます。',
+              description: '',
+            },
+            {
+              term: 'undefined の場合',
             },
           ]}
           termStyleType="blockTitle"

--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
@@ -22,7 +22,7 @@ const definitionListItem = tv({
     ],
     termEl: 'smarthr-ui-DefinitionListItem-term',
     descriptionEl:
-      'smarthr-ui-DefinitionListItem-description shr-ms-[initial] shr-pb-0.25 min-h-[theme(lineHeight.normal)]',
+      'smarthr-ui-DefinitionListItem-description shr-ms-[initial] shr-pb-0.25 shr-min-h-[calc(1em*theme(lineHeight.normal))]',
   },
   variants: {
     fullWidth: {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- tailwind 移行時の不具合がありました
- `min-h-` に `shr-` prefix が付いておらず、値が効いていませんでした
- 1文字分である `calc(1em * leading.NORMAL)`  となるように修正しました
- 再発しないよう Story を追加しました

リリースを待たずに修正したい場合は、`.smarthr-ui-DefinitionListItem-description` というクラスに対して `min-height: calc(1em * leading.NORMAL)` と同等のスタイルを充ててください。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
