### PR TITLE
refactor: [RadioButton]コンポーネントのpropsやstateに依存関係のないものは関数外で定義した

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
@@ -52,18 +52,20 @@ const radioButton = tv({
   },
 })
 
+const { wrapper, innerWrapper, box, input, label } = radioButton()
+const innerWrapperStyle = innerWrapper()
+const inputStyle = input()
+
 export const RadioButton = forwardRef<HTMLInputElement, Props>(
   ({ onChange, children, className, required, ...props }, ref) => {
-    const { wrapperStyle, innerWrapperStyle, boxStyle, inputStyle, labelStyle } = useMemo(() => {
-      const { wrapper, innerWrapper, box, input, label } = radioButton()
-      return {
+    const { wrapperStyle, boxStyle, labelStyle } = useMemo(
+      () => ({
         wrapperStyle: wrapper({ className }),
-        innerWrapperStyle: innerWrapper(),
         boxStyle: box({ disabled: !!props.disabled }),
-        inputStyle: input(),
         labelStyle: label({ disabled: !!props.disabled }),
-      }
-    }, [className, props.disabled])
+      }),
+      [className, props.disabled],
+    )
 
     const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
       (e) => {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

タイトルの通りで、特にコンポーネント内部で定義する必要がないものについてはコンポーネント外で定義しました。
再レンダリング時に再評価されるのを防いだり、直接的にコンポーネントのpropsやstateの依存関係のない静的なものはコンポーネント外で出すことでコードを見やすくするため。

## 変更内容

マージ後なにも影響はない想定です。

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
