### PR TITLE
feat: Loaderを200ms経過後に表示する

### DIFF
--- a/packages/smarthr-ui/src/components/Button/Button.tsx
+++ b/packages/smarthr-ui/src/components/Button/Button.tsx
@@ -80,7 +80,9 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps & P
     )
     const { createPortal } = usePortal()
 
-    const loader = <Loader size="s" className={loaderStyle} role="presentation" />
+    const loader = (
+      <Loader size="s" deferDisplay={false} className={loaderStyle} role="presentation" />
+    )
     const actualPrefix = !loading && prefix
     const actualSuffix = loading && !square ? loader : suffix
     const disabledOnLoading = loading || disabled

--- a/packages/smarthr-ui/src/components/Loader/Loader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.stories.tsx
@@ -1,6 +1,5 @@
 import { StoryFn } from '@storybook/react'
-import * as React from 'react'
-import { ComponentProps } from 'react'
+import React from 'react'
 import styled, { css } from 'styled-components'
 
 import { Loader } from './Loader'
@@ -10,50 +9,58 @@ export default {
   component: Loader,
 }
 
-// NOTE: 本来はアニメーションの表示を遅延させているが、Chromaticでのスナップショットテストが失敗するため、その影響を受けないように設定。
-const CustomLoader = (props: ComponentProps<typeof Loader>) => (
-  <Loader {...props} className="shr-opacity-100 shr-animate-none" />
-)
+export const All: StoryFn = () => {
+  // NOTE: 本来は表示を遅延させているが、VRT 向けにデフォルトでは表示を遅延させない。
+  const [deferDisplay, setDeferDisplay] = React.useState(false)
+  return (
+    <>
+      <label>
+        <input
+          type="checkbox"
+          name="defer_display"
+          checked={deferDisplay}
+          onChange={() => setDeferDisplay(!deferDisplay)}
+        />
+        defer display
+      </label>
+      <Wrapper>
+        <Text>Primary</Text>
+        <List>
+          <dt>Default</dt>
+          <dd>
+            <Loader deferDisplay={deferDisplay} />
+          </dd>
+          <dt>Small</dt>
+          <dd>
+            <Loader deferDisplay={deferDisplay} size="s" />
+          </dd>
+          <dt>With text</dt>
+          <dd>
+            <Loader deferDisplay={deferDisplay} text="loading message" />
+          </dd>
+        </List>
+      </Wrapper>
 
-export const All: StoryFn = () => (
-  <>
-    <Wrapper>
-      <Text>Primary</Text>
-      <List>
-        <dt>Default</dt>
-        <dd>
-          <CustomLoader />
-        </dd>
-        <dt>Small</dt>
-        <dd>
-          <CustomLoader size="s" />
-        </dd>
-        <dt>With text</dt>
-        <dd>
-          <CustomLoader text="loading message" />
-        </dd>
-      </List>
-    </Wrapper>
-
-    <GrayWrapper>
-      <Text>Light</Text>
-      <List>
-        <dt>Default</dt>
-        <dd>
-          <CustomLoader type="light" />
-        </dd>
-        <dt>Small</dt>
-        <dd>
-          <CustomLoader type="light" size="s" />
-        </dd>
-        <dt>With text</dt>
-        <dd>
-          <CustomLoader type="light" text="loading message" />
-        </dd>
-      </List>
-    </GrayWrapper>
-  </>
-)
+      <GrayWrapper>
+        <Text>Light</Text>
+        <List>
+          <dt>Default</dt>
+          <dd>
+            <Loader deferDisplay={deferDisplay} type="light" />
+          </dd>
+          <dt>Small</dt>
+          <dd>
+            <Loader deferDisplay={deferDisplay} type="light" size="s" />
+          </dd>
+          <dt>With text</dt>
+          <dd>
+            <Loader deferDisplay={deferDisplay} type="light" text="loading message" />
+          </dd>
+        </List>
+      </GrayWrapper>
+    </>
+  )
+}
 All.storyName = 'all'
 All.parameters = { withTheming: true }
 

--- a/packages/smarthr-ui/src/components/Loader/Loader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.stories.tsx
@@ -1,5 +1,6 @@
 import { StoryFn } from '@storybook/react'
 import * as React from 'react'
+import { ComponentProps } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Loader } from './Loader'
@@ -9,6 +10,11 @@ export default {
   component: Loader,
 }
 
