### PR TITLE
fix: レイアウトコンポーネントなどと StyledComponent を組み合わせた場合に、見出しレベルの自動設定が機能しない不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
@@ -2,7 +2,7 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 
-import { Heading } from '../Heading'
+import { Heading, PageHeading } from '../Heading'
 
 import { Article, Aside, Nav, Section } from './SectioningContent'
 
@@ -108,5 +108,19 @@ describe('SectioningContent', () => {
       </Section>,
     )
     expect(ref.current?.querySelector('h2')).toBeInTheDocument()
+  })
+
+  it('SectioningContent に PageHeading が含まれている場合、見出しレベルは常に1になること', async () => {
+    const { container } = render(
+      <Section>
+        <Section>
+          <Section>
+            <PageHeading>PageHeading</PageHeading>
+          </Section>
+        </Section>
+      </Section>,
+    )
+
+    expect(container.querySelector('h1')?.textContent).toEqual('PageHeading')
   })
 })

--- a/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
@@ -63,11 +63,11 @@ describe('SectioningContent', () => {
         </Section>
       </Section>,
     )
-    expect(container.querySelector('h2')?.textContent).toEqual('level 2')
-    expect(container.querySelector('h3')?.textContent).toEqual('level 3')
-    expect(container.querySelector('h4')?.textContent).toEqual('level 4')
-    expect(container.querySelector('h5')?.textContent).toEqual('level 5')
-    expect(container.querySelector('h6')?.textContent).toEqual('level 6')
+    expect(container.querySelector('h2')).toHaveTextContent('level 2')
+    expect(container.querySelector('h3')).toHaveTextContent('level 3')
+    expect(container.querySelector('h4')).toHaveTextContent('level 4')
+    expect(container.querySelector('h5')).toHaveTextContent('level 5')
+    expect(container.querySelector('h6')).toHaveTextContent('level 6')
   })
 
   it('SectioningContent が並列にある場合、それぞれの見出しレベルは独立してインクリメントすること', async () => {
@@ -89,11 +89,11 @@ describe('SectioningContent', () => {
       </Section>,
     )
 
-    expect(document.querySelector('h2')?.textContent).toEqual('level 2')
-    expect(document.querySelectorAll('h3')[0].textContent).toEqual('level 3-1')
-    expect(document.querySelectorAll('h3')[1].textContent).toEqual('level 3-2')
-    expect(document.querySelectorAll('h4')[0].textContent).toEqual('level 4-1')
-    expect(document.querySelectorAll('h4')[1].textContent).toEqual('level 4-2')
+    expect(document.querySelector('h2')).toHaveTextContent('level 2')
+    expect(document.querySelectorAll('h3')[0]).toHaveTextContent('level 3-1')
+    expect(document.querySelectorAll('h3')[1]).toHaveTextContent('level 3-2')
+    expect(document.querySelectorAll('h4')[0]).toHaveTextContent('level 4-1')
+    expect(document.querySelectorAll('h4')[1]).toHaveTextContent('level 4-2')
   })
 
   it('SectioningContent に含まれる見出し要素は、見出しレベルが6を超えると span になり、role と aria-level が設定される', async () => {
@@ -143,6 +143,6 @@ describe('SectioningContent', () => {
       </Section>,
     )
 
-    expect(container.querySelector('h1')?.textContent).toEqual('PageHeading')
+    expect(container.querySelector('h1')).toHaveTextContent('PageHeading')
   })
 })

