### PR TITLE
chore: Node のバージョンアップは renovate では行わないようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
       "matchCurrentVersion": "!/^0/",
       "schedule": ["after 8am and before 5pm on Monday"],
       "automerge": false
+    },
+    {
+      "packagePatterns": ["cimg/node"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Related URL

関連JIRA
https://smarthr.atlassian.net/browse/SHRUI-1015

関連PR
https://github.com/kufu/smarthr-ui/pull/4878

関連スレ(社内)
https://kufuinc.slack.com/archives/CGC58MW01/p1724288220410419

## Overview

本リポジトリでは、CircleCI で単体テストなどを動かしており、その際に使用する Node のバージョンとして、LTS バージョンと maintenance バージョンを指定して回している。

しかし、関連PRの通り、renovate がすべてひっくるめて最新版にバージョンアップしようとするため、うっかりマージしてしまって意図に反したバージョンでテストが実行されることが複数回あった。

CI で使用する Node のバージョンを正確に調整する必要性も無さそうなので、renovate 自体を無効化することにした。

## What I did

renovate の設定ファイルを更新し、`cimg/node` はバージョンアップの対象外とする