### PR TITLE
fix: TabBar が margin を持たないように修正

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabBar.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.tsx
@@ -6,7 +6,7 @@ import { Reel } from '../Layout'
 const tabBar = tv({
   slots: {
     wrapper: 'smarthr-ui-TabBar',
-    inner: 'shr-grow shr-m-0.25',
+    inner: 'shr-grow',
   },
   variants: {
     bordered: {

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -13,7 +13,7 @@ const tabItem = tv({
       'shr-group/tabitem',
       'shr-relative shr-px-1 shr-py-0.75 shr-inline-flex shr-items-center shr-gap-0.5',
       'hover:shr-bg-white-darken',
-      'focus-visible:shr-z-1',
+      'focus-visible:shr-z-1 focus-visible:shr-focus-indicator--inner',
       'disabled:shr-cursor-not-allowed disabled:shr-bg-transparent',
       'aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-content-[""] aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-z-1',
       'forced-colors:aria-selected:before:shr-bg-[Highlight]',

--- a/packages/smarthr-ui/src/components/TabBar/stories/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/TabBar.stories.tsx
@@ -25,12 +25,6 @@ export default {
   },
 } as Meta<typeof TabBar>
 
-export const Default: StoryObj<typeof TabBar> = {
-  args: {
-    bordered: true,
-  },
-}
-
 export const Playground: StoryObj<typeof TabBar> = {
   args: {
     bordered: true,

--- a/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
@@ -8,7 +8,7 @@ import { Stack } from '../../Layout'
 import { TabBar } from '../TabBar'
 import { TabItem } from '../TabItem'
 
-import type { StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 export default {
   title: 'Navigation（ナビゲーション）/TabBar/VRT',
@@ -20,84 +20,71 @@ export default {
    * true     false    true     なし    あり
    * true     true     false    あり    あり
    * true     false    false    なし    なし */
-  render: (args: any) => (
-    <Stack {...args}>
-      <TabBar bordered={false}>
-        <TabItem id="tab1" onClick={action('clicked')} suffix={<Badge count={100} />}>
-          タブ1
-        </TabItem>
-        <TabItem
-          id="tab2"
-          onClick={action('clicked')}
-          selected
-          disabled
-          disabledDetail={{ message: 'タブが無効な理由' }}
-        >
-          タブ2
-        </TabItem>
-      </TabBar>
-      <TabBar>
-        <TabItem
-          id="tab3"
-          onClick={action('clicked')}
-          selected
-          disabled
-          suffix={<Badge count={100} />}
-        >
-          タブ3
-        </TabItem>
-        <TabItem
-          id="tab4"
-          onClick={action('clicked')}
-          disabled
-          disabledDetail={{ message: 'タブが無効な理由' }}
-        >
-          タブ4
-        </TabItem>
-        <TabItem
-          id="tab5"
-          onClick={action('clicked')}
-          selected
-          suffix={<FaCircleExclamationIcon color="DANGER" />}
-          disabledDetail={{ message: 'タブが無効な理由' }}
-        >
-          タブ5
-        </TabItem>
-        <TabItem id="tab6" onClick={action('clicked')}>
-          タブ6
-        </TabItem>
-      </TabBar>
+  render: (args) => (
+    <Stack>
+      {[undefined, 'hover', 'focus-visible'].map((variant) => (
+        <Stack id={variant} key={variant}>
+          <TabBar {...args} bordered={false}>
+            <TabItem id="tab1" onClick={action('clicked')} suffix={<Badge count={100} />}>
+              タブ1
+            </TabItem>
+            <TabItem
+              id="tab2"
+              onClick={action('clicked')}
+              selected
+              disabled
+              disabledDetail={{ message: 'タブが無効な理由' }}
+            >
+              タブ2
+            </TabItem>
+          </TabBar>
+          <TabBar>
+            <TabItem
+              id="tab3"
+              onClick={action('clicked')}
+              selected
+              disabled
+              suffix={<Badge count={100} />}
+            >
+              タブ3
+            </TabItem>
+            <TabItem
+              id="tab4"
+              onClick={action('clicked')}
+              disabled
+              disabledDetail={{ message: 'タブが無効な理由' }}
+            >
+              タブ4
+            </TabItem>
+            <TabItem
+              id="tab5"
+              onClick={action('clicked')}
+              selected
+              suffix={<FaCircleExclamationIcon color="DANGER" />}
+              disabledDetail={{ message: 'タブが無効な理由' }}
+            >
+              タブ5
+            </TabItem>
+            <TabItem id="tab6" onClick={action('clicked')}>
+              タブ6
+            </TabItem>
+          </TabBar>
+        </Stack>
+      ))}
     </Stack>
   ),
   parameters: {
     chromatic: { disableSnapshot: false },
   },
   tags: ['!autodocs'],
-}
+} satisfies Meta<typeof TabBar>
 
-export const VRT = {}
-
-export const VRTHover = {
-  ...VRT,
-  args: {
-    id: 'hover',
-  },
+export const VRT = {
   parameters: {
     pseudo: {
       hover: ['#hover .smarthr-ui-TabItem'],
+      focusVisible: ['#focus-visible .smarthr-ui-TabItem'],
     },
-    // MEMO: VRT として機能していないので、解決するまでスナップショットを無効化
-    chromatic: { disableSnapshot: true },
-  },
-}
-
-export const VRTKeyboardFocus: StoryObj = {
-  ...VRT,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-    const tabs = canvas.getAllByRole('tab')
-    // bordered で disabledDetail が存在するアイテムにフォーカス
-    tabs[3].focus()
   },
 }
 

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -44,6 +44,7 @@ defaultConfig.twMergeConfig = {
         ],
       },
     ],
+    focus: ['focus-indicator', 'focus-indicator--inner'],
   },
 }
 
@@ -385,6 +386,11 @@ export default {
           outline: 'none',
           isolation: 'isolate',
           boxShadow: `0 0 0 2px ${theme('colors.white')}, 0 0 0 4px ${theme('colors.outline')}`,
+        },
+        '.focus-indicator--inner': {
+          outline: 'none',
+          isolation: 'isolate',
+          boxShadow: `inset 0 0 0 2px ${theme('colors.outline')}, inset 0 0 0 4px ${theme('colors.white')}`,
         },
         '.border-shorthand': {
           borderWidth: theme('borderWidth.DEFAULT'),


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1190

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

Tabbar の実装が Reel > TabBar となっており、focus-ring が見切れてしまう対処として TabBar に margin が設定されていた。
レイアウト上の不都合や視覚的な違和感が強いため修正することにした。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- focus-ring を TabItem の外側ではなく内側にセットされるように修正
- Story をついでに見直し

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
