### PR TITLE
chore: CircleCI の image/resource_class の調整

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,14 @@ commands:
 jobs:
   node-maintenance:
     executor: node-maintenance
+    resource_class: small
     steps:
       - setup-for-test
       - check-source
       - run-npm-test
   node-active-lts:
     executor: node-active-lts
+    resource_class: small
     steps:
       - setup-for-test
       - check-source
@@ -116,7 +118,7 @@ jobs:
   a11y-test:
     executor: node-active-lts-browsers
     working_directory: ~/repo
-    resource_class: medium+
+    resource_class: medium
     steps:
       - setup-for-test
       - install-noto-sans-cjk-jp
@@ -124,19 +126,19 @@ jobs:
   e2e-test:
     executor: node-active-lts-browsers
     working_directory: ~/repo
-    resource_class: large
+    resource_class: medium+
     steps:
       - setup-for-test
       - run-e2e-test
   chromatic-deployment:
     executor: node-active-lts
-    resource_class: medium+
+    resource_class: small
     steps:
       - setup-for-test
       - run-chromatic
   chromatic-deployment-master:
     executor: node-active-lts
-    resource_class: medium+
+    resource_class: small
     steps:
       - setup-for-test
       - run-chromatic-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,19 @@ version: 2.1
 executors:
   node-maintenance:
     docker:
-      - image: cimg/node:18.20.4
+      - image: cimg/node:20.18.0
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
   node-active-lts:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:22.11.0
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN
   node-active-lts-browsers:
     docker:
-      - image: cimg/node:20.17.0-browsers
+      - image: cimg/node:22.11.0-browsers
         auth:
           username: smarthrinc
           password: $DOCKER_HUB_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,13 +132,13 @@ jobs:
       - run-e2e-test
   chromatic-deployment:
     executor: node-active-lts
-    resource_class: medium
+    resource_class: medium+
     steps:
       - setup-for-test
       - run-chromatic
   chromatic-deployment-master:
     executor: node-active-lts
-    resource_class: medium
+    resource_class: medium+
     steps:
       - setup-for-test
       - run-chromatic-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
   a11y-test:
     executor: node-active-lts-browsers
     working_directory: ~/repo
-    resource_class: medium
+    resource_class: medium+
     steps:
       - setup-for-test
       - install-noto-sans-cjk-jp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,14 +103,14 @@ commands:
 jobs:
   node-maintenance:
     executor: node-maintenance
-    resource_class: small
+    resource_class: medium
     steps:
       - setup-for-test
       - check-source
       - run-npm-test
   node-active-lts:
     executor: node-active-lts
-    resource_class: small
+    resource_class: medium
     steps:
       - setup-for-test
       - check-source
@@ -132,13 +132,13 @@ jobs:
       - run-e2e-test
   chromatic-deployment:
     executor: node-active-lts
-    resource_class: small
+    resource_class: medium
     steps:
       - setup-for-test
       - run-chromatic
   chromatic-deployment-master:
     executor: node-active-lts
-    resource_class: small
+    resource_class: medium
     steps:
       - setup-for-test
       - run-chromatic-master


### PR DESCRIPTION
## 概要

CircleCI の不適切な設定を調整します

## 変更内容

- 過剰なリソースクラスの使用を見直し、必要十分なクラスに変更します。
- Node18/20 を利用しているテストを Node20/22 に変更します。

## 確認方法

CI が通ればOKです。
フレーキーでないことを確認するため10連続実行して問題ないことを確認済みです。