### PR TITLE
fix: Button コンポーネントが disabled/loading の場合も onClick イベントがバブリングしてしまう問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Button/Button.test.tsx
+++ b/packages/smarthr-ui/src/components/Button/Button.test.tsx
@@ -1,0 +1,69 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { Button } from './Button'
+
+describe('Button', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  describe('onClick', () => {
+    it('disabled / loading でない場合、発火する', () => {
+      const onClick = jest.fn()
+      act(() => {
+        createRoot(container).render(<Button onClick={onClick}>button</Button>)
+      })
+      document.querySelector('button')!.click()
+      expect(onClick).toHaveBeenCalled()
+    })
+
+    it('disabled / loading の場合、発火しない', () => {
+      const onClick = jest.fn()
+      act(() => {
+        createRoot(container).render(
+          <Button onClick={onClick} disabled>
+            button
+          </Button>,
+        )
+      })
+      document.querySelector('button')!.click()
+      expect(onClick).not.toHaveBeenCalled()
+    })
+
+    describe('form 要素でラップされている場合', () => {
+      it('disabled / loading でない場合、発火しない', () => {
+        const onSubmit = jest.fn()
+        act(() => {
+          createRoot(container).render(
+            <form onSubmit={onSubmit}>
+              <Button type="submit">button</Button>
+            </form>,
+          )
+        })
+        document.querySelector('button')!.click()
+        expect(onSubmit).toHaveBeenCalled()
+      })
+
+      it('disabled / loading の場合、発火しない', () => {
+        const onSubmit = jest.fn()
+        act(() => {
+          createRoot(container).render(
+            <form onSubmit={onSubmit}>
+              <Button type="submit" loading>
+                button
+              </Button>
+            </form>,
+          )
+        })
+        document.querySelector('button')!.click()
+        expect(onSubmit).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -68,7 +68,7 @@ export function ButtonWrapper({
         aria-disabled={disabled}
         className={buttonStyle}
         ref={buttonRef}
-        onClick={disabled ? undefined : onClick}
+        onClick={disabled ? (e) => e.preventDefault() : onClick}
       />
     )
   }

--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -68,7 +68,14 @@ export function ButtonWrapper({
         aria-disabled={disabled}
         className={buttonStyle}
         ref={buttonRef}
-        onClick={disabled ? (e) => e.preventDefault() : onClick}
+        onClick={
+          disabled
+            ? (e) => {
+                e.preventDefault()
+                e.stopPropagation()
+              }
+            : onClick
+        }
       />
     )
   }


### PR DESCRIPTION
## Related URL

[報告スレッド(社内)](https://app.slack.com/client/T02FXTZ7A)
[調査スレッド(社内)](https://kufuinc.slack.com/archives/C06KVP5PL23/p1723010431280679)

## Overview

以下PRの修正にて、Button コンポーネントに loading (あるいは disabled) を付与した場合、ボタンはネイティブの disabled 状態にはせずに、onClick イベントを破棄をすることで挙動を維持するようにした。
- https://github.com/kufu/smarthr-ui/pull/4684

しかし、以下のように form でラップして onSubmit を受け取るようにすると、 loading (あるいは disabled) 属性を付与しても、ボタンクリックによって submit イベントが発火してしまう問題が見つかったので、これを解決する。

```tsx
<form onSubmit={() => alert('submit')}>
  <Button type="submit" loading>Loading...</Button>
</form>
```

## What I did

Button コンポーネントへの onClick ハンドラを undefined で上書きすることで握りつぶす対応をしていたが、これだとイベントのバブリングが発生し、親要素 (たいていは form) にイベントが伝搬してしまっていた。

そこで、undefined で上書きするのではなく、ハンドラを定義の上、preventDefault / stopPropagation だけすることでイベントの伝播をブロックした。

## 確認事項

- [x] onSubmit のみ: 発火する
- [x] onSubmit + loading:  発火しない
- [x] onSubmit + disabled: 発火しない 
- [x] onClick のみ: 発火する
- [x] onClick + loading:  発火しない
- [x] onClick + disabled: 発火しない   