### PR TITLE
feat: ダイアログコンテンツに背景色とパディングを設定できるようにする

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialog.tsx
@@ -15,6 +15,8 @@ export const ActionDialog: React.FC<Props & ElementProps> = ({
   title,
   subtitle,
   titleTag,
+  contentBgColor,
+  contentPadding,
   actionText,
   actionTheme,
   onClickAction,
@@ -59,6 +61,8 @@ export const ActionDialog: React.FC<Props & ElementProps> = ({
         titleId={titleId}
         subtitle={subtitle}
         titleTag={titleTag}
+        contentBgColor={contentBgColor}
+        contentPadding={contentPadding}
         actionText={actionText}
         actionTheme={actionTheme}
         actionDisabled={actionDisabled}

--- a/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContent.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContent.tsx
@@ -14,6 +14,8 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 export const ActionDialogContent: React.FC<Props & ElementProps> = ({
   children,
   title,
+  contentBgColor,
+  contentPadding,
   actionText,
   actionTheme,
   onClickAction,
@@ -53,6 +55,8 @@ export const ActionDialogContent: React.FC<Props & ElementProps> = ({
       <ActionDialogContentInner
         title={title}
         titleId={titleId}
+        contentBgColor={contentBgColor}
+        contentPadding={contentPadding}
         actionText={actionText}
         actionTheme={actionTheme}
         onClickAction={handleClickAction}

--- a/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -7,7 +7,7 @@ import { ResponseMessage } from '../../ResponseMessage'
 import { Section } from '../../SectioningContent'
 import { Text } from '../../Text'
 import { useOffsetHeight } from '../dialogHelper'
-import { useDialoginnerStyle } from '../useDialogInnerStyle'
+import { type ContentBodyProps, useDialoginnerStyle } from '../useDialogInnerStyle'
 
 import type { DecoratorsType, ResponseMessageType } from '../../../types'
 
@@ -49,7 +49,8 @@ export type BaseProps = PropsWithChildren<{
   subActionArea?: ReactNode
   /** コンポーネント内の文言を変更するための関数を設定 */
   decorators?: DecoratorsType<'closeButtonLabel'>
-}>
+}> &
+  ContentBodyProps
 
 export type ActionDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
@@ -64,6 +65,8 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
   titleId,
   subtitle,
   titleTag,
+  contentBgColor,
+  contentPadding,
   actionText,
   actionTheme = 'primary',
   onClickAction,
@@ -82,7 +85,7 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
   const isRequestProcessing = responseMessage && responseMessage.status === 'processing'
 
   const { titleAreaStyle, bodyStyleProps, actionAreaStyle, buttonAreaStyle, messageStyle } =
-    useDialoginnerStyle(offsetHeight)
+    useDialoginnerStyle(offsetHeight, contentBgColor, contentPadding)
 
   return (
     <Section>

--- a/packages/smarthr-ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.stories.tsx
@@ -907,8 +907,15 @@ export const RegOpendMessage: StoryFn = () => (
   <MessageDialog
     isOpen={true}
     title="MessageDialog"
-    description={<p>{dummyText}</p>}
+    description={
+      <p>
+        <code>contentBgColor</code> と <code>contentPadding</code>{' '}
+        でコンテンツ領域の背景色とパディングを設定できます。
+      </p>
+    }
     onClickClose={action('clicked close')}
+    contentBgColor="BACKGROUND"
+    contentPadding={1.5}
   />
 )
 RegOpendMessage.parameters = { docs: { disable: true } }
@@ -920,22 +927,40 @@ export const RegOpendAction: StoryFn = () => (
     actionText="保存"
     onClickAction={action('clicked action')}
     onClickClose={action('clicked close')}
+    contentBgColor="BACKGROUND"
+    contentPadding={1.5}
   >
     <p>
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
+      <code>contentBgColor</code> と <code>contentPadding</code>{' '}
+      でコンテンツ領域の背景色とパディングを設定できます。
     </p>
     <label>
       <input name="reg_opend_action_checkbox" type="checkbox" />
       Agree
     </label>
   </ActionDialog>
+)
+RegOpendAction.parameters = { docs: { disable: true } }
+
+export const RegOpendForm: StoryFn = () => (
+  <FormDialog
+    isOpen={true}
+    title="FormDialog"
+    actionText="保存"
+    onSubmit={action('clicked submit')}
+    onClickClose={action('clicked close')}
+    contentBgColor="BACKGROUND"
+    contentPadding={1.5}
+  >
+    <p>
+      <code>contentBgColor</code> と <code>contentPadding</code>{' '}
+      でコンテンツ領域の背景色とパディングを設定できます。
+    </p>
+    <label>
+      <input name="reg_opend_action_checkbox" type="checkbox" />
+      Agree
+    </label>
+  </FormDialog>
 )
 RegOpendAction.parameters = { docs: { disable: true } }
 
@@ -947,13 +972,12 @@ export const RegOpenedModeless: StoryFn = () => (
     footer={<ModelessFooter>フッタ</ModelessFooter>}
     height={500}
     width={600}
+    contentBgColor="BACKGROUND"
+    contentPadding={1.5}
   >
     <p>
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
-      {dummyText}
+      <code>contentBgColor</code> と <code>contentPadding</code>{' '}
+      でコンテンツ領域の背景色とパディングを設定できます。
     </p>
   </ModelessDialog>
 )

--- a/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialog.tsx
@@ -15,6 +15,8 @@ export const FormDialog: React.FC<Props & ElementProps> = ({
   title,
   subtitle,
   titleTag,
+  contentBgColor,
+  contentPadding,
   actionText,
   actionTheme,
   onSubmit,
@@ -64,6 +66,8 @@ export const FormDialog: React.FC<Props & ElementProps> = ({
         titleId={titleId}
         subtitle={subtitle}
         titleTag={titleTag}
+        contentBgColor={contentBgColor}
+        contentPadding={contentPadding}
         actionText={actionText}
         actionTheme={actionTheme}
         actionDisabled={actionDisabled}

--- a/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContent.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContent.tsx
@@ -14,6 +14,8 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 export const FormDialogContent: React.FC<Props & ElementProps> = ({
   children,
   title,
+  contentBgColor,
+  contentPadding,
   actionText,
   actionTheme,
   onSubmit,
@@ -58,6 +60,8 @@ export const FormDialogContent: React.FC<Props & ElementProps> = ({
       <FormDialogContentInner
         title={title}
         titleId={titleId}
+        contentBgColor={contentBgColor}
+        contentPadding={contentPadding}
         actionText={actionText}
         actionTheme={actionTheme}
         onSubmit={handleSubmitAction}

--- a/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -7,7 +7,7 @@ import { ResponseMessage } from '../../ResponseMessage'
 import { Section } from '../../SectioningContent'
 import { Text } from '../../Text'
 import { useOffsetHeight } from '../dialogHelper'
-import { useDialoginnerStyle } from '../useDialogInnerStyle'
+import { type ContentBodyProps, useDialoginnerStyle } from '../useDialogInnerStyle'
 
 import type { DecoratorsType, ResponseMessageType } from '../../../types'
 
@@ -49,7 +49,8 @@ export type BaseProps = PropsWithChildren<{
   subActionArea?: ReactNode
   /** コンポーネント内の文言を変更するための関数を設定 */
   decorators?: DecoratorsType<'closeButtonLabel'>
-}>
+}> &
+  ContentBodyProps
 
 export type FormDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
@@ -65,6 +66,8 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   titleId,
   subtitle,
   titleTag,
+  contentBgColor,
+  contentPadding,
   actionText,
   actionTheme = 'primary',
   onSubmit,
@@ -90,7 +93,7 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   const isRequestProcessing = responseMessage && responseMessage.status === 'processing'
 
   const { titleAreaStyle, bodyStyleProps, actionAreaStyle, buttonAreaStyle, messageStyle } =
-    useDialoginnerStyle(offsetHeight)
+    useDialoginnerStyle(offsetHeight, contentBgColor, contentPadding)
 
   return (
     <Section>

--- a/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialog.tsx
@@ -20,6 +20,8 @@ export const MessageDialog: React.FC<Props & ElementProps> = ({
   description,
   onClickClose,
   onPressEscape = onClickClose,
+  contentBgColor,
+  contentPadding,
   className,
   portalParent,
   decorators,
@@ -48,6 +50,8 @@ export const MessageDialog: React.FC<Props & ElementProps> = ({
         titleId={titleId}
         subtitle={subtitle}
         description={description}
+        contentBgColor={contentBgColor}
+        contentPadding={contentPadding}
         onClickClose={handleClickClose}
         decorators={decorators}
       />

--- a/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialogContent.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialogContent.tsx
@@ -16,6 +16,8 @@ export const MessageDialogContent: React.FC<Props & ElementProps> = ({
   description,
   portalParent,
   className,
+  contentBgColor,
+  contentPadding,
   decorators,
   ...props
 }) => {
@@ -41,6 +43,8 @@ export const MessageDialogContent: React.FC<Props & ElementProps> = ({
         title={title}
         titleId={titleId}
         description={description}
+        contentBgColor={contentBgColor}
+        contentPadding={contentPadding}
         onClickClose={handleClickClose}
         decorators={decorators}
       />

--- a/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialogContentInner.tsx
@@ -7,8 +7,9 @@ import { Stack } from '../../Layout'
 import { Section } from '../../SectioningContent'
 import { Text } from '../../Text'
 import { useOffsetHeight } from '../dialogHelper'
+import { type ContentBodyProps } from '../useDialogInnerStyle'
 
-import type { DecoratorsType } from '../../../types'
+import type { DecoratorsType, Gap } from '../../../types'
 
 export type BaseProps = {
   /**
@@ -29,7 +30,7 @@ export type BaseProps = {
   description: React.ReactNode
   /** コンポーネント内の文言を変更するための関数を設定 */
   decorators?: DecoratorsType<'closeButtonLabel'>
-}
+} & ContentBodyProps
 
 export type MessageDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
@@ -42,9 +43,80 @@ const messegeDialogContentInner = tv({
   slots: {
     titleArea:
       'smarthr-ui-Dialog-titleArea shr-border-b-shorthand shr-my-[unset] shr-px-1.5 shr-py-1',
-    body: 'smarthr-ui-Dialog-description shr-overflow-auto shr-p-1.5 shr-text-base',
     footer:
       'smarthr-ui-Dialog-buttonArea shr-border-t-shorthand shr-flex shr-justify-end shr-px-1.5 shr-py-1',
+  },
+})
+// FIXME: 他のダイアログと共通化したかったが別でやる
+const dialogBody = tv({
+  base: ['smarthr-ui-Dialog-description', 'shr-overflow-auto shr-text-base'],
+  variants: {
+    contentPaddingBlock: {
+      0: 'shr-py-0',
+      0.25: 'shr-py-0.25',
+      0.5: 'shr-py-0.5',
+      0.75: 'shr-py-0.75',
+      1: 'shr-py-1',
+      1.25: 'shr-py-1.25',
+      1.5: 'shr-py-1.5',
+      2: 'shr-py-2',
+      2.5: 'shr-py-2.5',
+      3: 'shr-py-3',
+      3.5: 'shr-py-3.5',
+      4: 'shr-py-4',
+      8: 'shr-py-8',
+      X3S: 'shr-py-0.25',
+      XXS: 'shr-py-0.5',
+      XS: 'shr-py-1',
+      S: 'shr-py-1.5',
+      M: 'shr-py-2',
+      L: 'shr-py-2.5',
+      XL: 'shr-py-3',
+      XXL: 'shr-py-3.5',
+      X3L: 'shr-py-4',
+    } as { [key in Gap]: string },
+    contentPaddingInline: {
+      0: 'shr-px-0',
+      0.25: 'shr-px-0.25',
+      0.5: 'shr-px-0.5',
+      0.75: 'shr-px-0.75',
+      1: 'shr-px-1',
+      1.25: 'shr-px-1.25',
+      1.5: 'shr-px-1.5',
+      2: 'shr-px-2',
+      2.5: 'shr-px-2.5',
+      3: 'shr-px-3',
+      3.5: 'shr-px-3.5',
+      4: 'shr-px-4',
+      8: 'shr-px-8',
+      X3S: 'shr-px-0.25',
+      XXS: 'shr-px-0.5',
+      XS: 'shr-px-1',
+      S: 'shr-px-1.5',
+      M: 'shr-px-2',
+      L: 'shr-px-2.5',
+      XL: 'shr-px-3',
+      XXL: 'shr-px-3.5',
+      X3L: 'shr-px-4',
+    } as { [key in Gap]: string },
+    contentBgColor: {
+      BACKGROUND: 'shr-bg-background',
+      COLUMN: 'shr-bg-column',
+      BASE_GREY: 'shr-bg-base-grey',
+      OVER_BACKGROUND: 'shr-bg-over-background',
+      HEAD: 'shr-bg-head',
+      BORDER: 'shr-bg-[theme(colors.grey.20)]',
+      ACTION_BACKGROUND: 'shr-bg-action-background',
+      WHITE: 'shr-bg-white',
+      GREY_5: 'shr-bg-[theme(colors.grey.5)]',
+      GREY_6: 'shr-bg-[theme(colors.grey.6)]',
+      GREY_7: 'shr-bg-[theme(colors.grey.7)]',
+      GREY_9: 'shr-bg-[theme(colors.grey.9)]',
+      GREY_20: 'shr-bg-[theme(colors.grey.20)]',
+      GREY_30: 'shr-bg-[theme(colors.grey.30)]',
+      GREY_65: 'shr-bg-[theme(colors.grey.65)]',
+      GREY_100: 'shr-bg-[theme(colors.grey.100)]',
+    },
   },
 })
 
@@ -53,6 +125,8 @@ export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
   subtitle,
   titleTag,
   titleId,
+  contentBgColor,
+  contentPadding = 1.5,
   description,
   onClickClose,
   decorators,
@@ -60,18 +134,25 @@ export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
   const { offsetHeight, titleRef, bottomRef } = useOffsetHeight()
 
   const { titleAreaStyle, bodyStyleProps, footerStyle } = useMemo(() => {
-    const { titleArea, body, footer } = messegeDialogContentInner()
+    const { titleArea, footer } = messegeDialogContentInner()
+    const paddingBlock = contentPadding instanceof Object ? contentPadding.block : contentPadding
+    const paddingInline = contentPadding instanceof Object ? contentPadding.inline : contentPadding
+
     return {
       titleAreaStyle: titleArea(),
       bodyStyleProps: {
         style: {
           maxHeight: `calc(100svh - ${offsetHeight}px)`,
         },
-        className: body(),
+        className: dialogBody({
+          contentBgColor,
+          contentPaddingBlock: paddingBlock,
+          contentPaddingInline: paddingInline,
+        }),
       },
       footerStyle: footer(),
     }
-  }, [offsetHeight])
+  }, [contentBgColor, contentPadding, offsetHeight])
 
   return (
     <Section>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
@@ -22,10 +22,10 @@ import { Button } from '../Button'
 import { FaGripHorizontalIcon, FaTimesIcon } from '../Icon'
 
 import { DialogOverlap } from './DialogOverlap'
+import { type ContentBodyProps } from './useDialogInnerStyle'
 import { useDialogPortal } from './useDialogPortal'
 
 import type { DecoratorsType, Gap } from '../../types'
-import { type ContentBodyProps } from './useDialogInnerStyle'
 
 type Props = PropsWithChildren<{
   /**

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
@@ -24,7 +24,8 @@ import { FaGripHorizontalIcon, FaTimesIcon } from '../Icon'
 import { DialogOverlap } from './DialogOverlap'
 import { useDialogPortal } from './useDialogPortal'
 
-import type { DecoratorsType } from '../../types'
+import type { DecoratorsType, Gap } from '../../types'
+import { type ContentBodyProps } from './useDialogInnerStyle'
 
 type Props = PropsWithChildren<{
   /**
@@ -80,7 +81,8 @@ type Props = PropsWithChildren<{
     dialogHandlerAriaLabel?: (txt: string) => string
     dialogHandlerAriaValuetext?: (txt: string, data: DOMRect | undefined) => string
   }
-}>
+}> &
+  ContentBodyProps
 
 const DIALOG_HANDLER_ARIA_LABEL = 'ダイアログの位置'
 const CLOSE_BUTTON_ICON_ALT = '閉じる'
@@ -103,15 +105,90 @@ const modelessDialog = tv({
       'shr-relative' /* DialogHandlerの上に出すためにスタッキングコンテキストを生成 */,
       'shr-ml-auto shr-shrink-0',
     ],
-    content:
-      'smarthr-ui-ModelessDialog-content shr-flex-1 shr-overflow-auto shr-overscroll-contain shr-p-1.5',
     footerEl: 'smarthr-ui-ModelessDialog-footer shr-border-t-shorthand',
+  },
+})
+// FIXME: 他のダイアログと共通化したかったが別でやる
+const dialogBody = tv({
+  base: [
+    'smarthr-ui-ModelessDialog-content',
+    'shr-flex-1 shr-overflow-auto shr-overscroll-contain',
+  ],
+  variants: {
+    contentPaddingBlock: {
+      0: 'shr-py-0',
+      0.25: 'shr-py-0.25',
+      0.5: 'shr-py-0.5',
+      0.75: 'shr-py-0.75',
+      1: 'shr-py-1',
+      1.25: 'shr-py-1.25',
+      1.5: 'shr-py-1.5',
+      2: 'shr-py-2',
+      2.5: 'shr-py-2.5',
+      3: 'shr-py-3',
+      3.5: 'shr-py-3.5',
+      4: 'shr-py-4',
+      8: 'shr-py-8',
+      X3S: 'shr-py-0.25',
+      XXS: 'shr-py-0.5',
+      XS: 'shr-py-1',
+      S: 'shr-py-1.5',
+      M: 'shr-py-2',
+      L: 'shr-py-2.5',
+      XL: 'shr-py-3',
+      XXL: 'shr-py-3.5',
+      X3L: 'shr-py-4',
+    } as { [key in Gap]: string },
+    contentPaddingInline: {
+      0: 'shr-px-0',
+      0.25: 'shr-px-0.25',
+      0.5: 'shr-px-0.5',
+      0.75: 'shr-px-0.75',
+      1: 'shr-px-1',
+      1.25: 'shr-px-1.25',
+      1.5: 'shr-px-1.5',
+      2: 'shr-px-2',
+      2.5: 'shr-px-2.5',
+      3: 'shr-px-3',
+      3.5: 'shr-px-3.5',
+      4: 'shr-px-4',
+      8: 'shr-px-8',
+      X3S: 'shr-px-0.25',
+      XXS: 'shr-px-0.5',
+      XS: 'shr-px-1',
+      S: 'shr-px-1.5',
+      M: 'shr-px-2',
+      L: 'shr-px-2.5',
+      XL: 'shr-px-3',
+      XXL: 'shr-px-3.5',
+      X3L: 'shr-px-4',
+    } as { [key in Gap]: string },
+    contentBgColor: {
+      BACKGROUND: 'shr-bg-background',
+      COLUMN: 'shr-bg-column',
+      BASE_GREY: 'shr-bg-base-grey',
+      OVER_BACKGROUND: 'shr-bg-over-background',
+      HEAD: 'shr-bg-head',
+      BORDER: 'shr-bg-[theme(colors.grey.20)]',
+      ACTION_BACKGROUND: 'shr-bg-action-background',
+      WHITE: 'shr-bg-white',
+      GREY_5: 'shr-bg-[theme(colors.grey.5)]',
+      GREY_6: 'shr-bg-[theme(colors.grey.6)]',
+      GREY_7: 'shr-bg-[theme(colors.grey.7)]',
+      GREY_9: 'shr-bg-[theme(colors.grey.9)]',
+      GREY_20: 'shr-bg-[theme(colors.grey.20)]',
+      GREY_30: 'shr-bg-[theme(colors.grey.30)]',
+      GREY_65: 'shr-bg-[theme(colors.grey.65)]',
+      GREY_100: 'shr-bg-[theme(colors.grey.100)]',
+    },
   },
 })
 
 export const ModelessDialog: FC<Props & BaseElementProps> = ({
   header,
   children,
+  contentBgColor,
+  contentPadding = 1.5,
   footer,
   isOpen,
   onClickClose,
@@ -142,8 +219,10 @@ export const ModelessDialog: FC<Props & BaseElementProps> = ({
     contentStyle,
     footerStyle,
   } = useMemo(() => {
-    const { layout, box, headerEl, title, dialogHandler, closeButtonLayout, content, footerEl } =
+    const { layout, box, headerEl, title, dialogHandler, closeButtonLayout, footerEl } =
       modelessDialog()
+    const paddingBlock = contentPadding instanceof Object ? contentPadding.block : contentPadding
+    const paddingInline = contentPadding instanceof Object ? contentPadding.inline : contentPadding
     return {
       layoutStyle: layout({ className }),
       boxStyle: box(),
@@ -151,10 +230,14 @@ export const ModelessDialog: FC<Props & BaseElementProps> = ({
       titleStyle: title(),
       dialogHandlerStyle: dialogHandler(),
       closeButtonLayoutStyle: closeButtonLayout(),
-      contentStyle: content(),
+      contentStyle: dialogBody({
+        contentBgColor,
+        contentPaddingBlock: paddingBlock,
+        contentPaddingInline: paddingInline,
+      }),
       footerStyle: footerEl(),
     }
-  }, [className])
+  }, [className, contentBgColor, contentPadding])
   const boxStyleProps = useMemo(() => {
     const leftMargin = typeof left === 'number' ? `${left}px` : left
     const rightMargin = typeof right === 'number' ? `${right}px` : right

--- a/packages/smarthr-ui/src/components/Dialog/useDialogInnerStyle.ts
+++ b/packages/smarthr-ui/src/components/Dialog/useDialogInnerStyle.ts
@@ -1,23 +1,110 @@
 import { useMemo } from 'react'
-import { tv } from 'tailwind-variants'
+import { type VariantProps, tv } from 'tailwind-variants'
+
+import { type Gap } from '../../types'
 
 const dialogContentInner = tv({
   slots: {
     titleArea: ['smarthr-ui-Dialog-titleArea', 'shr-border-b-shorthand shr-px-1.5 shr-py-1'],
-    body: ['smarthr-ui-Dialog-body', 'shr-overflow-auto shr-p-1.5'],
     actionArea: ['smarthr-ui-Dialog-actionArea', 'shr-border-t-shorthand shr-px-1.5 shr-py-1'],
     buttonArea: ['smarthr-ui-Dialog-buttonArea', 'shr-ms-auto'],
     message: 'shr-text-right',
   },
 })
+const dialogBody = tv({
+  base: ['smarthr-ui-Dialog-body', 'shr-overflow-auto'],
+  variants: {
+    contentPaddingBlock: {
+      0: 'shr-py-0',
+      0.25: 'shr-py-0.25',
+      0.5: 'shr-py-0.5',
+      0.75: 'shr-py-0.75',
+      1: 'shr-py-1',
+      1.25: 'shr-py-1.25',
+      1.5: 'shr-py-1.5',
+      2: 'shr-py-2',
+      2.5: 'shr-py-2.5',
+      3: 'shr-py-3',
+      3.5: 'shr-py-3.5',
+      4: 'shr-py-4',
+      8: 'shr-py-8',
+      X3S: 'shr-py-0.25',
+      XXS: 'shr-py-0.5',
+      XS: 'shr-py-1',
+      S: 'shr-py-1.5',
+      M: 'shr-py-2',
+      L: 'shr-py-2.5',
+      XL: 'shr-py-3',
+      XXL: 'shr-py-3.5',
+      X3L: 'shr-py-4',
+    } as { [key in Gap]: string },
+    contentPaddingInline: {
+      0: 'shr-px-0',
+      0.25: 'shr-px-0.25',
+      0.5: 'shr-px-0.5',
+      0.75: 'shr-px-0.75',
+      1: 'shr-px-1',
+      1.25: 'shr-px-1.25',
+      1.5: 'shr-px-1.5',
+      2: 'shr-px-2',
+      2.5: 'shr-px-2.5',
+      3: 'shr-px-3',
+      3.5: 'shr-px-3.5',
+      4: 'shr-px-4',
+      8: 'shr-px-8',
+      X3S: 'shr-px-0.25',
+      XXS: 'shr-px-0.5',
+      XS: 'shr-px-1',
+      S: 'shr-px-1.5',
+      M: 'shr-px-2',
+      L: 'shr-px-2.5',
+      XL: 'shr-px-3',
+      XXL: 'shr-px-3.5',
+      X3L: 'shr-px-4',
+    } as { [key in Gap]: string },
+    contentBgColor: {
+      BACKGROUND: 'shr-bg-background',
+      COLUMN: 'shr-bg-column',
+      BASE_GREY: 'shr-bg-base-grey',
+      OVER_BACKGROUND: 'shr-bg-over-background',
+      HEAD: 'shr-bg-head',
+      BORDER: 'shr-bg-[theme(colors.grey.20)]',
+      ACTION_BACKGROUND: 'shr-bg-action-background',
+      WHITE: 'shr-bg-white',
+      GREY_5: 'shr-bg-[theme(colors.grey.5)]',
+      GREY_6: 'shr-bg-[theme(colors.grey.6)]',
+      GREY_7: 'shr-bg-[theme(colors.grey.7)]',
+      GREY_9: 'shr-bg-[theme(colors.grey.9)]',
+      GREY_20: 'shr-bg-[theme(colors.grey.20)]',
+      GREY_30: 'shr-bg-[theme(colors.grey.30)]',
+      GREY_65: 'shr-bg-[theme(colors.grey.65)]',
+      GREY_100: 'shr-bg-[theme(colors.grey.100)]',
+    },
+  },
+})
 
-export const useDialoginnerStyle = (offsetHeight: number) =>
+export type ContentBodyProps = Pick<VariantProps<typeof dialogBody>, 'contentBgColor'> & {
+  contentPadding?: Gap | { block?: Gap; inline?: Gap }
+}
+
+export const useDialoginnerStyle = (
+  offsetHeight: number,
+  bgColor: ContentBodyProps['contentBgColor'],
+  padding: ContentBodyProps['contentPadding'] = 1.5,
+) =>
   useMemo(() => {
-    const { titleArea, body, actionArea, buttonArea, message } = dialogContentInner()
+    const { titleArea, actionArea, buttonArea, message } = dialogContentInner()
+    const paddingBlock = padding instanceof Object ? padding.block : padding
+    const paddingInline = padding instanceof Object ? padding.inline : padding
+
     return {
       titleAreaStyle: titleArea(),
       bodyStyleProps: {
-        className: body(),
+        className: dialogBody({
+          contentBgColor: bgColor,
+          contentPaddingBlock: paddingBlock,
+          contentPaddingInline: paddingInline,
+        }),
         style: {
           maxHeight: `calc(100svh - ${offsetHeight}px)`,
         },
@@ -26,4 +113,4 @@ export const useDialoginnerStyle = (offsetHeight: number) =>
       buttonAreaStyle: buttonArea(),
       messageStyle: message(),
     }
-  }, [offsetHeight])
+  }, [bgColor, offsetHeight, padding])


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-866

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

#4644 でダイアログコンテンツの padding を統一したが、背景色を敷きたい場合などに実装側でスタイリングを別途あてないと使えない状態だったため、`contentBgColor` と `contentPadding` を生やしました。

利用側が negative margin などを駆使しなくてもスタイリングできるようになります。

「Reg Opened Hoge」な Story で確認できるように Story を修正しました。

既存の構成に追記したため、同一の記述が3箇所に分かれてしまい煩雑化しましたが、リファクタリングは別途行ったほうが良いと考えたため行っていません。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
