### PR TITLE
feat: TextLink コンポーネントを react-router や Next のリンクコンポーネントでも使用できるようにする

### DIFF
--- a/packages/smarthr-ui/src/components/TextLink/TextLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.stories.tsx
@@ -2,6 +2,7 @@ import { StoryFn } from '@storybook/react'
 import React from 'react'
 import styled, { css } from 'styled-components'
 
+import { BaseColumn } from '../Base'
 import { FaAddressCardIcon } from '../Icon'
 
 import { TextLink } from './TextLink'
@@ -51,6 +52,22 @@ export const All: StoryFn = () => (
     <li>
       <TextLink href="/?path=/story/textlink--all" prefix={<FaAddressCardIcon />} target="_blank">
         健康保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者生年月日訂正届船員保険厚生年金保険被保険者資格記録訂正届船員保険厚生年金保険被保険者資格記録取消届船員保険被保険者離職事由訂正届基礎年金番号氏名生年月日性別変更（訂正）届
+      </TextLink>
+    </li>
+    <li>
+      <TextLink
+        href="/"
+        prefix={<FaAddressCardIcon />}
+        suffix={<FaAddressCardIcon />}
+        renderLink={(props) => (
+          <BaseColumn>
+            <a href={props.href} className={props.className}>
+              {props.children}
+            </a>
+          </BaseColumn>
+        )}
+      >
+        カスタムリンク要素
       </TextLink>
     </li>
   </Wrapper>

--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -11,6 +11,8 @@ type Props = {
   prefix?: ReactNode
   /** テキストの後ろに表示するアイコン */
   suffix?: ReactNode
+  /** react-router/Link や next/link などのカスタムリンク要素を差し込むためのレンダー関数 */
+  renderLink?: (props: { className: string; href: string; children: ReactNode }) => ReactNode
 }
 
 const textLink = tv({
@@ -26,7 +28,10 @@ const prefixWrapperClassName = prefixWrapper()
 const suffixWrapperClassName = suffixWrapper()
 
 export const TextLink = forwardRef<HTMLAnchorElement, Props & ElementProps>(
-  ({ href, target, rel, onClick, children, prefix, suffix, className, ...others }, ref) => {
+  (
+    { href, target, rel, onClick, children, prefix, suffix, className, renderLink, ...others },
+    ref,
+  ) => {
     const actualSuffix = useMemo(() => {
       if (target === '_blank' && suffix === undefined) {
         return <FaExternalLinkAltIcon aria-label="別タブで開く" />
@@ -63,6 +68,22 @@ export const TextLink = forwardRef<HTMLAnchorElement, Props & ElementProps>(
       }
     }, [href, onClick])
 
+    const actualChildren = (
+      <>
+        {prefix && <span className={prefixWrapperClassName}>{prefix}</span>}
+        {children}
+        {actualSuffix && <span className={suffixWrapperClassName}>{actualSuffix}</span>}
+      </>
+    )
+
+    if (renderLink && actualHref) {
+      return renderLink({
+        href: actualHref,
+        className: anchorClassName,
+        children: actualChildren,
+      })
+    }
+
     return (
       <a
         {...others}
@@ -73,9 +94,7 @@ export const TextLink = forwardRef<HTMLAnchorElement, Props & ElementProps>(
         onClick={actualOnClick}
         className={anchorClassName}
       >
-        {prefix && <span className={prefixWrapperClassName}>{prefix}</span>}
-        {children}
-        {actualSuffix && <span className={suffixWrapperClassName}>{actualSuffix}</span>}
+        {actualChildren}
       </a>
     )
   },


### PR DESCRIPTION
## Related URL

https://smarthr.atlassian.net/browse/SHRUI-1018 (のための下準備)

## Overview

`TextLink` コンポーネントは、テキストリンクのスタイルを整えたり属性を調整しつつ、`<a>` タグを展開してくれるコンポーネントだが、react-router や Next.js の Link コンポーネントといった、SPA 用のリンクで使用することが出来ない問題がある。

また、 `UpwardLink` コンポーネントも `TextLink` コンポーネントを使用するため、SPA 用途では使用できないといった二次的な問題にも繋がっている。

## What I did

`TextLink` コンポーネントに、任意のリンク用のコンポーネントを注入できる `renderLink` props を追加した。

これによって、例えば Next.js の `<Link>`(next/link) の場合は、以下のようにすることで `TextLink` の意匠、機能を引き継ぎつつ、ソフトナビゲーションを行うことができるようになる。

```tsx
<TextLink
  href={'/about'}
  renderLink={(props) => (
    <Link href={props.href} className={props.className}>
      {props.children}
    </Link>
  )}
  prefix={<FaArrowUpIcon />}
  suffix={<FaArrowDownIcon />}
>
  About Page
</TextLink>
```

## Capture

前述の Next.js での実行例。 TextLink のスタイルが適用され、prefix/suffix が使用できる上、　`/about` へのソフトナビゲーションができる。

![CleanShot 2024-08-22 at 18 30 38](https://github.com/user-attachments/assets/c9703d9a-1043-432e-8f95-8d5e669c6fa3)
