### PR TITLE
feat: Icon に FaTableColumns を 追加

### DIFF
--- a/packages/smarthr-ui/src/components/Icon/Icon.tsx
+++ b/packages/smarthr-ui/src/components/Icon/Icon.tsx
@@ -157,6 +157,7 @@ import {
   FaStar,
   FaSuitcaseMedical,
   FaTable,
+  FaTableColumns,
   FaTableList,
   FaTag,
   FaTags,
@@ -347,6 +348,7 @@ export const FaStarIcon = /*#__PURE__*/ createIcon(FaStar)
 export const FaSuitcaseMedicalIcon = /*#__PURE__*/ createIcon(FaSuitcaseMedical)
 export const FaTableIcon = /*#__PURE__*/ createIcon(FaTable)
 export const FaTableListIcon = /*#__PURE__*/ createIcon(FaTableList)
+export const FaTableColumnsIcon = /*#__PURE__*/ createIcon(FaTableColumns)
 export const FaTagIcon = /*#__PURE__*/ createIcon(FaTag)
 export const FaTagsIcon = /*#__PURE__*/ createIcon(FaTags)
 export const FaThumbtackIcon = /*#__PURE__*/ createIcon(FaThumbtack)


### PR DESCRIPTION
## Related URL
- なし

## Overview
- Icon に FaTableColumns を追加したいです
    - https://react-icons.github.io/react-icons/search/#q=FaTableColumns
    - https://fontawesome.com/icons/table-columns?f=classic&s=solid

## What I did
- FaTableColumns を追加

## Capture
<img width="126" alt="SS 1214" src="https://github.com/user-attachments/assets/5f6aa46c-1549-4a02-a26a-749f3a364594">


