### PR TITLE
fix: AppNaviDropdownMenuButton の current 装飾ロジックを見直し

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
@@ -5,7 +5,6 @@ import React, {
   type ReactElement,
   type ReactNode,
   useMemo,
-  useState,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -33,7 +32,12 @@ const {
 const appNaviDropdownMenuButton = tv({
   extend: appNaviItemStyle,
   slots: {
-    wrapper: ['smarthr-ui-AppNavi-dropdownMenuButton', triggerButton],
+    wrapper: [
+      'smarthr-ui-AppNavi-dropdownMenuButton',
+      'has-[[aria-current="page"]]:shr-relative has-[[aria-current="page"]]:shr-text-black',
+      'has-[[aria-current="page"]]:after:shr-bottom-0 has-[[aria-current="page"]]:after:shr-inset-x-0 has-[[aria-current="page"]]:after:shr-block has-[[aria-current="page"]]:after:shr-h-0.25 has-[[aria-current="page"]]:after:shr-bg-main has-[[aria-current="page"]]:after:shr-content-[""] has-[[aria-current="page"]]:after:shr-absolute',
+      triggerButton,
+    ],
     actionList,
   },
 })
@@ -42,30 +46,25 @@ export const AppNaviDropdownMenuButton: FC<AppNaviDropdownMenuButtonProps> = ({
   children,
   label,
 }) => {
-  const [hasCurrentPage, setHasCurrentPage] = useState(false)
   const actualChildren = useMemo(
     () =>
-      React.Children.map(children, (item, i) => {
-        if (React.isValidElement(item) && item.props['aria-current'] === 'page') {
-          setHasCurrentPage(true)
-        }
-
+      React.Children.map(children, (item, i) =>
         // MEMO: {flag && <Button/>}のような書き方に対応させる為、型を変換する
         // itemの存在チェックでfalsyな値は弾かれている想定
-        return item ? <li key={i}>{item as ActionItemTruthyType}</li> : null
-      }),
+        item ? <li key={i}>{item as ActionItemTruthyType}</li> : null,
+      ),
     [children],
   )
 
-  const { wrapper: wrapperStyle, actionList: actionListStyle } = appNaviDropdownMenuButton({
-    active: hasCurrentPage,
-  })
+  const { wrapper: wrapperStyle, actionList: actionListStyle } = appNaviDropdownMenuButton()
 
   return (
     <Dropdown>
       <DropdownTrigger>
         <UnstyledButton className={wrapperStyle()}>
           {label}
+          {/* has([aria-current="page"]) を書くために複製 */}
+          <span hidden>{actualChildren}</span>
           <FaCaretDownIcon />
         </UnstyledButton>
       </DropdownTrigger>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/C06KVP5PL23/p1727780133229749

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

AppNaviDropdownMenuButton に `aria-current="page"` を1度でも指定すると、再読み込みされるまで current 装飾がつき続けてしまう不具合の修正提案です。

既存ロジックは current をつけるだけで、外す処理がありませんでした。children として渡される要素の `aria-current="page"` を検知する方法できないため、本 PR では引き金ボタン内に hidden 付きの要素として複製し、CSS の `has()` でスタイリングしています。


<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- `React.Children.map` 内で `aria-current="page"` を探すのをやめる
- chlidren を引き金 button 内に複製し `hidden` 属性を付与
- `has()` に（tailwlind では `has-[[aria-current="page"]]` に）まかせてスタイリング

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
