### PR TITLE
feat: Table に table-layout 相当の props を追加 ほか

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Table.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.stories.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import { Base } from '../Base'
 import { Button } from '../Button'
+import { Cluster } from '../Layout'
 import { Text } from '../Text'
 
 import { TdCheckbox } from './TdCheckbox'
@@ -20,6 +21,111 @@ export default {
     withTheming: true,
   },
 }
+
+const employeeData = [
+  {
+    employeeNo: 'SMP001',
+    name: '須磨英知',
+    divisionName:
+      'table の幅計算は UA に依って仕様が異なるため、幅の指定は最小限にすることをおすすめします。',
+    date: '2024-06-29',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SMP002',
+    name: '須磨叡智郎',
+    divisionName:
+      'Th や Td の contentWidth に number か string を与えると width に反映されます。number は文字数 string は任意の値を指定できます。',
+    date: '2024-06-29',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SMP003',
+    name: '須磨端央',
+    divisionName:
+      'Td の contentWidth には { base: number | string, min: number | string, max: number | string } という object を与えられます。base は width に、min / max はそれぞれ min-width / max-width に対応します。',
+    date: '2024-06-29',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SMP004',
+    name: '須磨英千尋',
+    divisionName:
+      '社員番号や日付、操作列など、絶対に改行させたくない場合は Text[whitespace="nowrap"] を使ってください。合わせて contentWidth に 1px など小さい値を与えると、内包要素の最大幅で列幅が固定されます。',
+    date: '2024-06-29',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR001',
+    name: '田中 太郎',
+    divisionName: '経営企画部/マーケティング部/デジタルマーケティング課/ソーシャルメディアチーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR002',
+    name: '鈴木 花子',
+    divisionName: '営業部/国内営業部/西日本営業課/大阪支店/法人営業チーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR003',
+    name: '佐藤 健一',
+    divisionName: '研究開発部/製品開発部/新製品開発課/プロジェクト管理チーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR004',
+    name: '伊藤 美咲',
+    divisionName: '人事部/人事管理部/採用課/新卒採用チーム/東京オフィス',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR005',
+    name: '渡辺 次郎',
+    divisionName: 'IT部/システム開発部/インフラ部/ネットワーク課/セキュリティチーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR006',
+    name: 'ジョナサン・アレハンドロ・マルティネス・サンチェス',
+    divisionName: '総務部/総務課/オフィスマネジメントチーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR007',
+    name: 'アレクサンドラ・マリー・アンジェリーナ・ド・ソウザ',
+    divisionName: '財務部/経理部/財務管理課/支払チーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR008',
+    name: 'マイケル・フランシス・ジョンソン・ウィリアムズ',
+    divisionName: '法務部/契約管理部/コンプライアンス課',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR009',
+    name: 'カタリーナ・エリザベス・ロドリゲス・ガルシア',
+    divisionName: '営業部/国際営業部/アジア営業課/中国支店',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+  {
+    employeeNo: 'SHR010',
+    name: 'クリスティーナ・マリー・アンジェラ・マクドナルド',
+    divisionName: '研究開発部/技術開発部/AI技術課/データサイエンステーム',
+    date: '2021-04-01',
+    amount: '999,999円',
+  },
+]
 
 const data = [
   {
@@ -83,35 +189,42 @@ const data = [
 export const All: StoryFn = () => (
   <Ul>
     <li>
-      table
       <Table>
         <thead>
           <tr>
             <ThCheckbox name="tableAllCheckbox" />
-            <Th sort="asc" onSort={action('降順に並び替え')}>
-              Name
+            <Th sort="desc" onSort={action('昇順に並び替え')}>
+              <Text whiteSpace="nowrap">社員番号</Text>
             </Th>
+            <Th>氏名</Th>
+            <Th>部署</Th>
             <Th sort="none" onSort={action('昇順に並び替え')}>
-              Calories
+              申請日
             </Th>
-            <Th>Fat (g)</Th>
-            <Th>Carbs (g)</Th>
-            <Th>Protein (g)</Th>
-            <Th>Button</Th>
+            <Th align="right">総額</Th>
+            <Th>操作</Th>
           </tr>
-          <BulkActionRow>Bulk action area</BulkActionRow>
         </thead>
         <tbody>
-          {data.map(({ name, calories, fat, carbs, protein }, i) => (
-            <tr key={name}>
-              <TdCheckbox name={`tableCheckBox-${i}`} aria-labelledby={`name-${i}`} />
-              <Td id={`name-${i}`}>{name}</Td>
-              <Td>{calories}</Td>
-              <Td>{fat}</Td>
-              <Td>{carbs}</Td>
-              <Td>{protein}</Td>
-              <Td>
-                <Button size="s">Button</Button>
+          {employeeData.map(({ employeeNo, name, divisionName, date, amount }, i) => (
+            <tr key={employeeNo}>
+              <TdCheckbox name={`tableCheckbox-${i}`} aria-labelledby={`name-${employeeNo}`} />
+              <Td contentWidth="1px">
+                <Text whiteSpace="nowrap">{employeeNo}</Text>
+              </Td>
+              <Td contentWidth={{ min: 10, max: 20 }} id={`name-${employeeNo}`}>
+                {name}
+              </Td>
+              <Td contentWidth={{ min: 15, max: 30 }}>{divisionName}</Td>
+              <Td contentWidth="1px">
+                <Text whiteSpace="nowrap">{date}</Text>
+              </Td>
+              <Td align="right">{amount}</Td>
+              <Td contentWidth="1px">
+                <Cluster style={{ flexWrap: 'nowrap' }}>
+                  <Button size="s">編集</Button>
+                  <Button size="s">削除</Button>
+                </Cluster>
               </Td>
             </tr>
           ))}
@@ -266,13 +379,6 @@ export const All: StoryFn = () => (
       Table with empty state
       <Base overflow="auto">
         <Table>
-          <thead>
-            <tr>
-              <Th>cell</Th>
-              <Th>cell</Th>
-              <Th>cell</Th>
-            </tr>
-          </thead>
           <EmptyTableBody>
             <Text>お探しの条件に該当する項目はありません。</Text>
             <Text>別の条件をお試しください。</Text>

--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, FC, PropsWithChildren, createContext, useMemo } from 'react'
-import { tv } from 'tailwind-variants'
+import { VariantProps, tv } from 'tailwind-variants'
 
 export const TableGroupContext = createContext<{
   group: 'head' | 'body'
@@ -7,10 +7,7 @@ export const TableGroupContext = createContext<{
   group: 'body',
 })
 
-type Props = PropsWithChildren<{
-  /** `true` のとき、スクロール時にヘッダーを固定表示する */
-  fixedHead?: boolean
-}>
+type Props = PropsWithChildren<VariantProps<typeof table>>
 type ElementProps = Omit<ComponentProps<'table'>, keyof Props>
 
 const table = tv({
@@ -27,11 +24,13 @@ const table = tv({
     'contrast-more:shr-border-shorthand contrast-more:shr-border-high-contrast',
   ],
   variants: {
+    layout: {
+      auto: '',
+      fixed: 'shr-table-fixed',
+    },
     fixedHead: {
       true: [
-        '[&_thead]:shr-sticky',
-        '[&_thead]:shr-start-0',
-        '[&_thead]:shr-top-0',
+        '[&_thead]:shr-sticky [&_thead]:shr-start-0 [&_thead]:shr-top-0',
         /* zIndexの値はセマンティックトークンとして管理しているため、明示的に値を指定しないと重なり順が崩れるため設定しています */
         '[&_thead]:shr-z-fixed-menu',
       ],
@@ -39,7 +38,15 @@ const table = tv({
   },
 })
 
-export const Table: FC<Props & ElementProps> = ({ fixedHead = false, className, ...props }) => {
-  const styles = useMemo(() => table({ fixedHead, className }), [className, fixedHead])
+export const Table: FC<Props & ElementProps> = ({
+  fixedHead = false,
+  layout = 'auto',
+  className,
+  ...props
+}) => {
+  const styles = useMemo(
+    () => table({ fixedHead, layout, className }),
+    [className, fixedHead, layout],
+  )
   return <table {...props} className={styles} />
 }

--- a/packages/smarthr-ui/src/components/Table/Td.tsx
+++ b/packages/smarthr-ui/src/components/Table/Td.tsx
@@ -15,6 +15,7 @@ export type Props = PropsWithChildren<
 type ElementProps = Omit<ComponentPropsWithoutRef<'td'>, keyof Props>
 
 export const Td: FC<Props & ElementProps> = ({
+  align = 'left',
   nullable = false,
   fixed = false,
   contentWidth,
@@ -23,7 +24,7 @@ export const Td: FC<Props & ElementProps> = ({
   ...props
 }) => {
   const styleProps = useMemo(() => {
-    const tdStyles = td({ nullable, fixed, className })
+    const tdStyles = td({ align, nullable, fixed, className })
     const reelShadowStyles = fixed ? reelShadowStyle({ direction: 'right' }) : ''
     return {
       className: `${tdStyles} ${reelShadowStyles}`.trim(),
@@ -32,7 +33,7 @@ export const Td: FC<Props & ElementProps> = ({
         ...getWidthStyle(contentWidth),
       },
     }
-  }, [className, contentWidth, fixed, nullable, style])
+  }, [align, className, contentWidth, fixed, nullable, style])
 
   return <td {...props} {...styleProps} />
 }
@@ -43,6 +44,10 @@ const td = tv({
     'shr-border-t-shorthand shr-h-[calc(1em_*_theme(lineHeight.normal))] shr-px-1 shr-py-0.5 shr-align-middle shr-text-base shr-leading-normal shr-text-black',
   ],
   variants: {
+    align: {
+      left: '',
+      right: 'shr-text-right',
+    },
     nullable: {
       true: "empty:after:shr-content-['-----']",
     },

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -7,7 +7,7 @@ import React, {
   ReactNode,
   useMemo,
 } from 'react'
-import { tv } from 'tailwind-variants'
+import { type VariantProps, tv } from 'tailwind-variants'
 
 import { UnstyledButton } from '../Button'
 import { FaSortDownIcon, FaSortUpIcon } from '../Icon'
@@ -18,19 +18,19 @@ import { reelShadowStyle } from './useReelShadow'
 import type { CellContentWidth } from './type'
 
 type sortTypes = keyof typeof SORT_DIRECTION_LABEL
-export type Props = PropsWithChildren<{
-  /** 並び替え状態 */
-  sort?: sortTypes
-  /** 並び替えをクリックした時に発火するコールバック関数 */
-  onSort?: () => void
-  /** 文言を変更するための関数 */
-  decorators?: {
-    sortDirectionIconAlt: (text: string, { sort }: { sort: sortTypes }) => ReactNode
-  }
-  /** `true` のとき、TableReel内で固定表示になる */
-  fixed?: boolean
-  contentWidth?: CellContentWidth
-}>
+export type Props = PropsWithChildren<
+  {
+    /** 並び替え状態 */
+    sort?: sortTypes
+    /** 並び替えをクリックした時に発火するコールバック関数 */
+    onSort?: () => void
+    /** 文言を変更するための関数 */
+    decorators?: {
+      sortDirectionIconAlt: (text: string, { sort }: { sort: sortTypes }) => ReactNode
+    }
+    contentWidth?: CellContentWidth
+  } & VariantProps<typeof thWrapper>
+>
 type ElementProps = Omit<ComponentPropsWithoutRef<'th'>, keyof Props | 'onClick'>
 
 const SORT_DIRECTION_LABEL = {
@@ -51,6 +51,10 @@ const thWrapper = tv({
     '[&[aria-sort=descending]_.smarthr-ui-Icon:first-of-type]:forced-colors:shr-fill-[GrayText] [&[aria-sort=descending]_.smarthr-ui-Icon:last-of-type]:forced-colors:shr-fill-[CanvasText]',
   ],
   variants: {
+    align: {
+      left: '',
+      right: 'shr-text-right',
+    },
     fixed: {
       true: [
         /* これ以降の記述はTableReel内で'fixed'を利用した際に追従させるために必要 */
@@ -75,6 +79,7 @@ export const Th: FC<Props & ElementProps> = ({
   sort,
   onSort,
   decorators,
+  align = 'left',
   fixed = false,
   contentWidth,
   className,
@@ -82,7 +87,7 @@ export const Th: FC<Props & ElementProps> = ({
   ...props
 }) => {
   const styleProps = useMemo(() => {
-    const thWrapperStyle = thWrapper({ className, fixed })
+    const thWrapperStyle = thWrapper({ className, align, fixed })
     const reelShadowStyles = fixed ? reelShadowStyle({ showShadow: false, direction: 'right' }) : ''
     return {
       className: `${thWrapperStyle} ${reelShadowStyles}`.trim(),
@@ -91,7 +96,7 @@ export const Th: FC<Props & ElementProps> = ({
         width: convertContentWidth(contentWidth),
       },
     }
-  }, [className, contentWidth, fixed, style])
+  }, [align, className, contentWidth, fixed, style])
 
   const sortLabel = useMemo(
     () =>
@@ -116,7 +121,7 @@ export const Th: FC<Props & ElementProps> = ({
   return (
     <th {...ariaSortProps} {...props} {...styleProps}>
       {sort ? (
-        <SortButton onClick={onSort}>
+        <SortButton align={align} onClick={onSort}>
           {children}
           <SortIcon sort={sort} />
           <VisuallyHiddenText>{sortLabel}</VisuallyHiddenText>
@@ -130,14 +135,24 @@ export const Th: FC<Props & ElementProps> = ({
 
 const sortButton = tv({
   base: [
-    '-shr-mx-1 -shr-my-0.75 shr-inline-flex shr-w-full shr-justify-between shr-gap-x-0.5 shr-px-1 shr-py-0.75 shr-font-bold',
+    '-shr-mx-1 -shr-my-0.75 shr-inline-flex shr-w-full shr-gap-x-0.5 shr-px-1 shr-py-0.75 shr-font-bold',
     // UnstyledButton に stretch がなぜか指定されてて負けてしまうため（UnstyledButton を見直した方がよさそう）
     '[&]:shr-items-center',
   ],
+  variants: {
+    align: {
+      left: 'shr-justify-between',
+      right: 'shr-justify-end',
+    },
+  },
 })
 
-const SortButton: FC<ComponentProps<typeof UnstyledButton>> = ({ className, ...props }) => {
-  const sortButtonStyle = useMemo(() => sortButton({ className }), [className])
+const SortButton: FC<ComponentProps<typeof UnstyledButton> & Pick<Props, 'align'>> = ({
+  align,
+  className,
+  ...props
+}) => {
+  const sortButtonStyle = useMemo(() => sortButton({ align, className }), [align, className])
   return <UnstyledButton {...props} className={sortButtonStyle} />
 }
 

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -15,6 +15,8 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { reelShadowStyle } from './useReelShadow'
 
+import type { CellContentWidth } from './type'
+
 type sortTypes = keyof typeof SORT_DIRECTION_LABEL
 export type Props = PropsWithChildren<{
   /** 並び替え状態 */
@@ -27,6 +29,7 @@ export type Props = PropsWithChildren<{
   }
   /** `true` のとき、TableReel内で固定表示になる */
   fixed?: boolean
+  contentWidth?: CellContentWidth
 }>
 type ElementProps = Omit<ComponentPropsWithoutRef<'th'>, keyof Props | 'onClick'>
 
@@ -58,20 +61,37 @@ const thWrapper = tv({
   },
 })
 
+const convertContentWidth = (contentWidth?: CellContentWidth) => {
+  if (typeof contentWidth === 'number') {
+    // Th は fontSize.S のため、rem で指定する
+    return `${contentWidth}rem`
+  }
+
+  return contentWidth
+}
+
 export const Th: FC<Props & ElementProps> = ({
   children,
   sort,
   onSort,
   decorators,
   fixed = false,
+  contentWidth,
   className,
+  style,
   ...props
 }) => {
-  const styles = useMemo(() => {
+  const styleProps = useMemo(() => {
     const thWrapperStyle = thWrapper({ className, fixed })
     const reelShadowStyles = fixed ? reelShadowStyle({ showShadow: false, direction: 'right' }) : ''
-    return `${thWrapperStyle} ${reelShadowStyles}`.trim()
-  }, [className, fixed])
+    return {
+      className: `${thWrapperStyle} ${reelShadowStyles}`.trim(),
+      style: {
+        ...style,
+        width: convertContentWidth(contentWidth),
+      },
+    }
+  }, [className, contentWidth, fixed, style])
 
   const sortLabel = useMemo(
     () =>
@@ -94,7 +114,7 @@ export const Th: FC<Props & ElementProps> = ({
   )
 
   return (
-    <th {...ariaSortProps} {...props} className={styles}>
+    <th {...ariaSortProps} {...props} {...styleProps}>
       {sort ? (
         <SortButton onClick={onSort}>
           {children}

--- a/packages/smarthr-ui/src/components/Table/type.ts
+++ b/packages/smarthr-ui/src/components/Table/type.ts
@@ -1,0 +1,1 @@
+export type CellContentWidth = number | string


### PR DESCRIPTION
悪いクセで複数のチケットを混ぜました:pray:（コミットは分けたし、大きくはないので大丈夫だと判断）

## Related URL

- https://smarthr.atlassian.net/browse/SHRUI-993
- https://smarthr.atlassian.net/browse/SHRUI-963

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

- table-layout 相当の layout props を Table に追加
- Th / Td に contentWidth を追加
  - number / string で指定できます
  - number はフォントサイズの何文字分かで指定
  - string は任意の文字列
- Th / Td に align を追加
- Story を整理

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
