### PR TITLE
chore: CompactInformationPanel の Storybook が重複表示される問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/CompactInformationPanel/VRTCompactInformationPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/CompactInformationPanel/VRTCompactInformationPanel.stories.tsx
@@ -9,7 +9,7 @@ import { Type } from './CompactInformationPanel.stories'
 import { CompactInformationPanel } from '.'
 
 export default {
-  title: 'Data Display（データ表示）/CompactInformationPanel',
+  title: 'Data Display（データ表示）/CompactInformationPanel（非推奨）',
   component: CompactInformationPanel,
   parameters: {
     withTheming: true,


### PR DESCRIPTION
## Related URL

N/A

## Overview

Storybook にて、CompactInformationPanel の Storybook が重複して表示されているのを修正する
![CleanShot 2024-07-22 at 16 14 15](https://github.com/user-attachments/assets/848f7937-61b1-4b6b-bc13-11fb25ac592c)

## What I did

対象コンポーネントを非推奨化した際に、通常の Story 側のタイトルをリネーム (`(非推奨)` を追加) したのに、VRT用の Story のリネームが漏れていたようなので、タイトルを揃える。

## Capture

![CleanShot 2024-07-22 at 16 16 32](https://github.com/user-attachments/assets/a8672bef-c4f8-423b-976c-40028e7b0762)
