### PR TITLE
fix: Tooltip メッセージが機械側に過足提供していたので修正

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -177,7 +177,9 @@ export const Tooltip: FC<Props & ElementProps> = ({
           portalRoot,
         )}
       {childrenWithProps}
-      <VisuallyHiddenText id={messageId}>{hiddenText}</VisuallyHiddenText>
+      <VisuallyHiddenText id={messageId} aria-hidden={!isVisible}>
+        {hiddenText}
+      </VisuallyHiddenText>
     </span>
   )
 }


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

表示されていない Tooltip メッセージも DOM 上に表示されていたので、Tooltip が表示される時に絞りました。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
