### PR TITLE
fix: FormControl内のInputFileのアクセシブルネームに可視ラベルを含める

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -204,11 +204,20 @@ export const ActualFormControl: React.FC<Props & ElementProps> = ({
 
       const input = inputWrapper.querySelector('[data-smarthr-ui-input="true"]')
 
-      if (input && !input.getAttribute('id')) {
-        input.setAttribute('id', managedHtmlFor)
+      if (input) {
+        if (!input.getAttribute('id')) {
+          input.setAttribute('id', managedHtmlFor)
+        }
+
+        const isInputFile = input instanceof HTMLInputElement && input.type === 'file'
+        const inputLabelledByIds = input.getAttribute('aria-labelledby')
+        if (isInputFile && inputLabelledByIds) {
+          // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
+          input.setAttribute('aria-labelledby', `${inputLabelledByIds} ${managedLabelId}`)
+        }
       }
     }
-  }, [managedHtmlFor, isRoleGroup])
+  }, [managedHtmlFor, isRoleGroup, managedLabelId])
   useEffect(() => {
     const inputWrapper = inputWrapperRef?.current
 


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1069

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

InputFile コンポーネントを `<label>` 要素などで紐づけた場合(FormControlで利用する時に)にアクセシブルネームに `<label>` 内のテキストが反映されないため、 `<label>` 内のテキストもInputFileのアクセシブルネームに含める

reference:
https://github.com/kufu/wcag-guide/wiki/SmartHR-UI#inputfile%E3%81%AEaccessible-name%E3%81%AF%E3%81%A9%E3%82%93%E3%81%AA%E5%86%85%E5%AE%B9%E3%81%8C%E9%81%A9%E5%88%87%E3%81%8B

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

FormControl内でInputFile利用する際には`<label>` 要素で可視ラベルとして紐づけるため、`<label>` 要素の可視ラベルをInputFileのアクセシブルネームに含める
<img width="1446" alt="ブラウザのdevtoolのアクセシビリティタブでInputFile componentのアクセシブルネームにラベル要素の可視ラベルが含まれていることを示している画像" src="https://github.com/user-attachments/assets/a899d60b-3d68-4882-8985-d3fb895e624b">

メリット
https://smarthr.design/accessibility/check-list/accessible-name/#h2-2


## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Storybook や Chromatic で確認してください。
