### PR TITLE
chore: リリース用 GitHub Actions における利用ライブラリ更新に追従

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -72,9 +72,6 @@ jobs:
       - name: Send message to Slack
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           payload: |
-            {
-              "text": "<!subteam^S01RJL6PHJ8> npm publish が完了しました。Release Pull Request を手動でマージしたらリリース完了です。"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            text: "<!subteam^S01RJL6PHJ8> npm publish が完了しました。Release Pull Request を手動でマージしたらリリース完了です。"

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -72,7 +72,8 @@ jobs:
         if: ${{ github.event.client_payload.channel_id != null }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          channel-id: ${{ github.event.client_payload.channel_id }}
-          payload: ${{ github.event.client_payload.say }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ github.event.client_payload.channel_id }}
+            text: ${{ github.event.client_payload.say }}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- https://github.com/kufu/smarthr-ui/actions/runs/12063086686/job/33637730278
- https://github.com/kufu/smarthr-ui/actions/runs/12063194282/job/33638001325
- https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

リリース用の GitHub Actions が slackapi/slack-github-action の更新に追従できていなかったため修正しました。

[slack-github-action のリリースノート](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0)を参考に修正しましたが、しっかり読まず雰囲気で修正しています🙏

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

特記事項なし


<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

ローカルで確認できないためマージする必要があります。
