### PR TITLE
fix: Table コンポーネントの使われていない記述を削除

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -1,11 +1,5 @@
-import React, { ComponentProps, FC, PropsWithChildren, createContext, useMemo } from 'react'
+import React, { ComponentProps, FC, PropsWithChildren, useMemo } from 'react'
 import { VariantProps, tv } from 'tailwind-variants'
-
-export const TableGroupContext = createContext<{
-  group: 'head' | 'body'
-}>({
-  group: 'body',
-})
 
 type Props = PropsWithChildren<VariantProps<typeof table>>
 type ElementProps = Omit<ComponentProps<'table'>, keyof Props>


### PR DESCRIPTION
## 関連URL

なし

## 概要

Table コンポーネントに使用されていないコードが残っていたので削除したい

## 変更内容

- createContext でコンテキストを作っていた処理を削除
  - 以前使っていた名残の消し忘れっぽい
  - これがなくなると、Table コンポーネントが Server Component から使用できるようになります
    - Th がまだ Server Component から使えないのでこの PR 単体だとあんまり意味ないけど…

## 確認方法

Story で Table が以前同様動いていれば ok
