### PR TITLE
docs(SegmentedControl): [isSquare=true]のときにアイコンになるように修正

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
@@ -9,7 +9,7 @@ import {
   FaTableIcon,
 } from '../../Icon'
 import { Stack } from '../../Layout'
-import { type Option, SegmentedControl } from '../SegmentedControl'
+import { SegmentedControl } from '../SegmentedControl'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -67,6 +67,7 @@ export const Options: StoryObj<typeof SegmentedControl> = {
       />
       <SegmentedControl
         {...args}
+        isSquare={true}
         options={[
           { value: 'table', ariaLabel: 'テーブル', content: tableIcon },
           { value: 'chartBar', ariaLabel: 'バーチャート', content: chartBarIcon },
@@ -105,8 +106,26 @@ export const IsSquare: StoryObj<typeof SegmentedControl> = {
   name: 'isSquare',
   render: (args) => (
     <Stack>
-      <SegmentedControl {...args} isSquare={false} />
-      <SegmentedControl {...args} isSquare={true} />
+      <SegmentedControl
+        {...args}
+        options={[
+          { value: 'table', ariaLabel: 'テーブル', content: tableIcon },
+          { value: 'chartBar', ariaLabel: 'バーチャート', content: chartBarIcon },
+          { value: 'chartArea', ariaLabel: 'エリアチャート', content: chartAreaIcon },
+          { value: 'chartLine', ariaLabel: 'ラインチャート', content: chartLineIcon },
+          { value: 'chartPie', ariaLabel: 'パイチャート', content: chartPieIcon },
+        ]}
+        isSquare={false}
+      />
+      <SegmentedControl
+        {...args}
+        options={[
+          { value: 'departments', content: '部署', disabled: true },
+          { value: 'crew', content: '従業員', disabled: true },
+          { value: 'both', content: '部署と従業員', disabled: true },
+        ]}
+        isSquare={true}
+      />
     </Stack>
   ),
 }


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://kufuinc.slack.com/archives/CGC58MW01/p1728614020390679

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

SegmentedControl[isSquare=true]はアイコンのときにのみ使用されるので、Storybookもそうなるように修正

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- SegmentedControl[isSquare=true]の箇所について、options propsにアイコンを使用したものが渡るように修正

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
