### PR TITLE
fix: Balloon のコンテンツを折り返すように修正する

### DIFF
--- a/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
@@ -46,7 +46,7 @@ export const All: StoryFn = () => (
         <Txt>{'long text '.repeat(30)} </Txt>
       </Balloon>
       <Balloon horizontal="right" vertical="middle">
-        <Txt>{'longext'.repeat(30)} </Txt>
+        <Txt>{'あ'.repeat(50)} </Txt>
       </Balloon>
     </li>
   </List>

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
@@ -41,6 +41,14 @@ export const All: StoryFn = () => (
         <Txt>middle right</Txt>
       </Balloon>
     </li>
+    <li>
+      <Balloon horizontal="left" vertical="middle">
+        <Txt>{'long text '.repeat(30)} </Txt>
+      </Balloon>
+      <Balloon horizontal="right" vertical="middle">
+        <Txt>{'longext'.repeat(30)} </Txt>
+      </Balloon>
+    </li>
   </List>
 )
 All.storyName = 'all'

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
@@ -46,7 +46,9 @@ export const All: StoryFn = () => (
         <Txt>{'long text '.repeat(30)} </Txt>
       </Balloon>
       <Balloon horizontal="right" vertical="middle">
-        <Txt>{'あ'.repeat(50)} </Txt>
+        <Txt>
+          吾輩わがはいは猫である。名前はまだ無い。どこで生れたかとんと見当けんとうがつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。
+        </Txt>
       </Balloon>
     </li>
   </List>

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
@@ -43,7 +43,15 @@ export const All: StoryFn = () => (
     </li>
     <li>
       <Balloon horizontal="left" vertical="middle">
-        <Txt>{'long text '.repeat(30)} </Txt>
+        <Txt>
+          Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+          been the industry&apos;s standard dummy text ever since the 1500s, when an unknown printer
+          took a galley of type and scrambled it to make a type specimen book. It has survived not
+          only five centuries, but also the leap into electronic typesetting, remaining essentially
+          unchanged. It was popularised in the 1960s with the release of Letraset sheets containing
+          Lorem Ipsum passages, and more recently with desktop publishing software like Aldus
+          PageMaker including versions of Lorem Ipsum.
+        </Txt>
       </Balloon>
       <Balloon horizontal="right" vertical="middle">
         <Txt>

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
@@ -14,7 +14,6 @@ const balloon = tv({
     'shr-drop-shadow-[0_2px_2.5px_theme(colors.transparency.30)]',
     // Safariでdrop-shadowが残り続けてしまうバグの対応
     'shr-will-change-[filter]',
-    'shr-break-words',
     'shr-bg-white',
     'shr-text-black',
     'after:shr-block',

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
@@ -14,7 +14,7 @@ const balloon = tv({
     'shr-drop-shadow-[0_2px_2.5px_theme(colors.transparency.30)]',
     // Safariでdrop-shadowが残り続けてしまうバグの対応
     'shr-will-change-[filter]',
-    'shr-break-words',
+    'shr-break-all',
     'shr-bg-white',
     'shr-text-black',
     'after:shr-block',

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
@@ -14,7 +14,7 @@ const balloon = tv({
     'shr-drop-shadow-[0_2px_2.5px_theme(colors.transparency.30)]',
     // Safariでdrop-shadowが残り続けてしまうバグの対応
     'shr-will-change-[filter]',
-    'shr-break-all',
+    'shr-break-words',
     'shr-bg-white',
     'shr-text-black',
     'after:shr-block',

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
@@ -14,7 +14,7 @@ const balloon = tv({
     'shr-drop-shadow-[0_2px_2.5px_theme(colors.transparency.30)]',
     // Safariでdrop-shadowが残り続けてしまうバグの対応
     'shr-will-change-[filter]',
-    'shr-whitespace-nowrap',
+    'shr-break-words',
     'shr-bg-white',
     'shr-text-black',
     'after:shr-block',


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-984

## Overview

`<Balloon>` コンポーネントにて、ラベルがスペースを含まない半角文字列の場合に、親コンテナを溢れて横スクロールが発生することがあり、これが WCAG 1.4.10 リフロー (レベル AA) に違反するため修正する。

## What I did

常に折り返せるようにスタイルを修正

## Capture

before
![CleanShot 2024-06-12 at 20 26 55](https://github.com/kufu/smarthr-ui/assets/16274215/2af3ad2b-2d46-43bc-b25b-8a705b0c52b1)

after
![CleanShot 2024-06-12 at 20 27 20](https://github.com/kufu/smarthr-ui/assets/16274215/ee5be3a5-0421-4e9f-80a5-57918a1714f6)
