### PR TITLE
fix: SearchInputのwrapperであるlabel要素に対してwidthを指定する

### DIFF
--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.stories.tsx
@@ -2,7 +2,8 @@ import { Meta, StoryObj } from '@storybook/react'
 import React from 'react'
 import styled, { css } from 'styled-components'
 
-import { Stack } from '../../Layout'
+import { Button } from '../../Button'
+import { Cluster, Stack } from '../../Layout'
 
 import { SearchInput } from './SearchInput'
 
@@ -39,6 +40,42 @@ export const Default: Story = {
           decorators={{ iconAlt: (txt) => `search.(${txt})` }}
         />
       </div>
+      <div>
+        <p>width: 300px in Cluster</p>
+        <StyledCluster>
+          <SearchInput
+            name="default"
+            width={300}
+            tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+            decorators={{ iconAlt: (txt) => `search.(${txt})` }}
+          />
+          <Button>検索</Button>
+        </StyledCluster>
+      </div>
+      <div>
+        <p>width: 100% in Cluster</p>
+        <StyledCluster justify="space-between">
+          <SearchInput
+            name="default"
+            width="100%"
+            tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+            decorators={{ iconAlt: (txt) => `search.(${txt})` }}
+          />
+          <Button>検索</Button>
+        </StyledCluster>
+      </div>
+      <div>
+        <p>width: 50% in Cluster</p>
+        <StyledCluster>
+          <SearchInput
+            name="default"
+            width="50%"
+            tooltipMessage="氏名、ヨミガナ、社員番号で検索できます。スペース区切りでAND検索ができます。"
+            decorators={{ iconAlt: (txt) => `search.(${txt})` }}
+          />
+          <Button>検索</Button>
+        </StyledCluster>
+      </div>
     </StyledStack>
   ),
 }
@@ -47,4 +84,8 @@ const StyledStack = styled(Stack)`
   ${({ theme: { space } }) => css`
     padding: ${space(2)};
   `}
+`
+
+const StyledCluster = styled(Cluster)`
+  flex-wrap: nowrap;
 `

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -16,7 +16,7 @@ const ICON_ALT = '検索'
 export const SearchInput = forwardRef<HTMLInputElement, Props>(
   ({ decorators, width, ...props }, ref) => {
     const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
-    const styles = useMemo(() => {
+    const widths = useMemo(() => {
       const widthStyle = typeof width === 'number' ? `${width}px` : width
 
       if (!widthStyle) {

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -35,11 +35,11 @@ export const SearchInput = forwardRef<HTMLInputElement, Props>(
     }, [width])
 
     return (
-      <label style={styles.label}>
+      <label style={widths.label}>
         <InputWithTooltip
           {...props}
           ref={ref}
-          width={styles.input}
+          width={widths.input}
           prefix={<FaSearchIcon alt={iconAlt} color="TEXT_GREY" />}
         />
       </label>

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -13,16 +13,36 @@ type Props = Omit<ComponentProps<typeof InputWithTooltip>, 'tooltipMessage' | 'p
 
 const ICON_ALT = '検索'
 
-export const SearchInput = forwardRef<HTMLInputElement, Props>(({ decorators, ...props }, ref) => {
-  const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
+export const SearchInput = forwardRef<HTMLInputElement, Props>(
+  ({ decorators, width, ...props }, ref) => {
+    const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
+    const styles = useMemo(() => {
+      const widthStyle = typeof width === 'number' ? `${width}px` : width
 
-  return (
-    <label>
-      <InputWithTooltip
-        {...props}
-        ref={ref}
-        prefix={<FaSearchIcon alt={iconAlt} color="TEXT_GREY" />}
-      />
-    </label>
-  )
-})
+      if (!widthStyle) {
+        return {
+          label: undefined,
+          input: undefined,
+        }
+      }
+
+      return {
+        label: {
+          width: widthStyle,
+        },
+        input: '100%',
+      }
+    }, [width])
+
+    return (
+      <label style={styles.label}>
+        <InputWithTooltip
+          {...props}
+          ref={ref}
+          width={styles.input}
+          prefix={<FaSearchIcon alt={iconAlt} color="TEXT_GREY" />}
+        />
+      </label>
+    )
+  },
+)


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- Clusterなどの中でSearchInputに対してwitdh propsを指定した場合、正常に幅指定がされない問題があったので修正したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- SearchInput内にあるlabel要素に対してwidhtを指定、その場合、子要素となるinputなどにはwidth 100% を指定するように修正
  - これは `width: 50%` などが指定された場合の対応

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- diffとCIを確認する
