### PR TITLE
fix: ソートできる場合はクリッカブルなので Th に `cursor: pointer` を当てた

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -149,10 +149,9 @@ const sortButton = tv({
 
 const SortButton: FC<ComponentProps<typeof UnstyledButton> & Pick<Props, 'align'>> = ({
   align,
-  className,
   ...props
 }) => {
-  const sortButtonStyle = useMemo(() => sortButton({ align, className }), [align, className])
+  const sortButtonStyle = useMemo(() => sortButton({ align }), [align])
   return <UnstyledButton {...props} className={sortButtonStyle} />
 }
 

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -151,7 +151,10 @@ const SortButton: FC<ComponentProps<typeof UnstyledButton> & Pick<Props, 'align'
   align,
   ...props
 }) => {
-  const sortButtonStyle = useMemo(() => sortButton({ align }), [align])
+  const sortButtonStyle = useMemo(
+    () => sortButton({ align, className: 'shr-cursor-pointer' }),
+    [align],
+  )
   return <UnstyledButton {...props} className={sortButtonStyle} />
 }
 

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -151,10 +151,7 @@ const SortButton: FC<ComponentProps<typeof UnstyledButton> & Pick<Props, 'align'
   align,
   ...props
 }) => {
-  const sortButtonStyle = useMemo(
-    () => sortButton({ align, className: 'shr-cursor-pointer' }),
-    [align],
-  )
+  const sortButtonStyle = useMemo(() => sortButton({ align }), [align])
   return <UnstyledButton {...props} className={sortButtonStyle} />
 }
 

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -135,7 +135,7 @@ export const Th: FC<Props & ElementProps> = ({
 
 const sortButton = tv({
   base: [
-    '-shr-mx-1 -shr-my-0.75 shr-inline-flex shr-w-full shr-gap-x-0.5 shr-px-1 shr-py-0.75 shr-font-bold',
+    '-shr-mx-1 -shr-my-0.75 shr-inline-flex shr-w-full shr-gap-x-0.5 shr-px-1 shr-py-0.75 shr-font-bold shr-cursor-pointer',
     // UnstyledButton に stretch がなぜか指定されてて負けてしまうため（UnstyledButton を見直した方がよさそう）
     '[&]:shr-items-center',
   ],


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

タイトルの通り

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

### before

https://github.com/kufu/smarthr-ui/assets/40714517/7f361ae4-1091-48d3-8554-91563ab0811f

### after

https://github.com/kufu/smarthr-ui/assets/40714517/54b72a14-7ac6-4120-ba88-11114347e0c9
