### PR TITLE
fix: Text[styleType] の時 Heading と同等とみなし leading="TIGHT" があたるように修正

### DIFF
--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.stories.tsx
@@ -23,7 +23,7 @@ export const All: StoryFn = () => (
         基本
       </Text>
       <Stack as="dd">
-        <Fieldset title="就業形態" innerMargin={0.5}>
+        <Fieldset title="就業形態" innerMargin={0.75}>
           <Cluster gap={1.25}>
             <RadioButton name="employment" defaultChecked={true}>
               正社員
@@ -34,7 +34,7 @@ export const All: StoryFn = () => (
             <RadioButton name="employment">その他</RadioButton>
           </Cluster>
         </Fieldset>
-        <Fieldset title="その他の設定" innerMargin={0.5}>
+        <Fieldset title="その他の設定" innerMargin={0.75}>
           <CheckBox name="includeBoardMembers">役員を含める</CheckBox>
         </Fieldset>
       </Stack>
@@ -50,7 +50,7 @@ export const All: StoryFn = () => (
           errorMessages="入力されていない項目があります。"
         >
           <Stack>
-            <Fieldset title="設定の有無" titleType="subBlockTitle" innerMargin={0.5}>
+            <Fieldset title="設定の有無" titleType="subBlockTitle" innerMargin={0.75}>
               <Cluster gap={1.25}>
                 <RadioButton name="existsConfig" defaultChecked={true}>
                   あり
@@ -90,7 +90,7 @@ export const All: StoryFn = () => (
           disabled
         >
           <Stack>
-            <Fieldset title="就業形態" innerMargin={0.5}>
+            <Fieldset title="就業形態" innerMargin={0.75}>
               <Cluster gap={1.25}>
                 <RadioButton name="employment2">正社員</RadioButton>
                 <RadioButton name="employment2">契約社員</RadioButton>
@@ -99,7 +99,7 @@ export const All: StoryFn = () => (
                 <RadioButton name="employment2">その他</RadioButton>
               </Cluster>
             </Fieldset>
-            <Fieldset title="その他の設定" innerMargin={0.5}>
+            <Fieldset title="その他の設定" innerMargin={0.75}>
               <CheckBox name="includeBoardMembers">役員を含める</CheckBox>
             </Fieldset>
             <Cluster gap={1}>
@@ -139,7 +139,7 @@ export const All: StoryFn = () => (
               }
             />
           }
-          innerMargin={0.5}
+          innerMargin={0.75}
           dangerouslyTitleHidden
         >
           <Cluster gap={1.25}>

--- a/packages/smarthr-ui/src/components/Heading/Heading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.tsx
@@ -33,23 +33,28 @@ type ElementProps = Omit<
 export const MAPPER_SIZE_AND_WEIGHT: { [key in HeadingTypes]: TextProps } = {
   screenTitle: {
     size: 'XL',
+    leading: 'TIGHT',
     weight: 'normal',
   },
   sectionTitle: {
     size: 'L',
+    leading: 'TIGHT',
     weight: 'normal',
   },
   blockTitle: {
     size: 'M',
+    leading: 'TIGHT',
     weight: 'bold',
   },
   subBlockTitle: {
     size: 'M',
+    leading: 'TIGHT',
     weight: 'bold',
     color: 'TEXT_GREY',
   },
   subSubBlockTitle: {
     size: 'S',
+    leading: 'TIGHT',
     weight: 'bold',
     color: 'TEXT_GREY',
   },
@@ -101,11 +106,7 @@ export const Heading: FC<Props & ElementProps> = ({
     className: styles,
   }
 
-  return visuallyHidden ? (
-    <VisuallyHiddenText {...actualProps} />
-  ) : (
-    <Text {...actualProps} leading="TIGHT" />
-  )
+  return visuallyHidden ? <VisuallyHiddenText {...actualProps} /> : <Text {...actualProps} />
 }
 
 export const PageHeading: FC<Omit<Props & ElementProps, 'visuallyHidden' | 'tag'>> = ({

--- a/packages/smarthr-ui/src/components/Text/Text.tsx
+++ b/packages/smarthr-ui/src/components/Text/Text.tsx
@@ -72,7 +72,7 @@ export const Text: React.FC<PropsWithChildren<TextProps & ComponentProps<'span'>
         weight: weight || styleTypeValues?.weight,
         color: color || styleTypeValues?.color,
         italic,
-        leading,
+        leading: leading || styleTypeValues?.leading,
         whiteSpace,
         className,
       }),


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

FormControl や Fieldset のラベルに line-height の指定がなく、継承された line-height があたっていたので修正。
Heading と同等のスタイルでは必ず `leading=TIGHT` となるとして修正した。

もし `leading=TIGHT` 以外を使いたい場合は、別途上書きすればよい。

例

```
<Text styleType="blockTitle" leading="NONE" />
```

`Text[styleType]` を利用しているところでは、別途 `leding="TIGHT"` を指定していない限り視覚差分が必ず出るため、周知すること。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
