### PR TITLE
docs: TabBar の Story を見直し

### DIFF
--- a/packages/smarthr-ui/.storybook/main.ts
+++ b/packages/smarthr-ui/.storybook/main.ts
@@ -61,9 +61,6 @@ const config: StorybookConfig = {
     options: {},
   },
   staticDirs: ['../public'],
-  docs: {
-    autodocs: true,
-  },
   typescript: {
     reactDocgen: 'react-docgen-typescript',
   },

--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -102,6 +102,7 @@ const preview: Preview = {
       )
     },
   ],
+  tags: ['autodocs'],
 }
 
 export default preview

--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -75,6 +75,9 @@ const preview: Preview = {
           <Stories includePrimary={false} />
         </>
       ),
+      canvas: {
+        sourceState: 'shown',
+      },
     },
     chromatic: {
       forcedColors: 'none',

--- a/packages/smarthr-ui/src/components/TabBar/TabBar-bordered.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar-bordered.stories.tsx
@@ -1,0 +1,23 @@
+import TabBarStories from './TabBar.stories'
+
+import type { StoryObj } from '@storybook/react'
+
+export default {
+  ...TabBarStories,
+  title: 'Navigation（ナビゲーション）/TabBar/bordered',
+  tags: ['!autodocs'],
+}
+
+export const True: StoryObj = {
+  name: 'true',
+  args: {
+    bordered: true,
+  },
+}
+
+export const False = {
+  name: 'false',
+  args: {
+    bordered: false,
+  },
+}

--- a/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
@@ -1,54 +1,65 @@
 import { action } from '@storybook/addon-actions'
-import { StoryFn } from '@storybook/react'
-import { userEvent } from '@storybook/test'
-import React from 'react'
+import React, { type ComponentProps } from 'react'
 
-import { Badge } from '../Badge'
+import { Heading } from '../Heading'
 import { Stack } from '../Layout'
 
 import { TabBar } from './TabBar'
 import { TabItem } from './TabItem'
 
-export default {
-  title: 'Navigation（ナビゲーション）/TabBar',
-  component: TabBar,
-  subcomponents: { TabItem },
-}
+import type { Meta, StoryFn } from '@storybook/react'
 
-export const All: StoryFn = () => (
-  <Stack as="ul" className="shr-list-none">
-    <li>
-      <p>標準</p>
-      <Template subid={1} />
-    </li>
-    <li>
-      <p>下線なし</p>
-      <Template subid={2} bordered={false} />
-    </li>
-  </Stack>
-)
-
-const Template: StoryFn = ({ subid, ...props }) => (
-  <TabBar {...props}>
-    <TabItem id={`border-${subid}-1`} onClick={action('clicked')} selected>
-      基本情報
+const Template: StoryFn<ComponentProps<typeof TabBar>> = (args) => (
+  <TabBar {...args}>
+    <TabItem id="tab1" onClick={action('tab1')} selected>
+      タブ1
     </TabItem>
-    <TabItem id={`border-${subid}-2`} onClick={action('clicked')} suffix={<Badge count={7} />}>
-      コメント
-    </TabItem>
-    <TabItem
-      id={`border-${subid}-3`}
-      onClick={action('clicked')}
-      disabled
-      disabledDetail={{ message: 'この機能は使用できません。' }}
-    >
-      分析対象
+    <TabItem id="tab2" onClick={action('tab2')}>
+      タブ2
     </TabItem>
   </TabBar>
 )
 
-export const RegFocusBorder = All.bind({})
-RegFocusBorder.play = () => userEvent.tab()
+export default {
+  title: 'Navigation（ナビゲーション）/TabBar',
+  component: TabBar,
+  subcomponents: { TabItem },
+  render: Template,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+} as Meta<typeof TabBar>
 
-export const RegFocusNoBorder = All.bind({})
-RegFocusNoBorder.play = () => [...Array(4)].forEach((_) => userEvent.tab())
+export const Default = () => (
+  <TabBar>
+    <TabItem id="tab1" onClick={action('tab1')} selected>
+      タブ1
+    </TabItem>
+    <TabItem id="tab2" onClick={action('tab2')}>
+      タブ2
+    </TabItem>
+  </TabBar>
+)
+
+export const Playground = {
+  args: {
+    bordered: true,
+  },
+}
+
+export const Boardered = {
+  name: 'bordered',
+  render: () => (
+    <Stack gap={2} as="section">
+      <Heading>bordered</Heading>
+      <Stack as="section" gap={0.5}>
+        <Heading type="blockTitle">線あり（デフォルト）</Heading>
+        <Template bordered />
+      </Stack>
+      <Stack as="section" gap={0.5}>
+        <Heading type="blockTitle">線なし</Heading>
+        <Template bordered={false} />
+      </Stack>
+    </Stack>
+  ),
+}

--- a/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
@@ -1,65 +1,38 @@
 import { action } from '@storybook/addon-actions'
-import React, { type ComponentProps } from 'react'
-
-import { Heading } from '../Heading'
-import { Stack } from '../Layout'
+import React from 'react'
 
 import { TabBar } from './TabBar'
 import { TabItem } from './TabItem'
 
-import type { Meta, StoryFn } from '@storybook/react'
-
-const Template: StoryFn<ComponentProps<typeof TabBar>> = (args) => (
-  <TabBar {...args}>
-    <TabItem id="tab1" onClick={action('tab1')} selected>
-      タブ1
-    </TabItem>
-    <TabItem id="tab2" onClick={action('tab2')}>
-      タブ2
-    </TabItem>
-  </TabBar>
-)
+import type { Meta } from '@storybook/react'
 
 export default {
   title: 'Navigation（ナビゲーション）/TabBar',
   component: TabBar,
   subcomponents: { TabItem },
-  render: Template,
+  render: (args) => (
+    <TabBar {...args}>
+      <TabItem id="tab1" onClick={action('tab1')} selected>
+        タブ1
+      </TabItem>
+      <TabItem id="tab2" onClick={action('tab2')}>
+        タブ2
+      </TabItem>
+    </TabBar>
+  ),
   parameters: {
     chromatic: { disableSnapshot: true },
   },
 } as Meta<typeof TabBar>
 
-export const Default = () => (
-  <TabBar>
-    <TabItem id="tab1" onClick={action('tab1')} selected>
-      タブ1
-    </TabItem>
-    <TabItem id="tab2" onClick={action('tab2')}>
-      タブ2
-    </TabItem>
-  </TabBar>
-)
-
-export const Playground = {
+export const Default = {
   args: {
     bordered: true,
   },
 }
 
-export const Boardered = {
-  name: 'bordered',
-  render: () => (
-    <Stack gap={2} as="section">
-      <Heading>bordered</Heading>
-      <Stack as="section" gap={0.5}>
-        <Heading type="blockTitle">線あり（デフォルト）</Heading>
-        <Template bordered />
-      </Stack>
-      <Stack as="section" gap={0.5}>
-        <Heading type="blockTitle">線なし</Heading>
-        <Template bordered={false} />
-      </Stack>
-    </Stack>
-  ),
+export const Playground = {
+  args: {
+    bordered: true,
+  },
 }

--- a/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { TabBar } from './TabBar'
 import { TabItem } from './TabItem'
 
-import type { Meta } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 export default {
   title: 'Navigation（ナビゲーション）/TabBar',
@@ -25,13 +25,13 @@ export default {
   },
 } as Meta<typeof TabBar>
 
-export const Default = {
+export const Default: StoryObj<typeof TabBar> = {
   args: {
     bordered: true,
   },
 }
 
-export const Playground = {
+export const Playground: StoryObj<typeof TabBar> = {
   args: {
     bordered: true,
   },

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.stories.tsx
@@ -1,0 +1,96 @@
+import { action } from '@storybook/addon-actions'
+import { type ComponentProps } from 'react'
+import React from 'react'
+
+import { Badge } from '../Badge'
+import { Heading } from '../Heading'
+import { Stack } from '../Layout'
+
+import { TabItem } from './TabItem'
+
+import type { Meta, StoryFn } from '@storybook/react'
+
+const TemplateTabItem: StoryFn<ComponentProps<typeof TabItem>> = (args) => <TabItem {...args} />
+
+export default {
+  title: 'Navigation（ナビゲーション）/TabBar/TabItem',
+  component: TabItem,
+  render: TemplateTabItem,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+} as Meta<typeof TabItem>
+
+export const TabItemControl = {
+  name: 'Playground',
+  args: {
+    children: 'タブ',
+    id: 'tab1',
+    selected: true,
+    disabled: false,
+    onClick: action('clicked'),
+  },
+}
+
+export const Selected = {
+  name: 'selected',
+  render: () => (
+    <Stack gap={2} as="section">
+      <Heading>selected</Heading>
+      <div>
+        <TemplateTabItem id="tab1" onClick={action('clicked')} selected>
+          タブ
+        </TemplateTabItem>
+      </div>
+    </Stack>
+  ),
+}
+
+export const Disabled = {
+  name: 'disabled',
+  render: () => (
+    <Stack gap={2} as="section">
+      <Heading>disabled</Heading>
+      <div>
+        <TemplateTabItem id="tab1" onClick={action('clicked')} disabled>
+          タブ
+        </TemplateTabItem>
+      </div>
+    </Stack>
+  ),
+}
+
+export const Suffix = {
+  name: 'suffix',
+  render: () => (
+    <Stack gap={2} as="section">
+      <Heading>suffix</Heading>
+      <div>
+        <TemplateTabItem id="tab1" onClick={action('clicked')} suffix={<Badge count={1} />}>
+          タブ
+        </TemplateTabItem>
+      </div>
+    </Stack>
+  ),
+}
+
+export const DisabledDetail = {
+  name: 'disabledDetail',
+  render: () => (
+    <Stack gap={2} as="section">
+      <Heading>disabledDetail</Heading>
+      <div>
+        <TemplateTabItem
+          id="tab1"
+          onClick={action('clicked')}
+          disabled
+          disabledDetail={{
+            message: '無効な理由',
+          }}
+        >
+          タブ
+        </TemplateTabItem>
+      </div>
+    </Stack>
+  ),
+}

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.stories.tsx
@@ -5,7 +5,7 @@ import { Badge } from '../Badge'
 
 import { TabItem } from './TabItem'
 
-import type { Meta } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 export default {
   title: 'Navigation（ナビゲーション）/TabBar/TabItem',
@@ -21,7 +21,7 @@ export default {
   },
 } as Meta<typeof TabItem>
 
-export const TabItemControl = {
+export const TabItemControl: StoryObj<typeof TabItem> = {
   name: 'Playground',
   args: {
     selected: true,
@@ -29,28 +29,28 @@ export const TabItemControl = {
   },
 }
 
-export const Selected = {
+export const Selected: StoryObj<typeof TabItem> = {
   name: 'selected',
   args: {
     selected: true,
   },
 }
 
-export const Suffix = {
+export const Suffix: StoryObj<typeof TabItem> = {
   name: 'suffix',
   args: {
     suffix: <Badge count={1} />,
   },
 }
 
-export const Disabled = {
+export const Disabled: StoryObj<typeof TabItem> = {
   name: 'disabled',
   args: {
     disabled: true,
   },
 }
 
-export const DisabledDetail = {
+export const DisabledDetail: StoryObj<typeof TabItem> = {
   name: 'disabledDetail',
   args: {
     disabled: true,

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.stories.tsx
@@ -1,21 +1,21 @@
 import { action } from '@storybook/addon-actions'
-import { type ComponentProps } from 'react'
 import React from 'react'
 
 import { Badge } from '../Badge'
-import { Heading } from '../Heading'
-import { Stack } from '../Layout'
 
 import { TabItem } from './TabItem'
 
-import type { Meta, StoryFn } from '@storybook/react'
-
-const TemplateTabItem: StoryFn<ComponentProps<typeof TabItem>> = (args) => <TabItem {...args} />
+import type { Meta } from '@storybook/react'
 
 export default {
   title: 'Navigation（ナビゲーション）/TabBar/TabItem',
   component: TabItem,
-  render: TemplateTabItem,
+  render: (args) => <TabItem {...args} />,
+  args: {
+    children: 'タブ',
+    id: 'tab1',
+    onClick: action('clicked'),
+  },
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -24,73 +24,38 @@ export default {
 export const TabItemControl = {
   name: 'Playground',
   args: {
-    children: 'タブ',
-    id: 'tab1',
     selected: true,
     disabled: false,
-    onClick: action('clicked'),
   },
 }
 
 export const Selected = {
   name: 'selected',
-  render: () => (
-    <Stack gap={2} as="section">
-      <Heading>selected</Heading>
-      <div>
-        <TemplateTabItem id="tab1" onClick={action('clicked')} selected>
-          タブ
-        </TemplateTabItem>
-      </div>
-    </Stack>
-  ),
-}
-
-export const Disabled = {
-  name: 'disabled',
-  render: () => (
-    <Stack gap={2} as="section">
-      <Heading>disabled</Heading>
-      <div>
-        <TemplateTabItem id="tab1" onClick={action('clicked')} disabled>
-          タブ
-        </TemplateTabItem>
-      </div>
-    </Stack>
-  ),
+  args: {
+    selected: true,
+  },
 }
 
 export const Suffix = {
   name: 'suffix',
-  render: () => (
-    <Stack gap={2} as="section">
-      <Heading>suffix</Heading>
-      <div>
-        <TemplateTabItem id="tab1" onClick={action('clicked')} suffix={<Badge count={1} />}>
-          タブ
-        </TemplateTabItem>
-      </div>
-    </Stack>
-  ),
+  args: {
+    suffix: <Badge count={1} />,
+  },
+}
+
+export const Disabled = {
+  name: 'disabled',
+  args: {
+    disabled: true,
+  },
 }
 
 export const DisabledDetail = {
   name: 'disabledDetail',
-  render: () => (
-    <Stack gap={2} as="section">
-      <Heading>disabledDetail</Heading>
-      <div>
-        <TemplateTabItem
-          id="tab1"
-          onClick={action('clicked')}
-          disabled
-          disabledDetail={{
-            message: '無効な理由',
-          }}
-        >
-          タブ
-        </TemplateTabItem>
-      </div>
-    </Stack>
-  ),
+  args: {
+    disabled: true,
+    disabledDetail: {
+      message: '無効な理由',
+    },
+  },
 }

--- a/packages/smarthr-ui/src/components/TabBar/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/VRTTabBar.stories.tsx
@@ -1,148 +1,128 @@
 import { action } from '@storybook/addon-actions'
-import { StoryFn } from '@storybook/react'
 import { fireEvent, within } from '@storybook/test'
 import React from 'react'
-import styled from 'styled-components'
 
-import { InformationPanel } from '../InformationPanel'
+import { Badge } from '../Badge'
+import { FaCircleExclamationIcon } from '../Icon'
+import { Stack } from '../Layout'
 
 import { TabBar } from './TabBar'
-import { All } from './TabBar.stories'
 import { TabItem } from './TabItem'
 
+import type { StoryObj } from '@storybook/react'
+
 export default {
-  title: 'Navigation（ナビゲーション）/TabBar',
-  component: TabBar,
+  title: 'Navigation（ナビゲーション）/TabBar/VRT',
+  /* ペアワイズ法による網羅
+   * bordered selected diasbled suffix disabledDetail
+   * false    false    false    あり    なし
+   * false    true     true     なし    あり
+   * true     true     true     あり    なし
+   * true     false    true     なし    あり
+   * true     true     false    あり    あり
+   * true     false    false    なし    なし */
+  render: (args: any) => (
+    <Stack {...args}>
+      <TabBar bordered={false}>
+        <TabItem id="tab1" onClick={action('clicked')} suffix={<Badge count={100} />}>
+          タブ1
+        </TabItem>
+        <TabItem
+          id="tab2"
+          onClick={action('clicked')}
+          selected
+          disabled
+          disabledDetail={{ message: 'タブが無効な理由' }}
+        >
+          タブ2
+        </TabItem>
+      </TabBar>
+      <TabBar>
+        <TabItem
+          id="tab3"
+          onClick={action('clicked')}
+          selected
+          disabled
+          suffix={<Badge count={100} />}
+        >
+          タブ3
+        </TabItem>
+        <TabItem
+          id="tab4"
+          onClick={action('clicked')}
+          disabled
+          disabledDetail={{ message: 'タブが無効な理由' }}
+        >
+          タブ4
+        </TabItem>
+        <TabItem
+          id="tab5"
+          onClick={action('clicked')}
+          selected
+          suffix={<FaCircleExclamationIcon color="DANGER" />}
+          disabledDetail={{ message: 'タブが無効な理由' }}
+        >
+          タブ5
+        </TabItem>
+        <TabItem id="tab6" onClick={action('clicked')}>
+          タブ6
+        </TabItem>
+      </TabBar>
+    </Stack>
+  ),
   parameters: {
-    withTheming: true,
+    chromatic: { disableSnapshot: false },
   },
+  tags: ['!autodocs'],
 }
 
-export const VRTHover: StoryFn = () => (
-  <>
-    <VRTInformationPanel title="VRT 用の Story です">hoverの状態で表示されます</VRTInformationPanel>
-    <Ul>
-      <li>
-        <TabBar id="hover">
-          <TabItem id="border-1" onClick={action('clicked')}>
-            Tab
-          </TabItem>
-          <TabItem id="border-2" onClick={action('clicked')} selected>
-            Selected
-          </TabItem>
-          <TabItem id="border-3" onClick={action('clicked')} disabled>
-            Disabled
-          </TabItem>
-        </TabBar>
-      </li>
-    </Ul>
-  </>
-)
-VRTHover.parameters = {
-  controls: { hideNoControlsWarning: true },
-  pseudo: {
-    hover: ['#hover button'],
-  },
-}
+export const VRT = {}
 
-export const VRTUserFocus: StoryFn = () => (
-  <>
-    <VRTInformationPanel title="VRT 用の Story です">
-      ユーザー操作のfocusをシミュレートした状態で表示されます
-    </VRTInformationPanel>
-    <Ul>
-      <li>
-        <TabBar>
-          <TabItem id="border-1" onClick={action('clicked')}>
-            Tab
-          </TabItem>
-          <TabItem id="border-2" onClick={action('clicked')} selected>
-            Selected
-          </TabItem>
-          <TabItem id="border-3" onClick={action('clicked')} disabled>
-            Disabled
-          </TabItem>
-        </TabBar>
-      </li>
-    </Ul>
-  </>
-)
-VRTUserFocus.play = async ({ canvasElement }) => {
-  const canvas = await within(canvasElement)
-  const tabs = await canvas.getAllByRole('tab')
-  // fireEvent.focusでは内部的にdispatchEventメソッドを使用し、バインドされたハンドラのみのトリガーとなり、イベントを受け取った要素のUI（ブラウザ）の動作はトリガーされない
-  tabs[0].focus()
-}
-
-export const VRTScroll: StoryFn = () => (
-  <>
-    <VRTInformationPanel title="VRT 用の Story です">
-      画面幅が狭い状態でスクロールされるか確認します
-    </VRTInformationPanel>
-    <Ul>
-      <li>
-        <TabBar>
-          <TabItem id="border-1" onClick={action('clicked')}>
-            Tab1
-          </TabItem>
-          <TabItem id="border-2" onClick={action('clicked')}>
-            Tab2
-          </TabItem>
-          <TabItem id="border-3" onClick={action('clicked')}>
-            Tab3
-          </TabItem>
-          <TabItem id="border-4" onClick={action('clicked')}>
-            Tab4
-          </TabItem>
-          <TabItem id="border-5" onClick={action('clicked')}>
-            Tab5
-          </TabItem>
-          <TabItem id="border-6" onClick={action('clicked')}>
-            Tab6
-          </TabItem>
-        </TabBar>
-      </li>
-    </Ul>
-  </>
-)
-VRTScroll.parameters = {
-  viewport: {
-    defaultViewport: 'vrtMobile',
+export const VRTHover = {
+  ...VRT,
+  args: {
+    id: 'hover',
   },
-  chromatic: {
-    modes: {
-      vrtMobile: { viewport: 'vrtMobile' },
+  parameters: {
+    pseudo: {
+      hover: ['#hover .smarthr-ui-TabItem'],
     },
   },
 }
-VRTScroll.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement)
-  // nav要素の直下のdiv要素がスクロールする要素
-  const scrollableElement = await canvas.findByRole('tablist')
-  await fireEvent.scroll(scrollableElement, { target: { scrollLeft: 1000 } })
+
+export const VRTKeyboardFocus: StoryObj = {
+  ...VRT,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const tabs = canvas.getAllByRole('tab')
+    // bordered で disabledDetail が存在するアイテムにフォーカス
+    tabs[3].focus()
+  },
 }
 
-export const VRTForcedColors: StoryFn = () => (
-  <>
-    <VRTInformationPanel title="VRT 用の Story です">
-      Chromatic 上では強制カラーモードで表示されます
-    </VRTInformationPanel>
-    <All />
-  </>
-)
-VRTForcedColors.parameters = {
-  chromatic: { forcedColors: 'active' },
+export const VRTNarrowView: StoryObj = {
+  ...VRT,
+  parameters: {
+    viewport: {
+      defaultViewport: 'vrtMobile',
+    },
+    chromatic: {
+      modes: {
+        vrtMobile: { viewport: 'vrtMobile' },
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const tabs = canvas.getAllByRole('tablist')
+    const scrollableElement = tabs[1]
+    await fireEvent.scroll(scrollableElement, { target: { scrollLeft: 1000 } })
+  },
 }
 
-const VRTInformationPanel = styled(InformationPanel)`
-  margin-bottom: 24px;
-`
-
-const Ul = styled.ul`
-  padding: 0 1rem;
-
-  li {
-    margin-bottom: 1rem;
-    list-style: none;
-  }
-`
+export const VRTForcedColors: StoryObj = {
+  ...VRT,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/smarthr-ui/src/components/TabBar/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/VRTTabBar.stories.tsx
@@ -87,6 +87,8 @@ export const VRTHover = {
     pseudo: {
       hover: ['#hover .smarthr-ui-TabItem'],
     },
+    // MEMO: VRT として機能していないので、解決するまでスナップショットを無効化
+    chromatic: { disableSnapshot: true },
   },
 }
 

--- a/packages/smarthr-ui/test-runner-jest.config.js
+++ b/packages/smarthr-ui/test-runner-jest.config.js
@@ -42,5 +42,10 @@ module.exports = {
      * error: "ARIA attributes must conform to valid values"
      */
     'Dialog.stories.tsx',
+    /**
+     * TabItem を TabBar と組み合わせていないためにエラーが出ている。無視で良い。
+     * critical: "Required ARIA parent role not present: tablist"
+     */
+    'TabItem.stories.tsx',
   ],
 }


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1040

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

Story のあり方を定義し直し、他の見本となる Story を作ろうとしています。

構成は次の通りです。

Story 名 | 説明 | Chromatic 対象
--- | --- | :-:
Default | デザインシステムサイト用。過渡期として用意 | -
Playground | コンポーネントごとに必ず設置する Control | -
props 系 | id や onClick など汎用的なものは省略 | -
VRT | ペアワイズ法で props の組み合わせを網羅する | ✓

TabBar / TabItem のようにサブコンポーネントを持つ場合、コンポーネントごとに作成。

VRT を除いて、Story ごとに表示する状態は一つとしました。

ペアワイズ法の組み合わせ作成は、[pict](https://github.com/microsoft/pict) を使いました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
