### PR TITLE
fix: iOS系端末の場合、Select, Radio系入力要素にrequired属性を設定しないように変更

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
@@ -84,10 +84,12 @@ export const RadioButton = forwardRef<HTMLInputElement, Props>(
             id={radioButtonId}
             onChange={handleChange}
             className={inputStyle}
-            // HINT: requiredを設定すると、iOS端末で操作すると以下の問題が起きる
-            //  - submit時にvalidateは正しく行われるがフィードバックがない(対象入力要素までスクロールせず、popupも表示されない)
-            // 基本的にhtml validateだけで実装される可能性はない(歴史的にrequiredなどが無視される端末が存在する)ため
-            // iOS系端末の場合、required属性を設定しないことで、ユーザーがsubmit出来なかった理由がエラーなどで正しく理解できるようにする
+            // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
+            //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
+            //    - エラーメッセージが表示されない
+            //    - 問題のある入力フィールドまでスクロールしない
+            // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
+            // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
             required={isIOS ? undefined : required}
             ref={ref}
           />

--- a/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
@@ -9,6 +9,7 @@ import React, {
 import { tv } from 'tailwind-variants'
 
 import { useId } from '../../hooks/useId'
+import { isIOS } from '../../libs/ua'
 
 type Props = PropsWithChildren<ComponentPropsWithRef<'input'>>
 
@@ -52,7 +53,7 @@ const radioButton = tv({
 })
 
 export const RadioButton = forwardRef<HTMLInputElement, Props>(
-  ({ onChange, children, className, ...props }, ref) => {
+  ({ onChange, children, className, required, ...props }, ref) => {
     const { wrapperStyle, innerWrapperStyle, boxStyle, inputStyle, labelStyle } = useMemo(() => {
       const { wrapper, innerWrapper, box, input, label } = radioButton()
       return {
@@ -83,6 +84,11 @@ export const RadioButton = forwardRef<HTMLInputElement, Props>(
             id={radioButtonId}
             onChange={handleChange}
             className={inputStyle}
+            // HINT: requiredを設定すると、iOS端末で操作すると以下の問題が起きる
+            //  - submit時にvalidateは正しく行われるがフィードバックがない(対象入力要素までスクロールせず、popupも表示されない)
+            // 基本的にhtml validateだけで実装される可能性はない(歴史的にrequiredなどが無視される端末が存在する)ため
+            // iOS系端末の場合、required属性を設定しないことで、ユーザーがsubmit出来なかった理由がエラーなどで正しく理解できるようにする
+            required={isIOS ? undefined : required}
             ref={ref}
           />
           <span className={boxStyle} aria-hidden="true" />

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -143,10 +143,12 @@ const ActualSelect = <T extends string>(
         onChange={handleChange}
         aria-invalid={error || undefined}
         disabled={disabled}
-        // HINT: requiredを設定すると、iOS端末で操作すると以下の問題が起きる
-        //  - submit時にvalidateは正しく行われるがフィードバックがない(対象入力要素までスクロールせず、popupも表示されない)
-        // 基本的にhtml validateだけで実装される可能性はない(歴史的にrequiredなどが無視される端末が存在する)ため
-        // iOS系端末の場合、required属性を設定しないことで、ユーザーがsubmit出来なかった理由がエラーなどで正しく理解できるようにする
+        // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
+        //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
+        //    - エラーメッセージが表示されない
+        //    - 問題のある入力フィールドまでスクロールしない
+        // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
+        // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
         required={isIOS ? undefined : required}
         ref={ref}
         className={selectStyle}

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { isMobileSafari } from '../../libs/ua'
+import { isIOS, isMobileSafari } from '../../libs/ua'
 import { genericsForwardRef } from '../../libs/util'
 import { FaSortIcon } from '../Icon'
 
@@ -98,6 +98,7 @@ const ActualSelect = <T extends string>(
     size = 'default',
     className,
     disabled,
+    required,
     ...props
   }: Props<T> & ElementProps,
   ref: ForwardedRef<HTMLSelectElement>,
@@ -142,6 +143,11 @@ const ActualSelect = <T extends string>(
         onChange={handleChange}
         aria-invalid={error || undefined}
         disabled={disabled}
+        // HINT: requiredを設定すると、iOS端末で操作すると以下の問題が起きる
+        //  - submit時にvalidateは正しく行われるがフィードバックがない(対象入力要素までスクロールせず、popupも表示されない)
+        // 基本的にhtml validateだけで実装される可能性はない(歴史的にrequiredなどが無視される端末が存在する)ため
+        // iOS系端末の場合、required属性を設定しないことで、ユーザーがsubmit出来なかった理由がエラーなどで正しく理解できるようにする
+        required={isIOS ? undefined : required}
         ref={ref}
         className={selectStyle}
       >

--- a/packages/smarthr-ui/src/libs/ua.ts
+++ b/packages/smarthr-ui/src/libs/ua.ts
@@ -1,20 +1,28 @@
 const ua = typeof window !== 'undefined' ? window.navigator.userAgent.toLowerCase() : 'SSR'
 
+const isWindows = ua.indexOf('windows') !== -1
+const isAndroid = ua.indexOf('android') !== -1
+const isMobile = ua.indexOf('mobile') !== -1
+const isFirefox = ua.indexOf('firefox') !== -1
+const isIphone = ua.indexOf('iphone') !== -1
+const isIpod = ua.indexOf('ipod') !== -1
+const isIpad = ua.indexOf('ipad') !== -1
+
 export const isIe = ua.indexOf('msie') !== -1 || ua.indexOf('trident') !== -1
 
 export const isSp =
-  (ua.indexOf('windows') !== -1 && ua.indexOf('phone') !== -1) ||
-  (ua.indexOf('android') !== -1 && ua.indexOf('mobile') !== -1) ||
-  (ua.indexOf('firefox') !== -1 && ua.indexOf('mobile') !== -1) ||
-  ua.indexOf('iphone') !== -1 ||
-  ua.indexOf('ipod') !== -1 ||
+  (isWindows && ua.indexOf('phone') !== -1) ||
+  (isAndroid && isMobile) ||
+  (isFirefox && isMobile) ||
+  isIphone ||
+  isIpod ||
   ua.indexOf('blackberry') !== -1
 
 export const isTablet =
-  (ua.indexOf('windows') !== -1 && ua.indexOf('touch') !== -1 && ua.indexOf('tablet pc') === -1) ||
-  (ua.indexOf('android') !== -1 && ua.indexOf('mobile') === -1) ||
-  (ua.indexOf('firefox') !== -1 && ua.indexOf('tablet') !== -1) ||
-  ua.indexOf('ipad') !== -1 ||
+  (isWindows && ua.indexOf('touch') !== -1 && ua.indexOf('tablet pc') === -1) ||
+  (isAndroid && !isMobile) ||
+  (isFirefox && ua.indexOf('tablet') !== -1) ||
+  isIpad ||
   ua.indexOf('kindle') !== -1 ||
   ua.indexOf('silk') !== -1 ||
   ua.indexOf('playbook') !== -1
@@ -24,6 +32,6 @@ export const isPc = !isSp && !isTablet
 export const isTouchDevice = isSp || isTablet
 export const isMouseDevice = isPc
 export const isMobileSafari =
-  (ua.indexOf('iphone') !== -1 || ua.indexOf('ipod') !== -1) &&
-  ua.indexOf('safari') !== -1 &&
-  ua.indexOf('apple') !== -1
+  (isIphone || isIpod) && ua.indexOf('safari') !== -1 && ua.indexOf('apple') !== -1
+
+export const isIOS = isIphone || isIpad || isIpod


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- タイトルの通り、iOS系端末のブラウザ(safari, chrome, アプリ内ブラウザで確認)において、select, radioにrequired属性が設定されていると、submitの阻害は行われるがユーザーフィードバックがない、という状態になる問題を解決したい
- そのため、iOS系端末の場合、required属性を設定しないように修正します
  - これによりフロントのvalidate自体が行われなくなりますが、そもそもhtml validate単体での実装は、実用上存在しないはずなのでこのような対応にしています
    - 歴史的経緯により、required属性を正しく認識出来ないブラウザが存在する、そもそもhtmlでの記述なのでユーザーが突破しようと思えば突破できてしまうなど、単独での実装はそもそも問題が有るため

## Capture

<!--
Please attach a capture if it looks different.
-->
