### PR TITLE
feat: TextLinkをnext/linkなどのラップされたコンポーネントに対応

### DIFF
--- a/packages/smarthr-ui/src/components/UpwardLink/UpwardLink.tsx
+++ b/packages/smarthr-ui/src/components/UpwardLink/UpwardLink.tsx
@@ -15,14 +15,17 @@ const upwardLink = tv({
 })
 
 type Props = Omit<ComponentProps<typeof TextLink>, 'prefix' | 'suffix'> &
-  VariantProps<typeof upwardLink>
+  VariantProps<typeof upwardLink> & {
+    /** `TextLink`に渡す `elementAs` をオプションで指定 */
+    elementAs?: ComponentProps<typeof TextLink>['elementAs']
+  }
 
-export const UpwardLink: React.FC<Props> = ({ indent = true, className, ...rest }) => {
+export const UpwardLink: React.FC<Props> = ({ indent = true, className, elementAs, ...rest }) => {
   const style = upwardLink({ indent, className })
   return (
     <div className={style}>
       {/* eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute */}
-      <TextLink {...rest} prefix={<FaArrowLeftIcon />} />
+      <TextLink {...rest} elementAs={elementAs} prefix={<FaArrowLeftIcon />} />
     </div>
   )
 }

--- a/sandbox/next/src/app/about/page.tsx
+++ b/sandbox/next/src/app/about/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+import Link from 'next/link'
+import { Heading, Section, UpwardLink } from 'smarthr-ui'
+
+export default function About() {
+  return (
+    <main>
+      <Section>
+        <Heading>Welcome to the About Page</Heading>
+      </Section>
+
+      <UpwardLink elementAs={Link} href="/" indent={false}>
+        前へ戻る
+      </UpwardLink>
+    </main>
+  )
+}

--- a/sandbox/next/src/app/page.tsx
+++ b/sandbox/next/src/app/page.tsx
@@ -1,7 +1,26 @@
 'use client'
-
-import { Button } from 'smarthr-ui'
+import Link from 'next/link'
+import { Button, FaAddressCardIcon, FaArrowRightIcon, TextLink } from 'smarthr-ui'
 
 export default function Home() {
-  return <Button variant="primary">Hello, Next.</Button>
+  return (
+    <main>
+      <Button variant="primary">Hello, Next.</Button>
+      <ol>
+        <li>
+          <Link href="/about">next/link</Link>
+        </li>
+        <li>
+          <TextLink elementAs={Link} href="/about" suffix={<FaArrowRightIcon />}>
+            smarthr-ui with next/link
+          </TextLink>
+        </li>
+        <li>
+          <TextLink elementAs={Link} href="/about" prefix={<FaAddressCardIcon />}>
+            smarthr-ui with next/link
+          </TextLink>
+        </li>
+      </ol>
+    </main>
+  )
 }


### PR DESCRIPTION
## Related URL
https://smarthr.atlassian.net/browse/SHRUI-1018

<!--
the relevant ticket or issue link.

e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
-->

## Overview
`UpwardLink` をSPA対応するために、内部で使われている `TextLink`コンポーネントに`elementAs`プロパティを追加しました。この`elementAs`プロパティに要素を指定した場合、指定された要素に固有の`props`が自動的に引き継がれるようになります。


<!--
Summary of this change.

e.g.
- Why are you making this change
- What is the problem
- How this solves
-->

## What I did
- `TextLink`コンポーネントにジェネリック型`T`を導入しました。
- この変更は、既存の`TextLink`コンポーネントの使用方法に影響を与えません。
- `elementAs`と定義したのはnext/linkが[`as`](https://github.com/vercel/next.js/blob/d588515c62b5058ff36df66308a2242dab6229b8/packages/next/src/client/link.tsx#L45)というpropsを持っていたので被りが発生しないようにしています。

next/linkを利用した場合

```tsx
import Link from 'next/link'
import { TextLink, UpwardLink } from 'smarthr-ui'

<TextLink elementAs={Link} href="/about" suffix={<FaArrowRightIcon />}>
  smarthr-ui with next/link
</TextLink>

<UpwardLink elementAs={Link} href="/" indent={false}>
  前へ戻る
</UpwardLink>
```

<!--
What kind of changes were made specifically.

e.g.
- Description of changes from a technical point of view
-->

## Capture
nextのSandbox環境での例
TextLinkのStyleを適用しつつ next/linkが問題なく動作する
![image](https://github.com/user-attachments/assets/2022eec3-c3af-473b-a212-3356f49e9b40)


<!--
Please attach a capture if it looks different.
-->
