### PR TITLE
fix: InformationPanel の開閉ボタンはデフォルトなしにする

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/VRTAccordionPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/VRTAccordionPanel.stories.tsx
@@ -26,7 +26,7 @@ export default {
 
 export const VRTOpenAccordion: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       パネルを開いた状態で表示されます
     </VRTInformationPanel>
     <AccordionStyle />
@@ -35,7 +35,7 @@ export const VRTOpenAccordion: StoryFn = () => (
 
 export const VRTAccordionFocus: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       それぞれ1番目、2番目、3番目のアイテムにフォーカスが当たった状態で表示されます
     </VRTInformationPanel>
     <AccordionStyle />
@@ -44,7 +44,7 @@ export const VRTAccordionFocus: StoryFn = () => (
 
 export const VRTOpenAccordionNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭く、パネルを開いた状態で表示されます
     </VRTInformationPanel>
     <AccordionStyle />
@@ -53,7 +53,7 @@ export const VRTOpenAccordionNarrow: StoryFn = () => (
 
 export const VRTAccordionForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <AccordionStyle />

--- a/packages/smarthr-ui/src/components/AppNavi/VRTAppNavi.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/VRTAppNavi.stories.tsx
@@ -90,7 +90,7 @@ export const VRTHover: StoryFn = () => {
 
   return (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         hoverした状態で表示されます
       </VRTInformationPanel>
       <InnerWrapper>
@@ -126,7 +126,7 @@ export const VRTFocusButton: StoryFn = () => {
 
   return (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         ボタンをフォーカスした状態で表示されます
       </VRTInformationPanel>
       <InnerWrapper>
@@ -156,7 +156,7 @@ export const VRTFocusAnchor: StoryFn = () => {
 
   return (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         アンカーをフォーカスした状態で表示されます
       </VRTInformationPanel>
       <InnerWrapper>
@@ -186,7 +186,7 @@ export const VRTDropDown: StoryFn = () => {
 
   return (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         ドロップダウンを表示した状態で表示されます
       </VRTInformationPanel>
       <InnerWrapperDropdown>
@@ -207,7 +207,7 @@ VRTDropDown.play = async ({ canvasElement }) => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <Wrapper>

--- a/packages/smarthr-ui/src/components/Badge/VRTBadge.stories.tsx
+++ b/packages/smarthr-ui/src/components/Badge/VRTBadge.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTBadgeForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Balloon/VRTBalloon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/VRTBalloon.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Base/BaseColumn/VRTBaseColumn.stories.tsx
+++ b/packages/smarthr-ui/src/components/Base/BaseColumn/VRTBaseColumn.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTBaseForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Base/VRTBase.stories.tsx
+++ b/packages/smarthr-ui/src/components/Base/VRTBase.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTBaseNarrow: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <BaseStory />
@@ -36,7 +36,7 @@ VRTBaseNarrow.parameters = {
 
 export const VRTBaseForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <BaseStory />

--- a/packages/smarthr-ui/src/components/BottomFixedArea/VRTBottomFixedArea.stories.tsx
+++ b/packages/smarthr-ui/src/components/BottomFixedArea/VRTBottomFixedArea.stories.tsx
@@ -25,7 +25,7 @@ export default {
 
 export const VRTHover: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       通常のボタン、アンカー風のボタンすべてがhoverされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -40,7 +40,7 @@ VRTHover.parameters = {
 
 export const VRTFocusVisibleButton: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       通常のボタンがfocusされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -55,7 +55,7 @@ VRTFocusVisibleButton.parameters = {
 
 export const VRTFocusVisibleAnchor: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       アンカー風のボタンの1つ目がfocusされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -69,7 +69,7 @@ VRTFocusVisibleAnchor.play = async ({ canvasElement }) => {
 
 export const VRTNarrow: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -88,7 +88,7 @@ VRTNarrow.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Button/VRTButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/VRTButton.stories.tsx
@@ -20,7 +20,7 @@ export default {
 
 export const _VRTButtonState: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
     <dl className="*:shr-ms-0">
@@ -179,7 +179,7 @@ _VRTButtonState.parameters = {
 
 export const _VRTButtonAnchorState: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
     <dl className="*:shr-ms-0">
@@ -383,7 +383,7 @@ _VRTButtonAnchorState.parameters = {
 const ButtonTemplate = _Button.bind({})
 export const _VRTButtonForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <ButtonTemplate />
@@ -396,7 +396,7 @@ _VRTButtonForcedColors.parameters = {
 const ButtonAnchorTemplate = _ButtonAnchor.bind({})
 export const _VRTButtonAnchorForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <ButtonAnchorTemplate />

--- a/packages/smarthr-ui/src/components/Calendar/VRTCalendar.stories.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/VRTCalendar.stories.tsx
@@ -21,7 +21,7 @@ export const VRTFocus: StoryFn = () => {
   const [value, setValue] = useState(new Date(2020, 0, 1))
   return (
     <>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         各ボタンにフォーカスを当てた状態で表示されます
       </VRTInformationPanel>
       <Calendar
@@ -43,7 +43,7 @@ VRTFocus.parameters = {
 
 export const VRTSelectionYear: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       年を選択する状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -61,7 +61,7 @@ export const VRTFocusSelectionYear: StoryFn = () => {
   const [value, setValue] = useState(new Date(2020, 0, 1))
   return (
     <>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         年選択で特定の年にフォーカスを当てた状態で表示されます
       </VRTInformationPanel>
       <Calendar
@@ -85,7 +85,7 @@ VRTFocusSelectionYear.play = async ({ canvasElement }) => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/CheckBox/VRTCheckBox.stories.tsx
+++ b/packages/smarthr-ui/src/components/CheckBox/VRTCheckBox.stories.tsx
@@ -30,7 +30,7 @@ export const VRTState: StoryFn = () => {
 
   return (
     <WrapperList>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         hover, activeなどの状態で表示されます
       </VRTInformationPanel>
       <li>
@@ -146,7 +146,7 @@ export const VRTState: StoryFn = () => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/ComboBox/VRTMultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/VRTMultiCombobox.stories.tsx
@@ -20,7 +20,7 @@ export default {
 
 export const VRTMultiCombobox: StoryFn = () => (
   <Stack>
-    <InformationPanel title="VRT 用の Story です" togglable={false}>
+    <InformationPanel title="VRT 用の Story です">
       Multiコンボボックスのリストを展開して1つ目と2つ目の項目を選択した状態で表示されます
     </InformationPanel>
     <Multi />
@@ -51,7 +51,7 @@ VRTMultiCombobox.play = playMulti
 
 export const VRTMultiComboboxForcedColors: StoryFn = () => (
   <Stack>
-    <InformationPanel title="VRT 用の Story です" togglable={false}>
+    <InformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます{' '}
     </InformationPanel>
     <Multi />

--- a/packages/smarthr-ui/src/components/ComboBox/VRTSingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/VRTSingleCombobox.stories.tsx
@@ -20,7 +20,7 @@ export default {
 
 export const VRTSingleCombobox: StoryFn = () => (
   <Stack>
-    <InformationPanel title="VRT 用の Story です" togglable={false}>
+    <InformationPanel title="VRT 用の Story です">
       Singleコンボボックスのリストを展開して1つ目の項目をホバーした状態で表示されます
     </InformationPanel>
     <Single />
@@ -38,7 +38,7 @@ VRTSingleCombobox.play = playSingle
 
 export const VRTSingleComboboxForcedColors: StoryFn = () => (
   <Stack>
-    <InformationPanel title="VRT 用の Story です" togglable={false}>
+    <InformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます{' '}
     </InformationPanel>
     <Single />

--- a/packages/smarthr-ui/src/components/CompactInformationPanel/VRTCompactInformationPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/CompactInformationPanel/VRTCompactInformationPanel.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 export const VRTNarrow: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <Type />
@@ -37,7 +37,7 @@ VRTNarrow.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <Type />

--- a/packages/smarthr-ui/src/components/DatePicker/VRTDatePicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/VRTDatePicker.stories.tsx
@@ -31,7 +31,7 @@ const NormalDatePicker = ({ name, title }: { name: string; title: string }) => (
 
 export const VRTExpanded: StoryFn = () => (
   <WrapperList>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       カレンダーを展開した状態で表示されます
     </VRTInformationPanel>
     <NormalDatePicker name="default" title="default" />
@@ -47,7 +47,7 @@ VRTExpanded.play = playExpanded
 
 export const VRTExpandedForcedColors: StoryFn = () => (
   <WrapperList>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <NormalDatePicker name="default" title="default" />
@@ -60,7 +60,7 @@ VRTExpandedForcedColors.parameters = {
 
 export const VRTExpandedYears: StoryFn = () => (
   <WrapperList>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       カレンダーを展開し、年を選択する状態で表示されます
     </VRTInformationPanel>
     <NormalDatePicker name="default" title="default" />
@@ -77,7 +77,7 @@ const playExpandedYears = async ({ canvasElement }: { canvasElement: HTMLElement
 VRTExpandedYears.play = playExpandedYears
 export const VRTExpandedYearsForcedColors: StoryFn = () => (
   <WrapperList>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <NormalDatePicker name="default" title="default" />
@@ -90,7 +90,7 @@ VRTExpandedYearsForcedColors.parameters = {
 
 export const VRTBottomExpanded: StoryFn = () => (
   <WrapperList>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ページ下部でカレンダーを展開し、上方向に表示されることを確認します
     </VRTInformationPanel>
     <BottomFormControl title="Place on the page bottom">

--- a/packages/smarthr-ui/src/components/DefinitionList/VRTDefinitionList.stories.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/VRTDefinitionList.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 export const VRTNarrow: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -37,7 +37,7 @@ VRTNarrow.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Dialog/VRTDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/VRTDialog.stories.tsx
@@ -40,7 +40,7 @@ export default {
 }
 export const VRTOpenDialogNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭く、ダイアログを開いた状態で表示されます
     </VRTInformationPanel>
     <Default />
@@ -49,7 +49,7 @@ export const VRTOpenDialogNarrow: StoryFn = () => (
 
 export const VRTDialogForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <Default />

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/VRTDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/VRTDropdownMenuButton.stories.tsx
@@ -42,7 +42,7 @@ export const VRTOpenDropdownMenuButtonNarrow: Story = {
   },
   render: () => (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         画面幅が狭く、ドロップダウンメニューを開いた状態で表示されます
       </VRTInformationPanel>
       <Render />
@@ -66,7 +66,7 @@ export const VRTDropdownMenuButtonForcedColors: Story = {
   },
   render: () => (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         Chromatic 上では強制カラーモードで表示されます
       </VRTInformationPanel>
       <Render />

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/VRTFilterDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/VRTFilterDropdown.stories.tsx
@@ -42,7 +42,7 @@ export const VRTOpenFilterDropdownNarrow: Story = {
   },
   render: () => (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         画面幅が狭く、ドロップダウンメニューを開いた状態で表示されます
       </VRTInformationPanel>
       <Render />
@@ -66,7 +66,7 @@ export const VRTFilterDropdownForcedColors: Story = {
   },
   render: () => (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         Chromatic 上では強制カラーモードで表示されます
       </VRTInformationPanel>
       <Render />

--- a/packages/smarthr-ui/src/components/Dropdown/VRTDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/VRTDropdown.stories.tsx
@@ -28,7 +28,7 @@ export default {
 
 export const VRTOpenDropdownNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭く、入れ子を開いた状態で表示されます
     </VRTInformationPanel>
     <ControllableDropdown />
@@ -37,7 +37,7 @@ export const VRTOpenDropdownNarrow: StoryFn = () => (
 
 export const VRTOpenNested: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       入れ子を開いた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -46,7 +46,7 @@ export const VRTOpenNested: StoryFn = () => (
 
 export const VRTDropdownForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/FloatArea/VRTFloatArea.stories.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/VRTFloatArea.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTHover: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       通常のボタン、アンカー風のボタンすべてがhoverされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -32,7 +32,7 @@ VRTHover.parameters = {
 
 export const VRTFocusVisibleButton: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       通常のボタンがfocusされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -47,7 +47,7 @@ VRTFocusVisibleButton.parameters = {
 
 export const VRTNarrow: StoryFn = () => (
   <>
-    <VRTNarrowInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTNarrowInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTNarrowInformationPanel>
     <All />
@@ -66,7 +66,7 @@ VRTNarrow.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/VRTLanguageSwitcher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/VRTLanguageSwitcher.stories.tsx
@@ -16,7 +16,7 @@ export default {
 
 export const VRTDropDown: StoryFn = () => (
   <Stack>
-    <InformationPanel title="VRT 用の Story です" togglable={false}>
+    <InformationPanel title="VRT 用の Story です">
       defaultのlocaleが変更されたDropDownを表示して、defaultが切り替わっているかを見ています
     </InformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Header/VRTHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/VRTHeader.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 export const VRTFocusVisible: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       通常のボタンがfocusされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -33,7 +33,7 @@ VRTFocusVisible.parameters = {
 
 export const VRTDropDown: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ドロップダウンを表示した状態で表示されます
     </VRTInformationPanel>
     <WrapperForDropdown>
@@ -49,7 +49,7 @@ VRTDropDown.play = async ({ canvasElement }) => {
 
 export const VRTLauncher: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ランチャーを表示した状態で表示されます
     </VRTInformationPanel>
     <WrapperForLauncher>
@@ -65,7 +65,7 @@ VRTLauncher.play = async ({ canvasElement }) => {
 
 export const VRTNarrowTablet: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       タブレットの画面幅で表示されます
     </VRTInformationPanel>
     <All />
@@ -84,7 +84,7 @@ VRTNarrowTablet.parameters = {
 
 export const VRTNarrowMobile: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       モバイルの画面幅で表示されます
     </VRTInformationPanel>
     <All />
@@ -103,7 +103,7 @@ VRTNarrowMobile.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <WrapperForLauncher>

--- a/packages/smarthr-ui/src/components/Heading/VRTHeading.stories.tsx
+++ b/packages/smarthr-ui/src/components/Heading/VRTHeading.stories.tsx
@@ -14,7 +14,7 @@ export default {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Icon/VRTIcon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Icon/VRTIcon.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <Title>Color</Title>

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.stories.tsx
@@ -12,31 +12,20 @@ export default {
 
 export const All: StoryFn = () => (
   <Stack>
-    <InformationPanel title="書類に記載する扶養家族" togglable={false}>
+    <InformationPanel title="書類に記載する扶養家族">
       借り換え直前の残高3,000万円、借り換え後の借入額2,900万円の場合→借り換え後の借入額が少ないので「借り換え後の借入額の方が少ない・同じ」を選択
     </InformationPanel>
     <InformationPanel
-      title={<span>SmartHRの項目一覧表をダウンロード1</span>}
+      title={<span>SmartHRの項目一覧表をダウンロード</span>}
       type="success"
       active={false}
     >
       従業員リストをダウンロードする際に指定するフォーマットを、カスタマイズして登録、管理できます。登録したフォーマットを利用することで、外部システムへの取り込みに適したファイルを書き出せます。詳しくは、カスタムダウンロードフォーマットの追加・編集・削除を参照してください。
     </InformationPanel>
-    <InformationPanel
-      title={<span>SmartHRの項目一覧表をダウンロード2</span>}
-      type="success"
-      decorators={{
-        openButtonLabel: (txt) => `open.(${txt})`,
-        closeButtonLabel: (txt) => `close.(${txt})`,
-      }}
-      active={false}
-    >
-      従業員リストをダウンロードする際に指定するフォーマットを、カスタマイズして登録、管理できます。登録したフォーマットを利用することで、外部システムへの取り込みに適したファイルを書き出せます。詳しくは、カスタムダウンロードフォーマットの追加・編集・削除を参照してください。
-    </InformationPanel>
-    <InformationPanel title="項目全体がわかるよう撮影してください" type="warning" togglable={false}>
+    <InformationPanel title="項目全体がわかるよう撮影してください" type="warning">
       離職日の翌日から1ヶ月ごとにさかのぼって区切り、それぞれの期間中に賃金支払基礎日数が11日以上ある、または、賃金支払の基礎となった時間が80時間以上ある期間を入力します。この期間を被保険者期間と言い、失業給付を受けるためには原則としてこの被保険者期間が2年間のうち12ヶ月必要となります。
     </InformationPanel>
-    <InformationPanel title="お探しのページは見つかりませんでした" type="error" togglable={false}>
+    <InformationPanel title="お探しのページは見つかりませんでした" type="error">
       書類の様式によって日付の記載先が異なります。手元の書類の日付が記載されている欄を回答してください。
     </InformationPanel>
     <InformationPanel
@@ -46,6 +35,7 @@ export const All: StoryFn = () => (
         openButtonLabel: (txt) => `open.(${txt})`,
         closeButtonLabel: (txt) => `close.(${txt})`,
       }}
+      togglable
     >
       借り入れしている金融機関が3つ以上ある場合は、SmartHRで住宅ローン控除申告書を作成できません。回答履歴から［住宅ローン控除申告書作成対象外確認］の設問に戻って、「対象外に該当する」を選択してください。「対象外に該当する」を選択すると、これまでに作成した書類の最終確認画面に移動します。住宅ローン控除については手書きで申告書を作成し、必要な原本を添えて担当者に提出してください。
     </InformationPanel>

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -46,7 +46,7 @@ export const InformationPanel: FC<Props & Omit<BaseElementProps, keyof Props>> =
   title,
   titleTag,
   type = 'info',
-  togglable = true,
+  togglable = false,
   active: activeProps = true,
   className,
   children,

--- a/packages/smarthr-ui/src/components/InformationPanel/VRTInformationPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/VRTInformationPanel.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTNarrow: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -36,7 +36,7 @@ VRTNarrow.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
@@ -28,7 +28,7 @@ const SearchInputStory: StoryFn = () => (
 
 export const VRTHoverSearchInput: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hoverしてツールチップを表示した状態で表示されます
     </VRTInformationPanel>
     <SearchInputStory />
@@ -43,7 +43,7 @@ VRTHoverSearchInput.play = playHover
 
 export const VRTFocusSearchInput: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       focusしてツールチップを表示した状態で表示されます
     </VRTInformationPanel>
     <SearchInputStory />
@@ -56,7 +56,7 @@ VRTFocusSearchInput.play = async ({ canvasElement }: { canvasElement: HTMLElemen
 
 export const VRTHoverSearchInputForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <SearchInputStory />

--- a/packages/smarthr-ui/src/components/Input/VRTInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/VRTInput.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTFocus: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       focus した状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -32,7 +32,7 @@ VRTFocus.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/InputFile/VRTInputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/VRTInputFile.stories.tsx
@@ -20,7 +20,7 @@ export default {
 
 export const VRTState: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
     <Stack>
@@ -75,7 +75,7 @@ VRTState.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Layout/Center/VRTCenter.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Center/VRTCenter.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTCenterNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -26,7 +26,7 @@ export const VRTCenterNarrow: StoryFn = () => (
 
 export const VRTCenterForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Layout/Cluster/VRTCluster.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/VRTCluster.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTClusterNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -26,7 +26,7 @@ export const VRTClusterNarrow: StoryFn = () => (
 
 export const VRTClusterForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Layout/Reel/VRTReel.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Reel/VRTReel.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTReelForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Layout/Sidebar/VRTSidebar.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Sidebar/VRTSidebar.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTSidebarNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -26,7 +26,7 @@ export const VRTSidebarNarrow: StoryFn = () => (
 
 export const VRTSidebarForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Layout/Stack/VRTStack.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Stack/VRTStack.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTStackNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -26,7 +26,7 @@ export const VRTStackNarrow: StoryFn = () => (
 
 export const VRTStackForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/LineClamp/VRTLineClamp.stories.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/VRTLineClamp.stories.tsx
@@ -27,7 +27,7 @@ Ipsum.`
 
 export const VRTUserHover: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ユーザー操作のhoverをシミュレートしてツールチップを表示します
     </VRTInformationPanel>
     <Wrapper>
@@ -53,7 +53,7 @@ VRTUserHover.play = async ({ canvasElement }) => {
 
 export const VRTUserFocus: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ユーザー操作のfocusをシミュレートしてツールチップを表示します
     </VRTInformationPanel>
     <Wrapper>
@@ -79,7 +79,7 @@ VRTUserFocus.play = async ({ canvasElement }) => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <Wrapper>

--- a/packages/smarthr-ui/src/components/Loader/VRTLoader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Loader/VRTLoader.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTLoaderForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/NotificationBar/VRTNotificationBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/VRTNotificationBar.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 export const VRTNotificationBarNarrow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -27,7 +27,7 @@ export const VRTNotificationBarNarrow: StoryFn = () => (
 
 export const VRTNotificationBarShow: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       NotificationBarを表示した状態で表示されます
     </VRTInformationPanel>
     <Demo />
@@ -36,7 +36,7 @@ export const VRTNotificationBarShow: StoryFn = () => (
 
 export const VRTNotificationBarFocus: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       それぞれ1番目のNotificationBarの閉じるボタンにフォーカスした状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -45,7 +45,7 @@ export const VRTNotificationBarFocus: StoryFn = () => (
 
 export const VRTNotificationBarForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/PageCounter/VRTPageCounter.stories.tsx
+++ b/packages/smarthr-ui/src/components/PageCounter/VRTPageCounter.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Pagination/VRTPagination.stories.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/VRTPagination.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const VRTState: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
     <List>
@@ -54,7 +54,7 @@ VRTState.parameters = {
 
 export const VRTScroll: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態でスクロールされるか確認します
     </VRTInformationPanel>
     <Pagination current={7} total={13} onClick={action('click!!')} />
@@ -79,7 +79,7 @@ VRTScroll.play = async ({ canvasElement }) => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/RadioButton/VRTRadioButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/VRTRadioButton.stories.tsx
@@ -23,7 +23,7 @@ export const VRTState: StoryFn = () => {
 
   return (
     <WrapperList>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         hover, activeなどの状態で表示されます
       </VRTInformationPanel>
       <li>
@@ -127,7 +127,7 @@ export const VRTState: StoryFn = () => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/SegmentedControl/VRTSegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/VRTSegmentedControl.stories.tsx
@@ -28,7 +28,7 @@ export const VRTState: StoryFn = () => {
 
   return (
     <Wrapper>
-      <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+      <VRTInformationPanel title="VRT 用の Story です">
         hover, activeなどの状態で表示されます
       </VRTInformationPanel>
       <List>
@@ -90,7 +90,7 @@ export const VRTState: StoryFn = () => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Select/VRTSelect.stories.tsx
+++ b/packages/smarthr-ui/src/components/Select/VRTSelect.stories.tsx
@@ -26,7 +26,7 @@ const options = [
 
 export const VRTState: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
     <WrapperList>
@@ -119,7 +119,7 @@ export const VRTState: StoryFn = () => (
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/SideNav/VRTSideNav.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/VRTSideNav.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTHover: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hoverされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -32,7 +32,7 @@ VRTHover.parameters = {
 
 export const VRTFocus: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       focusされた状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -47,7 +47,7 @@ VRTFocus.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/SpreadsheetTable/VRTSpreadsheetTable.stories.tsx
+++ b/packages/smarthr-ui/src/components/SpreadsheetTable/VRTSpreadsheetTable.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTMobile: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -36,7 +36,7 @@ VRTMobile.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/StatusLabel/VRTStatusLabel.stories.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/VRTStatusLabel.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTStatusLabelForcedColors: StoryFn = () => (
   <Wrapper>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/TabBar/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/VRTTabBar.stories.tsx
@@ -20,9 +20,7 @@ export default {
 
 export const VRTHover: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
-      hoverの状態で表示されます
-    </VRTInformationPanel>
+    <VRTInformationPanel title="VRT 用の Story です">hoverの状態で表示されます</VRTInformationPanel>
     <Ul>
       <li>
         <TabBar id="hover">
@@ -49,7 +47,7 @@ VRTHover.parameters = {
 
 export const VRTUserFocus: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ユーザー操作のfocusをシミュレートした状態で表示されます
     </VRTInformationPanel>
     <Ul>
@@ -78,7 +76,7 @@ VRTUserFocus.play = async ({ canvasElement }) => {
 
 export const VRTScroll: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅が狭い状態でスクロールされるか確認します
     </VRTInformationPanel>
     <Ul>
@@ -126,7 +124,7 @@ VRTScroll.play = async ({ canvasElement }) => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Table/VRTTable.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/VRTTable.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTNarrowTablet: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅がタブレットを想定した幅の状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -36,7 +36,7 @@ VRTNarrowTablet.parameters = {
 
 export const VRTNarrowMobile: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅がモバイルを想定した幅の状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -55,7 +55,7 @@ VRTNarrowMobile.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />
@@ -67,7 +67,7 @@ VRTForcedColors.parameters = {
 
 export const VRTWithReelNarrowTablet: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅がタブレットを想定した幅の状態で表示されます
     </VRTInformationPanel>
     <WithReel />
@@ -86,7 +86,7 @@ VRTWithReelNarrowTablet.parameters = {
 
 export const VRTWithReelNarrowMobile: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       画面幅がモバイルを想定した幅の状態で表示されます
     </VRTInformationPanel>
     <WithReel />
@@ -105,7 +105,7 @@ VRTWithReelNarrowMobile.parameters = {
 
 export const VRTWithReelForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <WithReel />

--- a/packages/smarthr-ui/src/components/Text/VRTText.stories.tsx
+++ b/packages/smarthr-ui/src/components/Text/VRTText.stories.tsx
@@ -14,7 +14,7 @@ export default {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <Default />

--- a/packages/smarthr-ui/src/components/TextLink/VRTTextLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/VRTTextLink.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const VRTState: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       hover, activeなどの状態で表示されます
     </VRTInformationPanel>
     <Wrapper>
@@ -62,7 +62,7 @@ VRTState.parameters = {
 
 export const VRTUserFocus: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       ユーザーのフォーカス操作をシミュレートした状態で表示されます
     </VRTInformationPanel>
     <Wrapper>
@@ -83,7 +83,7 @@ VRTUserFocus.play = async ({ canvasElement }) => {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Textarea/VRTTextarea.stories.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/VRTTextarea.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const VRTFocus: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       focus した状態で表示されます
     </VRTInformationPanel>
     <All />
@@ -32,7 +32,7 @@ VRTFocus.parameters = {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <All />

--- a/packages/smarthr-ui/src/components/Tooltip/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/VRTTooltip.stories.tsx
@@ -18,7 +18,7 @@ export default {
 
 export const VRTForcedColors: StoryFn = () => (
   <>
-    <VRTInformationPanel title="VRT 用の Story です" togglable={false}>
+    <VRTInformationPanel title="VRT 用の Story です">
       Chromatic 上では強制カラーモードで表示されます
     </VRTInformationPanel>
     <RegHover />


### PR DESCRIPTION
## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-698
- https://github.com/kufu/smarthr-design-system/pull/1145

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

ガイドラインを定め togglable はデフォルト表示しないことになったので修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
