### PR TITLE
feat: Dropdown 及び FilterDropdown に onOpen/onClose オプションを追加する

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -84,7 +84,7 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) =
       if (!active) return null
       return createPortal(props.children)
     },
-    [createPortal, isPortalRootMounted, onToggle],
+    [active, createPortal, isPortalRootMounted],
   )
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,3 @@
-import { on } from 'events'
-
 import React, {
   FC,
   MutableRefObject,

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -1,3 +1,5 @@
+import { on } from 'events'
+
 import React, {
   FC,
   MutableRefObject,
@@ -17,7 +19,7 @@ import { usePortal } from '../../hooks/usePortal'
 import { Rect, getFirstTabbable, isEventFromChild } from './dropdownHelper'
 
 type Props = {
-  onOpen?: () => void
+  onToggle?: (active: boolean) => void
 }
 
 type DropdownContextType = {
@@ -48,7 +50,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   contentId: '',
 })
 
-export const Dropdown: FC<PropsWithChildren<Props>> = ({ onOpen, children }) => {
+export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) => {
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
@@ -81,12 +83,13 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onOpen, children }) => 
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(
     () => (props) => {
+      if (onToggle) onToggle(active)
       if (!active) return null
-      onOpen?.()
       return createPortal(props.children)
     },
-    [active, createPortal, isPortalRootMounted],
+    [active, createPortal, isPortalRootMounted, onToggle],
   )
+
   // set the displayName explicit for DevTools
   DropdownContentRoot.displayName = 'DropdownContentRoot'
 

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -91,7 +91,7 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) =
     if (isPortalRootMounted() && onToggle) {
       onToggle(active)
     }
-  }, [active, onToggle])
+  }, [active])
 
   // set the displayName explicit for DevTools
   DropdownContentRoot.displayName = 'DropdownContentRoot'

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -17,7 +17,8 @@ import { usePortal } from '../../hooks/usePortal'
 import { Rect, getFirstTabbable, isEventFromChild } from './dropdownHelper'
 
 type Props = {
-  onToggle?: (active: boolean) => void
+  onOpen?: () => void
+  onClose?: () => void
 }
 
 type DropdownContextType = {
@@ -48,7 +49,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   contentId: '',
 })
 
-export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) => {
+export const Dropdown: FC<PropsWithChildren<Props>> = ({ onOpen, onClose, children }) => {
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
@@ -88,8 +89,9 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) =
   )
 
   useEffect(() => {
-    if (isPortalRootMounted() && onToggle) {
-      onToggle(active)
+    if (isPortalRootMounted()) {
+      if (active) onOpen?.()
+      else onClose?.()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active])

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -91,6 +91,7 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) =
     if (isPortalRootMounted() && onToggle) {
       onToggle(active)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active])
 
   // set the displayName explicit for DevTools

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -81,12 +81,15 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) =
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(
     () => (props) => {
-      if (onToggle) onToggle(active)
       if (!active) return null
       return createPortal(props.children)
     },
-    [active, createPortal, isPortalRootMounted, onToggle],
+    [createPortal, isPortalRootMounted, onToggle],
   )
+
+  useEffect(() => {
+    onToggle?.(active)
+  }, [active, onToggle])
 
   // set the displayName explicit for DevTools
   DropdownContentRoot.displayName = 'DropdownContentRoot'

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,10 @@ import { usePortal } from '../../hooks/usePortal'
 
 import { Rect, getFirstTabbable, isEventFromChild } from './dropdownHelper'
 
+type Props = {
+  onOpen?: () => void
+}
+
 type DropdownContextType = {
   active: boolean
   triggerRect: Rect
@@ -44,7 +48,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   contentId: '',
 })
 
