### PR TITLE
fix(DropZone): ドラッグ＆ドロップ時に選択したファイルがFormDataに格納されるようにした

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -86,6 +86,9 @@ export const DropZone = forwardRef<HTMLInputElement, DropZoneProps & ElementProp
         overrideEventDefault(e)
         setFilesDraggedOver(false)
         onSelectFiles(e, e.dataTransfer.files)
+        if (fileRef.current) {
+          fileRef.current.files = e.dataTransfer.files
+        }
       },
       [setFilesDraggedOver, onSelectFiles],
     )


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

`DropZone` コンポーネントで、ドラッグ＆ドロップで選択されたファイルが `input` タグのDOMに格納されず、 `form` で送信した際に意図したファイルが `FormData` オブジェクトに格納されない問題がありました。

## 変更内容

`DropZone` コンポーネントで、ドラッグ＆ドロップで選択されたファイルが `input` タグのDOMにデータが格納されるようにした。

## 確認方法

`pnpm add https://pkg.pr.new/kufu/smarthr-ui@4964` で変更したパッケージをインストールし、 `DropZone` でファイルをドラッグ＆ドロップしてから `form` を `submit` して正常に選択したファイルが送信されていること。
