### PR TITLE
fix: RadioButtonPanel と Switch の focus-indicator を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Base/Base.tsx
+++ b/packages/smarthr-ui/src/components/Base/Base.tsx
@@ -75,7 +75,7 @@ const base = tv({
       auto: 'shr-overflow-x-auto',
     },
     layer: {
-      0: 'shr-shadow-layer-0',
+      0: '',
       1: 'shr-shadow-layer-1',
       2: 'shr-shadow-layer-2',
       3: 'shr-shadow-layer-3',

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -13,7 +13,7 @@ const MEANLESS_TAG_NAMES = ['div', 'span']
 const radioButtonPanel = tv({
   base: [
     'smarthr-ui-RadioButtonPanel',
-    'shr-border-shorthand shr-list-none shr-shadow-none',
+    'shr-border-shorthand shr-list-none',
     // なぜか :has が動作しないので重ねて書いている
     'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
     '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
@@ -43,6 +43,7 @@ export const RadioButtonPanel: React.FC<Props> = ({ onClick, as, className, ...p
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
     <Base
       padding={1}
+      layer={0}
       role={MEANLESS_TAG_NAMES.includes(`${as || ''}`) ? 'presentation' : undefined}
       onClick={handleOuterClick}
       as={as}

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -14,8 +14,8 @@ const radioButtonPanel = tv({
   base: [
     'smarthr-ui-RadioButtonPanel',
     'shr-border-shorthand shr-list-none',
-    // なぜか :has が動作しないので重ねて書いている
-    'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
+    // なぜか focus-indicator が機能しないので box-shadow で代用
+    '[&:has(:focus-visible)]:shr-shadow-outline',
     '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
     '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
     'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/VRTHasFocusVisible.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/VRTHasFocusVisible.stories.tsx
@@ -1,0 +1,31 @@
+import { userEvent } from '@storybook/test'
+import React from 'react'
+
+import { RadioButtonPanel } from './RadioButtonPanel'
+
+import type { Meta, StoryObj } from '@storybook/react/*'
+
+const meta: Meta<typeof RadioButtonPanel> = {
+  title: 'Forms（フォーム）/RadioButtonPanel',
+  component: RadioButtonPanel,
+}
+
+export default meta
+type Story = StoryObj<typeof RadioButtonPanel>
+
+export const HasFocusVisible: Story = {
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
+  play: async () => {
+    userEvent.keyboard('{tab}', { delay: 100 })
+  },
+  render: () => (
+    // eslint-disable-next-line smarthr/a11y-input-in-form-control
+    <RadioButtonPanel name="has_focus_visible">
+      <code>:has(:focus-visible)</code> を確かめるための Story です。
+    </RadioButtonPanel>
+  ),
+}

--- a/packages/smarthr-ui/src/components/Switch/Switch.tsx
+++ b/packages/smarthr-ui/src/components/Switch/Switch.tsx
@@ -10,8 +10,8 @@ const switchStyle = tv({
       'shr-border-shorthand shr-relative shr-inline-flex shr-w-[calc(theme(fontSize.base)*2)] shr-items-center shr-rounded-full shr-bg-white shr-h-fit',
       // 理想的には padding: 2px; だが、box-shadow を outline で使用しているため、border と padding で2pxの疑似余白を作っている。
       'shr-p-px',
-      // :focus-visible-within の代替, なぜかhasが機能しないので以下の書き方で代用している
-      'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
+      // なぜか focus-indicator が機能しないので box-shadow で代用
+      '[&:has(:focus-visible)]:shr-shadow-outline',
       'has-[:checked]:shr-border-[theme(colors.main)] has-[:checked]:shr-bg-main',
       'has-[:disabled]:shr-border-[theme(borderColor.default)] has-[:disabled]:shr-bg-border',
       'forced-colors:has-[:disabled]:shr-border-[GrayText]',

--- a/packages/smarthr-ui/src/components/Switch/VRTHasFocusVisible.stories.tsx
+++ b/packages/smarthr-ui/src/components/Switch/VRTHasFocusVisible.stories.tsx
@@ -1,0 +1,39 @@
+import { userEvent } from '@storybook/test'
+import React from 'react'
+
+import { Cluster, Stack } from '../Layout'
+
+import { Switch } from './Switch'
+
+import type { Meta, StoryObj } from '@storybook/react/*'
+
+const meta: Meta<typeof Switch> = {
+  title: 'Forms（フォーム）/Switch',
+  component: Switch,
+}
+
+export default meta
+type Story = StoryObj<typeof Switch>
+
+export const HasFocusVisible: Story = {
+  parameters: {
+    chromatic: {
+      delay: 200,
+    },
+  },
+  play: async () => {
+    userEvent.keyboard('{tab}', { delay: 100 })
+  },
+  render: () => (
+    <Stack>
+      <p>
+        <code>:has(:focus-visible)</code> を確かめるための Story です。
+      </p>
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <Cluster align="center" as="label">
+        フォーカスリングを表示
+        <Switch />
+      </Cluster>
+    </Stack>
+  ),
+}

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -335,7 +335,7 @@ export default {
         '.focus-indicator': {
           outline: 'none',
           isolation: 'isolate',
-          boxShadow: `0 0 0 2px ${theme('colors.white')}, 0 0 0 4px ${theme('colors.outline')}`,
+          boxShadow: theme('boxShadow.outline'),
         },
         '.border-shorthand': {
           borderWidth: theme('borderWidth.DEFAULT'),


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- focus-indicator の box-shadow を token で置き換え
- RadioButtonPanel[layer=0] で当たっていた shadow-none を focus-indicator で上書きできないし、不要なのでやめる
- Switch と RadioButtonPanel で `:has(:focus-visible)` が動作しないため、focus-indicator ではなく `shadow-outline` のみ適用する

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
