### PR TITLE
fix: TabItem に disabledDetail があるときのフォーカスリングを修正

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -84,6 +84,7 @@ export const TabItem: FC<Props & ElementProps> = ({
         vertical="auto"
         ariaDescribedbyTarget="inner"
         aria-disabled={rest.disabled}
+        className="focus-visible:shr-focus-indicator--inner"
       >
         <TabButton {...rest} suffix={Icon} />
       </Tooltip>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

#5054 

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

#5054 の修正漏れです。
TabItem が disabled かつ disabledDetail を持つ時に Tooltip > TabButton という構造になるが、Tooltip への focus ring が外側についているため見切れてしまう。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

TabItem を囲う Tooltip の focus ring を内側につける。

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
