### PR TITLE
docs(DefinitionList): 値がない項目の表示のStoryを基準にあわせて修正

### DIFF
--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -6,6 +6,7 @@ import { Heading } from '../Heading'
 import { FaExclamationCircleIcon } from '../Icon'
 import { Cluster, Stack } from '../Layout'
 import { Text } from '../Text'
+import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { DefinitionList } from './DefinitionList'
 
@@ -50,7 +51,14 @@ const items = [
   },
   {
     term: '退職年月日',
-    description: '-',
+    description: (
+      <>
+        <Text color="TEXT_DISABLED" aria-hidden>
+          -
+        </Text>
+        <VisuallyHiddenText>未設定</VisuallyHiddenText>
+      </>
+    ),
   },
   {
     term: (


### PR DESCRIPTION
## Related URL

- https://github.com/kufu/smarthr-design-system/pull/1157 を見てて気になったので

## Overview

DefinitionListのStory内の、値がない項目の表示を基準に合わせて修正
参考: https://smarthr.design/products/design-patterns/empty-data/

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- DefinitionListのStory内の、値がない項目の表示を基準に合わせて `TEXT_DISABLED` で `-` を表示するように修正
  - `-`だけだとスクリーンリーダーでの読み上げで問題があるのでVisuallyHiddenTextで対応

## Capture

<!--
Please attach a capture if it looks different.
-->

| Before | After |
| :-- | :-- |
| <img width="263" alt="image" src="https://github.com/kufu/smarthr-ui/assets/8467289/a18b498f-5985-44f4-9891-88c5352428e9"> |  <img width="222" alt="image" src="https://github.com/kufu/smarthr-ui/assets/8467289/7fda35b2-814a-4204-9b8c-f8c92fc536da"> |
