### PR TITLE
chore: 強制カラーモード用のデフォルトのパラメータを設定する

### DIFF
--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -74,6 +74,9 @@ const preview: Preview = {
         </>
       ),
     },
+    chromatic: {
+      forcedColors: 'none',
+    },
   },
   decorators: [
     (Story, context) => {


### PR DESCRIPTION
## Related URL

N/A

## Overview

Chromatic の VRT にて、強制カラーモードを意図した Story でだけ有効化したいのに、ランダムに有効になったり無効になったりする事象があって解決したい。

## What I did

根本原因は全然わかってないけど、とりあえずデフォルト設定を `none` に明示的に設定するのを試したい。
