### PR TITLE
test: 選択済みのアイテムをクリックしてもアイテムが追加されないこと

### DIFF
--- a/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.test.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.test.tsx
@@ -5,9 +5,8 @@ import React, { ComponentProps, act } from 'react'
 import { FormControl } from '../FormControl'
 
 import { MultiComboBox } from './MultiComboBox'
-import { SingleComboBox } from './SingleComboBox'
 
-describe('SingleComboBox', () => {
+describe('MultiComboBox', () => {
   beforeEach(() => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
       cb(0)
@@ -298,5 +297,35 @@ describe('SingleComboBox', () => {
 
     // Backspace によって削除した末尾アイテムはテキスト化されること
     expect(combobox()).toHaveValue('option 2')
+  })
+
+  it('選択済みのアイテムをクリックしてもアイテムが追加されないこと', async () => {
+    const onSelect = vi.fn()
+    render(template({ onSelect }))
+
+    // コンボボックスをクリックしてリストボックスを表示
+    await act(() => userEvent.click(combobox()))
+
+    // 選択中のアイテムをクリックしても onSelect が呼ばれないこと
+    await act(() => userEvent.click(screen.getByRole('option', { name: 'option 1' })))
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('labelにJSX Elementを渡した場合、選択済みのアイテムをクリックしてもアイテムが追加されないこと', async () => {
+    const onSelect = vi.fn()
+    render(
+      template({
+        onSelect,
+        items: [{ label: <>option 1</>, value: 'value-1' }],
+        selectedItems: [{ label: <>option 1</>, value: 'value-1' }],
+      }),
+    )
+
+    // コンボボックスをクリックしてリストボックスを表示
+    await act(() => userEvent.click(combobox()))
+
+    // 選択中のアイテムをクリックしても onSelect が呼ばれないこと
+    await act(() => userEvent.click(screen.getByRole('option', { name: 'option 1' })))
+    expect(onSelect).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
のちほどslackにて報告させてください。

## 概要
MultiCombobox の挙動についてこちらの期待と異なる動作をする場合があったため報告用のテストを書きました。
ComboBoxItem は label に React.ReactNode を受け取ることができる仕様ですが、実際にJ SXElement を label に渡した際に、既に選択されているアイテムを選択した際のonSelectのフィルタリング（既に選択されているアイテムは押下しても何も起こらない）が動作していないようです。
おそらく、アイテムの比較に label の `===` を行っていることが原因かと思います。

https://github.com/kufu/smarthr-ui/blob/v62.2.0/packages/smarthr-ui/src/components/ComboBox/MultiComboBox.tsx#L215

こちらの比較を valueのみの比較に変えることで問題が解消することは確認済みです。

## 変更内容
- 「labelにJSX Elementを渡した場合、選択済みのアイテムをクリックしてもアイテムが追加されないこと」をtest
- 同ファイルのちょっとした修正
<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法
テストの内容と問題のケースが落ちていることを確認お願いします。
<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
