### PR TITLE
feat: Loaderを強制カラーモードに対応

### DIFF
--- a/packages/smarthr-ui/src/components/Button/Button.tsx
+++ b/packages/smarthr-ui/src/components/Button/Button.tsx
@@ -37,7 +37,10 @@ const buttonStyle = tv({
         loader: '[&&&_.smarthr-ui-Loader-line]:shr-border-disabled',
       },
       false: {
-        loader: '[&&&_.smarthr-ui-Loader-line]:shr-border-white/50',
+        loader: [
+          '[&&&_.smarthr-ui-Loader-line]:shr-border-white/50',
+          '[&&&_.smarthr-ui-Loader-line]:forced-colors:shr-border-[ButtonBorder]',
+        ],
       },
     },
   },

--- a/packages/smarthr-ui/src/components/Loader/Loader.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.tsx
@@ -53,6 +53,7 @@ const loaderStyle = tv({
       'shr-border-inherit',
       'shr-border-b-transparent',
       'shr-rounded-[50%]',
+      'shr-forced-color-adjust-none',
     ],
     textSlot: ['shr-block', 'shr-mt-1', 'shr-text-base', 'shr-text-center'],
   },
@@ -70,11 +71,11 @@ const loaderStyle = tv({
     type: {
       primary: {
         textSlot: ['shr-text-black'],
-        line: ['shr-border-main'],
+        line: ['shr-border-main', 'forced-colors:shr-border-[ButtonBorder]'],
       },
       light: {
         textSlot: ['shr-text-white'],
-        line: ['shr-border-white'],
+        line: ['shr-border-white', 'forced-colors:shr-border-[ButtonBorder]'],
       },
     },
     lineNum: {


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

強制カラーモードの際、`<Loader>` のアニメーションが機能していなかったため、修正

## What I did

- `<Loader>` に `forced-color-adjust: none` を設定し、transparentを有効に
- border-colorに system-color の `ButtonBorder` を付与し色を背景に依存しない色に

## Capture

On emulate `forced-colors: active` and `prefers-colors-scheme: dark`

### Before
`<Loader>`
<img width="103" alt="スクリーンショット 2024-05-10 19 03 49" src="https://github.com/kufu/smarthr-ui/assets/6724665/d9063fbc-5f6a-4a2b-9e5f-801051ff1ec7">

`<Button>`
<img width="120" alt="スクリーンショット 2024-05-10 19 03 07" src="https://github.com/kufu/smarthr-ui/assets/6724665/51f466c6-ac5d-4ef6-8ce7-0bc26c29754f">

### After

`<Loader>`
<img width="113" alt="スクリーンショット 2024-05-10 19 01 17" src="https://github.com/kufu/smarthr-ui/assets/6724665/9269274a-c734-4d38-91b0-a6d6021932cb">


`<Button>`
<img width="132" alt="スクリーンショット 2024-05-10 19 00 29" src="https://github.com/kufu/smarthr-ui/assets/6724665/9f83b1b5-a0df-456a-8fd6-7b7a13811f40">
