### PR TITLE
fix(ModelessDialog): ヘッダー部にキーボードフォーカスが当たると文字列が消えてしまう不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog.tsx
@@ -97,7 +97,11 @@ const modelessDialog = tv({
       'smarthr-ui-ModelessDialog-handle shr-absolute shr-inset-x-0 shr-bottom-0 shr-top-[2px] shr-m-auto shr-flex shr-justify-center shr-rounded-tl-s shr-rounded-tr-s shr-text-grey shr-transition-colors shr-duration-100 shr-ease-in-out',
       'focus-visible:shr-bg-white-darken focus-visible:shr-shadow-outline focus-visible:shr-outline-none',
     ],
-    title: ['shr-my-1 shr-me-1'],
+    title: [
+      'shr-my-1 shr-me-1',
+      /* DialogHandlerの上に出すためにスタッキングコンテキストを生成 */
+      '[.smarthr-ui-ModelessDialog-handle:focus-visible_+_&]:shr-relative',
+    ],
     closeButtonLayout: [
       'shr-relative' /* DialogHandlerの上に出すためにスタッキングコンテキストを生成 */,
       'shr-ml-auto shr-shrink-0',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

ModelessDialog のヘッダー部にキーボードフォーカスすると文字列が消えてしまう不具合があったため修正しました。
ヘッダー部分にフォーカス中は、文字列部分でドラッグアンドドロップできなくなりますが、許容範囲と考えました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
で十分な場合、そのURLを記載してください。
-->


Storybook や Chromatic で確認してください。