### PR TITLE
docs: TabItem の disabled 例の改善提案

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
@@ -37,7 +37,12 @@ const Template: StoryFn = ({ subid, ...props }) => (
     <TabItem id={`border-${subid}-2`} onClick={action('clicked')}>
       コメント
     </TabItem>
-    <Tooltip message="権限がないため利用できません" ariaDescribedbyTarget="inner">
+    <Tooltip
+      message="権限がないため利用できません"
+      ariaDescribedbyTarget="inner"
+      role="tab"
+      aria-disabled
+    >
       <TabItem id={`border-${subid}-3`} onClick={action('clicked')} disabled>
         <Cluster align="center">
           分析対象

--- a/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
@@ -3,7 +3,9 @@ import { StoryFn } from '@storybook/react'
 import { userEvent } from '@storybook/test'
 import * as React from 'react'
 
-import { Stack } from '../Layout'
+import { FaCircleInfoIcon } from '../Icon'
+import { Cluster, Stack } from '../Layout'
+import { Tooltip } from '../Tooltip'
 
 import { TabBar } from './TabBar'
 import { TabItem } from './TabItem'
@@ -35,9 +37,14 @@ const Template: StoryFn = ({ subid, ...props }) => (
     <TabItem id={`border-${subid}-2`} onClick={action('clicked')}>
       コメント
     </TabItem>
-    <TabItem id={`border-${subid}-3`} onClick={action('clicked')} disabled>
-      分析対象
-    </TabItem>
+    <Tooltip message="権限がないため利用できません" ariaDescribedbyTarget="inner">
+      <TabItem id={`border-${subid}-3`} onClick={action('clicked')} disabled>
+        <Cluster align="center">
+          分析対象
+          <FaCircleInfoIcon color="TEXT_GREY" />
+        </Cluster>
+      </TabItem>
+    </Tooltip>
   </TabBar>
 )
 


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

#4791 を受けて、Story を見直してみました。
どこに Tooltip を紐づけるかを考えると、button に対して紐づいた方が良いと考え disabledDetail を実装するのではなく `Tooltip > TabItem` としてみました。

TabItem に組み込むことも考えましたが、Tooltip の実装を見直す予定があるためこの PR は Story の変更に留めます。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