+// NOTE: 本来はアニメーションの表示を遅延させているが、Chromaticでのスナップショットテストが失敗するため、その影響を受けないように設定。
+const CustomLoader = (props: ComponentProps<typeof Loader>) => (
+  <Loader {...props} className="shr-opacity-100 shr-animate-none" />
+)
+
 export const All: StoryFn = () => (
   <>
     <Wrapper>
@@ -16,15 +22,15 @@ export const All: StoryFn = () => (
       <List>
         <dt>Default</dt>
         <dd>
-          <Loader />
+          <CustomLoader />
         </dd>
         <dt>Small</dt>
         <dd>
-          <Loader size="s" />
+          <CustomLoader size="s" />
         </dd>
         <dt>With text</dt>
         <dd>
-          <Loader text="loading message" />
+          <CustomLoader text="loading message" />
         </dd>
       </List>
     </Wrapper>
@@ -34,15 +40,15 @@ export const All: StoryFn = () => (
       <List>
         <dt>Default</dt>
         <dd>
-          <Loader type="light" />
+          <CustomLoader type="light" />
         </dd>
         <dt>Small</dt>
         <dd>
-          <Loader type="light" size="s" />
+          <CustomLoader type="light" size="s" />
         </dd>
         <dt>With text</dt>
         <dd>
-          <Loader type="light" text="loading message" />
+          <CustomLoader type="light" text="loading message" />
         </dd>
       </List>
     </GrayWrapper>

--- a/packages/smarthr-ui/src/components/Loader/Loader.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes, ReactNode, useMemo } from 'react'
+import React, { ComponentProps, FC, ReactNode, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
@@ -12,18 +12,15 @@ type Props = {
   text?: ReactNode
   /** コンポーネントの色調 */
   type?: 'primary' | 'light'
+  /** 表示を遅延させるかどうか */
+  deferDisplay?: boolean
   as?: string | React.ComponentType<any>
 }
-type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
+type ElementProps = Omit<ComponentProps<'span'>, keyof Props>
 
 const loaderStyle = tv({
   slots: {
-    wrapper: [
-      'smarthr-ui-Loader',
-      'shr-inline-block shr-overflow-hidden',
-      // NOTE: Loaderの表示時間が短い場合のUIのちらつきを抑えるため、opacityの変化でアニメーションの表示を遅延させる
-      'shr-transition-opacity shr-ease-[unset] shr-opacity-0 shr-animate-[loader-fade-in_auto_ease_200ms_forwards]',
-    ],
+    wrapper: ['smarthr-ui-Loader', 'shr-inline-block shr-overflow-hidden'],
     spinner: [
       'smarthr-ui-Loader-spinner', // Button コンポーネントで使用
       'shr-relative',
@@ -123,6 +120,13 @@ const loaderStyle = tv({
         ],
       },
     },
+    deferDisplay: {
+      true: {
+        // NOTE: Loaderの表示時間が短い場合のUIのちらつきを抑えるため、opacityの変化でアニメーションの表示を遅延させる
+        wrapper: 'shr-opacity-0 shr-animate-[loader-fade-in_0s_ease_200ms_forwards]',
+      },
+      false: {},
+    },
   },
 })
 export const Loader: FC<Props & ElementProps> = ({
@@ -131,12 +135,14 @@ export const Loader: FC<Props & ElementProps> = ({
   text,
   type = 'primary',
   role = 'status',
+  deferDisplay = true,
   className,
   ...props
 }) => {
   const { wrapper, spinner, line, cog, cogInner, textSlot } = loaderStyle({
     type,
     size,
+    deferDisplay,
   })
   const wrapperStyle = useMemo(() => wrapper({ className }), [wrapper, className])
   const spinnerStyle = useMemo(() => spinner(), [spinner])

--- a/packages/smarthr-ui/src/components/Loader/Loader.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.tsx
@@ -18,7 +18,12 @@ type ElementProps = Omit<HTMLAttributes<HTMLDivElement>, keyof Props>
 
 const loaderStyle = tv({
   slots: {
-    wrapper: ['smarthr-ui-Loader', 'shr-inline-block', 'shr-overflow-hidden'],
+    wrapper: [
+      'smarthr-ui-Loader',
+      'shr-inline-block shr-overflow-hidden',
+      // NOTE: Loaderの表示時間が短い場合のUIのちらつきを抑えるため、opacityの変化でアニメーションの表示を遅延させる
+      'shr-transition-opacity shr-ease-[unset] shr-opacity-0 shr-animate-[loader-fade-in_auto_ease_200ms_forwards]',
+    ],
     spinner: [
       'smarthr-ui-Loader-spinner', // Button コンポーネントで使用
       'shr-relative',

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -179,6 +179,14 @@ export default {
         '0.5': '0.5',
       },
       keyframes: ({ theme }) => ({
+        'loader-fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          to: {
+            opacity: '1',
+          },
+        },
         'loader-line-full-unfill-rotate': {
           '12.5%': {
             transform: 'rotate(135deg)',


### PR DESCRIPTION
## Related URL
[チケット](https://smarthr.atlassian.net/jira/software/projects/SHRUI/boards/99/backlog?selectedIssue=SHRUI-960)

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- レスポンスが早い際にLoaderのちらつきが発生してしまう。それを抑制するために200ms経過後に表示するように変更する。
- 現状は各個別のプロダクトで対応している状況だが、SmartHR UIに変更を入れることで統一の仕様とする。
<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- props関係なく常に 200ms 固定で animation-delay する
<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

https://github.com/kufu/smarthr-ui/assets/25091548/43f1ab11-654a-41ea-ad20-8276ad852962


<!--
Please attach a capture if it looks different.
-->
