### PR TITLE
feat!: useId の独自実装を削除し、React 18 未満のサポートを終了する

### DIFF
--- a/packages/smarthr-ui/package.json
+++ b/packages/smarthr-ui/package.json
@@ -91,8 +91,8 @@
     "webpack": "^5.94.0"
   },
   "peerDependencies": {
-    "react": "16.13.0 || ^17.0.1 || ^18.0.0",
-    "react-dom": "16.13.0 || ^17.0.1 || ^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "styled-components": "^5.0.1"
   },
   "bugs": {

--- a/packages/smarthr-ui/src/hooks/useId.test.ts
+++ b/packages/smarthr-ui/src/hooks/useId.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react'
+
+import { useId } from './useId'
+
+describe('useId', () => {
+  it('defaultId を指定した場合、毎回同じ値を返す', () => {
+    const { result: id1 } = renderHook(() => useId('test'))
+    const { result: id2 } = renderHook(() => useId('test'))
+    const { result: id3 } = renderHook(() => useId('test'))
+
+    expect(id1.current).toEqual('test')
+    expect(id2.current).toEqual('test')
+    expect(id3.current).toEqual('test')
+  })
+
+  it('defaultId を指定しない場合、異なる値を返す', () => {
+    const { result: id1 } = renderHook(() => useId())
+    const { result: id2 } = renderHook(() => useId())
+    const { result: id3 } = renderHook(() => useId())
+
+    expect(id1.current).not.toEqual(id2.current)
+    expect(id2.current).not.toEqual(id3.current)
+    expect(id3.current).not.toEqual(id1.current)
+  })
+})

--- a/packages/smarthr-ui/src/hooks/useId.tsx
+++ b/packages/smarthr-ui/src/hooks/useId.tsx
@@ -1,35 +1,7 @@
-import React, { ReactNode, VFC, createContext, useContext, useMemo } from 'react'
-
-type IdContextValue = {
-  prefix: number
-  current: number
-}
-
-const defaultContext: IdContextValue = {
-  prefix: 0,
-  current: 0,
-}
-
-const IdContext = createContext<IdContextValue>(defaultContext)
-
-function useId_OLD() {
-  const context = useContext(IdContext)
-  return useMemo(() => `id-${context.prefix}-${++context.current}`, [context])
-}
+import React from 'react'
 
 export const useId = (defaultId?: string): string => {
   if (defaultId) return defaultId
-
-  // React v18 以降は React.useId を使う
-  return ('useId' in React ? React.useId : useId_OLD)()
-}
-
-export const SequencePrefixIdProvider: VFC<{ children: ReactNode }> = ({ children }) => {
-  const context = useContext(IdContext)
-  // increment `prefix` and reset `current` to 0 on every Provider
-  const value: IdContextValue = {
-    prefix: context.prefix + 1,
-    current: 0,
-  }
-  return <IdContext.Provider value={value}>{children}</IdContext.Provider>
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return React.useId()
 }

--- a/packages/smarthr-ui/src/hooks/useId.tsx
+++ b/packages/smarthr-ui/src/hooks/useId.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 export const useId = (defaultId?: string): string => {
-  if (defaultId) return defaultId
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  return React.useId()
+  const id = React.useId()
+  return defaultId || id
 }

--- a/packages/smarthr-ui/src/index.ts
+++ b/packages/smarthr-ui/src/index.ts
@@ -127,6 +127,3 @@ export { defaultBreakpoint } from './themes/createBreakpoint'
 
 // constants
 export { FONT_FAMILY, CHART_COLORS, OTHER_CHART_COLOR } from './constants'
-
-// utils
-export { SequencePrefixIdProvider } from './hooks/useId'


### PR DESCRIPTION
## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1047

## 概要

React 17 以下にも提供していた独自の `userId` の仕組みを廃止します。これによって事実上 React 18 未満のサポートを終了します。

## 変更内容

SmartHR UI が提供する `useId` は、React 組み込みの `useId` をラップし、一部機能を拡張して提供しています。

その中で、useId が存在しない React 18 未満でも使用できるように、同等の機能を独自実装していました。

独自実装では `useContext` が使われていますが、これによって、 `useId` を使用している各種コンポーネントがサーバーコンポーネントとして利用できない問題が発生しています。

RSC 対応を進めたいという気持ちと、React 18 未満のサポートはぼちぼち終了しても良さそうという背景から、独自実装を廃止し、React 18 のみをサポートするように変更します。

## 確認方法

React 18 を使用している場合には影響は一切ありません。

React 17 以下を使用している場合、SmartHR UI を使用することができなくなるため、SmartHR UI のバージョンアップを止めるか、React をバージョンアップしてください。