### PR TITLE
fix(Switch): 未選択時のコントラスト比を 3:1 確保する

### DIFF
--- a/packages/smarthr-ui/src/components/Switch/Switch.tsx
+++ b/packages/smarthr-ui/src/components/Switch/Switch.tsx
@@ -21,8 +21,8 @@ const switchStyle = tv({
       'supports-[not_selector(:has(+_*))]:shr-border-[revert] supports-[not_selector(:has(+_*))]:shr-bg-[revert]',
 
       // Switch ツマミ
-      'before:shr-box-border before:shr-inline-block before:shr-size-[theme(fontSize.base)] before:shr-scale-[calc(2/3)] before:shr-rounded-full before:shr-border before:shr-border-solid before:shr-border-[theme(colors.grey.65)] before:shr-bg-[theme(colors.grey.65)] before:shr-transition-[transform,margin] before:shr-duration-150 before:shr-ease-out before:shr-content-[""]',
-      'has-[input:disabled:not(:checked)]:before:shr-border-[theme(colors.grey.30)] has-[input:disabled:not(:checked)]:before:shr-bg-[theme(colors.grey.30)]',
+      'before:shr-box-border before:shr-inline-block before:shr-size-[theme(fontSize.base)] before:shr-scale-[calc(2/3)] before:shr-rounded-full before:shr-border before:shr-border-solid before:shr-border-[theme(textColor.grey)] before:shr-bg-[theme(textColor.grey)] before:shr-transition-[transform,margin] before:shr-duration-150 before:shr-ease-out before:shr-content-[""]',
+      'has-[input:disabled:not(:checked)]:before:shr-border-[theme(textColor.disabled)] has-[input:disabled:not(:checked)]:before:shr-bg-[theme(textColor.disabled)]',
       'has-[:checked]:before:shr-border-shorthand has-[:checked]:before:shr-ms-[theme(fontSize.base)] has-[:checked]:before:shr-scale-100 has-[:checked]:before:shr-bg-white',
       'forced-colors:has-[input:not(:disabled)]:before:shr-bg-[ButtonBorder]',
       'forced-colors:has-[:disabled:not(:checked)]:before:shr-border-solid forced-colors:has-[:disabled:not(:checked)]:before:shr-border-[GrayText]',

--- a/packages/smarthr-ui/src/components/Switch/Switch.tsx
+++ b/packages/smarthr-ui/src/components/Switch/Switch.tsx
@@ -21,7 +21,8 @@ const switchStyle = tv({
       'supports-[not_selector(:has(+_*))]:shr-border-[revert] supports-[not_selector(:has(+_*))]:shr-bg-[revert]',
 
       // Switch ツマミ
-      'before:shr-box-border before:shr-inline-block before:shr-size-[theme(fontSize.base)] before:shr-scale-[calc(2/3)] before:shr-rounded-full before:shr-border before:shr-border-solid before:shr-border-[theme(colors.grey.30)] before:shr-bg-[theme(colors.grey.30)] before:shr-transition-[transform,margin] before:shr-duration-150 before:shr-ease-out before:shr-content-[""]',
+      'before:shr-box-border before:shr-inline-block before:shr-size-[theme(fontSize.base)] before:shr-scale-[calc(2/3)] before:shr-rounded-full before:shr-border before:shr-border-solid before:shr-border-[theme(colors.grey.65)] before:shr-bg-[theme(colors.grey.65)] before:shr-transition-[transform,margin] before:shr-duration-150 before:shr-ease-out before:shr-content-[""]',
+      'has-[input:disabled:not(:checked)]:before:shr-border-[theme(colors.grey.30)] has-[input:disabled:not(:checked)]:before:shr-bg-[theme(colors.grey.30)]',
       'has-[:checked]:before:shr-border-shorthand has-[:checked]:before:shr-ms-[theme(fontSize.base)] has-[:checked]:before:shr-scale-100 has-[:checked]:before:shr-bg-white',
       'forced-colors:has-[input:not(:disabled)]:before:shr-bg-[ButtonBorder]',
       'forced-colors:has-[:disabled:not(:checked)]:before:shr-border-solid forced-colors:has-[:disabled:not(:checked)]:before:shr-border-[GrayText]',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://smarthr.atlassian.net/browse/SHRUI-1072

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- Switchは非テキストとして、未選択時のコントラスト比をミニマムでも3:1を確保したい
- 視覚障害を持つユーザーや色を見分けることが難しいユーザーが内容が見やすくなる
- borderもコントラスト比をミニマムでも3:1を確保したいけど、他のform control componentも影響があるため、まとめて別途検討する

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- 未選択時のSwitchのコントラスト比をミニマムでも3:1を確保するために、つまみの部分のカラーを変更する
    - #c1bdb7(TEXT_DISABLED) から #706d65(TEXT_GREY)
    - コントラスト比：**1.87:1**　＝＞　**5.16:1**
    
    
### Reduced contrastで検証
BEFORE | AFTER
--- | ---
<img width="819" alt="Switch componentのコントラスト比改善前の画面のReduced contrast設定されてるstorybookの画面" src="https://github.com/user-attachments/assets/37600dd4-86c2-42bc-809b-5447b97e19b4"> | <img width="775" alt="Switch componentのコントラスト比改善後の画面のReduced contrast設定されてるstorybookの画面" src="https://github.com/user-attachments/assets/5cd41e97-559e-4753-81b0-45d6928eaf46">



## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Storybook や Chromatic で確認してください。