### PR TITLE
feat(AppNaviDropdownMenuButton): 選択中の項目が視覚的にも伝わるように装飾を追加

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
@@ -1,6 +1,7 @@
-import React, { type FC, type PropsWithChildren, type ReactNode } from 'react'
+import React, { type FC, type PropsWithChildren, ReactElement, type ReactNode } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { DropdownMenuGroup } from '../Dropdown'
 import { DropdownMenuButton } from '../Dropdown/DropdownMenuButton/DropdownMenuButton'
 
 type AppNaviDropdownMenuButtonProps = PropsWithChildren<{
@@ -8,29 +9,57 @@ type AppNaviDropdownMenuButtonProps = PropsWithChildren<{
   label: ReactNode
 }>
 
-const dropdownMenuButton = tv({
-  base: [
-    'smarthr-ui-AppNavi-dropdownMenuButton',
-    [
-      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-border-none',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-px-0.5',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-text-grey',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-rounded-none',
+const { trigger: triggerStyle, actionItem: actionItemStyle } = tv({
+  slots: {
+    trigger: [
+      'smarthr-ui-AppNavi-dropdownMenuButton',
+      [
+        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-border-none',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-px-0.5',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-text-grey',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-rounded-none',
+      ],
+      [
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:shr-relative',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:shr-text-black',
+      ],
+      [
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-content-[""]',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-absolute',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-bottom-0',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-inset-x-0',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-h-0.25',
+        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-bg-main',
+      ],
     ],
-    [
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:shr-relative',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:shr-text-black',
+    actionItem: [
+      'aria-current-page:shr-bg-grey-9 aria-current-page:shr-font-bold',
+      // aria-current-page より詳細度を確実に上げる
+      '[&&]:hover:shr-bg-head-darken',
     ],
-    [
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-content-[""]',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-absolute',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-bottom-0',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-inset-x-0',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-h-0.25',
-      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current=page])]:after:shr-bg-main',
-    ],
-  ],
-})
+  },
+})()
+
+const renderItemList = (children: ReactNode) =>
+  React.Children.map(children, (item): ReactNode => {
+    if (!React.isValidElement(item)) {
+      return null
+    }
+
+    if (item.type === React.Fragment) {
+      return renderItemList(item.props.children)
+    }
+
+    if (item.type === DropdownMenuGroup) {
+      return (
+        <DropdownMenuGroup {...item.props}>{renderItemList(item.props.children)}</DropdownMenuGroup>
+      )
+    }
+
+    return React.cloneElement(item as ReactElement, {
+      className: actionItemStyle({ className: item.props.className }),
+    })
+  })
 
 export const AppNaviDropdownMenuButton: FC<AppNaviDropdownMenuButtonProps> = ({
   label,
@@ -44,8 +73,8 @@ export const AppNaviDropdownMenuButton: FC<AppNaviDropdownMenuButtonProps> = ({
         <span hidden>{children}</span>
       </>
     }
-    className={dropdownMenuButton()}
+    className={triggerStyle()}
   >
-    {children}
+    {renderItemList(children)}
   </DropdownMenuButton>
 )

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNavi.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNavi.stories.tsx
@@ -26,13 +26,13 @@ const Link: React.FC<{
 
 export const Template: StoryFn<typeof AppNavi> = (args) => (
   <AppNavi {...args}>
-    <AppNaviButton current>ボタン</AppNaviButton>
+    <AppNaviButton>ボタン</AppNaviButton>
     <AppNaviAnchor href="/">アンカーボタン</AppNaviAnchor>
     <AppNaviDropdownMenuButton label="ドロップダウンボタン">
       <Button>ボタン</Button>
       <AnchorButton href="#">アンカーボタン</AnchorButton>
       <DropdownMenuGroup name="グループ">
-        <Button>権限</Button>
+        <Button aria-current="page">権限</Button>
         <AnchorButton href="#">その他</AnchorButton>
       </DropdownMenuGroup>
     </AppNaviDropdownMenuButton>

--- a/packages/smarthr-ui/src/components/AppNavi/stories/VRTAppNavi.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/VRTAppNavi.stories.tsx
@@ -9,7 +9,7 @@ import { AppNavi } from '../AppNavi'
 
 import { Template } from './AppNavi.stories'
 
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta } from '@storybook/react'
 
 export default {
   title: 'Navigation（ナビゲーション）/AppNavi/VRT',

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -58,7 +58,7 @@ export const dropdownMenuButton = tv({
       ],
     ],
     actionListItemButton: [
-      'shr-justify-start shr-border-none shr-py-0.5 shr-font-normal',
+      'shr-justify-start shr-rounded-none shr-border-none shr-py-0.5 shr-font-normal',
       'focus-visible:shr-focus-indicator--inner',
     ],
   },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1180

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

AppNaviDropdownMenuButton に current と同等の表現を付与するために `aria-current="page"` を使っています。ドロップダウンメニュー内の項目に `aria-current="page"` が存在する場合に、ドロップダウントリガーを current にする、という処理になっています。

`aria-current="page"` が付いているため、どの項目が現在地なのか機械可読になっていますが、視覚的には伝わらない状態になっているため、これを修正します。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- AppNaviDropdownMenuButton 内の要素に `aria-current="page"` が付いている場合、背景色と太字の装飾が付くように修正
- DropdownMenuButton および AppNaviDropdownMenuButton 内の項目の角丸を消しました
- Story を修正

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
