### PR TITLE
fix: body の base スタイルに約物を詰めないよう指定

### DIFF
--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -405,6 +405,8 @@ export default {
           fontFamily: 'system-ui, sans-serif',
           lineHeight: theme('lineHeight.normal'),
           color: theme('colors.black'),
+          // Windows 環境で Yu Gothic が不用意に記号を詰めてしまうのを避ける
+          textSpacingTrim: 'space-all',
         },
         'p, dl': {
           marginBlock: 'unset',


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

Windows など特定の環境で約物が詰められてしまう不具合を解決するため、一切の約物を詰めないよう `text-spacing-trim: space-all` を body に指定しました。

まだ Chromium くらいしか対応していませんが、対応していなければ無視されるので設定されてても影響は薄いです。
https://caniuse.com/mdn-css_properties_text-spacing-trim

また、約物を詰めたい場合は適宜上書いて指定すれば良いので問題ありません。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
