### PR TITLE
fix: AccordionPanel がデフォルトで複数パネル開く設定に変更

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -42,7 +42,7 @@ export const AccordionPanelContext = React.createContext<{
 }>({
   iconPosition: 'left',
   expandedItems: new Map(),
-  expandableMultiply: false,
+  expandableMultiply: true,
   parentRef: null,
 })
 
@@ -52,7 +52,7 @@ const accordionWrapper = tv({
 
 export const AccordionPanel: React.FC<Props & ElementProps> = ({
   iconPosition = 'left',
-  expandableMultiply = false,
+  expandableMultiply = true,
   defaultExpanded = [],
   className,
   onClick: onClickProps,


### PR DESCRIPTION
## Related URL

https://github.com/kufu/smarthr-design-system/pull/1220

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

AccordionPanel のガイドライン追記による見直しで、expandableMultiply の初期値を true に変える。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
