### PR TITLE
fix(LanguageSwitcher): スクリーンリーダーで各言語のリンクを正しく読み上げられるようにlang属性を追加

### DIFF
--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.stories.tsx
@@ -28,6 +28,9 @@ export const All: StoryFn = () => {
   const handleLanguageSelect = (code: string) => {
     setLang(code)
     action('onLanguageSelect')
+    // Storybook上でもスクリーンリーダーでの読み上げを確認できるためhtmlのlangを変更してます
+    const page = document.querySelector('html')
+    page?.setAttribute('lang', code)
   }
 
   return (

--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.stories.tsx
@@ -42,6 +42,7 @@ export const All: StoryFn = () => {
           />
         </dd>
       </div>
+
       <div>
         <dt>narrow</dt>
         <dd className="shr-flex shr-bg-main-darken">
@@ -54,6 +55,7 @@ export const All: StoryFn = () => {
           />
         </dd>
       </div>
+
       <div>
         <dt>invert & ボタンラベル変更</dt>
         <dd className="shr-flex">
@@ -66,6 +68,7 @@ export const All: StoryFn = () => {
           />
         </dd>
       </div>
+
       <div>
         <dt>narrow invert & defaultのlocaleを変更</dt>
         <dd className="shr-flex">

--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.stories.tsx
@@ -28,9 +28,6 @@ export const All: StoryFn = () => {
   const handleLanguageSelect = (code: string) => {
     setLang(code)
     action('onLanguageSelect')
-    // Storybook上でもスクリーンリーダーでの読み上げを確認できるためhtmlのlangを変更してます
-    const page = document.querySelector('html')
-    page?.setAttribute('lang', code)
   }
 
   return (

--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
@@ -132,7 +132,7 @@ export const LanguageSwitcher: React.FC<Props & ElementProps> = ({
           {locales.map(([code, label]) => {
             const isCurrent = currentLang === code
             return (
-              <li key={code} className={languageItem()} aria-current={isCurrent}>
+              <li key={code} className={languageItem()} aria-current={isCurrent} lang={code}>
                 <Button
                   wide
                   prefix={isCurrent ? <FaCheckIcon color="MAIN" alt={checkIconAlt} /> : null}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1177

[Storybook](https://story.smarthr-ui.dev/?path=/docs/navigation%EF%BC%88%E3%83%8A%E3%83%93%E3%82%B2%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%EF%BC%89-header-languageswitcher--docs)
[WCAG Reference](https://waic.jp/translations/WCAG21/Understanding/language-of-parts.html)
<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

言語切替メニューのリンクのテキストが各言語の言葉のため、pageに設定されている言語によってスクリーンリーダーで読み上げるときに発音がおかしかったり、読み上げられない場合がります

## 変更内容

- スクリーンリーダーで各言語の発音で読み上げるために、LanguageSwitcherの各アイテム言語ごとにlang属性を追加
<img width="520" alt="image" src="https://github.com/user-attachments/assets/319e4fb3-10cb-4abb-9295-9fe8e080c823">



<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

現在の状態の確認は
- ローカルのStorbookで確認したい場合一旦LanguageSwitcherで追加したlang属性を削除してから、スクリーンリーダーで各アイテムを読み上げる
- SmartHR上のヘッダーにあるLanguageSwitcherでスクリーンリーダーで各アイテムを読み上げる
- 一番わかりやすいのがポルトガル語やベトナム語を選択し、漢字、ハングルを読み上げると選択中の言語で読み方がないため何も読み上げられない

