### PR TITLE
fix: declarationsが空配列の場合も後続の処理をスキップする

### DIFF
--- a/packages/smarthr-ui/scripts/exportUIProps.ts
+++ b/packages/smarthr-ui/scripts/exportUIProps.ts
@@ -30,7 +30,7 @@ glob(SRC_PATH).then(
         const propItem = props[name]
         const declarations = propItem.declarations
 
-        if (!declarations) {
+        if (!declarations || declarations.length === 0) {
           return propItem
         }
 


### PR DESCRIPTION
## 概要

- リリースで `write: ui-props` を実行するとき発生するエラーに対応したい

## 変更内容

- `exportUIProps` の中で、[後続の処理](https://github.com/kufu/smarthr-ui/blob/b1a1bc62e83d8bfa5b47cde6c4695405f362f00a/packages/smarthr-ui/scripts/exportUIProps.ts#L37) で参照する配列の中身が空でも進める状態になっていて、例外エラーが起きているので `propItem.declarations` が空配列を返す場合は後の処理をスキップするようにしました
