### PR TITLE
fix: Dialog 背景に z-index を追加

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ActionDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ActionDialog.stories.tsx
@@ -52,6 +52,8 @@ export const Action_Dialog: StoryFn = () => {
         aria-haspopup="dialog"
         aria-controls="dialog-action"
         data-test="dialog-trigger"
+        // 別のスタッキングコンテキストがダイアログ背景よりも上に来ないことを確認するための記述
+        style={{ position: 'relative', zIndex: 21 }}
       >
         ActionDialog
       </Button>

--- a/packages/smarthr-ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.stories.tsx
@@ -73,6 +73,8 @@ export const Default: StoryFn = () => {
           aria-haspopup="dialog"
           aria-controls="dialog-default"
           data-test="dialog-trigger"
+          // 別のスタッキングコンテキストがダイアログ背景よりも上に来ないことを確認するための記述
+          style={{ zIndex: 21, position: 'relative' }}
         >
           Dialog
         </Button>
@@ -188,6 +190,8 @@ export const Form_Dialog: StoryFn = () => {
         aria-haspopup="dialog"
         aria-controls="dialog-form"
         data-test="dialog-trigger"
+        // 別のスタッキングコンテキストがダイアログ背景よりも上に来ないことを確認するための記述
+        style={{ position: 'relative', zIndex: 21 }}
       >
         FormDialog
       </Button>

--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -20,7 +20,7 @@ type Props = PropsWithChildren<
 
 const dialogOverlap = tv({
   base: [
-    'shr-absolute shr-inset-0',
+    'shr-absolute shr-inset-0 shr-z-overlap-base',
     '[&.shr-dialog-transition-enter]:shr-opacity-0',
     '[&.shr-dialog-transition-enter-active]:shr-transition-opacity',
     '[&.shr-dialog-transition-enter-active]:shr-duration-300',

--- a/packages/smarthr-ui/src/components/Dialog/MessageDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/MessageDialog.stories.tsx
@@ -61,6 +61,8 @@ export const Message_Dialog: StoryFn = () => {
         aria-haspopup="dialog"
         aria-controls="dialog-message"
         data-test="dialog-trigger"
+        // 別のスタッキングコンテキストがダイアログ背景よりも上に来ないことを確認するための記述
+        style={{ position: 'relative', zIndex: 21 }}
       >
         MessageDialog
       </Button>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

一部環境においてスタッキングコンテキストの発生した特定要素がダイアログ背景よりも上に現れてしまう不具合を修正します。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

ダイアログ背景の `shr-z-overlap-base` を消したのが原因だったため、戻しました。
https://github.com/kufu/smarthr-ui/pull/4848/files#diff-41a98e1c7f207238823888de15eee54e035b490d73a741f885cd1e7b834a15ebL20 

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

各ダイアログの Story にスタッキングコンテキストを追加したので、Chromatic に差分がでていなければ問題ありません。
