### PR TITLE
feat: TimePickerに様々な状態に応じたスタイルをあてたい

### DIFF
--- a/packages/smarthr-ui/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/TimePicker/TimePicker.stories.tsx
@@ -11,9 +11,28 @@ export default {
 }
 
 const _Template: StoryFn = (args) => (
-  <FormControl title="時刻">
-    <TimePicker {...args} />
-  </FormControl>
+  <ul className="shr-list-none shr-space-y-1">
+    <li>
+      <FormControl title="時刻">
+        <TimePicker {...args} />
+      </FormControl>
+    </li>
+    <li>
+      <FormControl title="非活性">
+        <TimePicker {...args} disabled={true} />
+      </FormControl>
+    </li>
+    <li>
+      <FormControl title="エラーあり">
+        <TimePicker {...args} error={true} />
+      </FormControl>
+    </li>
+    <li>
+      <FormControl title="読み取り専用">
+        <TimePicker {...args} readOnly={true} />
+      </FormControl>
+    </li>
+  </ul>
 )
 
 export const Default = _Template.bind({})

--- a/packages/smarthr-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/smarthr-ui/src/components/TimePicker/TimePicker.tsx
@@ -1,28 +1,55 @@
 import React, { ComponentPropsWithoutRef, forwardRef } from 'react'
 import { tv } from 'tailwind-variants'
 
-type Props = ComponentPropsWithoutRef<'input'>
+type Props = {
+  /** フォームにエラーがあるかどうか */
+  error?: boolean
+}
+type ElementProps = Omit<ComponentPropsWithoutRef<'input'>, keyof Props>
 
-const timePicker = tv({
-  slots: {
-    wrapper: [
-      'smarthr-ui-TimePicker',
-      'shr-inline-block shr-border-shorthand shr-rounded-m shr-bg-white shr-px-0.5 shr-leading-none',
-      'contrast-more:shr-border-high-contrast',
-      'focus-within:shr-focus-indicator',
-    ],
-    input:
-      'shr-border-none shr-text-base shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-h-[theme(fontSize.base)] shr-tabular-nums',
+const wrapper = tv({
+  base: [
+    'smarthr-ui-TimePicker',
+    'shr-inline-block shr-border-shorthand shr-rounded-m shr-bg-white shr-px-0.5 shr-leading-none',
+    'contrast-more:shr-border-high-contrast',
+    'focus-within:shr-focus-indicator',
+  ],
+  variants: {
+    disabled: {
+      true: 'shr-pointer-events-none shr-bg-white-darken [&&&]:shr-border-default/50',
+    },
+    error: {
+      true: '[&]:shr-border-danger',
+    },
+    readOnly: {
+      true: '[&&&]:shr-border-[theme(backgroundColor.background)] [&&&]:shr-bg-background',
+    },
   },
 })
 
-export const TimePicker: React.FC<Props> = forwardRef<HTMLInputElement, Props>(
-  ({ className, ...rest }, ref) => {
-    const { wrapper, input } = timePicker()
+const inner = tv({
+  slots: {
+    input:
+      'shr-border-none shr-text-base shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-h-[theme(fontSize.base)] shr-tabular-nums',
+  },
+})
+
+export const TimePicker = forwardRef<HTMLInputElement, Props & ElementProps>(
+  ({ disabled, error, readOnly, className, ...rest }, ref) => {
+    const wrapperStyle = wrapper({ disabled, error, readOnly, className })
+    const { input } = inner()
     return (
-      <span className={wrapper({ className })}>
+      <span className={wrapperStyle}>
         {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute, smarthr/a11y-input-in-form-control */}
-        <input {...rest} ref={ref} type="time" className={input()} />
+        <input
+          {...rest}
+          ref={ref}
+          type="time"
+          disabled={disabled}
+          readOnly={readOnly}
+          aria-invalid={error || undefined}
+          className={input()}
+        />
       </span>
     )
   },

--- a/packages/smarthr-ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/smarthr-ui/src/components/TimePicker/TimePicker.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, forwardRef } from 'react'
+import React, { ComponentPropsWithoutRef, forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 type Props = {
@@ -7,37 +7,47 @@ type Props = {
 }
 type ElementProps = Omit<ComponentPropsWithoutRef<'input'>, keyof Props>
 
-const wrapper = tv({
-  base: [
-    'smarthr-ui-TimePicker',
-    'shr-inline-block shr-border-shorthand shr-rounded-m shr-bg-white shr-px-0.5 shr-leading-none',
-    'contrast-more:shr-border-high-contrast',
-    'focus-within:shr-focus-indicator',
-  ],
+const timePicker = tv({
+  slots: {
+    wrapper: [
+      'smarthr-ui-TimePicker',
+      'shr-inline-block shr-border-shorthand shr-rounded-m shr-bg-white shr-px-0.5 shr-leading-none',
+      'contrast-more:shr-border-high-contrast',
+      'focus-within:shr-focus-indicator',
+    ],
+    inner: [
+      'shr-border-none shr-text-base shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-h-[theme(fontSize.base)] shr-tabular-nums',
+    ],
+  },
   variants: {
     disabled: {
-      true: 'shr-pointer-events-none shr-bg-white-darken [&&&]:shr-border-default/50',
+      true: {
+        wrapper: 'shr-pointer-events-none shr-bg-white-darken [&&&]:shr-border-default/50',
+      },
     },
     error: {
-      true: '[&]:shr-border-danger',
+      true: {
+        wrapper: '[&]:shr-border-danger',
+      },
     },
     readOnly: {
-      true: '[&&&]:shr-border-[theme(backgroundColor.background)] [&&&]:shr-bg-background',
+      true: {
+        wrapper: '[&&&]:shr-border-[theme(backgroundColor.background)] [&&&]:shr-bg-background',
+      },
     },
-  },
-})
-
-const inner = tv({
-  slots: {
-    input:
-      'shr-border-none shr-text-base shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-h-[theme(fontSize.base)] shr-tabular-nums',
   },
 })
 
 export const TimePicker = forwardRef<HTMLInputElement, Props & ElementProps>(
   ({ disabled, error, readOnly, className, ...rest }, ref) => {
-    const wrapperStyle = wrapper({ disabled, error, readOnly, className })
-    const { input } = inner()
+    const { wrapperStyle, innerStyle } = useMemo(() => {
+      const { wrapper, inner } = timePicker()
+      return {
+        wrapperStyle: wrapper({ className, disabled, error, readOnly }),
+        innerStyle: inner(),
+      }
+    }, [disabled, error, readOnly, className])
+
     return (
       <span className={wrapperStyle}>
         {/* eslint-disable-next-line smarthr/a11y-input-has-name-attribute, smarthr/a11y-input-in-form-control */}
@@ -48,7 +58,7 @@ export const TimePicker = forwardRef<HTMLInputElement, Props & ElementProps>(
           disabled={disabled}
           readOnly={readOnly}
           aria-invalid={error || undefined}
-          className={input()}
+          className={innerStyle}
         />
       </span>
     )


### PR DESCRIPTION
## Related URL

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

- N/A

## Overview

<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

- `TimePicker` コンポーネントに `Input` 等と同様のエラー時・読み取り専用時といった状態に応じたスタイリングをしたいです

## What I did

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

- props型を拡張し、スタイルをvariant化しました

## Capture

<!--
Please attach a capture if it looks different.
-->

下の3つが今回追加したものです

<img width="381" alt="通常時・非活性時・エラー時・読み取り専用時" src="https://github.com/user-attachments/assets/f1e429df-81ac-479e-b4f6-c2569ef0008b">
