### PR TITLE
fix: RadioButtonPanel内のradio buttonがフォーカス時にインジケーターが表示されない

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -16,7 +16,6 @@ const radioButtonPanel = tv({
     'shr-border-shorthand shr-list-none shr-shadow-none',
     // なぜか :has が動作しないので重ねて書いている
     'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
-    '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
     '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
     'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
   ],


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1070

## 概要

- RadioButtonPanel内のradio buttonをフォーカスしたときにフォーカスインジケーターが表示されてなくて、視覚的にフォーカスしたことが分からないため、フォーカスインジケーターが表示されるように修正
- アクセシビリティ簡易チェックのNG対応

## 変更内容

- radio buttonがフォーカスされる時にカスタムradio buttonの代替要素(span)のbox-shadowをnone(透明化)にされていましたのでフォーカスインジケーターが表示されていませんでしたので、そちらのスタイルがあたらないようにclassnameを削除しました
- `[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none`
    - RadioButtonPanelのもともとあったスタイルのため何かしらの理由があるかと思いますですが、いろいろ検証してみましたが、現状の見た目または強制カラーモード時でも特に影響なさそうのようでしたので削除して対応してみましたが、こちら問題ないのでしょうか？

見た目にも影響なさそう

https://github.com/user-attachments/assets/82ae4c9c-6171-4608-b1e3-1f0d4f0bd71f

強制カラーモード時はカスタムradio buttonの代替要素(span)はdisplay noneになるのと、box-shadowのスタイルもnoneにされるので影響なさそう。
inputがそのまま利用されるので現状でも強制カラーモード時ではフォーカスインジケーターが表示されてます

https://github.com/user-attachments/assets/79e9b938-e5ad-49e8-9078-3ecfef98f16f



## 確認方法

RadioButtonPanel内のradio buttonをキーボード操作移動してもフォーカスインジケーターが表示されない

https://story.smarthr-ui.dev/?path=/docs/forms%EF%BC%88%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%EF%BC%89-radiobuttonpanel--docs

https://github.com/user-attachments/assets/932743bb-bcb8-453f-bc1c-3011cdcf9694


