### PR TITLE
fix: `Dropdown` でメニュー表示時に最後のアイテムで `Tab` を押したら、 `Trigger` の次のアイテムに focus する

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
@@ -49,11 +49,8 @@ export function useKeyboardNavigation(
           trigger.focus()
         } else if (!e.shiftKey && e.target === lastTabbable) {
           // move focus next of the Trigger
-          const rootTriggers = tabbable(rootTriggerRef.current)
-          const rootTrigger = rootTriggers[rootTriggers.length - 1]
-          if (rootTrigger) {
-            rootTrigger.focus()
-          }
+          e.preventDefault()
+          firstTabbable.focus() // Dropdown内の最初の要素にフォーカスを移動
         }
       } else if (e.key === 'Escape' || e.key === 'Esc') {
         if (triggerElementRef.current) {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
[JIRA](https://smarthr.atlassian.net/browse/SHRUI-676)

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要
### これまで
- ドロップダウンメニューを開いた状態でTab移動を続けると、最後のフォーカス可能なアイテムでTabを押したタイミングでメニュー外にフォーカスがあたってしまっていた。

### これから
- ドロップダウンメニュー内の最後のフォーカス可能なアイテムでTabを押すと、ドロップダウンメニュー内の最初のアイテムにフォーカスが移動する仕様に変更。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
