### PR TITLE
docs(SideMenu): SideMenuGroupを使用しないサンプルを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Experimental/SideMenu/SideMenu.stories.tsx
+++ b/packages/smarthr-ui/src/components/Experimental/SideMenu/SideMenu.stories.tsx
@@ -13,6 +13,19 @@ export default {
 export const Default: StoryFn = () => (
   <div className="shr-bg-background shr-p-2 shr-max-w-[15rem]">
     <SideMenu>
+      <SideMenuItem href="#">アカウント</SideMenuItem>
+      <SideMenuItem href="#" current>
+        認証設定
+      </SideMenuItem>
+      <SideMenuItem href="#">評価項目の表示設定</SideMenuItem>
+      <SideMenuItem href="#">評価対象者の入力必須項目設定</SideMenuItem>
+    </SideMenu>
+  </div>
+)
+
+export const Grouped: StoryFn = () => (
+  <div className="shr-bg-background shr-p-2 shr-max-w-[15rem]">
+    <SideMenu>
       <SideMenuGroup title="個人設定">
         <SideMenuItem href="#">アカウント</SideMenuItem>
         <SideMenuItem href="#" current>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/CDG1XRPTP/p1727146089496589?thread_ts=1726813803.339369&cid=CDG1XRPTP

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- SideMenuのStorybookにSideMenuGroupを使わない例を追加した

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- SideMenuのStorybookにSideMenuGroupを使わない例を追加した
  - `Default` にSideMenuGroupを使わないシンプルなものを設置
  - 今までのものを `Grouped` に改名

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

https://63d0ccabb5d2dd29825524ab-ymnkzwtxnh.chromatic.com/?path=/docs/experimental%EF%BC%88%E5%AE%9F%E9%A8%93%E7%9A%84%EF%BC%89-sidemenu--docs

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
