### PR TITLE
feat!: SearchInput コンポーネントから onClickClear オプションを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.stories.tsx
@@ -22,46 +22,25 @@ export const Default: Story = {
   args: {
     tooltipMessage: '',
   },
-  render: () => {
-    const [value, setValue] = React.useState('value')
-    return (
-      <StyledStack>
-        <div>
-          <p>主に入力欄に対する説明をレイアウト上配置できない場合の利用を想定しています。</p>
-          <SearchInput
-            name="default"
-            onChange={(e) => setValue(e.target.value)}
-            value={value}
-            tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
-          />
-        </div>
-        <div>
-          <p>検索解除ボタンを表示</p>
-          <SearchInput
-            name="default"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
-            onClickClear={() => setValue('')}
-          />
-        </div>
-        <div>
-          <p>アイコンの代替テキストを設定</p>
-          <SearchInput
-            name="default"
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
-            decorators={{
-              iconAlt: (txt) => `search.(${txt})`,
-              clearButtonAlt: (txt) => `clear.(${txt})`,
-            }}
-            onClickClear={() => setValue('')}
-          />
-        </div>
-      </StyledStack>
-    )
-  },
+  render: () => (
+    <StyledStack>
+      <div>
+        <p>主に入力欄に対する説明をレイアウト上配置できない場合の利用を想定しています。</p>
+        <SearchInput
+          name="default"
+          tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+        />
+      </div>
+      <div>
+        <p>アイコンの代替テキストを設定</p>
+        <SearchInput
+          name="default"
+          tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+          decorators={{ iconAlt: (txt) => `search.(${txt})` }}
+        />
+      </div>
+    </StyledStack>
+  ),
 }
 
 const StyledStack = styled(Stack)`

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -1,9 +1,6 @@
-import React, { ComponentProps, forwardRef, useId, useMemo } from 'react'
-import { tv } from 'tailwind-variants'
+import React, { ComponentProps, forwardRef, useMemo } from 'react'
 
-import { UnstyledButton } from '../../Button'
-import { FaCircleXmarkIcon, FaMagnifyingGlassIcon } from '../../Icon'
-import { VisuallyHiddenText } from '../../VisuallyHiddenText'
+import { FaSearchIcon } from '../../Icon'
 import { InputWithTooltip } from '../InputWithTooltip'
 
 import type { DecoratorsType } from '../../../types'
@@ -11,72 +8,21 @@ import type { DecoratorsType } from '../../../types'
 type Props = Omit<ComponentProps<typeof InputWithTooltip>, 'tooltipMessage' | 'prefix'> & {
   /** 入力欄の説明を紐付けるツールチップに表示するメッセージ */
   tooltipMessage: React.ReactNode
-  decorators?: DecoratorsType<'iconAlt' | 'clearButtonAlt'>
-  onClickClear?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+  decorators?: DecoratorsType<'iconAlt'>
 }
 
 const ICON_ALT = '検索'
-const CLEAR_BUTTON_ALT = '削除'
 
-const searchInput = tv({
-  slots: {
-    clearButton: [
-      'smarthr-ui-SearchInput-clearButton',
-      'shr-group/clearButton',
-      'shr-cursor-pointer',
-      'focus-visible:shr-shadow-none',
-    ],
-    clearButtonIcon: [
-      'shr-block',
-      'group-focus-visible/clearButton:shr-focus-indicator group-focus-visible/clearButton:shr-rounded-full',
-    ],
-  },
+export const SearchInput = forwardRef<HTMLInputElement, Props>(({ decorators, ...props }, ref) => {
+  const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
+
+  return (
+    <label>
+      <InputWithTooltip
+        {...props}
+        ref={ref}
+        prefix={<FaSearchIcon alt={iconAlt} color="TEXT_GREY" />}
+      />
+    </label>
+  )
 })
-
-export const SearchInput = forwardRef<HTMLInputElement, Props>(
-  ({ decorators, onClickClear, ...props }, ref) => {
-    const { clearButton, clearButtonIcon } = searchInput()
-    const { clearButtonStyle, clearButtonIconStyle } = useMemo(
-      () => ({
-        clearButtonStyle: clearButton(),
-        clearButtonIconStyle: clearButtonIcon(),
-      }),
-      [clearButton, clearButtonIcon],
-    )
-
-    const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
-    const clearButtonAlt = useMemo(
-      () => decorators?.clearButtonAlt?.(CLEAR_BUTTON_ALT) || CLEAR_BUTTON_ALT,
-      [decorators],
-    )
-
-    const defaultInptuId = useId()
-    const inputId = props.id || defaultInptuId
-
-    return (
-      <span>
-        <label htmlFor={inputId}>
-          <VisuallyHiddenText>{iconAlt}</VisuallyHiddenText>
-        </label>
-        <InputWithTooltip
-          {...props}
-          id={inputId}
-          ref={ref}
-          prefix={<FaMagnifyingGlassIcon color="TEXT_GREY" />}
-          suffix={
-            onClickClear &&
-            props.value && (
-              <UnstyledButton onClick={(e) => onClickClear(e)} className={clearButtonStyle}>
-                <FaCircleXmarkIcon
-                  color="TEXT_BLACK"
-                  alt={clearButtonAlt}
-                  className={clearButtonIconStyle}
-                />
-              </UnstyledButton>
-            )
-          }
-        />
-      </span>
-    )
-  },
-)

--- a/packages/smarthr-ui/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/VRTSearchInput.stories.tsx
@@ -21,7 +21,6 @@ const SearchInputStory: StoryFn = () => (
     <SearchInput
       name="default"
       tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
-      onClickClear={() => alert('clear')}
     />
   </Wrapper>
 )


### PR DESCRIPTION
## Related URL

revert 対象のPR
- https://github.com/kufu/smarthr-ui/pull/4635

## Overview

`SearchInput` コンポーネントには、検索キーワードを削除するための `onClickClear` オプションが存在したが、削除ボタンの必要性や挙動の不十分さから、機能を削除することとした。

調べられる限りではこの機能は利用されていなかったので影響は限りなくありません。

## What I did

元PRのスカッシュマージコミット(48be8b414a97dfd0d917ac6ace05a6f58d46af36)をリバート