### PR TITLE
fix: DropdownContentの最後の要素でTabを押したときDropdownを閉じる

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
@@ -58,4 +58,20 @@ describe('Dropdown', () => {
     act(() => document.body.click())
     expect(screen.queryByRole('button', { name: 'Button1' })).toBeNull()
   })
+
+  it('ドロップダウンからフォーカスが外れるとドロップダウンが閉じること', async () => {
+    render(template)
+
+    act(() => screen.getByRole('button', { name: 'Trigger', expanded: false }).click())
+    expect(screen.getByRole('button', { name: 'Button1' })).toBeVisible()
+
+    await userEvent.tab()
+    expect(screen.getByRole('button', { name: 'Button1' })).toHaveFocus()
+    await userEvent.tab()
+    expect(screen.getByRole('button', { name: 'Button2' })).toHaveFocus()
+    await userEvent.tab()
+    expect(screen.getByRole('button', { name: 'Button3' })).toHaveFocus()
+    await userEvent.tab()
+    expect(screen.queryByRole('button', { name: 'Button1' })).toBeNull()
+  })
 })

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
@@ -59,6 +59,19 @@ describe('Dropdown', () => {
     expect(screen.queryByRole('button', { name: 'Button1' })).toBeNull()
   })
 
+  it('ドロップダウン展開後にShift+Tabでトリガーにフォーカスが戻るとドロップダウンが閉じること', async () => {
+    render(template)
+    act(() => screen.getByRole('button', { name: 'Trigger', expanded: false }).click())
+    expect(screen.getByRole('button', { name: 'Button1' })).toBeVisible()
+
+    await userEvent.tab()
+    expect(screen.getByRole('button', { name: 'Button1' })).toHaveFocus()
+
+    await userEvent.tab({ shift: true })
+    expect(screen.getByRole('button', { name: 'Trigger' })).toHaveFocus()
+    expect(screen.queryByRole('button', { name: 'Button1' })).toBeNull()
+  })
+
   it('ドロップダウンからフォーカスが外れるとドロップダウンが閉じること', async () => {
     render(template)
 

--- a/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
@@ -53,6 +53,7 @@ export function useKeyboardNavigation(
           const rootTrigger = rootTriggers[rootTriggers.length - 1]
           if (rootTrigger) {
             rootTrigger.focus()
+            onClickCloser()
           }
         }
       } else if (e.key === 'Escape' || e.key === 'Esc') {

--- a/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
@@ -47,6 +47,7 @@ export function useKeyboardNavigation(
           // focus the Trigger
           e.preventDefault()
           trigger.focus()
+          onClickCloser()
         } else if (!e.shiftKey && e.target === lastTabbable) {
           // move focus next of the Trigger
           const rootTriggers = tabbable(rootTriggerRef.current)


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- JIRA: https://smarthr.atlassian.net/browse/SHRUI-676

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

DropdownContent からフォーカスが外れても開いたままだった & Tabの逆順では DropdownContent には入らなかったため、[フォーカス順序が見た目と異なっていて](https://smarthr.design/accessibility/check-list/focus-order) 品質基準を満たせていませんでした！

そのため、フォーカスが外れたときは DropdownContent を閉じるように変更しました！

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- DropdownContent の最後の要素で Tab を押したとき次の要素へフォーカスするロジックに、閉じる実行を追加

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

- storybook で確認可能ですが、確認するには dropdown trigger の他にフォーカス可能な要素を追加する必要があります。

テスト動画

https://github.com/user-attachments/assets/5a874faf-693e-4aa5-8324-c782cd18ff51




<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
