### PR TITLE
fix: `<Table>` 中のチェックボックスの位置を調整

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
@@ -18,16 +18,18 @@ const tdCheckbox = tv({
   slots: {
     inner: 'shr-absolute shr-inset-0 [&:not(:has([disabled]))]:shr-cursor-pointer',
     wrapper: 'shr-relative shr-w-[theme(fontSize.base)] [&]:shr-p-0.75',
+    checkbox: '[&]:shr-block',
   },
 })
 
 export const TdCheckbox = forwardRef<HTMLInputElement, Omit<CheckBoxProps, keyof Props> & Props>(
   ({ 'aria-labelledby': ariaLabelledby, children, className, ...others }, ref) => {
-    const { wrapperStyle, innerStyle } = useMemo(() => {
-      const { wrapper, inner } = tdCheckbox()
+    const { wrapperStyle, innerStyle, checkboxStyle } = useMemo(() => {
+      const { wrapper, inner, checkbox } = tdCheckbox()
       return {
         wrapperStyle: wrapper({ className }),
         innerStyle: inner(),
+        checkboxStyle: checkbox(),
       }
     }, [className])
 
@@ -37,7 +39,12 @@ export const TdCheckbox = forwardRef<HTMLInputElement, Omit<CheckBoxProps, keyof
         <Center as="label" verticalCentering className={innerStyle}>
           {/* 使う側で lint をかけるため無効化 */}
           {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute  */}
-          <CheckBox {...others} ref={ref} aria-labelledby={ariaLabelledby} />
+          <CheckBox
+            {...others}
+            ref={ref}
+            aria-labelledby={ariaLabelledby}
+            className={checkboxStyle}
+          />
           {children && <VisuallyHiddenText>{children}</VisuallyHiddenText>}
         </Center>
       </Td>

--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -19,16 +19,18 @@ const thCheckbox = tv({
   slots: {
     inner: 'shr-absolute shr-inset-0 [&:not(:has([disabled]))]:shr-cursor-pointer',
     wrapper: 'shr-relative shr-w-[theme(fontSize.base)] [&]:shr-px-0.75',
+    checkbox: '[&]:shr-block',
   },
 })
 
 export const ThCheckbox = forwardRef<HTMLInputElement, CheckBoxProps & Props>(
   ({ decorators, className, ...others }, ref) => {
-    const { wrapperStyle, innerStyle } = useMemo(() => {
-      const { wrapper, inner } = thCheckbox()
+    const { wrapperStyle, innerStyle, checkboxStyle } = useMemo(() => {
+      const { wrapper, inner, checkbox } = thCheckbox()
       return {
         wrapperStyle: wrapper({ className }),
         innerStyle: inner(),
+        checkboxStyle: checkbox(),
       }
     }, [className])
 
@@ -38,7 +40,7 @@ export const ThCheckbox = forwardRef<HTMLInputElement, CheckBoxProps & Props>(
         <Center as="label" verticalCentering className={innerStyle}>
           {/* 使う側で lint をかけるため無効化 */}
           {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute  */}
-          <CheckBox {...others} ref={ref} />
+          <CheckBox {...others} ref={ref} className={checkboxStyle} />
           <VisuallyHiddenText>
             {decorators?.checkAllInvisibleLabel?.(CHECK_ALL_INVISIBLE_LABEL) ||
               CHECK_ALL_INVISIBLE_LABEL}


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

`<Table>` 中のチェックボックスの位置がずれてたので直した

## What I did

`<Checkbox>` の `display` を `block` に

## Capture

<img width="1147" alt="Tableのbefore/afterの差分を示したスクリーンショット" src="https://github.com/kufu/smarthr-ui/assets/6724665/5414a953-0b5c-4cc9-a901-51e8cd08af2f">
