### PR TITLE
fix(MultiCombobox): 高さのガタツキを修正

### DIFF
--- a/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.tsx
@@ -107,7 +107,7 @@ const multiCombobox = tv({
   slots: {
     wrapper: [
       'smarthr-ui-MultiComboBox',
-      'shr-box-border shr-inline-flex shr-min-w-[15em] shr-rounded-m shr-border shr-border-solid shr-px-0.5 shr-py-0.25',
+      'shr-box-border shr-inline-flex shr-min-w-[15em] shr-rounded-m shr-border shr-border-solid shr-px-0.5 shr-py-0.25 shr-align-bottom',
       'contrast-more:shr-border-high-contrast',
     ],
     inputArea: 'shr-flex shr-flex-1 shr-flex-wrap shr-gap-0.5 shr-overflow-y-auto',


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-951

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

MultiComboboxで高さがガタつくのを修正

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- `vertical-align: bottom` を追加

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->

[StorybookのMultiCombobox](https://63d0ccabb5d2dd29825524ab-fhnwavzcgm.chromatic.com/?path=/story/forms%EF%BC%88%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%EF%BC%89-multicombobox--multi-combobox)で、

- 未選択 → フォーカス
- 項目を選択済み → 削除

の2つを試し、高さがガタつかないことを確認してください。

レビュー担当の方へ: [FilterDropDownのVRTの差分](https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=664e85cc5451081b8a5d9633)が意図とあっているか (おそらく以前のものが崩れているのだとは思うが) 確認お願いしたいです！
