### PR TITLE
fix(TabBar): suffixにテキストのスタイルが継承されないように修正

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -10,13 +10,19 @@ const tabItem = tv({
   slots: {
     wrapper: [
       'smarthr-ui-TabItem',
-      'shr-relative shr-px-1 shr-py-0.75 shr-font-bold shr-text-grey shr-inline-flex shr-items-center shr-gap-0.5 shr-leading-none',
-      'hover:shr-bg-white-darken hover:shr-text-black',
+      'shr-group/tabitem',
+      'shr-relative shr-px-1 shr-py-0.75 shr-inline-flex shr-items-center shr-gap-0.5',
+      'hover:shr-bg-white-darken',
       'focus-visible:shr-z-1',
-      'disabled:shr-cursor-not-allowed disabled:shr-bg-transparent disabled:shr-text-grey/50',
-      'aria-selected:shr-text-black',
+      'disabled:shr-cursor-not-allowed disabled:shr-bg-transparent',
       'aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1',
       'forced-colors:aria-selected:before:shr-bg-[Highlight]',
+    ],
+    label: [
+      'shr-font-bold shr-text-grey shr-leading-none',
+      'group-hover/tabitem:shr-text-black',
+      'group-disabled/tabitem:shr-text-grey/50',
+      'group-aria-selected/tabitem:shr-text-black',
     ],
     suffixWrapper: [
       // Badge など内包要素に依って高さが変わらないようにするため、ネガティブマージンを指定
@@ -95,10 +101,11 @@ const TabButton: FC<Props & ElementProps> = ({
   className,
   ...rest
 }) => {
-  const { wrapperStyle, suffixStyle } = useMemo(() => {
-    const { wrapper, suffixWrapper } = tabItem({ isTouchDevice })
+  const { wrapperStyle, labelStyle, suffixStyle } = useMemo(() => {
+    const { wrapper, label, suffixWrapper } = tabItem({ isTouchDevice })
     return {
       wrapperStyle: wrapper({ className }),
+      labelStyle: label(),
       suffixStyle: suffixWrapper(),
     }
   }, [className])
@@ -111,7 +118,7 @@ const TabButton: FC<Props & ElementProps> = ({
       className={wrapperStyle}
       onClick={() => onClick(id)}
     >
-      {children}
+      <span className={labelStyle}>{children}</span>
       {suffix && <span className={suffixStyle}>{suffix}</span>}
     </UnstyledButton>
   )

--- a/packages/smarthr-ui/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/packages/smarthr-ui/src/components/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -10,34 +10,46 @@ exports[`TabBar should be match snapshot 1`] = `
   >
     <button
       aria-selected={false}
-      className="shr-box-content shr-cursor-pointer shr-select-auto shr-appearance-none shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit focus-visible:shr-focus-indicator smarthr-ui-TabItem shr-relative shr-px-1 shr-py-0.75 shr-font-bold shr-text-grey shr-inline-flex shr-items-center shr-gap-0.5 shr-leading-none hover:shr-bg-white-darken hover:shr-text-black focus-visible:shr-z-1 disabled:shr-cursor-not-allowed disabled:shr-bg-transparent disabled:shr-text-grey/50 aria-selected:shr-text-black aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1 forced-colors:aria-selected:before:shr-bg-[Highlight] shr-transition-colors"
+      className="shr-box-content shr-cursor-pointer shr-select-auto shr-appearance-none shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit shr-text-color-inherit focus-visible:shr-focus-indicator smarthr-ui-TabItem shr-group/tabitem shr-relative shr-px-1 shr-py-0.75 shr-inline-flex shr-items-center shr-gap-0.5 hover:shr-bg-white-darken focus-visible:shr-z-1 disabled:shr-cursor-not-allowed disabled:shr-bg-transparent aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1 forced-colors:aria-selected:before:shr-bg-[Highlight] shr-transition-colors"
       id="1"
       onClick={[Function]}
       role="tab"
       type="button"
     >
-      Tab
+      <span
+        className="shr-font-bold shr-text-grey shr-leading-none group-hover/tabitem:shr-text-black group-disabled/tabitem:shr-text-grey/50 group-aria-selected/tabitem:shr-text-black"
+      >
+        Tab
+      </span>
     </button>
     <button
       aria-selected={true}
-      className="shr-box-content shr-cursor-pointer shr-select-auto shr-appearance-none shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit focus-visible:shr-focus-indicator smarthr-ui-TabItem shr-relative shr-px-1 shr-py-0.75 shr-font-bold shr-text-grey shr-inline-flex shr-items-center shr-gap-0.5 shr-leading-none hover:shr-bg-white-darken hover:shr-text-black focus-visible:shr-z-1 disabled:shr-cursor-not-allowed disabled:shr-bg-transparent disabled:shr-text-grey/50 aria-selected:shr-text-black aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1 forced-colors:aria-selected:before:shr-bg-[Highlight] shr-transition-colors"
+      className="shr-box-content shr-cursor-pointer shr-select-auto shr-appearance-none shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit shr-text-color-inherit focus-visible:shr-focus-indicator smarthr-ui-TabItem shr-group/tabitem shr-relative shr-px-1 shr-py-0.75 shr-inline-flex shr-items-center shr-gap-0.5 hover:shr-bg-white-darken focus-visible:shr-z-1 disabled:shr-cursor-not-allowed disabled:shr-bg-transparent aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1 forced-colors:aria-selected:before:shr-bg-[Highlight] shr-transition-colors"
       id="2"
       onClick={[Function]}
       role="tab"
       type="button"
     >
-      Selected
+      <span
+        className="shr-font-bold shr-text-grey shr-leading-none group-hover/tabitem:shr-text-black group-disabled/tabitem:shr-text-grey/50 group-aria-selected/tabitem:shr-text-black"
+      >
+        Selected
+      </span>
     </button>
     <button
       aria-selected={false}
-      className="shr-box-content shr-cursor-pointer shr-select-auto shr-appearance-none shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit focus-visible:shr-focus-indicator smarthr-ui-TabItem shr-relative shr-px-1 shr-py-0.75 shr-font-bold shr-text-grey shr-inline-flex shr-items-center shr-gap-0.5 shr-leading-none hover:shr-bg-white-darken hover:shr-text-black focus-visible:shr-z-1 disabled:shr-cursor-not-allowed disabled:shr-bg-transparent disabled:shr-text-grey/50 aria-selected:shr-text-black aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1 forced-colors:aria-selected:before:shr-bg-[Highlight] shr-transition-colors"
+      className="shr-box-content shr-cursor-pointer shr-select-auto shr-appearance-none shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit shr-text-color-inherit focus-visible:shr-focus-indicator smarthr-ui-TabItem shr-group/tabitem shr-relative shr-px-1 shr-py-0.75 shr-inline-flex shr-items-center shr-gap-0.5 hover:shr-bg-white-darken focus-visible:shr-z-1 disabled:shr-cursor-not-allowed disabled:shr-bg-transparent aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1 forced-colors:aria-selected:before:shr-bg-[Highlight] shr-transition-colors"
       disabled={true}
       id="3"
       onClick={[Function]}
       role="tab"
       type="button"
     >
-      Disabled
+      <span
+        className="shr-font-bold shr-text-grey shr-leading-none group-hover/tabitem:shr-text-black group-disabled/tabitem:shr-text-grey/50 group-aria-selected/tabitem:shr-text-black"
+      >
+        Disabled
+      </span>
     </button>
   </div>
 </div>


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

https://kufuinc.slack.com/archives/CDG1XRPTP/p1724204204068229?thread_ts=1723185002.816649&cid=CDG1XRPTP

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

suffixにテキストのスタイルが継承されないように修正

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- TabItemのラベル部分の装飾をテキストのみに適用されるように修正
  - spanで囲った

## Capture

<!--
Please attach a capture if it looks different.
-->

- Badgeの太字がregularになっていることをVRTで確認してapproveしてください
