### PR TITLE
fix: SideMenuのPropsにchildrenを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Experimental/SideMenu/SideMenu.tsx
+++ b/packages/smarthr-ui/src/components/Experimental/SideMenu/SideMenu.tsx
@@ -7,7 +7,10 @@ const sideMenu = tv({
   base: 'smarthr-ui-SideMenu shr-list-none shr-py-0.5',
 })
 
-type Props = Pick<ComponentPropsWithoutRef<typeof Base>, 'radius' | 'layer' | 'className'> & {
+type Props = Pick<
+  ComponentPropsWithoutRef<typeof Base>,
+  'radius' | 'layer' | 'className' | 'children'
+> & {
   /**
    * @default ul
    */

--- a/packages/smarthr-ui/src/components/Experimental/SideMenu/SideMenu.tsx
+++ b/packages/smarthr-ui/src/components/Experimental/SideMenu/SideMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef, FC, useMemo } from 'react'
+import React, { ComponentPropsWithoutRef, FC, PropsWithChildren, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Base } from '../../Base'
@@ -7,9 +7,8 @@ const sideMenu = tv({
   base: 'smarthr-ui-SideMenu shr-list-none shr-py-0.5',
 })
 
-type Props = Pick<
-  ComponentPropsWithoutRef<typeof Base>,
-  'radius' | 'layer' | 'className' | 'children'
+type Props = PropsWithChildren<
+  Pick<ComponentPropsWithoutRef<typeof Base>, 'radius' | 'layer' | 'className'>
 > & {
   /**
    * @default ul


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
https://github.com/kufu/smarthr-ui/pull/4895
<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要
SideMenuのPropsから`children`が消えており、子要素を受け付けることができなくなっているので追加したい。
<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容
`PropsWithChildren`を利用して`children`を追加した。
<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法
コードを読んで修正方法が正しそうか確認。
型定義のみの変更なので挙動に変化はありません。
<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
