### PR TITLE
fix(MultiComboBox): item.labelがReactNodeだった場合のitemの比較を内部の文字列によって行うように

### DIFF
--- a/packages/smarthr-ui/src/components/ComboBox/MultiComboBox/MultiComboBox.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiComboBox/MultiComboBox.tsx
@@ -197,11 +197,7 @@ const ActualMultiComboBox = <T,>(
       requestAnimationFrame(() => {
         if (onDelete) onDelete(item)
         if (onChangeSelected)
-          onChangeSelected(
-            selectedItems.filter(
-              (selected) => selected.label !== item.label || selected.value !== item.value,
-            ),
-          )
+          onChangeSelected(selectedItems.filter((selected) => selected.value !== item.value))
       })
     },
     [onChangeSelected, onDelete, selectedItems],
@@ -211,9 +207,7 @@ const ActualMultiComboBox = <T,>(
       // HINT: Dropdown系コンポーネント内でComboBoxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
       // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
       requestAnimationFrame(() => {
-        const matchedSelectedItem = selectedItems.find(
-          (item) => item.label === selected.label && item.value === selected.value,
-        )
+        const matchedSelectedItem = selectedItems.find((item) => item.value === selected.value)
         if (matchedSelectedItem !== undefined) {
           if (matchedSelectedItem.deletable !== false) {
             handleDelete(selected)
@@ -468,7 +462,7 @@ const ActualMultiComboBox = <T,>(
           className={selectedListStyle}
         >
           {selectedItems.map((selectedItem, i) => (
-            <li key={`${selectedItem.label}-${selectedItem.value}`}>
+            <li key={selectedItem.value}>
               <MultiSelectedItem
                 item={selectedItem}
                 disabled={disabled}

--- a/packages/smarthr-ui/src/components/ComboBox/MultiComboBox/MultiComboBox.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiComboBox/MultiComboBox.tsx
@@ -24,6 +24,7 @@ import { useListBox } from '../useListBox'
 import { useOptions } from '../useOptions'
 
 import { MultiSelectedItem } from './MultiSelectedItem'
+import { areComboBoxItemsEqual } from './comboBoxHelper'
 import { hasParentElementByClassName } from './multiComboBoxHelper'
 
 import type { DecoratorsType } from '../../../types'
@@ -197,7 +198,9 @@ const ActualMultiComboBox = <T,>(
       requestAnimationFrame(() => {
         if (onDelete) onDelete(item)
         if (onChangeSelected)
-          onChangeSelected(selectedItems.filter((selected) => selected.value !== item.value))
+          onChangeSelected(
+            selectedItems.filter((selected) => !areComboBoxItemsEqual(selected, item)),
+          )
       })
     },
     [onChangeSelected, onDelete, selectedItems],
@@ -207,7 +210,9 @@ const ActualMultiComboBox = <T,>(
       // HINT: Dropdown系コンポーネント内でComboBoxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
       // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
       requestAnimationFrame(() => {
-        const matchedSelectedItem = selectedItems.find((item) => item.value === selected.value)
+        const matchedSelectedItem = selectedItems.find((item) =>
+          areComboBoxItemsEqual(item, selected),
+        )
         if (matchedSelectedItem !== undefined) {
           if (matchedSelectedItem.deletable !== false) {
             handleDelete(selected)
@@ -462,7 +467,7 @@ const ActualMultiComboBox = <T,>(
           className={selectedListStyle}
         >
           {selectedItems.map((selectedItem, i) => (
-            <li key={selectedItem.value}>
+            <li key={`${selectedItem.label}-${innerText(selectedItem.value)}`}>
               <MultiSelectedItem
                 item={selectedItem}
                 disabled={disabled}

--- a/packages/smarthr-ui/src/components/ComboBox/MultiComboBox/MultiComboBox.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/MultiComboBox/MultiComboBox.tsx
@@ -19,12 +19,12 @@ import { useOuterClick } from '../../../hooks/useOuterClick'
 import { genericsForwardRef } from '../../../libs/util'
 import { textColor } from '../../../themes'
 import { FaCaretDownIcon } from '../../Icon'
+import { areComboBoxItemsEqual } from '../comboBoxHelper'
 import { useFocusControl } from '../useFocusControl'
 import { useListBox } from '../useListBox'
 import { useOptions } from '../useOptions'
 
 import { MultiSelectedItem } from './MultiSelectedItem'
-import { areComboBoxItemsEqual } from './comboBoxHelper'
 import { hasParentElementByClassName } from './multiComboBoxHelper'
 
 import type { DecoratorsType } from '../../../types'

--- a/packages/smarthr-ui/src/components/ComboBox/__tests__/useOptions.test.tsx
+++ b/packages/smarthr-ui/src/components/ComboBox/__tests__/useOptions.test.tsx
@@ -234,7 +234,7 @@ describe('useOptions', () => {
         expect(options[0].item).toEqual({ label: labelElement3, value: 'value3' })
       })
 
-      it('isItemSelectedが渡されていなくてoptionのインスタンスが違うとき、selectedにならないこと', () => {
+      it('isItemSelectedが渡されていなくてvalueが同じかつlabelのインスタンスが違うとき、selectedになること', () => {
         const newLabelElement1 = (
           <div>
             label<span>1</span>
@@ -250,7 +250,7 @@ describe('useOptions', () => {
 
         expect(options.length).toBe(1)
         expect(options[0].item).toEqual({ label: labelElement1, value: 'value1' })
-        expect(options[0].selected).toBeFalsy()
+        expect(options[0].selected).toBeTruthy()
         expect(options[0].isNew).toBeFalsy()
       })
     })

--- a/packages/smarthr-ui/src/components/ComboBox/comboBoxHelper.ts
+++ b/packages/smarthr-ui/src/components/ComboBox/comboBoxHelper.ts
@@ -1,3 +1,7 @@
+import innerText from 'react-innertext'
+
+import { ComboBoxItem } from './types'
+
 export function convertMatchableString(original: string) {
   return (
     original
@@ -12,4 +16,8 @@ export function convertMatchableString(original: string) {
       .replace(/[！-｝]/g, (str) => String.fromCharCode(str.charCodeAt(0) - 0xfee0))
       .toLowerCase()
   )
+}
+
+export function areComboBoxItemsEqual<T>(a: ComboBoxItem<T>, b: ComboBoxItem<T>) {
+  return a.value === b.value && innerText(a.label) === innerText(b.label)
 }

--- a/packages/smarthr-ui/src/components/ComboBox/useOptions.ts
+++ b/packages/smarthr-ui/src/components/ComboBox/useOptions.ts
@@ -7,11 +7,7 @@ import { ComboBoxItem, ComboBoxOption } from './types'
 const defaultIsItemSelected = <T>(
   targetItem: ComboBoxItem<T>,
   selectedItems: Array<ComboBoxItem<T>>,
-) =>
-  selectedItems.find(
-    (selectedItem) =>
-      selectedItem.label === targetItem.label && selectedItem.value === targetItem.value,
-  ) !== undefined
+) => selectedItems.find((selectedItem) => selectedItem.value === targetItem.value) !== undefined
 
 export function useOptions<T>({
   items,
@@ -45,7 +41,7 @@ export function useOptions<T>({
       if (Array.isArray(selected)) {
         return isItemSelected(item, selected)
       } else {
-        return selected !== null && selected.label === item.label
+        return selected !== null && selected.value === item.value
       }
     },
     [isItemSelected, selected],

--- a/packages/smarthr-ui/src/components/ComboBox/useOptions.ts
+++ b/packages/smarthr-ui/src/components/ComboBox/useOptions.ts
@@ -1,13 +1,13 @@
 import { useCallback, useId, useMemo } from 'react'
 import innerText from 'react-innertext'
 
-import { convertMatchableString } from './comboBoxHelper'
+import { areComboBoxItemsEqual, convertMatchableString } from './comboBoxHelper'
 import { ComboBoxItem, ComboBoxOption } from './types'
 
 const defaultIsItemSelected = <T>(
   targetItem: ComboBoxItem<T>,
   selectedItems: Array<ComboBoxItem<T>>,
-) => selectedItems.find((selectedItem) => selectedItem.value === targetItem.value) !== undefined
+) => selectedItems.some((item) => areComboBoxItemsEqual(item, targetItem))
 
 export function useOptions<T>({
   items,
@@ -41,7 +41,7 @@ export function useOptions<T>({
       if (Array.isArray(selected)) {
         return isItemSelected(item, selected)
       } else {
-        return selected !== null && selected.value === item.value
+        return selected !== null && areComboBoxItemsEqual(selected, item)
       }
     },
     [isItemSelected, selected],


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
https://kufuinc.slack.com/archives/C06KVP5PL23/p1734060131150619

## 概要
close https://github.com/kufu/smarthr-ui/pull/5190

MultiComboBoxのitem同士が同一かどうかの判定でlabelも参照されているが、labelに設定できるJSX.Elementは等価であっても等値ではない場合がありうるので、label同士の === による判定が意図通りになるかはアプリケーションの実装による。
この判定が意図通りにならない場合、同じアイテムを複数回選択できてしまう・一度選択したアイテムを選択解除できないなどの問題が発生しそう

## 変更内容
~valueがitems内で一意（valueが同じでlabelが違うitemは無い）という前提を置き、MultiComboBox内でitem同士が同一かどうかの判定を行っていた部分でlabelも参照するのをやめました。~

item.labelがReactNodeだった場合のitemの比較を内部の文字列によって行うようにしました。

## 確認方法
- コードの確認
- 動作を確認 
  - https://github.com/kufu/smarthr-ui/pull/5201 にて不具合の挙動を再現したのでご確認ください。
  - このPRには https://github.com/kufu/smarthr-ui/pull/5201 の内容を取り込んでいるので不具合が修正されていることが動作確認できると思います
<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
