### PR TITLE
fix!: SSR対応や必要以上にイベントを登録しないように `useDevice` を変更した

### DIFF
--- a/packages/smarthr-ui/src/hooks/useDevice/DeviceProvider.tsx
+++ b/packages/smarthr-ui/src/hooks/useDevice/DeviceProvider.tsx
@@ -1,0 +1,29 @@
+'use client'
+import React, { FC, ReactNode, useSyncExternalStore } from 'react'
+
+import { defaultBreakpoint } from '../../themes/createBreakpoint'
+
+import { DeviceContext } from './useDevice'
+
+const mediaQuery = {
+  narrow: `(max-width: ${defaultBreakpoint.SP}px)`,
+}
+
+const subscribe = (onStoreChange: () => void) => {
+  const matchQueryList = matchMedia(mediaQuery.narrow)
+  matchQueryList.addEventListener('change', onStoreChange)
+
+  return () => {
+    matchQueryList.removeEventListener('change', onStoreChange)
+  }
+}
+
+const getSnapshot = () => matchMedia(mediaQuery.narrow).matches
+
+const getServerSnapshot = () => null
+
+export const DeviceProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const isNarrowView = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  return <DeviceContext.Provider value={isNarrowView}>{children}</DeviceContext.Provider>
+}

--- a/packages/smarthr-ui/src/hooks/useDevice/index.ts
+++ b/packages/smarthr-ui/src/hooks/useDevice/index.ts
@@ -1,1 +1,2 @@
 export { useDevice } from './useDevice'
+export { DeviceProvider } from './DeviceProvider'

--- a/packages/smarthr-ui/src/hooks/useDevice/useDevice.stories.tsx
+++ b/packages/smarthr-ui/src/hooks/useDevice/useDevice.stories.tsx
@@ -1,17 +1,25 @@
 import { StoryFn } from '@storybook/react/*'
 import React from 'react'
 
+import { DeviceProvider } from './DeviceProvider'
 import { useDevice } from './useDevice'
 
 export default {
   title: 'Hooks/useDevice',
   component: useDevice,
+  decorators: [
+    (Story: React.FC) => (
+      <DeviceProvider>
+        <Story />
+      </DeviceProvider>
+    ),
+  ],
 }
 
 export const Default: StoryFn = () => {
   const { isNarrowView } = useDevice()
 
-  return <p>isNarrowView: {isNarrowView.toString()}</p>
+  return <p>isNarrowView: {isNarrowView?.toString()}</p>
 }
 
 Default.parameters = {

--- a/packages/smarthr-ui/src/hooks/useDevice/useDevice.ts
+++ b/packages/smarthr-ui/src/hooks/useDevice/useDevice.ts
@@ -1,28 +1,9 @@
-import { useEffect, useState } from 'react'
+'use client'
+import { createContext, useContext } from 'react'
 
-import { defaultBreakpoint } from '../../themes/createBreakpoint'
-
-const mediaQuery = {
-  narrow: `(max-width: ${defaultBreakpoint.SP}px)`,
-}
+export const DeviceContext = createContext<boolean | null>(null)
 
 export const useDevice = () => {
-  const [isNarrowView, setIsNarrowView] = useState(matchMedia(mediaQuery.narrow).matches)
-  const handleChange = (e: MediaQueryListEvent) => {
-    setIsNarrowView(e.matches)
-  }
-
-  useEffect(() => {
-    const matchQueryList = matchMedia(mediaQuery.narrow)
-
-    matchQueryList.addEventListener('change', handleChange)
-
-    return () => {
-      matchQueryList.removeEventListener('change', handleChange)
-    }
-  }, [])
-
-  return {
-    isNarrowView,
-  }
+  const isNarrowView = useContext(DeviceContext)
+  return { isNarrowView }
 }

--- a/packages/smarthr-ui/src/index.ts
+++ b/packages/smarthr-ui/src/index.ts
@@ -96,7 +96,7 @@ export { Center, Cluster, Reel, Stack, Sidebar } from './components/Layout'
 
 // hooks
 export { useTheme } from './hooks/useTheme'
-export { useDevice } from './hooks/useDevice'
+export { useDevice, DeviceProvider } from './hooks/useDevice'
 
 // themes
 export { createTheme } from './themes/createTheme'


### PR DESCRIPTION
## 関連URL

- https://smarthr.atlassian.net/browse/SHRUI-1204

## 概要

下記問題に対応した。

- `useDevice` を使うたびにイベントリスナーが登録されてしまう。
-  `useState` の初期値に Web API を使っているため SSR 時にエラーになる。

## 変更内容

-  `useDevice` ごとの利用ごとにイベントリスナーを登録するのではなく、Provider でイベントリスナーの登録をし、 `useDevice` で Context を通じて値を購読するようにした。
- サーバーサイドレンダリング時と、メディアクエリの判定ができていない初期描画時の `isNarrow` の初期値は `null` とした。
- `useState` と `useEffect` ではなく、 `useSyncExternalStore` でスマートに書けたのでリファクタ。
- Provider や hook は RSC でもラップせずにそのまま利用できるように `use client` を付与した。

## マイグレーション方法

①プロジェクトのルートのコンポーネントで `DeviceProvider` を囲ってください。

```jsx
function App() {
  return <DeviceProvider><Main /></DeviceProvider>
}
```

② `useDevice` の `isNarrow` が `null` の場合の制御を追加してください。

`null` になるケースはサーバーサイドレンダリング時、もしくはクライアントサイドでの初期描画時のケースです。

```jsx
function Component() {
  const { isNarrow } = useDevice()
  
  // examples
  // モバイル or PCの判定されるまで待つ
  if (isNarrow === null) {
    return <Loading />
  }

  // SmartHRはPCユーザーが多いので初期描画時も一旦PCとして扱う
  // ただし、モバイルユーザーには一瞬PCのレイアウトが見える
  if (!isNarrow) {
    return <PCLayout />
  }
}
```


## 確認方法

* stackbizでパッケージをインストールして、下記を確認する。
  * SSRに関するエラーが消えていること。
  * `console.log` などを使って `isNarrowView` の値が次のようになっていること。
    * サーバーサイド： `null`
    * クライアントサイド（初期描画時）： `null`
    * クライアントサイド（PCのビューポート）： `false`
    * クライアントサイド（SPのビューポート）： `true`

| Before | After |
| :-----: | :-----: |
| ![スクリーンショット 2024-11-21 17 53 22](https://github.com/user-attachments/assets/03ac2653-a1ed-42be-ae2a-4a119b47d640) | 消滅 |

* `useDevice` を複数使用し、 `matchQueryList.addEventListener` する直前で`counter` と `console.log` を頑張って仕込んでイベントリスナーが必要以上に登録されていないのを確認すること
  * `window` やDOMに紐づいたイベント登録ではないので、このような確認しかできません。

```ts
// 確認するコード例
let counter = 0

const subscribe = (onStoreChange: () => void) => {
  const matchQueryList = matchMedia(mediaQuery.narrow)
  console.log(++counter)
  matchQueryList.addEventListener('change', onStoreChange)
```

| Before | After |
| :-----: | :-----: |
| <img width="37" alt="スクリーンショット 2024-11-21 18 25 24" src="https://github.com/user-attachments/assets/4ff086ba-9259-4f39-812a-54dddf286620"> | ![スクリーンショット 2024-11-21 18 25 47](https://github.com/user-attachments/assets/03a403c5-7e40-43e5-a334-9dcbd8905279) |


