### PR TITLE
fix: AppNaviDropdown の deprecated を削除

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdown.tsx
@@ -31,7 +31,6 @@ const appNaviDropdown = tv({
   },
 })
 
-/** @deprecated AppNaviDropdownMenuButton を使ってください */
 export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
   children,
   dropdownContent,


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1063

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

buttons を deprecated した際に、DrodownMenuButton への移行を考えていましたが、DropdownMenuButton 内でグルーピングしたいプロダクトが発生したため deprecated を外します。

DropdownMenuButton や AppNaviDropdownMenuButton でグルーピング対応ができるようになったら、また deprecated する予定です。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

ノールックでも問題ないです。
