### PR TITLE
fix: TabBar 内の Tooltip 縦位置を自動調整に変更

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -75,6 +75,7 @@ export const TabItem: FC<Props & ElementProps> = ({
         {...tabAttrs}
         message={disabledDetail.message}
         horizontal="center"
+        vertical="auto"
         ariaDescribedbyTarget="inner"
         aria-disabled={rest.disabled}
       >


### PR DESCRIPTION
## Related URL

https://github.com/kufu/smarthr-ui/pull/4793#pullrequestreview-2200646627

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

上記 URI の指摘を修正。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
