### PR TITLE
fix: RadioButtonPanel.storiesのlist-styleを修正

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.stories.tsx
@@ -18,7 +18,7 @@ export const All: StoryFn = () => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => setCheckedName(e.currentTarget.name)
 
   return (
-    <Stack as="ul" gap={2}>
+    <Stack as="ul" gap={2} className="shr-list-none">
       <li>
         <Fieldset title="標準的な使い方" titleType="blockTitle">
           <Stack as="ul" gap={0.5} className="shr-ps-[unset]">


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- RadioButtonPanelのstoryのlist-styleを修正しました

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

- shr-list-noneを追加

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

| Before | After |
| --- | --- |
| ![image](https://github.com/kufu/smarthr-ui/assets/16136015/bc2a58a1-5c80-4bc0-9673-46054d3c73dd) | ![image](https://github.com/kufu/smarthr-ui/assets/16136015/fa11b32d-823a-423d-ae3c-758261738a89) |

<!--
Please attach a capture if it looks different.
-->