-export const Dropdown: FC<PropsWithChildren> = ({ children }) => {
+export const Dropdown: FC<PropsWithChildren<Props>> = ({ onOpen, children }) => {
   const [active, setActive] = useState(false)
   const [triggerRect, setTriggerRect] = useState<Rect>(initialRect)
 
@@ -78,6 +82,7 @@ export const Dropdown: FC<PropsWithChildren> = ({ children }) => {
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(
     () => (props) => {
       if (!active) return null
+      onOpen?.()
       return createPortal(props.children)
     },
     [active, createPortal, isPortalRootMounted],

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -88,7 +88,9 @@ export const Dropdown: FC<PropsWithChildren<Props>> = ({ onToggle, children }) =
   )
 
   useEffect(() => {
-    onToggle?.(active)
+    if (isPortalRootMounted() && onToggle) {
+      onToggle(active)
+    }
   }, [active, onToggle])
 
   // set the displayName explicit for DevTools

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.stories.tsx
@@ -49,6 +49,8 @@ export const Render: React.FC = () => {
               setValue('hoge')
               setText('')
             }}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
             isFiltered={isFiltered}
           >
             <Fieldset
@@ -96,6 +98,8 @@ export const Render: React.FC = () => {
             isFiltered={isFiltered2}
             onApply={() => setIsFiltered2(true)}
             onReset={() => setIsFiltered2(false)}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
           >
             <p>You can change border color of the trigger button by setting `isFiltered`.</p>
           </FilterDropdown>
@@ -106,6 +110,8 @@ export const Render: React.FC = () => {
             isFiltered={isFiltered3}
             onApply={() => setIsFiltered3(true)}
             onReset={() => setIsFiltered3(false)}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
             hasStatusText
           >
             <p>
@@ -122,6 +128,8 @@ export const Render: React.FC = () => {
               setValue('hoge')
               setText('')
             }}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
             isFiltered={isFiltered}
             disabled
           >
@@ -134,6 +142,8 @@ export const Render: React.FC = () => {
             isFiltered={isFiltered4}
             onApply={() => setIsFiltered4(true)}
             onReset={() => setIsFiltered4(false)}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
             hasStatusText
             decorators={{
               status: (txt) => <span data-wovn-enable="true">{`filtered.(${txt})`}</span>,
@@ -154,6 +164,8 @@ export const Render: React.FC = () => {
             isFiltered={isFiltered4}
             onApply={() => setIsFiltered4(true)}
             onReset={() => setIsFiltered4(false)}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
             responseMessage={responseMessage}
           >
             <Stack gap={1}>
@@ -193,6 +205,8 @@ export const Render: React.FC = () => {
             isFiltered={isFiltered2}
             onApply={() => setIsFiltered2(true)}
             onReset={() => setIsFiltered2(false)}
+            onOpen={action('onOpen')}
+            onClose={action('onClose')}
             triggerSize="s"
           >
             <p>You can change border color of the trigger button by setting `isFiltered`.</p>

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -19,7 +19,8 @@ type Props = {
   onApply: React.MouseEventHandler<HTMLButtonElement>
   onCancel?: React.MouseEventHandler<HTMLButtonElement>
   onReset?: React.MouseEventHandler<HTMLButtonElement>
-  onToggle?: (active: boolean) => void
+  onOpen?: () => void
+  onClose?: () => void
   children: ReactNode
   hasStatusText?: boolean
   decorators?: DecoratorsType<
@@ -74,7 +75,8 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   onApply,
   onCancel,
   onReset,
-  onToggle,
+  onOpen,
+  onClose,
   children,
   hasStatusText,
   decorators,
@@ -142,7 +144,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   }, [isFiltered, triggerSize])
 
   return (
-    <Dropdown onToggle={onToggle}>
+    <Dropdown onOpen={onOpen} onClose={onClose}>
       <DropdownTrigger>
         <Button
           {...props}

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -19,7 +19,7 @@ type Props = {
   onApply: React.MouseEventHandler<HTMLButtonElement>
   onCancel?: React.MouseEventHandler<HTMLButtonElement>
   onReset?: React.MouseEventHandler<HTMLButtonElement>
-  onOpen?: () => void
+  onToggle?: (active: boolean) => void
   children: ReactNode
   hasStatusText?: boolean
   decorators?: DecoratorsType<
@@ -74,7 +74,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   onApply,
   onCancel,
   onReset,
-  onOpen,
+  onToggle,
   children,
   hasStatusText,
   decorators,
@@ -142,7 +142,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   }, [isFiltered, triggerSize])
 
   return (
-    <Dropdown onOpen={onOpen}>
+    <Dropdown onToggle={onToggle}>
       <DropdownTrigger>
         <Button
           {...props}

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -19,6 +19,7 @@ type Props = {
   onApply: React.MouseEventHandler<HTMLButtonElement>
   onCancel?: React.MouseEventHandler<HTMLButtonElement>
   onReset?: React.MouseEventHandler<HTMLButtonElement>
+  onOpen?: () => void
   children: ReactNode
   hasStatusText?: boolean
   decorators?: DecoratorsType<
@@ -73,6 +74,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   onApply,
   onCancel,
   onReset,
+  onOpen,
   children,
   hasStatusText,
   decorators,
@@ -140,7 +142,7 @@ export const FilterDropdown: FC<Props & ElementProps> = ({
   }, [isFiltered, triggerSize])
 
   return (
-    <Dropdown>
+    <Dropdown onOpen={onOpen}>
       <DropdownTrigger>
         <Button
           {...props}


### PR DESCRIPTION
## Related URL

N/A

## Overview

Dropdown 及び FilterDropdown に onOpen/onClose オプションを追加し、ドロップダウンコンテンツの開閉をプロダクト側でフックできるようにします。

一度以下で提案した後、「あったら嬉しいけど無くてもよい」と結論付けて見送りましたが、やはりプロダクト側でドロップダウンコンテンツの開閉をフックに非同期処理を呼び出したいユースケースがあったため対応したいです。
https://kufuinc.slack.com/archives/C06KVP5PL23/p1711607266418609

調べてみると他のプロダクトでも潜在需要があるっぽい？
https://kufuinc.slack.com/archives/C05TN64KD1V/p1717059738348349

## What I did

- `Dropdown` に `onOpen` / `onClose` オプションを追加
- `FilterDropdown` に `onOpen` / `onClose`  オプションを追加
- ドロップダウンコンテンツの開閉状態が変化するたびに `onOpen` / `onClose`  を発火する