### PR TITLE
chore: MultiCombobox の VRT はフレーキーな問題を修正する

### DIFF
--- a/packages/smarthr-ui/src/components/ComboBox/VRTMultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/VRTMultiCombobox.stories.tsx
@@ -44,6 +44,8 @@ const playMulti = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const option2 = await within(body).findByText('option 2')
   await userEvent.click(option2)
   await waitForRAF()
+  const helpMessage = await within(body).findAllByText('入力でフィルタリングできます。')
+  await userEvent.click(helpMessage[0]) // カーソルの点滅によるVRTのフレーキーを避けるためにフォーカスを移動する
 }
 VRTMultiCombobox.play = playMulti
 


### PR DESCRIPTION
## Related URL

N/A

## Overview

MultiCombobox の VRT で発生する、以下のようなフレーキーな結果が生じないようにする
https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=666b8d48fab7ae85ed175fce

## What I did

Play 関数にてコンボボックスを操作した直後で、カーソルが点滅状態になっているため、撮影されるスクリーンショットにブレが生じてしまっていた。

操作後にテキストボックスからフォーカスを外すことでこれを修正する。