### PR TITLE
fix: ModelessDialog に渡した className が当たる場所を変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
@@ -89,6 +89,7 @@ const CLOSE_BUTTON_ICON_ALT = '閉じる'
 
 const modelessDialog = tv({
   slots: {
+    overlap: 'shr-inset-[unset]',
     wrapper: 'smarthr-ui-ModelessDialog shr-fixed shr-flex shr-flex-col',
     headerEl:
       'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5 hover:shr-bg-white-darken',
@@ -143,6 +144,7 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
   const { spacing } = useTheme()
 
   const {
+    overlapStyle,
     wrapperStyle,
     headerStyle,
     titleStyle,
@@ -150,10 +152,11 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
     closeButtonLayoutStyle,
     footerStyle,
   } = useMemo(() => {
-    const { wrapper, headerEl, title, dialogHandler, closeButtonLayout, footerEl } =
+    const { overlap, wrapper, headerEl, title, dialogHandler, closeButtonLayout, footerEl } =
       modelessDialog()
     return {
-      wrapperStyle: wrapper({ resizable, className }),
+      overlapStyle: overlap({ className }),
+      wrapperStyle: wrapper({ resizable }),
       headerStyle: headerEl(),
       titleStyle: title(),
       dialogHandlerStyle: dialogHandler(),
@@ -314,7 +317,7 @@ export const ModelessDialog: FC<Props & BaseElementProps & VariantProps<typeof m
   )
 
   return createPortal(
-    <DialogOverlap isOpen={isOpen} className="shr-inset-[unset]">
+    <DialogOverlap isOpen={isOpen} className={overlapStyle}>
       <Draggable
         handle=".smarthr-ui-ModelessDialog-handle"
         onStart={(_, data) => setPosition({ x: data.x, y: data.y })}

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -30,6 +30,20 @@ defaultConfig.twMergeConfig = {
         leading: ['none', 'tight', 'normal', 'loose'],
       },
     ],
+    zIndex: [
+      {
+        z: [
+          'auto',
+          '0',
+          '1',
+          'fixed-menu',
+          'overlap-base',
+          'overlap',
+          'flash-message',
+          (classPart: string) => /^\[\d+\]$/.test(classPart),
+        ],
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

ModelessDialog の重なり順序を変えたいが、`z-index` 値が固定で上書けない問題を修正しました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

コンポーネントに渡した className をもう一つ外側の要素にあたるように修正しました。

styled-components を使った拡張をしている場合は見直しが必要になる可能性があります。


```jsx
// ## Before
const HogeModelessDialog = styled(ModelessDialog)`
  display: block; // 1

  > div {
    display: block; // 2
  }

  .smarthr-ui-ModelessDialog-header {
    display: block;  // 3

    > span {
      display: block; // 4
    }
  }
`

// ## After
const HogeModelessDialog = styled(ModelessDialog)`
  // 直下に書いていたものは .smarthr-ui-ModelessDialog に当ててください。
  .smarthr-ui-ModelessDialog {
    display: block; // 1'

    > div {
      display: block; // 2'
    }
  }

  // クラスセレクタなど、直下に書いていないスタイルへの影響はありません。
  .smarthr-ui-ModelessDialog-header {
    display: block;  // 3'

    > span {
      display: block; // 4'
    }
  }
`
```

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
