### PR TITLE
fix: ダイアログの背景がスクロールに依ってズレる不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -20,7 +20,7 @@ type Props = PropsWithChildren<
 
 const dialogOverlap = tv({
   base: [
-    'shr-absolute shr-inset-0 shr-z-overlap-base',
+    'shr-fixed shr-inset-0 shr-z-overlap-base',
     '[&.shr-dialog-transition-enter]:shr-opacity-0',
     '[&.shr-dialog-transition-enter-active]:shr-transition-opacity',
     '[&.shr-dialog-transition-enter-active]:shr-duration-300',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

画面をスクロールした状態でダイアログを開くとダイアログ背景がズレる不具合を修正しました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

ダイアログ背景の `position: absolute` を `position: fixed` に変更しました。

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Dialog の With Scroll Story で確認できます。
https://63d0ccabb5d2dd29825524ab-qumxppnwwd.chromatic.com/?path=/story/dialog%EF%BC%88%E3%83%80%E3%82%A4%E3%82%A2%E3%83%AD%E3%82%B0%EF%BC%89-dialog--with-scroll
