### PR TITLE
feat: TabItemにdisabledな理由を渡せるようにする

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
@@ -3,6 +3,7 @@ import { StoryFn } from '@storybook/react'
 import { userEvent } from '@storybook/test'
 import * as React from 'react'
 
+import { FaTriangleExclamationIcon } from '../Icon'
 import { Stack } from '../Layout'
 
 import { TabBar } from './TabBar'
@@ -37,6 +38,25 @@ const Template: StoryFn = ({ subid, ...props }) => (
     </TabItem>
     <TabItem id={`border-${subid}-3`} onClick={action('clicked')} disabled>
       分析対象
+    </TabItem>
+    <TabItem
+      id={`border-${subid}-4`}
+      onClick={action('clicked')}
+      disabled
+      disabledDetail={{ message: 'disabledDetailを指定しています' }}
+    >
+      アイテム4
+    </TabItem>
+    <TabItem
+      id={`border-${subid}-5`}
+      onClick={action('clicked')}
+      disabled
+      disabledDetail={{
+        message: 'disabledDetailのiconを指定できます',
+        icon: () => <FaTriangleExclamationIcon />,
+      }}
+    >
+      アイテム5
     </TabItem>
   </TabBar>
 )

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -3,6 +3,9 @@ import { tv } from 'tailwind-variants'
 
 import { isTouchDevice } from '../../libs/ua'
 import { UnstyledButton } from '../Button'
+import { FaCircleInfoIcon } from '../Icon'
+import { Cluster } from '../Layout'
+import { Tooltip } from '../Tooltip'
 
 const tabItem = tv({
   base: [
@@ -19,6 +22,9 @@ const tabItem = tv({
     },
   },
 })
+const disabledTooltip = tv({
+  base: ['[&_.smarthr-ui-Icon]:shr-text-grey'],
+})
 
 type Props = PropsWithChildren<{
   /** タブの ID */
@@ -27,6 +33,11 @@ type Props = PropsWithChildren<{
   selected?: boolean
   /** `true` のとき、タブを無効状態にしてクリック不能にする */
   disabled?: boolean
+  /** disabledが `true` のときにTooltipに表示する無効な理由 **/
+  disabledDetail?: {
+    icon?: React.FunctionComponent
+    message: React.ReactNode
+  }
   /** タブをクリックした時に発火するコールバック関数 */
   onClick: (tabId: string) => void
 }>
@@ -41,9 +52,40 @@ export const TabItem: FC<Props & ElementProps> = ({
   selected = false,
   className,
   disabled = false,
+  disabledDetail,
   ...props
 }) => {
   const tabItemStyle = useMemo(() => tabItem({ className, isTouchDevice }), [className])
+
+  if (disabled && disabledDetail) {
+    const DisabledDetailIcon = disabledDetail.icon || FaCircleInfoIcon
+
+    return (
+      <UnstyledButton
+        {...props}
+        id={id}
+        role="tab"
+        aria-selected={selected}
+        className={tabItemStyle}
+        onClick={() => onClick(id)}
+        disabled={disabled}
+        type="button"
+      >
+        <Cluster inline align="center" gap={0.25}>
+          {props.children}
+          <Tooltip
+            message={disabledDetail?.message}
+            triggerType="icon"
+            horizontal="auto"
+            vertical="auto"
+            className={disabledTooltip()}
+          >
+            <DisabledDetailIcon />
+          </Tooltip>
+        </Cluster>
+      </UnstyledButton>
+    )
+  }
 
   return (
     <UnstyledButton


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
- Buttonコンポーネントと同様、TabItemがdisabledな場合に無効な理由をTooltipで表示できるようにしたいです

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- TabItemのPropsとして `disabledDetail` を渡せるようにしました
- `disabled` が `true` かつ、 `disabledDetail` が渡された場合にIconとTooltipを表示するようにしました
    - この辺のロジックや `disabledDetail` の型はButtonコンポーネントを参考にしています

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/c7275db4-dad1-42cb-ac3b-665bcefabb36">


<!--
Please attach a capture if it looks different.
-->
