### PR TITLE
fix: SearchInput に幅があたらない不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
+++ b/packages/smarthr-ui/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
@@ -14,17 +14,17 @@ const inputWithTooltip = tv({
 })
 
 export const InputWithTooltip = forwardRef<HTMLInputElement, Props>(
-  ({ tooltipMessage, width, ...props }, ref) => {
+  ({ tooltipMessage, width, className, ...rest }, ref) => {
     const widthStyle = typeof width === 'number' ? `${width}px` : width
     const tooltipStyleProps = useMemo(() => {
-      const tooltip = inputWithTooltip()
+      const tooltip = inputWithTooltip({ className })
       return {
         className: tooltip,
         style: {
           width: widthStyle,
         },
       }
-    }, [widthStyle])
+    }, [className, widthStyle])
 
     return (
       <Tooltip
@@ -34,7 +34,7 @@ export const InputWithTooltip = forwardRef<HTMLInputElement, Props>(
         ariaDescribedbyTarget="inner"
       >
         {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
-        <Input {...props} width={widthStyle} ref={ref} />
+        <Input {...rest} width={widthStyle} ref={ref} />
       </Tooltip>
     )
   },

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -30,15 +30,15 @@ const searchInput = tv({
 })
 
 export const SearchInput = forwardRef<HTMLInputElement, Props>(
-  ({ decorators, width, ...props }, ref) => {
+  ({ decorators, width, className, ...rest }, ref) => {
     const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
     const labelWidth = typeof width === 'number' ? `${width}px` : width
     const { label, input } = searchInput({ existsWidth: !!labelWidth })
 
     return (
-      <label className={label()} style={{ width: labelWidth }}>
+      <label className={label({ className })} style={{ width: labelWidth }}>
         <InputWithTooltip
-          {...props}
+          {...rest}
           ref={ref}
           prefix={<FaMagnifyingGlassIcon alt={iconAlt} color="TEXT_GREY" />}
           className={input()}

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentProps, forwardRef, useMemo } from 'react'
+import { tv } from 'tailwind-variants'
 
-import { FaSearchIcon } from '../../Icon'
+import { FaMagnifyingGlassIcon } from '../../Icon'
 import { InputWithTooltip } from '../InputWithTooltip'
 
 import type { DecoratorsType } from '../../../types'
@@ -13,34 +14,34 @@ type Props = Omit<ComponentProps<typeof InputWithTooltip>, 'tooltipMessage' | 'p
 
 const ICON_ALT = '検索'
 
+const searchInput = tv({
+  slots: {
+    label: 'shr-inline-block',
+    input: '',
+  },
+  variants: {
+    existsWidth: {
+      true: {
+        // Tooltip > Input の構成になっているため、内部の幅を広げる
+        input: 'shr-w-full [&_.smarthr-ui-Input]:shr-w-full',
+      },
+    },
+  },
+})
+
 export const SearchInput = forwardRef<HTMLInputElement, Props>(
   ({ decorators, width, ...props }, ref) => {
     const iconAlt = useMemo(() => decorators?.iconAlt?.(ICON_ALT) || ICON_ALT, [decorators])
-    const widths = useMemo(() => {
-      const widthStyle = typeof width === 'number' ? `${width}px` : width
-
-      if (!widthStyle) {
-        return {
-          label: undefined,
-          input: undefined,
-        }
-      }
-
-      return {
-        label: {
-          width: widthStyle,
-        },
-        input: '100%',
-      }
-    }, [width])
+    const labelWidth = typeof width === 'number' ? `${width}px` : width
+    const { label, input } = searchInput({ existsWidth: !!labelWidth })
 
     return (
-      <label style={widths.label}>
+      <label className={label()} style={{ width: labelWidth }}>
         <InputWithTooltip
           {...props}
           ref={ref}
-          width={widths.input}
-          prefix={<FaSearchIcon alt={iconAlt} color="TEXT_GREY" />}
+          prefix={<FaMagnifyingGlassIcon alt={iconAlt} color="TEXT_GREY" />}
+          className={input()}
         />
       </label>
     )


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

SearchInput が inline なため幅があたらない不具合がありました。

flexitem や block になっていない場合、label に対して width があたっているため意図した幅を与えられませんでした。


<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- SearchInput の display を inline-block に変えました
- tailwind-variants 化しました

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Storybook や Chromatic で確認してください。