### PR TITLE
chore: .vscodeのディレクトリ配下をgit管理しない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ reg_storybook
 smarthr-ui.css
 
 .idea
+.vscode


### PR DESCRIPTION
## Related URL

https://github.com/kufu/smarthr-ui/pull/3845

## Overview

`.idea` ファイルと同様に、 `.vscode` もgit管理しないようにしたいです

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
