### PR TITLE
chore: Checkbox[mixed error] の時 mxied とならない Story の不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/CheckBox/CheckBox.stories.tsx
+++ b/packages/smarthr-ui/src/components/CheckBox/CheckBox.stories.tsx
@@ -86,7 +86,13 @@ export const All: StoryFn = () => {
           </li>
 
           <li>
-            <CheckBox name="mixed_error" mixed error onChange={handleChange}>
+            <CheckBox
+              name="mixed_error"
+              checked={checkedName.includes('mixed_error')}
+              mixed
+              error
+              onChange={handleChange}
+            >
               CheckBox / mixed / error
             </CheckBox>
           </li>

--- a/packages/smarthr-ui/src/components/CheckBox/CheckBox.tsx
+++ b/packages/smarthr-ui/src/components/CheckBox/CheckBox.tsx
@@ -133,7 +133,7 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
             onChange={handleChange}
             className={inputStyle}
             ref={inputRef}
-            // aria-invalid={error || undefined}
+            aria-invalid={error || undefined}
           />
           <span className={boxStyle} aria-hidden="true" />
           <span className={iconWrapStyle}>

--- a/packages/smarthr-ui/src/components/CheckBox/CheckBox.tsx
+++ b/packages/smarthr-ui/src/components/CheckBox/CheckBox.tsx
@@ -133,7 +133,7 @@ export const CheckBox = forwardRef<HTMLInputElement, Props>(
             onChange={handleChange}
             className={inputStyle}
             ref={inputRef}
-            aria-invalid={error || undefined}
+            // aria-invalid={error || undefined}
           />
           <span className={boxStyle} aria-hidden="true" />
           <span className={iconWrapStyle}>


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-968

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Checkbox が mixed かつ error の時、checkbox が mixed とならな不具合を修正。コンポーネントの実装に問題はなく、Story で checked が付いていないだけでした。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
