### PR TITLE
fix: 背景色として使う可能性のない色を bgColor 関連 props から消す

### DIFF
--- a/packages/smarthr-ui/src/components/Base/BaseColumn/BaseColumn.tsx
+++ b/packages/smarthr-ui/src/components/Base/BaseColumn/BaseColumn.tsx
@@ -24,9 +24,6 @@ const baseColumn = tv({
       GREY_7: '[&&&]:shr-bg-[theme(colors.grey.7)]',
       GREY_9: '[&&&]:shr-bg-[theme(colors.grey.9)]',
       GREY_20: '[&&&]:shr-bg-[theme(colors.grey.20)]',
-      GREY_30: '[&&&]:shr-bg-[theme(colors.grey.30)]',
-      GREY_65: '[&&&]:shr-bg-[theme(colors.grey.65)]',
-      GREY_100: '[&&&]:shr-bg-[theme(colors.grey.100)]',
     },
   },
   defaultVariants: {

--- a/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/MessageDialog/MessageDialogContentInner.tsx
@@ -113,9 +113,6 @@ const dialogBody = tv({
       GREY_7: 'shr-bg-[theme(colors.grey.7)]',
       GREY_9: 'shr-bg-[theme(colors.grey.9)]',
       GREY_20: 'shr-bg-[theme(colors.grey.20)]',
-      GREY_30: 'shr-bg-[theme(colors.grey.30)]',
-      GREY_65: 'shr-bg-[theme(colors.grey.65)]',
-      GREY_100: 'shr-bg-[theme(colors.grey.100)]',
     },
   },
 })

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
@@ -177,9 +177,6 @@ const dialogBody = tv({
       GREY_7: 'shr-bg-[theme(colors.grey.7)]',
       GREY_9: 'shr-bg-[theme(colors.grey.9)]',
       GREY_20: 'shr-bg-[theme(colors.grey.20)]',
-      GREY_30: 'shr-bg-[theme(colors.grey.30)]',
-      GREY_65: 'shr-bg-[theme(colors.grey.65)]',
-      GREY_100: 'shr-bg-[theme(colors.grey.100)]',
     },
   },
 })

--- a/packages/smarthr-ui/src/components/Dialog/useDialogInnerStyle.ts
+++ b/packages/smarthr-ui/src/components/Dialog/useDialogInnerStyle.ts
@@ -76,9 +76,6 @@ const dialogBody = tv({
       GREY_7: 'shr-bg-[theme(colors.grey.7)]',
       GREY_9: 'shr-bg-[theme(colors.grey.9)]',
       GREY_20: 'shr-bg-[theme(colors.grey.20)]',
-      GREY_30: 'shr-bg-[theme(colors.grey.30)]',
-      GREY_65: 'shr-bg-[theme(colors.grey.65)]',
-      GREY_100: 'shr-bg-[theme(colors.grey.100)]',
     },
   },
 })


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- WCAG AA 1.4.11 の試験で発覚しました
- フォーカスインジケーターに `OUTLINE` の色を使っていますが、GREY_30 以上の濃さのグレースケールではコントラスト比 3:1 を担保できません
- プロダクトを作る中で GREY_30 以上の背景を使う可能性はないため、bgColor 関連の props からも消します

参考： [コントラストグリッド](https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=%23ffffff%2C%20WHITE%0D%0A%23f8f7f6%2C%20GREY_5%2C%20BACKGROUND%2C%20COLUMN%0D%0A%23f5f4f3%2C%20GREY_6%0D%0A%23f2f1f0%2C%20GREY_7%2C%20OVER_BACKGROUND%0D%0A%23edebe8%2C%20GREY_9%2C%20HEAD%0D%0A%23d6d3d0%2C%20GREY_20%2C%20BORDER%0D%0A%23c1bdb7%2C%20GREY_30%0D%0A%23706d65%2C%20GREY_65%0D%0A%2323221e%2C%20GREY_100&foreground-colors=%230077c7%2C%20OUTLINE&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18)
![image](https://github.com/kufu/smarthr-ui/assets/19403400/eb958a6f-3770-4b04-890e-c304d23d7410)


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
