### PR TITLE
feat: Stepを持つダイアログをキーボードフォーカスしやすく開発しやすくするカスタムフックを作る

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogTest.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogTest.stories.tsx
@@ -23,7 +23,7 @@ type DialogContents = {
 }
 
 export const Default: StoryFn = () => {
-  const [currentStep, { setStep, nextStep, prevStep }, renderFocusTarget] = useDialogSteps()
+  const [currentStep, { setStep, nextStep, prevStep }] = useDialogSteps()
 
   const dialogContents: DialogContents = {
     0: {
@@ -72,7 +72,6 @@ export const Default: StoryFn = () => {
         isOpen={currentStep > 0}
         onClickClose={currentStep === 2 ? () => setStep(0) : prevStep}
       >
-        {renderFocusTarget()}
         {dialogContent.children}
       </ActionDialog>
     </>

--- a/packages/smarthr-ui/src/components/Dialog/DialogTest.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogTest.stories.tsx
@@ -1,10 +1,12 @@
 import { StoryFn } from '@storybook/react'
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode } from 'react'
 
 import { Button } from '../Button'
 import { FormControl } from '../FormControl'
 import { Input } from '../Input'
 import { Stack } from '../Layout'
+
+import { useDialogSteps } from './useDialogSteps'
 
 import { ActionDialog } from '.'
 
@@ -21,19 +23,17 @@ type DialogContents = {
 }
 
 export const Default: StoryFn = () => {
-  const [step, setStep] = useState<number>(0)
-  const [prevStep, setPrevStep] = useState<number>(step)
-
-  if (step !== prevStep && step > 0) {
-    setPrevStep(step)
-  }
-
-  const onClickClose = () => setStep((prev) => prev - 1)
+  const [currentStep, { setStep, nextStep, prevStep }, renderFocusTarget] = useDialogSteps()
 
   const dialogContents: DialogContents = {
+    0: {
+      actionText: '',
+      onClickAction: nextStep,
+      children: null,
+    },
     1: {
       actionText: '次へ',
-      onClickAction: () => setStep((prev) => prev + 1),
+      onClickAction: nextStep,
       children: (
         <FormControl title="Label 1">
           <Input name="input" />
@@ -51,13 +51,13 @@ export const Default: StoryFn = () => {
     },
   }
 
-  const dialogContent = dialogContents[step]
+  const dialogContent = dialogContents[currentStep]
 
   return (
     <>
       <Stack>
         <div>
-          <Button onClick={() => setStep(1)} aria-haspopup="dialog">
+          <Button onClick={nextStep} aria-haspopup="dialog">
             Dialog
           </Button>
         </div>
@@ -68,11 +68,13 @@ export const Default: StoryFn = () => {
 
       <ActionDialog
         {...dialogContent}
-        title={`Stepper Dialog ${step} / 2`}
-        isOpen={step > 0}
-        actionDisabled={step === 2}
-        onClickClose={onClickClose}
-      />
+        title={`Stepper Dialog ${currentStep} / 2`}
+        isOpen={currentStep > 0}
+        onClickClose={currentStep === 2 ? () => setStep(0) : prevStep}
+      >
+        {renderFocusTarget()}
+        {dialogContent.children}
+      </ActionDialog>
     </>
   )
 }

--- a/packages/smarthr-ui/src/components/Dialog/DialogTest.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogTest.stories.tsx
@@ -1,0 +1,78 @@
+import { StoryFn } from '@storybook/react'
+import React, { ReactNode, useState } from 'react'
+
+import { Button } from '../Button'
+import { FormControl } from '../FormControl'
+import { Input } from '../Input'
+import { Stack } from '../Layout'
+
+import { ActionDialog } from '.'
+
+export default {
+  title: 'Dialog（ダイアログ）/Step Dialog',
+  component: ActionDialog,
+}
+
+type DialogContents = {
+  [key: number]: Omit<
+    React.ComponentProps<typeof ActionDialog>,
+    'title' | 'onClickClose' | 'isOpen'
+  > & { children: ReactNode }
+}
+
+export const Default: StoryFn = () => {
+  const [step, setStep] = useState<number>(0)
+  const [prevStep, setPrevStep] = useState<number>(step)
+
+  if (step !== prevStep && step > 0) {
+    setPrevStep(step)
+  }
+
+  const onClickClose = () => setStep((prev) => prev - 1)
+
+  const dialogContents: DialogContents = {
+    1: {
+      actionText: '次へ',
+      onClickAction: () => setStep((prev) => prev + 1),
+      children: (
+        <FormControl title="Label 1">
+          <Input name="input" />
+        </FormControl>
+      ),
+    },
+    2: {
+      actionText: '完了',
+      onClickAction: () => setStep(0),
+      children: (
+        <FormControl title="Label 2">
+          <Input name="input" />
+        </FormControl>
+      ),
+    },
+  }
+
+  const dialogContent = dialogContents[step]
+
+  return (
+    <>
+      <Stack>
+        <div>
+          <Button onClick={() => setStep(1)} aria-haspopup="dialog">
+            Dialog
+          </Button>
+        </div>
+        <FormControl title="Dummy">
+          <Input name="input" />
+        </FormControl>
+      </Stack>
+
+      <ActionDialog
+        {...dialogContent}
+        title={`Stepper Dialog ${step} / 2`}
+        isOpen={step > 0}
+        actionDisabled={step === 2}
+        onClickClose={onClickClose}
+      />
+    </>
+  )
+}

--- a/packages/smarthr-ui/src/components/Dialog/useDialogSteps.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/useDialogSteps.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+type UseDialogStepsResult = [
+  number,
+  {
+    setStep: React.Dispatch<React.SetStateAction<number>>
+    nextStep: () => void
+    prevStep: () => void
+  },
+  () => React.JSX.Element,
+]
+
+export function useDialogSteps(startStep?: number): UseDialogStepsResult {
+  const [step, setStep] = useState<number>(startStep || 0)
+  const dialogContentStartElementRef = useRef<HTMLDivElement | null>(null)
+  const prevStep = useRef<number>(step)
+
+  useEffect(() => {
+    if (
+      step !== prevStep.current &&
+      step > 0 &&
+      dialogContentStartElementRef.current instanceof HTMLElement
+    ) {
+      dialogContentStartElementRef.current.focus()
+    }
+
+    prevStep.current = step
+  }, [step])
+
+  const renderFocusTarget = () => <div tabIndex={-1} ref={dialogContentStartElementRef} />
+
+  const dialogSteps: UseDialogStepsResult = [
+    step,
+    {
+      setStep,
+      nextStep: useCallback(() => {
+        setStep((prev) => prev + 1)
+      }, []),
+      prevStep: useCallback(() => {
+        setStep((prev) => prev - 1)
+      }, []),
+    },
+    renderFocusTarget,
+  ]
+
+  return dialogSteps
+}

--- a/packages/smarthr-ui/src/components/Dialog/useDialogSteps.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/useDialogSteps.tsx
@@ -7,27 +7,22 @@ type UseDialogStepsResult = [
     nextStep: () => void
     prevStep: () => void
   },
-  () => React.JSX.Element,
 ]
 
 export function useDialogSteps(startStep?: number): UseDialogStepsResult {
   const [step, setStep] = useState<number>(startStep || 0)
-  const dialogContentStartElementRef = useRef<HTMLDivElement | null>(null)
   const prevStep = useRef<number>(step)
 
   useEffect(() => {
-    if (
-      step !== prevStep.current &&
-      step > 0 &&
-      dialogContentStartElementRef.current instanceof HTMLElement
-    ) {
-      dialogContentStartElementRef.current.focus()
+    if (step !== prevStep.current && step > 0) {
+      const focusTarget = document.querySelector('[role=dialog] > div > div[tabindex]')
+      if (focusTarget instanceof HTMLDivElement) {
+        focusTarget.focus()
+      }
     }
 
     prevStep.current = step
   }, [step])
-
-  const renderFocusTarget = () => <div tabIndex={-1} ref={dialogContentStartElementRef} />
 
   const dialogSteps: UseDialogStepsResult = [
     step,
@@ -40,7 +35,6 @@ export function useDialogSteps(startStep?: number): UseDialogStepsResult {
         setStep((prev) => prev - 1)
       }, []),
     },
-    renderFocusTarget,
   ]
 
   return dialogSteps


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

useDialogStepsを作成

返り値
```typescript
type UseDialogStepsResult = [
  number, // currentStep
  {
    setStep: React.Dispatch<React.SetStateAction<number>> // stepをset
    nextStep: () => void // 次のstepへ
    prevStep: () => void // 前のstepへ
  },
  () => React.JSX.Element, // ステップ移動したときにフォーカスを当て直すための要素。通常は Dialog の children の最初に配置する
]
```

アプリケーション側の実装
```tsx
// useDialogSteps()を実行して必要なものを作る
const [currentStep, { setStep, nextStep, prevStep }, renderFocusTarget] = useDialogSteps()

const dialogContents: DialogContents = {
  0: (各ステップごとのDialogのPropsを定義しておく),
  1: ...,
  2: ...,
}

const dialogContent = dialogContents[currentStep]

return (
  <ActionDialog
    {...dialogContent}
    title={`Stepper Dialog ${currentStep} / 2`}
    isOpen={currentStep > 0}
    onClickClose={currentStep === 2 ? () => setStep(0) : prevStep}
  >
    /* childrenの最初で、renderFocusTarget() を実行する。stepが変わったらこの位置に focus がリセットされる */
    {renderFocusTarget()}
    {dialogContent.children}
  </ActionDialog>
)
```

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
