### PR TITLE
fix: ModelessDialog に指定した幅や高さを超えて resize できるように修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
@@ -89,8 +89,7 @@ const CLOSE_BUTTON_ICON_ALT = '閉じる'
 
 const modelessDialog = tv({
   slots: {
-    layout: 'smarthr-ui-ModelessDialog shr-fixed',
-    box: 'smarthr-ui-ModelessDialog-box shr-flex shr-h-full shr-max-h-full shr-flex-col',
+    wrapper: 'smarthr-ui-ModelessDialog shr-fixed shr-flex shr-flex-col',
     headerEl:
       'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5 hover:shr-bg-white-darken',
     dialogHandler: [
@@ -110,7 +109,7 @@ const modelessDialog = tv({
   variants: {
     resizable: {
       true: {
-        box: 'shr-resize shr-overflow-auto',
+        wrapper: 'shr-resize shr-overflow-auto',
       },
       false: {},
     },
@@ -144,19 +143,17 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
   const { spacing } = useTheme()
 
   const {
-    layoutStyle,
-    boxStyle,
+    wrapperStyle,
     headerStyle,
     titleStyle,
     dialogHandlerStyle,
     closeButtonLayoutStyle,
     footerStyle,
   } = useMemo(() => {
-    const { layout, box, headerEl, title, dialogHandler, closeButtonLayout, footerEl } =
+    const { wrapper, headerEl, title, dialogHandler, closeButtonLayout, footerEl } =
       modelessDialog()
     return {
-      layoutStyle: layout({ className }),
-      boxStyle: box({ resizable }),
+      wrapperStyle: wrapper({ resizable, className }),
       headerStyle: headerEl(),
       titleStyle: title(),
       dialogHandlerStyle: dialogHandler(),
@@ -164,7 +161,7 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
       footerStyle: footerEl(),
     }
   }, [className, resizable])
-  const boxStyleProps = useMemo(() => {
+  const wrapperStyleProps = useMemo(() => {
     const leftMargin = typeof left === 'number' ? `${left}px` : left
     const rightMargin = typeof right === 'number' ? `${right}px` : right
     /* TODO: 幅の定数指定は、トークンが決まり theme に入ったら差し替える */
@@ -177,10 +174,10 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
           }
         : undefined
     return {
-      className: boxStyle,
+      className: wrapperStyle,
       style,
     }
-  }, [boxStyle, left, right, spacing, width])
+  }, [wrapperStyle, left, right, spacing, width])
 
   const wrapperRef = useRef<HTMLDivElement>(null)
   const focusTargetRef = useRef<HTMLDivElement>(null)
@@ -310,8 +307,8 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
 
   useHandleEscape(
     useCallback(() => {
-      if (isOpen) {
-        onPressEscape && onPressEscape()
+      if (isOpen && onPressEscape) {
+        onPressEscape()
       }
     }, [isOpen, onPressEscape]),
   )
@@ -331,9 +328,11 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
         bounds={draggableBounds}
         nodeRef={wrapperRef}
       >
-        <div
+        <Base
           {...props}
-          className={layoutStyle}
+          {...wrapperStyleProps}
+          radius="m"
+          layer={3}
           style={{
             top: topStyle,
             left: leftStyle,
@@ -346,46 +345,44 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
           role="dialog"
           aria-labelledby={labelId}
         >
-          <Base {...boxStyleProps} radius="m" layer={3}>
-            <div tabIndex={-1} ref={focusTargetRef}>
-              {/* dummy element for focus management. */}
-            </div>
-            <div className={headerStyle}>
-              <div
-                className={dialogHandlerStyle}
-                tabIndex={0}
-                role="slider"
-                aria-label={dialogHandlerAriaLabel}
-                aria-valuetext={dialogHandlerAriaValuetext}
-                onKeyDown={handleArrowKey}
-              >
-                <FaGripIcon />
-              </div>
-              <div id={labelId} className={titleStyle}>
-                {header}
-              </div>
-              <div className={closeButtonLayoutStyle}>
-                <Button
-                  type="button"
-                  size="s"
-                  square
-                  onClick={onClickClose}
-                  className="smarthr-ui-ModelessDialog-closeButton"
-                >
-                  <FaXmarkIcon alt={closeButtonIconAlt} />
-                </Button>
-              </div>
-            </div>
-            <DialogBody
-              contentBgColor={contentBgColor}
-              contentPadding={contentPadding}
-              className="smarthr-ui-ModelessDialog-content shr-overscroll-contain"
+          <div tabIndex={-1} ref={focusTargetRef}>
+            {/* dummy element for focus management. */}
+          </div>
+          <div className={headerStyle}>
+            <div
+              className={dialogHandlerStyle}
+              tabIndex={0}
+              role="slider"
+              aria-label={dialogHandlerAriaLabel}
+              aria-valuetext={dialogHandlerAriaValuetext}
+              onKeyDown={handleArrowKey}
             >
-              {children}
-            </DialogBody>
-            {footer && <div className={footerStyle}>{footer}</div>}
-          </Base>
-        </div>
+              <FaGripIcon />
+            </div>
+            <div id={labelId} className={titleStyle}>
+              {header}
+            </div>
+            <div className={closeButtonLayoutStyle}>
+              <Button
+                type="button"
+                size="s"
+                square
+                onClick={onClickClose}
+                className="smarthr-ui-ModelessDialog-closeButton"
+              >
+                <FaXmarkIcon alt={closeButtonIconAlt} />
+              </Button>
+            </div>
+          </div>
+          <DialogBody
+            contentBgColor={contentBgColor}
+            contentPadding={contentPadding}
+            className="smarthr-ui-ModelessDialog-content shr-overscroll-contain"
+          >
+            {children}
+          </DialogBody>
+          {footer && <div className={footerStyle}>{footer}</div>}
+        </Base>
       </Draggable>
     </DialogOverlap>,
   )


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1026

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

ModelessDialog に幅や高さを指定すると、その指定以上に resize できない問題を修正しました。

resize のスタイリングを持っている Base の親要素に幅や高さを指定しているため、親要素以上に広げられないのが原因でした。


<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

「幅や高さを指定している div > Base」という DOM を、Base に集約しました。tailwlind 上では layout > box となっていたのを wrapper としました。


また [no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions/) でエラーが出ていたので合わせて修正しました。

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
