### PR TITLE
fix(smarthr-ui-preset): breakpointを設定

### DIFF
--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -2,6 +2,7 @@ import { darken } from 'polished'
 import { defaultConfig } from 'tailwind-variants'
 import plugin from 'tailwindcss/plugin'
 
+import { defaultBreakpoint } from './themes/createBreakpoint'
 import { defaultColor } from './themes/createColor'
 import { defaultFontSize, defaultHtmlFontSize } from './themes/createFontSize'
 import { defaultShadow } from './themes/createShadow'
@@ -153,6 +154,9 @@ export default {
     outlineColor: {
       DEFAULT: defaultColor.OUTLINE,
     },
+    screens: Object.fromEntries(
+      Object.entries(defaultBreakpoint).map(([key, value]) => [key, { max: `${value}px` }]),
+    ),
     spacing: {
       px: '1px',
       em: '1em',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://kufuinc.slack.com/archives/C013KCVC0P3/p1727686839153149

強い気持ちがある人が現れると修正内容がかわるかも https://kufuinc.slack.com/archives/CGC58MW01/p1727691651343259

## 概要

smarthr-ui-presetに対してbreakpointの設定を行った

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- smarthr-ui-presetにbreakpointの設定を追加
  - `createBreakpoint` と同じ値を設定
  - 通常Tailwind CSSでは `min-width` で設定されるが、SmartHRではデスクトップを先に作ってからモバイル対応という流れが多いため、 `SP:shr-hogehoge` でモバイル用のスタイルをあてられる方が利点が高いと考え `max-width` で追加

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

例えばButton.tsxのwrapperに `SP:shr-bg-[red]` を追加し、ブラウザの幅を縮めると背景色が赤くなることを確認


https://github.com/user-attachments/assets/eaffc6e8-62cc-4426-ab20-513f66a25e1c

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