--- a/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
@@ -7,7 +7,7 @@ import { Heading } from '../Heading'
 import { Article, Aside, Nav, Section } from './SectioningContent'
 
 describe('SectioningContent', () => {
-  it('<Section> を使用すると article 要素が描画されること', async () => {
+  it('<Section> を使用すると section 要素が描画されること', async () => {
     const { container } = render(<Section></Section>)
     expect(container.querySelector('section')).toBeInTheDocument()
   })

--- a/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
@@ -57,9 +57,6 @@ describe('SectioningContent', () => {
               <Heading>level 5</Heading>
               <Section>
                 <Heading>level 6</Heading>
-                <Section>
-                  <Heading>level 7</Heading>
-                </Section>
               </Section>
             </Section>
           </Section>
@@ -71,7 +68,6 @@ describe('SectioningContent', () => {
     expect(container.querySelector('h4')?.textContent).toEqual('level 4')
     expect(container.querySelector('h5')?.textContent).toEqual('level 5')
     expect(container.querySelector('h6')?.textContent).toEqual('level 6')
-    expect(container.querySelector('span')?.textContent).toEqual('level 7')
   })
 
   it('SectioningContent が並列にある場合、それぞれの見出しレベルは独立してインクリメントすること', async () => {
@@ -98,6 +94,32 @@ describe('SectioningContent', () => {
     expect(document.querySelectorAll('h3')[1].textContent).toEqual('level 3-2')
     expect(document.querySelectorAll('h4')[0].textContent).toEqual('level 4-1')
     expect(document.querySelectorAll('h4')[1].textContent).toEqual('level 4-2')
+  })
+
+  it('SectioningContent に含まれる見出し要素は、見出しレベルが6を超えると span になり、role と aria-level が設定される', async () => {
+    const { container } = render(
+      <Section>
+        <Heading>level 2</Heading>
+        <Section>
+          <Heading>level 3</Heading>
+          <Section>
+            <Heading>level 4</Heading>
+            <Section>
+              <Heading>level 5</Heading>
+              <Section>
+                <Heading>level 6</Heading>
+                <Section>
+                  <Heading>level 7</Heading>
+                </Section>
+              </Section>
+            </Section>
+          </Section>
+        </Section>
+      </Section>,
+    )
+    expect(container.querySelector('span')).toHaveTextContent('level 7')
+    expect(container.querySelector('span')).toHaveAttribute('role', 'heading')
+    expect(container.querySelector('span')).toHaveAttribute('aria-level', '7')
   })
 
   it('SectioningContent には ref を渡すことができる', async () => {

--- a/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.test.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable smarthr/a11y-heading-in-sectioning-content */
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { Heading } from '../Heading'
+
+import { Article, Aside, Nav, Section } from './SectioningContent'
+
+describe('SectioningContent', () => {
+  it('<Section> を使用すると article 要素が描画されること', async () => {
+    const { container } = render(<Section></Section>)
+    expect(container.querySelector('section')).toBeInTheDocument()
+  })
+
+  it('<Article> を使用すると article 要素が描画されること', async () => {
+    const { container } = render(<Article></Article>)
+    expect(container.querySelector('article')).toBeInTheDocument()
+  })
+
+  it('<Aside> を使用すると aside 要素が描画されること', async () => {
+    const { container } = render(<Aside></Aside>)
+    expect(container.querySelector('aside')).toBeInTheDocument()
+  })
+
+  it('<Nav> を使用すると nav 要素が描画されること', async () => {
+    const { container } = render(<Nav></Nav>)
+    expect(container.querySelector('nav')).toBeInTheDocument()
+  })
+
+  it('SectioningContent 直下の見出しレベルはデフォルトで2になること', async () => {
+    const { container } = render(
+      <Section>
+        <Heading>Heading</Heading>
+      </Section>,
+    )
+    expect(container.querySelector('h2')).toBeInTheDocument()
+  })
+
+  it('SectioningContent の見出しレベルは baseLevel で上書きできること', async () => {
+    const { container } = render(
+      <Section baseLevel={3}>
+        <Heading>Heading</Heading>
+      </Section>,
+    )
+    expect(container.querySelector('h3')).toBeInTheDocument()
+  })
+
+  it('SectioningContent がネストされた場合、見出しレベルがインクリメントされること', async () => {
+    const { container } = render(
+      <Section>
+        <Heading>level 2</Heading>
+        <Section>
+          <Heading>level 3</Heading>
+          <Section>
+            <Heading>level 4</Heading>
+            <Section>
+              <Heading>level 5</Heading>
+              <Section>
+                <Heading>level 6</Heading>
+                <Section>
+                  <Heading>level 7</Heading>
+                </Section>
+              </Section>
+            </Section>
+          </Section>
+        </Section>
+      </Section>,
+    )
+    expect(container.querySelector('h2')?.textContent).toEqual('level 2')
+    expect(container.querySelector('h3')?.textContent).toEqual('level 3')
+    expect(container.querySelector('h4')?.textContent).toEqual('level 4')
+    expect(container.querySelector('h5')?.textContent).toEqual('level 5')
+    expect(container.querySelector('h6')?.textContent).toEqual('level 6')
+    expect(container.querySelector('span')?.textContent).toEqual('level 7')
+  })
+
+  it('SectioningContent が並列にある場合、それぞれの見出しレベルは独立してインクリメントすること', async () => {
+    render(
+      <Section>
+        <Heading>level 2</Heading>
+        <Section>
+          <Heading>level 3-1</Heading>
+          <Section>
+            <Heading>level 4-1</Heading>
+          </Section>
+        </Section>
+        <Section>
+          <Heading>level 3-2</Heading>
+          <Section>
+            <Heading>level 4-2</Heading>
+          </Section>
+        </Section>
+      </Section>,
+    )
+
+    expect(document.querySelector('h2')?.textContent).toEqual('level 2')
+    expect(document.querySelectorAll('h3')[0].textContent).toEqual('level 3-1')
+    expect(document.querySelectorAll('h3')[1].textContent).toEqual('level 3-2')
+    expect(document.querySelectorAll('h4')[0].textContent).toEqual('level 4-1')
+    expect(document.querySelectorAll('h4')[1].textContent).toEqual('level 4-2')
+  })
+
+  it('SectioningContent には ref を渡すことができる', async () => {
+    const ref = React.createRef<HTMLDivElement>()
+    render(
+      <Section ref={ref}>
+        <Heading>heading</Heading>
+      </Section>,
+    )
+    expect(ref.current?.querySelector('h2')).toBeInTheDocument()
+  })
+})

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+import styled from 'styled-components'
+
+import { SectioningFragment } from './SectioningContent'
+import { useSectionWrapper } from './useSectioningWrapper'
+
+describe('useSectionWrapper', () => {
+  const sectioningContents = ['article', 'aside', 'nav', 'section'] as const
+  const notSectioningContents = ['div', 'span', 'p', 'h1', 'ul', 'li', 'a'] as const
+
+  it('sectioningContents に含まれる要素の場合、SectioningFragment が返ること', () => {
+    sectioningContents.forEach((type) => {
+      const { result } = renderHook(() => useSectionWrapper(type))
+      expect(result.current).toBe(SectioningFragment)
+    })
+  })
+
+  it('sectioningContents に含まれる要素の StyledComponent の場合、SectioningFragment が返ること', () => {
+    sectioningContents.forEach((type) => {
+      const component = styled[type]``
+      const { result } = renderHook(() => useSectionWrapper(component))
+      expect(result.current).toBe(SectioningFragment)
+    })
+  })
+
+  it('sectioningContents に含まれない要素の場合、Fragment が返ること', () => {
+    notSectioningContents.forEach((type) => {
+      const { result } = renderHook(() => useSectionWrapper(type))
+      expect(result.current).toBe(React.Fragment)
+    })
+  })
+
+  it('sectioningContents に含まれない要素の StyledComponent の場合、Fragment が返ること', () => {
+    notSectioningContents.forEach((type) => {
+      const component = styled[type]``
+      const { result } = renderHook(() => useSectionWrapper(component))
+      expect(result.current).toBe(React.Fragment)
+    })
+  })
+})

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
@@ -31,7 +31,7 @@ describe('useSectionWrapper', () => {
     })
   })
 
-  it('sectioningContents に含まれない要素の StyledComponent の場合、Fragment が返ること', () => {
+  it('sectioningContents に含まれない要素が StyledComponent の場合、Fragment が返ること', () => {
     notSectioningContents.forEach((type) => {
       const component = styled[type]``
       const { result } = renderHook(() => useSectionWrapper(component))

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
@@ -16,7 +16,7 @@ describe('useSectionWrapper', () => {
     })
   })
 
-  it('sectioningContents に含まれる要素の StyledComponent の場合、SectioningFragment が返ること', () => {
+  it('sectioningContents に含まれる要素が StyledComponent の場合、SectioningFragment が返ること', () => {
     sectioningContents.forEach((type) => {
       const component = styled[type]``
       const { result } = renderHook(() => useSectionWrapper(component))

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
@@ -9,7 +9,7 @@ const sectioningContents = ['article', 'aside', 'nav', 'section']
 
 const isSectioningContent = (type: ComponentType) => {
   const type_ = isStyledComponent(type) ? type.target : type
-  return typeof type === 'string' && sectioningContents.includes(type_)
+  return typeof type_ === 'string' && sectioningContents.includes(type_)
 }
 
 /** NOTE: Layout コンポーネントに変更がある場合、必ず [smarthr/a11y-heading-in-sectioning-content](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-heading-in-sectioning-content) を見直すこと


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

元は単体テストを書くぞってチケット
https://smarthr.atlassian.net/browse/SHRUI-1185

## 概要

SectioningContent コンポーネント及び useSectioningWrapper の単体テスト作成し、RSCに向けた対応の下準備します。

その過程で、以下のような不具合を発見したのでついでに修正します。

```tsx
<Stack as={StyledSection}>
  <Heading>heading</Heading>
</Stack>

// 中略

const StyledSection = styled.section``
```

上記のように、ネイティブの SectioningContent タグを拡張した StyledComponent を、Stack  (や Cluster, Base など) の  `as` オプションに指定した場合、内包される `Heading` タグの見出しレベルは自動計算されるべきですが、されずにすべて h1 になる不具合がありました。

## 変更内容

- 単体テストを追加
- 軽微な不具合修正

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

テストコードに過不足ないかを確認の上、CIが通ればOKです。

```
 ✓ src/components/SectioningContent/SectioningContent.test.tsx (11)
   ✓ SectioningContent (11)
     ✓ <Section> を使用すると section 要素が描画されること
     ✓ <Article> を使用すると article 要素が描画されること
     ✓ <Aside> を使用すると aside 要素が描画されること
     ✓ <Nav> を使用すると nav 要素が描画されること
     ✓ SectioningContent 直下の見出しレベルはデフォルトで2になること
     ✓ SectioningContent の見出しレベルは baseLevel で上書きできること
     ✓ SectioningContent がネストされた場合、見出しレベルがインクリメントされること
     ✓ SectioningContent が並列にある場合、それぞれの見出しレベルは独立してインクリメントすること
     ✓ SectioningContent に含まれる見出し要素は、見出しレベルが6を超えると span になり、role と aria-level が設定される
     ✓ SectioningContent には ref を渡すことができる
     ✓ SectioningContent に PageHeading が含まれている場合、見出しレベルは常に1になること
 ✓ src/components/SectioningContent/useSectioningWrapper.test.tsx (4)
   ✓ useSectionWrapper (4)
     ✓ sectioningContents に含まれる要素の場合、SectioningFragment が返ること
     ✓ sectioningContents に含まれる要素が StyledComponent の場合、SectioningFragment が返ること
     ✓ sectioningContents に含まれない要素の場合、Fragment が返ること
     ✓ sectioningContents に含まれない要素が StyledComponent の場合、Fragment が返ること
```