### PR TITLE
chore: types/reactの型定義更新に伴うエラーを修正

### DIFF
--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -3,7 +3,9 @@ import React, {
   ComponentPropsWithoutRef,
   ElementType,
   FC,
+  PropsWithoutRef,
   ReactNode,
+  Ref,
   forwardRef,
   useMemo,
 } from 'react'
@@ -60,8 +62,8 @@ export const TextLink: TextLinkComponent = forwardRef(
       suffix,
       className,
       ...others
-    }: Props<T> & ElementProps<T>,
-    ref: ElementRef<T>,
+    }: PropsWithoutRef<Props<T>> & ElementProps<T>,
+    ref: Ref<ElementRef<T>>,
   ) => {
     const Component = elementAs || 'a'
     const actualSuffix = useMemo(() => {

--- a/packages/smarthr-ui/src/libs/util.ts
+++ b/packages/smarthr-ui/src/libs/util.ts
@@ -1,4 +1,10 @@
-import React, { type ReactNode, type Ref, type RefAttributes, forwardRef } from 'react'
+import React, {
+  type PropsWithoutRef,
+  type ReactNode,
+  type Ref,
+  type RefAttributes,
+  forwardRef,
+} from 'react'
 
 export const includeDisabledTrigger = (trigger: React.ReactNode) =>
   React.Children.map(trigger, (t) => React.isValidElement(t) && t.props.disabled)?.some(
@@ -8,5 +14,5 @@ export const includeDisabledTrigger = (trigger: React.ReactNode) =>
 /** forwardRef でジェネリクスを使うためのラッパー
  * via https://www.totaltypescript.com/forwardref-with-generic-components */
 export const genericsForwardRef = <T, P = object>(
-  render: (props: P, ref: Ref<T>) => ReactNode,
+  render: (props: PropsWithoutRef<P>, ref: Ref<T>) => ReactNode,
 ): ((props: P & RefAttributes<T>) => ReactNode) => forwardRef(render) as any


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://github.com/kufu/smarthr-ui/pull/4885

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

@types/react 18.3.5で forwardRefの型定義が更新されたため
TextLinkとutil.tsでエラーが発生していた

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

forwardRef に期待される props の型にあうように修正

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

ローカルで@types/react 18.3.5で問題なくBuildが出来ることを確認済

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
