### PR TITLE
chore: RSC対応コンポーネント・非対応コンポーネントを機会的に洗い出して担保できる仕組みを導入する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
     dependencies:
       next:
         specifier: 14.2.14
-        version: 14.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.14(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -330,6 +330,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/smarthr-ui
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.47.2
+        version: 1.47.2
       '@types/node':
         specifier: ^20.16.10
         version: 20.16.10
@@ -1871,6 +1874,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.47.2':
+    resolution: {integrity: sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -4720,6 +4728,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esotope-hammerhead@0.6.8:
@@ -10705,6 +10714,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.47.2':
+    dependencies:
+      playwright: 1.47.2
+
   '@radix-ui/number@1.0.1':
     dependencies:
       '@babel/runtime': 7.24.5
@@ -16626,7 +16639,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@14.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.14(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.14
       '@swc/helpers': 0.5.5
@@ -16647,6 +16660,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.14
       '@next/swc-win32-ia32-msvc': 14.2.14
       '@next/swc-win32-x64-msvc': 14.2.14
+      '@playwright/test': 1.47.2
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros

--- a/sandbox/next/.gitignore
+++ b/sandbox/next/.gitignore
@@ -34,3 +34,11 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# yalc
+.yalc
+yalc.lock
+
+# playwright
+playwright-report/
+test-results/

--- a/sandbox/next/e2e/rsc.test.ts
+++ b/sandbox/next/e2e/rsc.test.ts
@@ -1,0 +1,124 @@
+import test, { expect } from '@playwright/test'
+
+/**
+ * サーバーコンポーネントとして利用できるコンポーネント一覧
+ */
+const SERVER_COMPONENTS = [
+  'Text',
+  'Table',
+  'Loader',
+  'Td',
+  'RadioButton',
+  'Chip',
+  'LineClamp',
+  'RemoteDialogTrigger',
+  'SpreadsheetTable',
+  'Balloon',
+  'Badge',
+  'VisuallyHiddenText',
+  'SmartHRLogo',
+  'UnstyledButton',
+  'RangeSeparator',
+  'TableReel',
+  'BulkActionRow',
+  'Tooltip',
+]
+
+/**
+ * サーバーコンポーネントでは利用できないコンポーネント一覧
+ */
+const CLIENT_COMPONENTS = [
+  'Button',
+  'Icon',
+  'Dropdown',
+  'Stack',
+  'Heading',
+  'Cluster',
+  'Base',
+  'Input',
+  'CheckBox',
+  'Dialog',
+  'TextLink',
+  'ActionDialog',
+  'DatePicker',
+  'AccordionPanel',
+  'DefinitionList',
+  'Fieldset',
+  'FlashMessage',
+  'Select',
+  'Section',
+  'Center',
+  'Pagination',
+  'Calendar',
+  'FormControl',
+  'Th',
+  'Cell',
+  'AppNavi',
+  'CompactInformationPanel',
+  'PageHeading',
+  'InformationPanel',
+  'Header',
+  'NotificationBar',
+  'StatusLabel',
+  'TabBar',
+  'FormGroup',
+  'BottomFixedArea',
+  'Textarea',
+  'DropdownMenuButton',
+  'FloatArea',
+  'CurrencyInput',
+  'Row',
+  'MultiComboBox',
+  'SingleComboBox',
+  'BaseColumn',
+  'InputFile',
+  'EmptyTableBody',
+  'Head',
+  'ErrorScreen',
+  'FilterDropdown',
+  'SegmentedControl',
+  'MessageDialog',
+  'DropZone',
+  'Sidebar',
+  'RemoteTriggerActionDialog',
+  'PageCounter',
+  'TabItem',
+  'SideNav',
+  'SearchInput',
+  'MessageScreen',
+  'ResponseMessage',
+  'ModelessDialog',
+  'Reel',
+  'RadioButtonPanel',
+  'Switch',
+  'RemoteTriggerFormDialog',
+  'FormDialog',
+  'TdCheckbox',
+  'ThCheckbox',
+  'Nav',
+  'Article',
+  'RemoteTriggerMessageDialog',
+  'SequencePrefixIdProvider',
+  'Aside',
+  'AppLauncher',
+]
+
+test.describe('RSC対応コンポーネントがRSCで利用できること', () => {
+  for (const component of SERVER_COMPONENTS) {
+    test(component, async ({ page }) => {
+      await page.goto(`http://localhost:3000/rsc_test/${component}`)
+      await expect(page.getByText(`Success: ${component}`)).toBeVisible()
+      await expect(page.getByText('Server Error')).not.toBeVisible()
+    })
+  }
+})
+
+test.describe('RSC非対応コンポーネントはRSCでエラーになること', () => {
+  for (const component of CLIENT_COMPONENTS) {
+    test(component, async ({ page }) => {
+      await page.goto(`http://localhost:3000/rsc_test/${component}`)
+      await expect(page.getByText('Server Error')).toBeVisible()
+      await expect(page.getByText(`Success: ${component}`)).not.toBeVisible()
+    })
+  }
+})

--- a/sandbox/next/package.json
+++ b/sandbox/next/package.json
@@ -15,6 +15,7 @@
     "smarthr-ui": "workspace:*"
   },
   "devDependencies": {
+    "@playwright/test": "^1.47.2",
     "@types/node": "^20.16.10",
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",

--- a/sandbox/next/playwright.config.ts
+++ b/sandbox/next/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  maxFailures: 10,
+  fullyParallel: true,
+  workers: 4,
+  reporter: [['list'], ['html']],
+  use: {
+    browserName: 'chromium',
+    trace: 'on-all-retries',
+    locale: 'ja-JP',
+    timezoneId: 'Asia/Tokyo',
+  },
+})

--- a/sandbox/next/src/app/rsc_test/AccordionPanel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/AccordionPanel/page.tsx
@@ -1,0 +1,6 @@
+import { AccordionPanel } from 'smarthr-ui'
+
+export default function AccordionPanelPage() {
+  console.log(AccordionPanel)
+  return <div>Success: AccordionPanel</div>
+}

--- a/sandbox/next/src/app/rsc_test/ActionDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/ActionDialog/page.tsx
@@ -1,0 +1,6 @@
+import { ActionDialog } from 'smarthr-ui'
+
+export default function ActionDialogPage() {
+  console.log(ActionDialog)
+  return <div>Success: ActionDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/AppLauncher/page.tsx
+++ b/sandbox/next/src/app/rsc_test/AppLauncher/page.tsx
@@ -1,0 +1,6 @@
+import { AppLauncher } from 'smarthr-ui'
+
+export default function AppLauncherPage() {
+  console.log(AppLauncher)
+  return <div>Success: AppLauncher</div>
+}

--- a/sandbox/next/src/app/rsc_test/AppNavi/page.tsx
+++ b/sandbox/next/src/app/rsc_test/AppNavi/page.tsx
@@ -1,0 +1,6 @@
+import { AppNavi } from 'smarthr-ui'
+
+export default function AppNaviPage() {
+  console.log(AppNavi)
+  return <div>Success: AppNavi</div>
+}

--- a/sandbox/next/src/app/rsc_test/Article/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Article/page.tsx
@@ -1,0 +1,6 @@
+import { Article } from 'smarthr-ui'
+
+export default function ArticlePage() {
+  console.log(Article)
+  return <div>Success: Article</div>
+}

--- a/sandbox/next/src/app/rsc_test/Aside/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Aside/page.tsx
@@ -1,0 +1,6 @@
+import { Aside } from 'smarthr-ui'
+
+export default function AsidePage() {
+  console.log(Aside)
+  return <div>Success: Aside</div>
+}

--- a/sandbox/next/src/app/rsc_test/Badge/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Badge/page.tsx
@@ -1,0 +1,6 @@
+import { Badge } from 'smarthr-ui'
+
+export default function BadgePage() {
+  console.log(Badge)
+  return <div>Success: Badge</div>
+}

--- a/sandbox/next/src/app/rsc_test/Balloon/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Balloon/page.tsx
@@ -1,0 +1,6 @@
+import { Balloon } from 'smarthr-ui'
+
+export default function BalloonPage() {
+  console.log(Balloon)
+  return <div>Success: Balloon</div>
+}

--- a/sandbox/next/src/app/rsc_test/Base/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Base/page.tsx
@@ -1,0 +1,6 @@
+import { Base } from 'smarthr-ui'
+
+export default function BasePage() {
+  console.log(Base)
+  return <div>Success: Base</div>
+}

--- a/sandbox/next/src/app/rsc_test/BaseColumn/page.tsx
+++ b/sandbox/next/src/app/rsc_test/BaseColumn/page.tsx
@@ -1,0 +1,6 @@
+import { BaseColumn } from 'smarthr-ui'
+
+export default function BaseColumnPage() {
+  console.log(BaseColumn)
+  return <div>Success: BaseColumn</div>
+}

--- a/sandbox/next/src/app/rsc_test/BottomFixedArea/page.tsx
+++ b/sandbox/next/src/app/rsc_test/BottomFixedArea/page.tsx
@@ -1,0 +1,6 @@
+import { BottomFixedArea } from 'smarthr-ui'
+
+export default function BottomFixedAreaPage() {
+  console.log(BottomFixedArea)
+  return <div>Success: BottomFixedArea</div>
+}

--- a/sandbox/next/src/app/rsc_test/BulkActionRow/page.tsx
+++ b/sandbox/next/src/app/rsc_test/BulkActionRow/page.tsx
@@ -1,0 +1,6 @@
+import { BulkActionRow } from 'smarthr-ui'
+
+export default function BulkActionRowPage() {
+  console.log(BulkActionRow)
+  return <div>Success: BulkActionRow</div>
+}

--- a/sandbox/next/src/app/rsc_test/Button/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Button/page.tsx
@@ -1,0 +1,6 @@
+import { Button } from 'smarthr-ui'
+
+export default function ButtonPage() {
+  console.log(Button)
+  return <div>Success: Button</div>
+}

--- a/sandbox/next/src/app/rsc_test/Calendar/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Calendar/page.tsx
@@ -1,0 +1,6 @@
+import { Calendar } from 'smarthr-ui'
+
+export default function CalendarPage() {
+  console.log(Calendar)
+  return <div>Success: Calendar</div>
+}

--- a/sandbox/next/src/app/rsc_test/Cell/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Cell/page.tsx
@@ -1,0 +1,6 @@
+import { Cell } from 'smarthr-ui'
+
+export default function CellPage() {
+  console.log(Cell)
+  return <div>Success: Cell</div>
+}

--- a/sandbox/next/src/app/rsc_test/Center/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Center/page.tsx
@@ -1,0 +1,6 @@
+import { Center } from 'smarthr-ui'
+
+export default function CenterPage() {
+  console.log(Center)
+  return <div>Success: Center</div>
+}

--- a/sandbox/next/src/app/rsc_test/CheckBox/page.tsx
+++ b/sandbox/next/src/app/rsc_test/CheckBox/page.tsx
@@ -1,0 +1,6 @@
+import { CheckBox } from 'smarthr-ui'
+
+export default function CheckBoxPage() {
+  console.log(CheckBox)
+  return <div>Success: CheckBox</div>
+}

--- a/sandbox/next/src/app/rsc_test/Chip/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Chip/page.tsx
@@ -1,0 +1,6 @@
+import { Chip } from 'smarthr-ui'
+
+export default function ChipPage() {
+  console.log(Chip)
+  return <div>Success: Chip</div>
+}

--- a/sandbox/next/src/app/rsc_test/Cluster/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Cluster/page.tsx
@@ -1,0 +1,6 @@
+import { Cluster } from 'smarthr-ui'
+
+export default function ClusterPage() {
+  console.log(Cluster)
+  return <div>Success: Cluster</div>
+}

--- a/sandbox/next/src/app/rsc_test/CompactInformationPanel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/CompactInformationPanel/page.tsx
@@ -1,0 +1,6 @@
+import { CompactInformationPanel } from 'smarthr-ui'
+
+export default function CompactInformationPanelPage() {
+  console.log(CompactInformationPanel)
+  return <div>Success: CompactInformationPanel</div>
+}

--- a/sandbox/next/src/app/rsc_test/CurrencyInput/page.tsx
+++ b/sandbox/next/src/app/rsc_test/CurrencyInput/page.tsx
@@ -1,0 +1,6 @@
+import { CurrencyInput } from 'smarthr-ui'
+
+export default function CurrencyInputPage() {
+  console.log(CurrencyInput)
+  return <div>Success: CurrencyInput</div>
+}

--- a/sandbox/next/src/app/rsc_test/DatePicker/page.tsx
+++ b/sandbox/next/src/app/rsc_test/DatePicker/page.tsx
@@ -1,0 +1,6 @@
+import { DatePicker } from 'smarthr-ui'
+
+export default function DatePickerPage() {
+  console.log(DatePicker)
+  return <div>Success: DatePicker</div>
+}

--- a/sandbox/next/src/app/rsc_test/DefinitionList/page.tsx
+++ b/sandbox/next/src/app/rsc_test/DefinitionList/page.tsx
@@ -1,0 +1,6 @@
+import { DefinitionList } from 'smarthr-ui'
+
+export default function DefinitionListPage() {
+  console.log(DefinitionList)
+  return <div>Success: DefinitionList</div>
+}

--- a/sandbox/next/src/app/rsc_test/Dialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Dialog/page.tsx
@@ -1,0 +1,6 @@
+import { Dialog } from 'smarthr-ui'
+
+export default function DialogPage() {
+  console.log(Dialog)
+  return <div>Success: Dialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/DropZone/page.tsx
+++ b/sandbox/next/src/app/rsc_test/DropZone/page.tsx
@@ -1,0 +1,6 @@
+import { DropZone } from 'smarthr-ui'
+
+export default function DropZonePage() {
+  console.log(DropZone)
+  return <div>Success: DropZone</div>
+}

--- a/sandbox/next/src/app/rsc_test/Dropdown/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Dropdown/page.tsx
@@ -1,0 +1,6 @@
+import { Dropdown } from 'smarthr-ui'
+
+export default function DropdownPage() {
+  console.log(Dropdown)
+  return <div>Success: Dropdown</div>
+}

--- a/sandbox/next/src/app/rsc_test/DropdownMenuButton/page.tsx
+++ b/sandbox/next/src/app/rsc_test/DropdownMenuButton/page.tsx
@@ -1,0 +1,6 @@
+import { DropdownMenuButton } from 'smarthr-ui'
+
+export default function DropdownMenuButtonPage() {
+  console.log(DropdownMenuButton)
+  return <div>Success: DropdownMenuButton</div>
+}

--- a/sandbox/next/src/app/rsc_test/EmptyTableBody/page.tsx
+++ b/sandbox/next/src/app/rsc_test/EmptyTableBody/page.tsx
@@ -1,0 +1,6 @@
+import { EmptyTableBody } from 'smarthr-ui'
+
+export default function EmptyTableBodyPage() {
+  console.log(EmptyTableBody)
+  return <div>Success: EmptyTableBody</div>
+}

--- a/sandbox/next/src/app/rsc_test/ErrorScreen/page.tsx
+++ b/sandbox/next/src/app/rsc_test/ErrorScreen/page.tsx
@@ -1,0 +1,6 @@
+import { ErrorScreen } from 'smarthr-ui'
+
+export default function ErrorScreenPage() {
+  console.log(ErrorScreen)
+  return <div>Success: ErrorScreen</div>
+}

--- a/sandbox/next/src/app/rsc_test/Fieldset/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Fieldset/page.tsx
@@ -1,0 +1,6 @@
+import { Fieldset } from 'smarthr-ui'
+
+export default function FieldSetPage() {
+  console.log(Fieldset)
+  return <div>Success: Fieldset</div>
+}

--- a/sandbox/next/src/app/rsc_test/FilterDropdown/page.tsx
+++ b/sandbox/next/src/app/rsc_test/FilterDropdown/page.tsx
@@ -1,0 +1,6 @@
+import { FilterDropdown } from 'smarthr-ui'
+
+export default function FilterDropdownPage() {
+  console.log(FilterDropdown)
+  return <div>Success: FilterDropdown</div>
+}

--- a/sandbox/next/src/app/rsc_test/FlashMessage/page.tsx
+++ b/sandbox/next/src/app/rsc_test/FlashMessage/page.tsx
@@ -1,0 +1,6 @@
+import { FlashMessage } from 'smarthr-ui'
+
+export default function FlashMessagePage() {
+  console.log(FlashMessage)
+  return <div>Success: FlashMessage</div>
+}

--- a/sandbox/next/src/app/rsc_test/FloatArea/page.tsx
+++ b/sandbox/next/src/app/rsc_test/FloatArea/page.tsx
@@ -1,0 +1,6 @@
+import { FloatArea } from 'smarthr-ui'
+
+export default function FloatAreaPage() {
+  console.log(FloatArea)
+  return <div>Success: FloatArea</div>
+}

--- a/sandbox/next/src/app/rsc_test/FormControl/page.tsx
+++ b/sandbox/next/src/app/rsc_test/FormControl/page.tsx
@@ -1,0 +1,6 @@
+import { FormControl } from 'smarthr-ui'
+
+export default function FormControlPage() {
+  console.log(FormControl)
+  return <div>Success: FormControl</div>
+}

--- a/sandbox/next/src/app/rsc_test/FormDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/FormDialog/page.tsx
@@ -1,0 +1,6 @@
+import { FormDialog } from 'smarthr-ui'
+
+export default function FormDialogPage() {
+  console.log(FormDialog)
+  return <div>Success: FormDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/FormGroup/page.tsx
+++ b/sandbox/next/src/app/rsc_test/FormGroup/page.tsx
@@ -1,0 +1,6 @@
+import { FormGroup } from 'smarthr-ui'
+
+export default function FormGroupPage() {
+  console.log(FormGroup)
+  return <div>Success: FormGroup</div>
+}

--- a/sandbox/next/src/app/rsc_test/Head/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Head/page.tsx
@@ -1,0 +1,6 @@
+import { Head } from 'smarthr-ui'
+
+export default function HeadPage() {
+  console.log(Head)
+  return <div>Success: Head</div>
+}

--- a/sandbox/next/src/app/rsc_test/Header/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Header/page.tsx
@@ -1,0 +1,6 @@
+import { Header } from 'smarthr-ui'
+
+export default function HeaderPage() {
+  console.log(Header)
+  return <div>Success: Header</div>
+}

--- a/sandbox/next/src/app/rsc_test/Heading/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Heading/page.tsx
@@ -1,0 +1,6 @@
+import { Heading } from 'smarthr-ui'
+
+export default function HeadingPage() {
+  console.log(Heading)
+  return <div>Success: Heading</div>
+}

--- a/sandbox/next/src/app/rsc_test/Icon/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Icon/page.tsx
@@ -1,0 +1,6 @@
+import { FaAddressBookIcon } from 'smarthr-ui'
+
+export default function IconPage() {
+  console.log(FaAddressBookIcon)
+  return <div>Success: Icon</div>
+}

--- a/sandbox/next/src/app/rsc_test/InformationPanel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/InformationPanel/page.tsx
@@ -1,0 +1,6 @@
+import { InformationPanel } from 'smarthr-ui'
+
+export default function InformationPanelPage() {
+  console.log(InformationPanel)
+  return <div>Success: InformationPanel</div>
+}

--- a/sandbox/next/src/app/rsc_test/Input/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Input/page.tsx
@@ -1,0 +1,6 @@
+import { Input } from 'smarthr-ui'
+
+export default function InputPage() {
+  console.log(Input)
+  return <div>Success: Input</div>
+}

--- a/sandbox/next/src/app/rsc_test/InputFile/page.tsx
+++ b/sandbox/next/src/app/rsc_test/InputFile/page.tsx
@@ -1,0 +1,6 @@
+import { InputFile } from 'smarthr-ui'
+
+export default function InputFilePage() {
+  console.log(InputFile)
+  return <div>Success: InputFile</div>
+}

--- a/sandbox/next/src/app/rsc_test/LineClamp/page.tsx
+++ b/sandbox/next/src/app/rsc_test/LineClamp/page.tsx
@@ -1,0 +1,6 @@
+import { LineClamp } from 'smarthr-ui'
+
+export default function LineClampPage() {
+  console.log(LineClamp)
+  return <div>Success: LineClamp</div>
+}

--- a/sandbox/next/src/app/rsc_test/Loader/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Loader/page.tsx
@@ -1,0 +1,6 @@
+import { Loader } from 'smarthr-ui'
+
+export default function LoaderPage() {
+  console.log(Loader)
+  return <div>Success: Loader</div>
+}

--- a/sandbox/next/src/app/rsc_test/MessageDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/MessageDialog/page.tsx
@@ -1,0 +1,6 @@
+import { MessageDialog } from 'smarthr-ui'
+
+export default function MessageDialogPage() {
+  console.log(MessageDialog)
+  return <div>Success: MessageDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/MessageScreen/page.tsx
+++ b/sandbox/next/src/app/rsc_test/MessageScreen/page.tsx
@@ -1,0 +1,6 @@
+import { MessageScreen } from 'smarthr-ui'
+
+export default function MessageScreenPage() {
+  console.log(MessageScreen)
+  return <div>Success: MessageScreen</div>
+}

--- a/sandbox/next/src/app/rsc_test/ModelessDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/ModelessDialog/page.tsx
@@ -1,0 +1,6 @@
+import { ModelessDialog } from 'smarthr-ui'
+
+export default function ModelessDialogPage() {
+  console.log(ModelessDialog)
+  return <div>Success: ModelessDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/MultiComboBox/page.tsx
+++ b/sandbox/next/src/app/rsc_test/MultiComboBox/page.tsx
@@ -1,0 +1,6 @@
+import { MultiComboBox } from 'smarthr-ui'
+
+export default function MultiComboBoxPage() {
+  console.log(MultiComboBox)
+  return <div>Success: MultiComboBox</div>
+}

--- a/sandbox/next/src/app/rsc_test/Nav/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Nav/page.tsx
@@ -1,0 +1,6 @@
+import { Nav } from 'smarthr-ui'
+
+export default function NavPage() {
+  console.log(Nav)
+  return <div>Success: Nav</div>
+}

--- a/sandbox/next/src/app/rsc_test/NotificationBar/page.tsx
+++ b/sandbox/next/src/app/rsc_test/NotificationBar/page.tsx
@@ -1,0 +1,6 @@
+import { NotificationBar } from 'smarthr-ui'
+
+export default function NotificationBarPage() {
+  console.log(NotificationBar)
+  return <div>Success: NotificationBar</div>
+}

--- a/sandbox/next/src/app/rsc_test/PageCounter/page.tsx
+++ b/sandbox/next/src/app/rsc_test/PageCounter/page.tsx
@@ -1,0 +1,6 @@
+import { PageCounter } from 'smarthr-ui'
+
+export default function PageCounterPage() {
+  console.log(PageCounter)
+  return <div>Success: PageCounter</div>
+}

--- a/sandbox/next/src/app/rsc_test/PageHeading/page.tsx
+++ b/sandbox/next/src/app/rsc_test/PageHeading/page.tsx
@@ -1,0 +1,6 @@
+import { PageHeading } from 'smarthr-ui'
+
+export default function PageHeadingPage() {
+  console.log(PageHeading)
+  return <div>Success: PageHeading</div>
+}

--- a/sandbox/next/src/app/rsc_test/Pagination/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Pagination/page.tsx
@@ -1,0 +1,6 @@
+import { Pagination } from 'smarthr-ui'
+
+export default function PaginationPage() {
+  console.log(Pagination)
+  return <div>Success: Pagination</div>
+}

--- a/sandbox/next/src/app/rsc_test/RadioButton/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RadioButton/page.tsx
@@ -1,0 +1,6 @@
+import { RadioButton } from 'smarthr-ui'
+
+export default function RadioButtonPage() {
+  console.log(RadioButton)
+  return <div>Success: RadioButton</div>
+}

--- a/sandbox/next/src/app/rsc_test/RadioButtonPanel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RadioButtonPanel/page.tsx
@@ -1,0 +1,6 @@
+import { RadioButtonPanel } from 'smarthr-ui'
+
+export default function RadioButtonPanelPage() {
+  console.log(RadioButtonPanel)
+  return <div>Success: RadioButtonPanel</div>
+}

--- a/sandbox/next/src/app/rsc_test/RangeSeparator/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RangeSeparator/page.tsx
@@ -1,0 +1,6 @@
+import { RangeSeparator } from 'smarthr-ui'
+
+export default function RangeSeparatorPage() {
+  console.log(RangeSeparator)
+  return <div>Success: RangeSeparator</div>
+}

--- a/sandbox/next/src/app/rsc_test/Reel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Reel/page.tsx
@@ -1,0 +1,6 @@
+import { Reel } from 'smarthr-ui'
+
+export default function ReelPage() {
+  console.log(Reel)
+  return <div>Success: Reel</div>
+}

--- a/sandbox/next/src/app/rsc_test/RemoteDialogTrigger/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RemoteDialogTrigger/page.tsx
@@ -1,0 +1,6 @@
+import { RemoteDialogTrigger } from 'smarthr-ui'
+
+export default function RemoteDialogTriggerPage() {
+  console.log(RemoteDialogTrigger)
+  return <div>Success: RemoteDialogTrigger</div>
+}

--- a/sandbox/next/src/app/rsc_test/RemoteTriggerActionDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RemoteTriggerActionDialog/page.tsx
@@ -1,0 +1,6 @@
+import { RemoteTriggerActionDialog } from 'smarthr-ui'
+
+export default function RemoteTriggerActionDialogPage() {
+  console.log(RemoteTriggerActionDialog)
+  return <div>Success: RemoteTriggerActionDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/RemoteTriggerFormDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RemoteTriggerFormDialog/page.tsx
@@ -1,0 +1,6 @@
+import { RemoteTriggerFormDialog } from 'smarthr-ui'
+
+export default function RemoteTriggerFormDialogPage() {
+  console.log(RemoteTriggerFormDialog)
+  return <div>Success: RemoteTriggerFormDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/RemoteTriggerMessageDialog/page.tsx
+++ b/sandbox/next/src/app/rsc_test/RemoteTriggerMessageDialog/page.tsx
@@ -1,0 +1,6 @@
+import { RemoteTriggerMessageDialog } from 'smarthr-ui'
+
+export default function RemoteTriggerMessageDialogPage() {
+  console.log(RemoteTriggerMessageDialog)
+  return <div>Success: RemoteTriggerMessageDialog</div>
+}

--- a/sandbox/next/src/app/rsc_test/ResponseMessage/page.tsx
+++ b/sandbox/next/src/app/rsc_test/ResponseMessage/page.tsx
@@ -1,0 +1,6 @@
+import { ResponseMessage } from 'smarthr-ui'
+
+export default function ResponseMessagePage() {
+  console.log(ResponseMessage)
+  return <div>Success: ResponseMessage</div>
+}

--- a/sandbox/next/src/app/rsc_test/Row/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Row/page.tsx
@@ -1,0 +1,6 @@
+import { Row } from 'smarthr-ui'
+
+export default function RowPage() {
+  console.log(Row)
+  return <div>Success: Row</div>
+}

--- a/sandbox/next/src/app/rsc_test/SearchInput/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SearchInput/page.tsx
@@ -1,0 +1,6 @@
+import { SearchInput } from 'smarthr-ui'
+
+export default function SearchInputPage() {
+  console.log(SearchInput)
+  return <div>Success: SearchInput</div>
+}

--- a/sandbox/next/src/app/rsc_test/Section/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Section/page.tsx
@@ -1,0 +1,6 @@
+import { Section } from 'smarthr-ui'
+
+export default function SectionPage() {
+  console.log(Section)
+  return <div>Success: Section</div>
+}

--- a/sandbox/next/src/app/rsc_test/SegmentedControl/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SegmentedControl/page.tsx
@@ -1,0 +1,6 @@
+import { SegmentedControl } from 'smarthr-ui'
+
+export default function SegmentedControlPage() {
+  console.log(SegmentedControl)
+  return <div>Success: SegmentedControl</div>
+}

--- a/sandbox/next/src/app/rsc_test/Select/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Select/page.tsx
@@ -1,0 +1,6 @@
+import { Select } from 'smarthr-ui'
+
+export default function SelectPage() {
+  console.log(Select)
+  return <div>Success: Select</div>
+}

--- a/sandbox/next/src/app/rsc_test/SequencePrefixIdProvider/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SequencePrefixIdProvider/page.tsx
@@ -1,0 +1,6 @@
+import { SequencePrefixIdProvider } from 'smarthr-ui'
+
+export default function SequencePrefixIdProviderPage() {
+  console.log(SequencePrefixIdProvider)
+  return <div>Success: SequencePrefixIdProvider</div>
+}

--- a/sandbox/next/src/app/rsc_test/SideNav/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SideNav/page.tsx
@@ -1,0 +1,6 @@
+import { SideNav } from 'smarthr-ui'
+
+export default function SideNavPage() {
+  console.log(SideNav)
+  return <div>Success: SideNav</div>
+}

--- a/sandbox/next/src/app/rsc_test/Sidebar/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Sidebar/page.tsx
@@ -1,0 +1,6 @@
+import { Sidebar } from 'smarthr-ui'
+
+export default function SidebarPage() {
+  console.log(Sidebar)
+  return <div>Success: Sidebar</div>
+}

--- a/sandbox/next/src/app/rsc_test/SingleComboBox/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SingleComboBox/page.tsx
@@ -1,0 +1,6 @@
+import { SingleComboBox } from 'smarthr-ui'
+
+export default function SingleComboBoxPage() {
+  console.log(SingleComboBox)
+  return <div>Success: SingleComboBox</div>
+}

--- a/sandbox/next/src/app/rsc_test/SmartHRLogo/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SmartHRLogo/page.tsx
@@ -1,0 +1,6 @@
+import { SmartHRLogo } from 'smarthr-ui'
+
+export default function SmartHRLogoPage() {
+  console.log(SmartHRLogo)
+  return <div>Success: SmartHRLogo</div>
+}

--- a/sandbox/next/src/app/rsc_test/SpreadsheetTable/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SpreadsheetTable/page.tsx
@@ -1,0 +1,6 @@
+import { SpreadsheetTable } from 'smarthr-ui'
+
+export default function SpreadsheetTablePage() {
+  console.log(SpreadsheetTable)
+  return <div>Success: SpreadsheetTable</div>
+}

--- a/sandbox/next/src/app/rsc_test/Stack/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Stack/page.tsx
@@ -1,0 +1,6 @@
+import { Stack } from 'smarthr-ui'
+
+export default function StackPage() {
+  console.log(Stack)
+  return <div>Success: Stack</div>
+}

--- a/sandbox/next/src/app/rsc_test/StatusLabel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/StatusLabel/page.tsx
@@ -1,0 +1,6 @@
+import { StatusLabel } from 'smarthr-ui'
+
+export default function StatusLabelPage() {
+  console.log(StatusLabel)
+  return <div>Success: StatusLabel</div>
+}

--- a/sandbox/next/src/app/rsc_test/Switch/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Switch/page.tsx
@@ -1,0 +1,6 @@
+import { Switch } from 'smarthr-ui'
+
+export default function SwitchPage() {
+  console.log(Switch)
+  return <div>Success: Switch</div>
+}

--- a/sandbox/next/src/app/rsc_test/TabBar/page.tsx
+++ b/sandbox/next/src/app/rsc_test/TabBar/page.tsx
@@ -1,0 +1,6 @@
+import { TabBar } from 'smarthr-ui'
+
+export default function TabBarPage() {
+  console.log(TabBar)
+  return <div>Success: TabBar</div>
+}

--- a/sandbox/next/src/app/rsc_test/TabItem/page.tsx
+++ b/sandbox/next/src/app/rsc_test/TabItem/page.tsx
@@ -1,0 +1,6 @@
+import { TabItem } from 'smarthr-ui'
+
+export default function TabItemPage() {
+  console.log(TabItem)
+  return <div>Success: TabItem</div>
+}

--- a/sandbox/next/src/app/rsc_test/Table/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Table/page.tsx
@@ -1,0 +1,6 @@
+import { Table } from 'smarthr-ui'
+
+export default function TablePage() {
+  console.log(Table)
+  return <div>Success: Table</div>
+}

--- a/sandbox/next/src/app/rsc_test/TableReel/page.tsx
+++ b/sandbox/next/src/app/rsc_test/TableReel/page.tsx
@@ -1,0 +1,6 @@
+import { TableReel } from 'smarthr-ui'
+
+export default function TableReelPage() {
+  console.log(TableReel)
+  return <div>Success: TableReel</div>
+}

--- a/sandbox/next/src/app/rsc_test/Td/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Td/page.tsx
@@ -1,0 +1,6 @@
+import { Td } from 'smarthr-ui'
+
+export default function TdPage() {
+  console.log(Td)
+  return <div>Success: Td</div>
+}

--- a/sandbox/next/src/app/rsc_test/TdCheckbox/page.tsx
+++ b/sandbox/next/src/app/rsc_test/TdCheckbox/page.tsx
@@ -1,0 +1,6 @@
+import { TdCheckbox } from 'smarthr-ui'
+
+export default function TdCheckboxPage() {
+  console.log(TdCheckbox)
+  return <div>Success: TdCheckbox</div>
+}

--- a/sandbox/next/src/app/rsc_test/Text/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Text/page.tsx
@@ -1,0 +1,6 @@
+import { Text } from 'smarthr-ui'
+
+export default function TextPage() {
+  console.log(Text)
+  return <div>Success: Text</div>
+}

--- a/sandbox/next/src/app/rsc_test/TextLink/page.tsx
+++ b/sandbox/next/src/app/rsc_test/TextLink/page.tsx
@@ -1,0 +1,6 @@
+import { TextLink } from 'smarthr-ui'
+
+export default function TextLinkPage() {
+  console.log(TextLink)
+  return <div>Success: TextLink</div>
+}

--- a/sandbox/next/src/app/rsc_test/Textarea/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Textarea/page.tsx
@@ -1,0 +1,6 @@
+import { Textarea } from 'smarthr-ui'
+
+export default function TextareaPage() {
+  console.log(Textarea)
+  return <div>Success: Textarea</div>
+}

--- a/sandbox/next/src/app/rsc_test/Th/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Th/page.tsx
@@ -1,0 +1,6 @@
+import { Th } from 'smarthr-ui'
+
+export default function ThPage() {
+  console.log(Th)
+  return <div>Success: Th</div>
+}

--- a/sandbox/next/src/app/rsc_test/ThCheckbox/page.tsx
+++ b/sandbox/next/src/app/rsc_test/ThCheckbox/page.tsx
@@ -1,0 +1,6 @@
+import { ThCheckbox } from 'smarthr-ui'
+
+export default function ThCheckboxPage() {
+  console.log(ThCheckbox)
+  return <div>Success: ThCheckbox</div>
+}

--- a/sandbox/next/src/app/rsc_test/Tooltip/page.tsx
+++ b/sandbox/next/src/app/rsc_test/Tooltip/page.tsx
@@ -1,0 +1,6 @@
+import { Tooltip } from 'smarthr-ui'
+
+export default function TooltipPage() {
+  console.log(Tooltip)
+  return <div>Success: Tooltip</div>
+}

--- a/sandbox/next/src/app/rsc_test/UnstyledButton/page.tsx
+++ b/sandbox/next/src/app/rsc_test/UnstyledButton/page.tsx
@@ -1,0 +1,6 @@
+import { UnstyledButton } from 'smarthr-ui'
+
+export default function UnstyledButtonPage() {
+  console.log(UnstyledButton)
+  return <div>Success: UnstyledButton</div>
+}

--- a/sandbox/next/src/app/rsc_test/VisuallyHiddenText/page.tsx
+++ b/sandbox/next/src/app/rsc_test/VisuallyHiddenText/page.tsx
@@ -1,0 +1,6 @@
+import { VisuallyHiddenText } from 'smarthr-ui'
+
+export default function VisuallyHiddenTextPage() {
+  console.log(VisuallyHiddenText)
+  return <div>Success: VisuallyHiddenText</div>
+}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

Jira
https://smarthr.atlassian.net/browse/SHRUI-1011

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

SmartHR UI では、Next.js 向けのサーバーコンポーネント(RSC)として可能な限り使用できるように現在取り組んでいます。

その中で、どのコンポーネントがRSCとして使えるかを機会的に洗い出したり、RSCで使えたものが突然使えなくなるデグレを避けるために、RSCとして使える・使えないを自動テストで担保する仕組みが必要だと考えました。

そこで、E2Eテストの形式で、Next.js 上でサーバーコンポーネントとして各コンポーネントをインポートした際に、エラーが発生する・しないをテストできるようにします。

## 変更内容

- Next.js のサンドボックス内に、smarthr-ui が提供するコンポーネントそれぞれに依存したページを作成する
- Playwright を利用して、それぞれのページ(コンポーネント) にアクセスし、エラーが発生するかしないかを検証するE2Eテストを追加する
- テストのCIワークフローを作成する

## 確認方法

WIP
