### PR TITLE
fix!: TimePicker/MonthPickerにtypeを指定できないようにする

### DIFF
--- a/packages/smarthr-ui/src/components/Picker/types.ts
+++ b/packages/smarthr-ui/src/components/Picker/types.ts
@@ -1,3 +1,4 @@
 import { ComponentPropsWithoutRef } from 'react'
 
-export type PickerProps<Props> = Props & Omit<ComponentPropsWithoutRef<'input'>, keyof Props>
+export type PickerProps<Props> = Props &
+  Omit<ComponentPropsWithoutRef<'input'>, keyof Props | 'type'>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

- 無

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- 従来の型定義だと `TimePicker` / `MonthPicker` は `input` 要素に付与可能なすべての属性をpropsとして受け取ります
- その結果 `<TimePicker type="date" />` といった意図のわからない指定が可能になっていました
    - ランタイムでは内部的に指定されている `type=time` が勝つので当該指定をしても挙動は変わりません
    - あくまで「型定義上は可能」という話
- `TimePicker` は既にコンポーネントとして提供されているため一応BREAKING CHANGEという扱いにしています

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- `PickerProps` から `type` を除外しました

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- ✅ `TimePicker` / `MonthPicker` に `type` 属性を指定すると型検査でエラーとなること