### PR TITLE
fix(DropdownMenuButton): ボタンリストの装飾適用条件を緩和

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -10,7 +10,7 @@ import React, {
 import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
-import { Dropdown, DropdownContent, DropdownTrigger } from '..'
+import { Dropdown, DropdownContent, DropdownMenuGroup, DropdownTrigger } from '..'
 import { AnchorButton, Button, BaseProps as ButtonProps } from '../../Button'
 import { RemoteDialogTrigger } from '../../Dialog'
 import { FaCaretDownIcon, FaEllipsisIcon } from '../../Icon'
@@ -119,9 +119,7 @@ export const renderButtonList = (children: Actions) =>
       return renderButtonList(item.props.children)
     }
 
-    if (
-      !(item.type === Button || item.type === AnchorButton || item.type === RemoteDialogTrigger)
-    ) {
+    if (item.type === DropdownMenuGroup) {
       return item
     }
 


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

DropdownMenuButton に何らかの形で拡張した Button や AnchorButton を使っていると、装飾があたらない不具合を修正します。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- Button や AnchorButton、RemoteDialogTrigger 以外にも装飾があたるように条件を見直し
- DropdownMenuGroup には装飾があたらないように修正

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
