### PR TITLE
feat!: Combobox の inputAttributes を消し、input に直接渡すように修正

### DIFF
--- a/packages/smarthr-ui/e2e/components/ComboBox/MultiComboBox.test.ts
+++ b/packages/smarthr-ui/e2e/components/ComboBox/MultiComboBox.test.ts
@@ -126,7 +126,7 @@ test('deletable でないコンボボックスアイテムは削除できない�
     // 削除ボタンが表示されていない
     .expect(
       combobox
-        .parent()
+        .parent(0)
         .sibling()
         .find('.smarthr-ui-MultiComboBox-selectedItem')
         .withText('option 1')
@@ -137,7 +137,7 @@ test('deletable でないコンボボックスアイテムは削除できない�
     .pressKey('backspace')
     .expect(
       combobox
-        .parent()
+        .parent(0)
         .sibling()
         .find('.smarthr-ui-MultiComboBox-selectedItem')
         .withText('option 1').exists,
@@ -146,28 +146,24 @@ test('deletable でないコンボボックスアイテムは削除できない�
 })
 
 test('disabled なコンボボックスではアイテムの選択と選択解除ができないこと', async (t) => {
-  const normal = Selector('[data-test=multi-combobox-default]')
-  const normalCombobox = normal.find('input[role=combobox]')
+  const normalCombobox = Selector('[data-test=multi-combobox-default]')
   const normalComboboxControls = ((await normalCombobox.getAttribute('aria-controls')) || '').split(
     ' ',
   )
   const normalListbox = elementWithId(normalComboboxControls[0])
 
-  const disabled = Selector('[data-test=multi-combobox-disabled]')
-  const disabledCombobox = disabled.find('input[role=combobox]')
+  const disabledCombobox = Selector('[data-test=multi-combobox-disabled]')
   const disabledComboboxControls = (
     (await disabledCombobox.getAttribute('aria-controls')) || ''
   ).split(' ')
-  const disabledListbox = elementWithId(disabledComboboxControls[0])
   const disabledSelectedItems = elementWithId(disabledComboboxControls[1])
 
   await t
-    // disabled なコンボボックスをクリックしてもリストボックスは表示されないこと
-    .click(disabled)
-    .expect(disabledListbox.visible)
+    // disabled なコンボボックスが不可視であること
+    .expect(disabledCombobox.visible)
     .notOk()
     // 有効なコンボボックスでアイテム選択
-    .click(normal)
+    .click(normalCombobox)
     .click(normalListbox.find('.smarthr-ui-ComboBox-selectButton').withText('option 1'))
     // disabled なコンボボックスの選択済みアイテムの削除ボタンが disabled であること
     .expect(
@@ -188,6 +184,8 @@ test('キーボードで選択済みアイテムリストが操作できるこ�
     listbox.find('.smarthr-ui-ComboBox-selectButton').withText(label)
   const findDeleteButton = (label: string) =>
     combobox
+      .parent(0)
+      .sibling()
       .find('.smarthr-ui-MultiComboBox-selectedItem')
       .withText(label)
       .find('.smarthr-ui-MultiComboBox-deleteButton')
@@ -239,7 +237,7 @@ test('キーボードで選択済みアイテムリストが操作できるこ�
     .pressKey('enter')
     .expect(
       combobox
-        .parent()
+        .parent(0)
         .sibling()
         .find('.smarthr-ui-MultiComboBox-selectedItem')
         .withText('option 6').exists,
@@ -249,7 +247,7 @@ test('キーボードで選択済みアイテムリストが操作できるこ�
     .pressKey('backspace')
     .expect(
       combobox
-        .parent()
+        .parent(0)
         .sibling()
         .find('.smarthr-ui-MultiComboBox-selectedItem')
         .withText('option 3').exists,
@@ -259,31 +257,31 @@ test('キーボードで選択済みアイテムリストが操作できるこ�
     .pressKey('backspace')
     .expect(
       combobox
-        .parent()
+        .parent(0)
         .sibling()
         .find('.smarthr-ui-MultiComboBoxyy-selectedItem')
         .withText('option 2').exists,
     )
     .notOk()
     // Backspace によって削除した末尾アイテムはテキスト化されるが、選択状態になっているので再度 Backspace でテキストも削除できること
-    .expect(combobox.parent().sibling().find('.smarthr-ui-MultiComboBox-input').value)
+    .expect(combobox.value)
     .eql('option 1')
     .pressKey('backspace')
-    .expect(combobox.parent().sibling().find('.smarthr-ui-MultiComboBox-input').value)
+    .expect(combobox.value)
     .eql('')
 })
 
 test('キーボードでリストボックスが操作できること', async (t) => {
   const combobox = Selector('[data-test=multi-combobox-default]')
   const comboBoxSelected = combobox
-    .parent()
+    .parent(0)
     .sibling()
     .find('.smarthr-ui-MultiComboBox-selectedItem')
 
   await t
     // タブキーでフォーカスされたとき、テキストボックスがフォーカスされること
     .pressKey('tab')
-    .expect(combobox.parent().sibling().find('.smarthr-ui-MultiComboBox-input').focused)
+    .expect(combobox.focused)
     .ok()
     // アイテムが選択できること
     .pressKey('down')

--- a/packages/smarthr-ui/e2e/components/ComboBox/MultiComboBox.test.ts
+++ b/packages/smarthr-ui/e2e/components/ComboBox/MultiComboBox.test.ts
@@ -14,15 +14,14 @@ function elementWithId(id: string | null | undefined) {
 }
 
 test('アイテムの選択と選択解除ができること', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-default]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-default]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
   const selectedItems = elementWithId(comboboxControls[1])
 
   await t
     // コンボボックスをクリックするとテキストボックスがフォーカスされること
-    .click(wrapper)
+    .click(combobox)
     .expect(combobox.focused)
     .ok()
     // アイテムを選択できること
@@ -46,14 +45,13 @@ test('アイテムの選択と選択解除ができること', async (t) => {
 })
 
 test('リストボックスが開閉できること', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-default]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-default]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
 
   await t
     // コンボボックスをクリックするとリストボックスが表示されること
-    .click(wrapper)
+    .click(combobox)
     .expect(listbox.visible)
     .ok()
     // 外側をクリックするとリストボックスが非表示になること
@@ -61,13 +59,13 @@ test('リストボックスが開閉できること', async (t) => {
     .expect(listbox.visible)
     .notOk()
     // 再度リストボックスを開く
-    .click(wrapper)
+    .click(combobox)
     // リストボックス表示中に Escape キーを押下するとリストボックスが非表示になること
     .pressKey('esc')
     .expect(listbox.visible)
     .notOk()
     // 再度リストボックスを開く
-    .click(wrapper)
+    .click(combobox)
     // リストボックス表示中に Tab キーを押下するとリストボックスが非表示になること
     .pressKey('tab')
     .expect(listbox.visible)
@@ -75,15 +73,14 @@ test('リストボックスが開閉できること', async (t) => {
 })
 
 test('コンボボックスがフォーカスされていない時に選択解除ボタンを押下してもリストボックスが表示されないこと', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-default]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-default]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
   const selectedItems = elementWithId(comboboxControls[1])
 
   await t
     // アイテムを選択
-    .click(wrapper)
+    .click(combobox)
     .click(listbox.find('.smarthr-ui-ComboBox-selectButton').withText('option 1'))
     // 外側をクリックしてフォーカスを外す
     .click('body', { offsetX: 0, offsetY: 0 })
@@ -94,8 +91,7 @@ test('コンボボックスがフォーカスされていない時に選択解�
 })
 
 test('新しいアイテムを追加できること', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-creatable]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-creatable]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
   const addButton = listbox.find('.smarthr-ui-ComboBox-addButton')
@@ -103,7 +99,7 @@ test('新しいアイテムを追加できること', async (t) => {
 
   await t
     // 新しいアイテムを追加できること
-    .click(wrapper)
+    .click(combobox)
     .typeText(combobox, 'test new item')
     .click(addButton)
     .expect(selectedItems.withText('test new item').exists)
@@ -113,24 +109,25 @@ test('新しいアイテムを追加できること', async (t) => {
     .expect(selectedItems.withText('test new item').exists)
     .notOk()
     // 新しく追加したアイテムがリストボックス内に存在すること
-    .click(wrapper)
+    .click(combobox)
     .expect(listbox.find('.smarthr-ui-ComboBox-selectButton').withText('test new item').exists)
     .ok()
 })
 
 test('deletable でないコンボボックスアイテムは削除できないこと', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-undeletable]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-undeletable]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
 
   await t
     // アイテムを選択
-    .click(wrapper)
+    .click(combobox)
     .click(listbox.find('.smarthr-ui-ComboBox-selectButton').withText('option 1'))
     // 削除ボタンが表示されていない
     .expect(
-      wrapper
+      combobox
+        .parent()
+        .sibling()
         .find('.smarthr-ui-MultiComboBox-selectedItem')
         .withText('option 1')
         .find('.smarthr-ui-MultiComboBox-deleteButton').exists,
@@ -138,7 +135,13 @@ test('deletable でないコンボボックスアイテムは削除できない�
     .notOk()
     // Backspace キーで削除できないこと
     .pressKey('backspace')
-    .expect(wrapper.find('.smarthr-ui-MultiComboBox-selectedItem').withText('option 1').exists)
+    .expect(
+      combobox
+        .parent()
+        .sibling()
+        .find('.smarthr-ui-MultiComboBox-selectedItem')
+        .withText('option 1').exists,
+    )
     .ok()
 })
 
@@ -177,22 +180,21 @@ test('disabled なコンボボックスではアイテムの選択と選択解�
 })
 
 test('キーボードで選択済みアイテムリストが操作できること', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-default]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-default]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
 
   const findOption = (label: string) =>
     listbox.find('.smarthr-ui-ComboBox-selectButton').withText(label)
   const findDeleteButton = (label: string) =>
-    wrapper
+    combobox
       .find('.smarthr-ui-MultiComboBox-selectedItem')
       .withText(label)
       .find('.smarthr-ui-MultiComboBox-deleteButton')
 
   await t
     // アイテムを選択
-    .click(wrapper)
+    .click(combobox)
     .click(findOption('option 1'))
     .click(findOption('option 2'))
     .click(findOption('option 5'))
@@ -235,32 +237,53 @@ test('キーボードで選択済みアイテムリストが操作できるこ�
     // 削除ボタンを操作できること
     .pressKey('left')
     .pressKey('enter')
-    .expect(wrapper.find('.smarthr-ui-MultiComboBox-selectedItem').withText('option 5').exists)
+    .expect(
+      combobox
+        .parent()
+        .sibling()
+        .find('.smarthr-ui-MultiComboBox-selectedItem')
+        .withText('option 6').exists,
+    )
     .notOk()
     .pressKey('left')
     .pressKey('backspace')
-    .expect(wrapper.find('.smarthr-ui-MultiComboBox-selectedItem').withText('option 2').exists)
+    .expect(
+      combobox
+        .parent()
+        .sibling()
+        .find('.smarthr-ui-MultiComboBox-selectedItem')
+        .withText('option 3').exists,
+    )
     .notOk()
     // テキストボックスにフォーカスがあたってる場合は Backspace で末尾のアイテムを削除できること
     .pressKey('backspace')
-    .expect(wrapper.find('.smarthr-ui-MultiComboBoxyy-selectedItem').withText('option 1').exists)
+    .expect(
+      combobox
+        .parent()
+        .sibling()
+        .find('.smarthr-ui-MultiComboBoxyy-selectedItem')
+        .withText('option 2').exists,
+    )
     .notOk()
     // Backspace によって削除した末尾アイテムはテキスト化されるが、選択状態になっているので再度 Backspace でテキストも削除できること
-    .expect(wrapper.find('.smarthr-ui-MultiComboBox-input').value)
+    .expect(combobox.parent().sibling().find('.smarthr-ui-MultiComboBox-input').value)
     .eql('option 1')
     .pressKey('backspace')
-    .expect(wrapper.find('.smarthr-ui-MultiComboBox-input').value)
+    .expect(combobox.parent().sibling().find('.smarthr-ui-MultiComboBox-input').value)
     .eql('')
 })
 
 test('キーボードでリストボックスが操作できること', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-default]')
-  const comboBoxSelected = wrapper.find('.smarthr-ui-MultiComboBox-selectedItem')
+  const combobox = Selector('[data-test=multi-combobox-default]')
+  const comboBoxSelected = combobox
+    .parent()
+    .sibling()
+    .find('.smarthr-ui-MultiComboBox-selectedItem')
 
   await t
     // タブキーでフォーカスされたとき、テキストボックスがフォーカスされること
     .pressKey('tab')
-    .expect(wrapper.find('.smarthr-ui-MultiComboBox-input').focused)
+    .expect(combobox.parent().sibling().find('.smarthr-ui-MultiComboBox-input').focused)
     .ok()
     // アイテムが選択できること
     .pressKey('down')
@@ -283,13 +306,12 @@ test('キーボードでリストボックスが操作できること', async (t
 })
 
 test('部分的レンダリングしているアイテム数がスクロールにより順次増加すること', async (t) => {
-  const wrapper = Selector('[data-test=multi-combobox-many]')
-  const combobox = wrapper.find('input[role=combobox]')
+  const combobox = Selector('[data-test=multi-combobox-many]')
   const comboboxControls = ((await combobox.getAttribute('aria-controls')) || '').split(' ')
   const listbox = elementWithId(comboboxControls[0])
 
   await t
-    .click(wrapper)
+    .click(combobox)
     .expect(listbox.find('.smarthr-ui-ComboBox-selectButton').count)
     .eql(100)
     .scroll(listbox, 'bottom')

--- a/packages/smarthr-ui/e2e/components/ComboBox/SingleComboBox.test.ts
+++ b/packages/smarthr-ui/e2e/components/ComboBox/SingleComboBox.test.ts
@@ -15,32 +15,30 @@ function elementWithId(id: string | null | undefined) {
 
 test('アイテムの選択と選択解除ができること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
-  const textbox = combobox.find('input[type=text]')
-  const listbox = elementWithId(await textbox.getAttribute('aria-controls'))
-  const clearButton = combobox.find('.smarthr-ui-SingleComboBox-clearButton')
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
+  const clearButton = combobox.sibling().find('.smarthr-ui-SingleComboBox-clearButton')
 
   await t
     // コンボボックスをクリックするとテキストボックスがフォーカスされること
     .click(combobox)
-    .expect(textbox.focused)
+    .expect(combobox.focused)
     .ok()
     // アイテムを選択できること
     .click(listbox.find('.smarthr-ui-ComboBox-selectButton').withText('option 1'))
-    .expect(textbox.value)
+    .expect(combobox.value)
     .eql('option 1')
     // リストボックスが非表示になること
     .expect(listbox.visible)
     .notOk()
     // 選択したアイテムを選択解除できること
     .click(clearButton)
-    .expect(textbox.value)
+    .expect(combobox.value)
     .eql('')
 })
 
 test('リストボックスが開閉できること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
-  const textbox = combobox.find('input[type=text]')
-  const listbox = elementWithId(await textbox.getAttribute('aria-controls'))
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
 
   await t
     // コンボボックスをクリックするとリストボックスが表示されること
@@ -67,9 +65,8 @@ test('リストボックスが開閉できること', async (t) => {
 
 test('コンボボックスがフォーカスされていない時に選択解除ボタンを押下してもリストボックスが表示されること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
-  const textbox = combobox.find('input[type=text]')
-  const listbox = elementWithId(await textbox.getAttribute('aria-controls'))
-  const clearButton = combobox.find('.smarthr-ui-SingleComboBox-clearButton')
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
+  const clearButton = combobox.sibling().find('.smarthr-ui-SingleComboBox-clearButton')
 
   await t
     // アイテムを選択
@@ -85,21 +82,20 @@ test('コンボボックスがフォーカスされていない時に選択解�
 
 test('新しいアイテムを追加できること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-creatable]')
-  const textbox = combobox.find('input[type=text]')
-  const listbox = elementWithId(await textbox.getAttribute('aria-controls'))
+  const listbox = elementWithId(await combobox.getAttribute('aria-controls'))
   const addButton = listbox.find('.smarthr-ui-ComboBox-addButton')
-  const clearButton = combobox.find('.smarthr-ui-SingleComboBox-clearButton')
+  const clearButton = combobox.sibling().find('.smarthr-ui-SingleComboBox-clearButton')
 
   await t
     // 新しいアイテムを追加できること
     .click(combobox)
-    .typeText(textbox, 'test new item')
+    .typeText(combobox, 'test new item')
     .click(addButton)
-    .expect(textbox.value)
+    .expect(combobox.value)
     .eql('test new item')
     // 選択したアイテムを選択解除できること
     .click(clearButton)
-    .expect(textbox.value)
+    .expect(combobox.value)
     .eql('')
     // 新しく追加したアイテムがリストボックス内に存在すること
     .click(combobox)
@@ -108,54 +104,45 @@ test('新しいアイテムを追加できること', async (t) => {
 })
 
 test('disabled なコンボボックスではアイテムの選択と選択解除ができないこと', async (t) => {
-  const normal = Selector('[data-test=single-combobox-default]')
-  const normalTextbox = normal.find('input[type=text]')
-  const normalListbox = elementWithId(await normalTextbox.getAttribute('aria-controls'))
-  const disabled = Selector('[data-test=single-combobox-disabled]')
-  const disabledTextBox = disabled.find('input[type=text]')
-  const disabledListbox = elementWithId(await disabledTextBox.getAttribute('aria-controls'))
+  const normalCombobox = Selector('[data-test=single-combobox-default]')
+  const normalListbox = elementWithId(await normalCombobox.getAttribute('aria-controls'))
+  const disabledCombobox = Selector('[data-test=single-combobox-disabled]')
+  const disabledListbox = elementWithId(await disabledCombobox.getAttribute('aria-controls'))
 
   await t
     // disabled なコンボボックスをクリックしてもリストボックスは表示されないこと
-    .click(disabled)
+    .click(disabledCombobox)
     .expect(disabledListbox.visible)
     .notOk()
     // 有効なコンボボックスでアイテム選択
-    .click(normal)
+    .click(normalCombobox)
     .click(normalListbox.find('.smarthr-ui-ComboBox-selectButton').withText('option 1'))
     // disabled なコンボボックスにクリアボタンが表示されないこと
-    .expect(disabled.find('.smarthr-ui-SingleComboBox-clearButton').visible)
+    .expect(disabledCombobox.sibling().find('.smarthr-ui-SingleComboBox-clearButton').visible)
     .notOk()
 })
 
 test('キーボードで操作できること', async (t) => {
   const combobox = Selector('[data-test=single-combobox-default]')
-  const comboboxInput = combobox.find('.smarthr-ui-Input-input')
 
   await t
     .pressKey('tab')
-    .expect(comboboxInput.focused)
+    .expect(combobox.focused)
     .ok()
     .pressKey('down')
     .pressKey('enter')
-    .expect(comboboxInput.value)
+    .expect(combobox.value)
     .eql('option 1')
     .pressKey('up')
     .pressKey('up')
     .pressKey('up')
     .pressKey('enter')
-    .expect(comboboxInput.value)
+    .expect(combobox.value)
     .eql('option 5')
 })
 
 test('キーボードで操作しても親要素のformがsubmitされないこと', async (t) => {
   const combobox = Selector('[data-test=single-combobox-no-form-submit]')
-  const comboboxInput = combobox.find('.smarthr-ui-Input-input')
 
-  await t
-    .pressKey('tab')
-    .pressKey('down')
-    .pressKey('enter')
-    .expect(comboboxInput.value)
-    .eql('option 1')
+  await t.pressKey('tab').pressKey('down').pressKey('enter').expect(combobox.value).eql('option 1')
 })

--- a/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.tsx
@@ -1,8 +1,7 @@
 import React, {
-  ComponentPropsWithoutRef,
-  InputHTMLAttributes,
-  KeyboardEvent,
-  Ref,
+  type ComponentPropsWithoutRef,
+  type KeyboardEvent,
+  type Ref,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -21,11 +20,11 @@ import { FaCaretDownIcon } from '../Icon'
 
 import { MultiSelectedItem } from './MultiSelectedItem'
 import { hasParentElementByClassName } from './multiComboBoxHelper'
-import { BaseProps, ComboBoxItem } from './types'
 import { useFocusControl } from './useFocusControl'
 import { useListBox } from './useListBox'
 import { useOptions } from './useOptions'
 
+import type { BaseProps, ComboBoxItem } from './types'
 import type { DecoratorsType } from '../../types'
 
 type Props<T> = BaseProps<T> & {
@@ -69,37 +68,9 @@ type Props<T> = BaseProps<T> & {
    * アイテムが選択されたときに選択済みかどうかを判定するコールバック関数/
    */
   isItemSelected?: (targetItem: ComboBoxItem<T>, selectedItems: Array<ComboBoxItem<T>>) => boolean
-
-  /**
-   * input 要素の属性
-   */
-  inputAttributes?: Omit<
-    InputHTMLAttributes<HTMLInputElement>,
-    | 'name'
-    | 'disabled'
-    | 'required'
-    | 'type'
-    | 'aria-activedescendant'
-    | 'aria-autocomplete'
-    | 'aria-controls'
-    | 'aria-disabled'
-    | 'aria-expanded'
-    | 'aria-haspopup'
-    | 'aria-invalid'
-    | 'className'
-    | 'onChange'
-    | 'onCompositionEnd'
-    | 'onCompositionStart'
-    | 'onFocus'
-    | 'onKeyDown'
-    | 'ref'
-    | 'role'
-    | 'tabIndex'
-    | 'value'
-  >
 }
 
-type ElementProps = Omit<ComponentPropsWithoutRef<'div'>, keyof Props<unknown>>
+type ElementProps = Omit<ComponentPropsWithoutRef<'input'>, keyof Props<unknown>>
 
 const SELECTED_LIST_ARIA_LABEL = '選択済みアイテム'
 
@@ -173,6 +144,7 @@ const ActualMultiComboBox = <T,>(
     error = false,
     creatable = false,
     placeholder = '',
+    autoComplete,
     dropdownHelpMessage,
     isLoading,
     selectedItemEllipsis,
@@ -191,9 +163,8 @@ const ActualMultiComboBox = <T,>(
     onKeyPress,
     decorators,
     isItemSelected,
-    inputAttributes,
     style,
-    ...props
+    ...rest
   }: Props<T> & ElementProps,
   ref: Ref<HTMLInputElement>,
 ) => {
@@ -416,7 +387,7 @@ const ActualMultiComboBox = <T,>(
   // アイテムをキーボードで選択し、Enterを押すとinput上でEnterを押したことになるため、
   // submitイベントが発生し、formが送信される場合がある
   const handleKeyPress = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
       e.key === 'Enter' && e.preventDefault()
       onKeyPress && onKeyPress(e)
     },
@@ -481,7 +452,6 @@ const ActualMultiComboBox = <T,>(
 
   return (
     <div
-      {...props}
       {...wrapperStyleProps}
       ref={outerRef}
       onClick={handleClick}
@@ -514,7 +484,7 @@ const ActualMultiComboBox = <T,>(
 
         <div className={inputWrapperStlye}>
           <input
-            {...inputAttributes}
+            {...rest}
             type="text"
             name={name}
             value={inputValue}
@@ -526,7 +496,7 @@ const ActualMultiComboBox = <T,>(
             onCompositionStart={handleCompositionStartInput}
             onCompositionEnd={handleCompositionEndInput}
             onKeyDown={handleInputKeyDown}
-            autoComplete={inputAttributes?.autoComplete ?? 'off'}
+            autoComplete={autoComplete ?? 'off'}
             tabIndex={0}
             role="combobox"
             aria-activedescendant={activeOption?.id}

--- a/packages/smarthr-ui/src/components/ComboBox/MultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiCombobox.stories.tsx
@@ -164,9 +164,7 @@ export const MultiCombobox: StoryFn = () => {
           name="inputAttributes"
           items={items}
           selectedItems={selectedItems}
-          inputAttributes={{
-            'aria-label': 'inputAttributes',
-          }}
+          aria-label="inputAttributes"
           onDelete={handleDelete}
           onSelect={handleSelectItem}
           data-test="multi-combobox-disabled"

--- a/packages/smarthr-ui/src/components/ComboBox/SingleComboBox.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/SingleComboBox.tsx
@@ -1,9 +1,9 @@
 import React, {
-  ChangeEvent,
-  ComponentPropsWithoutRef,
-  MouseEvent,
-  ReactNode,
-  Ref,
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  type MouseEvent,
+  type ReactNode,
+  type Ref,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -18,13 +18,13 @@ import { useClick } from '../../hooks/useClick'
 import { useTheme } from '../../hooks/useTailwindTheme'
 import { genericsForwardRef } from '../../libs/util'
 import { UnstyledButton } from '../Button'
-import { FaCaretDownIcon, FaTimesCircleIcon } from '../Icon'
+import { FaCaretDownIcon, FaCircleXmarkIcon } from '../Icon'
 import { Input } from '../Input'
 
-import { BaseProps, ComboBoxItem } from './types'
 import { useListBox } from './useListBox'
 import { useOptions } from './useOptions'
 
+import type { BaseProps, ComboBoxItem } from './types'
 import type { DecoratorsType } from '../../types'
 
 type Props<T> = BaseProps<T> & {
@@ -67,34 +67,9 @@ type Props<T> = BaseProps<T> & {
   decorators?: DecoratorsType<'noResultText'> & {
     destroyButtonIconAlt?: (text: string) => string
   }
-  /**
-   * input 要素の属性
-   */
-  inputAttributes?: Omit<
-    React.ComponentProps<typeof Input>,
-    | 'aria-activedescendant'
-    | 'aria-autocomplete'
-    | 'className'
-    | 'disabled'
-    | 'required'
-    | 'error'
-    | 'name'
-    | 'onChange'
-    | 'onClick'
-    | 'onCompositionEnd'
-    | 'onCompositionStart'
-    | 'onFocus'
-    | 'onKeyDown'
-    | 'placeholder'
-    | 'prefix'
-    | 'ref'
-    | 'suffix'
-    | 'type'
-    | 'value'
-  >
 }
 
-type ElementProps = Omit<ComponentPropsWithoutRef<'div'>, keyof Props<unknown>>
+type ElementProps = Omit<ComponentPropsWithoutRef<'input'>, keyof Props<unknown>>
 
 const DESTROY_BUTTON_TEXT = '削除'
 
@@ -145,6 +120,7 @@ const ActualSingleComboBox = <T,>(
     error = false,
     creatable = false,
     placeholder = '',
+    autoComplete,
     dropdownHelpMessage,
     isLoading,
     width,
@@ -161,9 +137,8 @@ const ActualSingleComboBox = <T,>(
     onBlur,
     onKeyPress,
     decorators,
-    inputAttributes,
     style,
-    ...props
+    ...rest
   }: Props<T> & ElementProps,
   ref: Ref<HTMLInputElement>,
 ) => {
@@ -330,7 +305,7 @@ const ActualSingleComboBox = <T,>(
   // アイテムをキーボードで選択し、Enterを押すとinput上でEnterを押したことになるため、
   // submitイベントが発生し、formが送信される場合がある
   const handleKeyPress = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
       e.key === 'Enter' && e.preventDefault()
       onKeyPress && onKeyPress(e)
     },
@@ -411,9 +386,9 @@ const ActualSingleComboBox = <T,>(
   ])
 
   return (
-    <div {...props} {...wrapperStyleProps} ref={outerRef}>
+    <div {...wrapperStyleProps} ref={outerRef}>
       <Input
-        {...inputAttributes}
+        {...rest}
         /* eslint-disable-next-line smarthr/a11y-prohibit-input-placeholder */
         placeholder={placeholder}
         type="text"
@@ -430,7 +405,7 @@ const ActualSingleComboBox = <T,>(
               ref={clearButtonRef}
               className={clearButtonStyle}
             >
-              <FaTimesCircleIcon
+              <FaCircleXmarkIcon
                 color="TEXT_BLACK"
                 alt={decorators?.destroyButtonIconAlt?.(DESTROY_BUTTON_TEXT) || DESTROY_BUTTON_TEXT}
                 className={clearButtonIconStyle}
@@ -450,7 +425,7 @@ const ActualSingleComboBox = <T,>(
         onKeyDown={onKeyDownInput}
         onKeyPress={handleKeyPress}
         ref={inputRef}
-        autoComplete={inputAttributes?.autoComplete ?? 'off'}
+        autoComplete={autoComplete ?? 'off'}
         role="combobox"
         aria-haspopup="listbox"
         aria-controls={listBoxId}

--- a/packages/smarthr-ui/src/components/ComboBox/SingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/SingleCombobox.stories.tsx
@@ -169,12 +169,10 @@ export const SingleCombobox: StoryFn = () => {
           name="inputAttributes"
           items={items}
           selectedItem={selectedItem}
-          inputAttributes={{
-            'aria-label': 'inputAttributes',
-          }}
           onSelect={handleSelectItem}
           onClear={handleClear}
           data-test="single-combobox-disabled"
+          aria-label="inputAttributes"
         />
       </FormControl>
       <FormControl title="エラー表示">

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -1,9 +1,9 @@
 import React, {
-  ComponentProps,
-  ComponentPropsWithoutRef,
-  PropsWithChildren,
-  ReactElement,
-  ReactNode,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
   useMemo,
 } from 'react'
 import { isStyledComponent } from 'styled-components'
@@ -25,6 +25,7 @@ import { TimePicker } from '../TimePicker'
 import { visuallyHiddenText } from '../VisuallyHiddenText/VisuallyHiddenText'
 
 import type { Gap } from '../../types'
+
 type StatusLabelProps = ComponentProps<typeof StatusLabel>
 
 type Props = PropsWithChildren<{
@@ -290,11 +291,7 @@ const decorateFirstInputElement = (
         inputAttributes['aria-describedby'] = describedbyIds
       }
 
-      if (isComboBoxElement(child)) {
-        return React.cloneElement(child, { inputAttributes })
-      } else {
-        return React.cloneElement(child, inputAttributes)
-      }
+      return React.cloneElement(child, inputAttributes)
     })
 
   return decorate(children)
@@ -336,15 +333,6 @@ const isInputElement = (
     type === InputFile ||
     type === DropZone
   )
-}
-
-type ComboboxComponent = typeof SingleComboBox | typeof MultiComboBox
-
-const isComboBoxElement = (
-  element: ReactElement,
-): element is React.ReactComponentElement<ComboboxComponent> => {
-  const type = isStyledComponent(element.type) ? element.type.target : element.type
-  return type === SingleComboBox || type === MultiComboBox
 }
 
 export const FormControl: React.FC<Omit<Props & ElementProps, 'as' | 'disabled'>> =


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-700

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview

他の入力系コンポーネントと合せて、Combobox の inputAttributes を消しました。
Combobox に渡した各種 attrs は内包する input に渡ります。

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture

<!--
Please attach a capture if it looks different.
-->
