### PR TITLE
fix(AccordionPanelTrigger): キャレットが shrink してしまう不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -46,7 +46,7 @@ const accordionPanelTrigger = tv({
   compoundSlots: [
     {
       slots: ['leftIcon', 'rightIcon'],
-      className: 'group-aria-expanded:shrink-0',
+      className: 'shr-shrink-0',
     },
   ],
 })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

AccordionPanelTrigger のキャレットアイコンが shrink してしまう不具合を修正しました。
なぜか aria-expanded に対して設定され、かつ `shr-` がついていないため機能していなかった。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
