### PR TITLE
feat: AppNaviAnchorにelementAsのpropsを追加

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNavi.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNavi.tsx
@@ -73,7 +73,7 @@ export const AppNavi: FC<Props & ElementProps> = ({
               )
             }
 
-            if ('href' in button || 'elementAs' in button) {
+            if ('href' in button) {
               return (
                 <li key={i} className={listItemStyle}>
                   {/* eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute */}

--- a/packages/smarthr-ui/src/components/AppNavi/AppNavi.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNavi.tsx
@@ -73,7 +73,7 @@ export const AppNavi: FC<Props & ElementProps> = ({
               )
             }
 
-            if ('href' in button) {
+            if ('href' in button || 'elementAs' in button) {
               return (
                 <li key={i} className={listItemStyle}>
                   {/* eslint-disable-next-line smarthr/a11y-anchor-has-href-attribute */}

--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviAnchor.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviAnchor.tsx
@@ -1,18 +1,40 @@
-import React, { FC, PropsWithChildren, useMemo } from 'react'
+import React, {
+  ComponentPropsWithoutRef,
+  ComponentType,
+  ElementType,
+  FC,
+  PropsWithoutRef,
+  ReactElement,
+  Ref,
+  forwardRef,
+  useMemo,
+} from 'react'
 import { tv } from 'tailwind-variants'
 
+import { ElementRef, ElementRefProps } from '../../types'
 import { ComponentProps as IconProps } from '../Icon'
 
 import { appNaviItemStyle } from './style'
 
-export type AppNaviAnchorProps = PropsWithChildren<{
+type ElementProps<T extends ElementType> = Omit<
+  ComponentPropsWithoutRef<T>,
+  keyof AppNaviAnchorProps<T> & ElementRefProps<T>
+>
+
+export type AppNaviAnchorProps<T extends ElementType = 'a'> = {
   /** アンカーの href */
-  href: string
+  href?: string
   /** 表示するアイコンタイプ */
-  icon?: React.ComponentType<IconProps>
+  icon?: ComponentType<IconProps>
   /** アクティブ状態であるかどうか */
   current?: boolean
-}>
+  /** next/link などのカスタムコンポーネントを指定します。指定がない場合はデフォルトで `a` タグが使用されます。 */
+  elementAs?: T
+}
+
+type AppNaviAnchorComponent = <T extends ElementType = 'a'>(
+  props: AppNaviAnchorProps<T> & ElementProps<T> & ElementRefProps<T>,
+) => ReturnType<FC>
 
 const appNaviAnchor = tv({
   extend: appNaviItemStyle,
@@ -21,24 +43,39 @@ const appNaviAnchor = tv({
   },
 })
 
-export const AppNaviAnchor: FC<AppNaviAnchorProps> = ({
-  children,
-  href,
-  icon: Icon,
-  current = false,
-}) => {
-  const { wrapperStyle, iconStyle } = useMemo(() => {
-    const { wrapper, icon } = appNaviAnchor({ active: current })
-    return {
-      wrapperStyle: wrapper(),
-      iconStyle: icon(),
-    }
-  }, [current])
+export const AppNaviAnchor: AppNaviAnchorComponent = forwardRef(
+  <T extends ElementType = 'a'>(
+    {
+      children,
+      href,
+      icon: Icon,
+      current = false,
+      elementAs,
+      ...others
+    }: PropsWithoutRef<AppNaviAnchorProps<T>> & ElementProps<T>,
+    ref: Ref<ElementRef<T>>,
+  ): ReactElement => {
+    const { wrapperStyle, iconStyle } = useMemo(() => {
+      const { wrapper, icon } = appNaviAnchor({ active: current })
+      return {
+        wrapperStyle: wrapper(),
+        iconStyle: icon(),
+      }
+    }, [current])
 
-  return (
-    <a aria-current={current ? 'page' : undefined} href={href} className={wrapperStyle}>
-      {Icon && <Icon className={iconStyle} />}
-      {children}
-    </a>
-  )
-}
+    const Component = elementAs || 'a'
+
+    return (
+      <Component
+        {...others}
+        ref={ref}
+        href={href}
+        aria-current={current ? 'page' : undefined}
+        className={wrapperStyle}
+      >
+        {Icon && <Icon className={iconStyle} />}
+        {children}
+      </Component>
+    )
+  },
+)


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1062

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

他のLink Componentと同様に`elementAs`をサポートしました

## 変更内容

`elementAs`で任意のnext/linkなどを渡せるようになっています

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

sandbox環境などで確認

```tsx
  <AppNavi label="機能名">
    <AppNaviAnchor elementAs={Link} href="/about" current>
      アンカーボタン
    </AppNaviAnchor>
  </AppNavi>
```

`buttons`についてはdeprecatedなので最低限使えるレベルの対応になってます

```ts
const buttons: = [
  {
    onClick: () => console.log('click'),
    children: 'ボタン',
  },
  {
    elementAs: Link,
    href: '/about',
    current: true,
    children: 'アンカーボタン',
  },
]
```

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
