### PR TITLE
feat: WarekiPicker を追加

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -76,6 +76,7 @@ const datePicker = tv({
   },
 })
 
+/** @deprecated DatePicker は非推奨です。Input[type=date] を使ってください。 */
 export const DatePicker = forwardRef<HTMLInputElement, Props & InputAttributes>(
   (
     {

--- a/packages/smarthr-ui/src/components/DatePicker/stories/DatePicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/stories/DatePicker.stories.tsx
@@ -20,6 +20,7 @@ export default {
   parameters: {
     chromatic: { disableSnapshot: true },
   },
+  tags: ['skip-test-runner'],
 } satisfies Meta<typeof DatePicker>
 
 export const Playground: StoryObj<typeof DatePicker> = {

--- a/packages/smarthr-ui/src/components/DatePicker/stories/VRTDatePicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/stories/VRTDatePicker.stories.tsx
@@ -55,7 +55,7 @@ export default {
   parameters: {
     chromatic: { disableSnapshot: false },
   },
-  tags: ['!autodocs'],
+  tags: ['!autodocs', 'skip-test-runner'],
 } satisfies Meta<typeof DatePicker>
 
 export const VRT = {}

--- a/packages/smarthr-ui/src/components/Input/stories/Input.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/stories/Input.stories.tsx
@@ -49,10 +49,15 @@ export const Type: StoryObj<typeof Input> = {
   name: 'type',
   render: (args) => (
     <Stack>
-      {[undefined, 'text', 'number', 'password'].map((type) => (
-        // eslint-disable-next-line smarthr/a11y-input-in-form-control
-        <Input {...args} type={type} key={type} />
-      ))}
+      {[undefined, 'text', 'number', 'password', 'date', 'datetime-local', 'time', 'month'].map(
+        (type) => (
+          <label key={type}>
+            {`${type ?? '未指定'}： `}
+            {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
+            <Input {...args} type={type} key={type} />
+          </label>
+        ),
+      )}
     </Stack>
   ),
 }

--- a/packages/smarthr-ui/src/components/Picker/DatetimeLocalPicker.tsx
+++ b/packages/smarthr-ui/src/components/Picker/DatetimeLocalPicker.tsx
@@ -8,6 +8,7 @@ type Props = {
   error?: boolean
 }
 
+/** @deprecated DatetimeLocalPicker は非推奨です。Input[type="datetime-local"] を使ってください。 */
 export const DatetimeLocalPicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
   ({ disabled, error, readOnly, className, ...rest }, ref) => {
     const { wrapperStyle, innerStyle } = useMemo(() => {

--- a/packages/smarthr-ui/src/components/Picker/MonthPicker.tsx
+++ b/packages/smarthr-ui/src/components/Picker/MonthPicker.tsx
@@ -8,6 +8,7 @@ type Props = {
   error?: boolean
 }
 
+/** @deprecated MonthPicker は非推奨です。Input[type="month"] を使ってください。 */
 export const MonthPicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
   ({ disabled, error, readOnly, className, ...rest }, ref) => {
     const { wrapperStyle, innerStyle } = useMemo(() => {

--- a/packages/smarthr-ui/src/components/Picker/TimePicker.tsx
+++ b/packages/smarthr-ui/src/components/Picker/TimePicker.tsx
@@ -8,6 +8,7 @@ type Props = {
   error?: boolean
 }
 
+/** @deprecated TimePicker は非推奨です。Input[type="time"] を使ってください。 */
 export const TimePicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
   ({ disabled, error, readOnly, className, ...rest }, ref) => {
     const { wrapperStyle, innerStyle } = useMemo(() => {

--- a/packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx
@@ -1,0 +1,15 @@
+import React, { ComponentProps } from 'react'
+
+import { DatePicker } from '../DatePicker'
+
+type Props = Omit<ComponentProps<typeof DatePicker>, 'showAlternative'>
+
+const handleShowWareki = (date: Date | null) =>
+  date?.toLocaleDateString('ja-JP-u-ca-japanese', {
+    dateStyle: 'long',
+  })
+
+export const WarekiPicker: React.FC<Props> = (props) => (
+  // eslint-disable-next-line smarthr/a11y-input-in-form-control
+  <DatePicker {...props} showAlternative={handleShowWareki} />
+)

--- a/packages/smarthr-ui/src/components/WarekiPicker/index.ts
+++ b/packages/smarthr-ui/src/components/WarekiPicker/index.ts
@@ -1,0 +1,1 @@
+export { WarekiPicker } from './WarekiPicker'

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
@@ -6,13 +6,13 @@ import dayjs from 'dayjs'
 import React from 'react'
 
 import { Cluster } from '../../Layout'
-import { DatePicker } from '../DatePicker'
+import { WarekiPicker } from '../WarekiPicker'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
 export default {
-  title: 'Forms（フォーム）/DatePicker（非推奨）/VRT',
-  component: DatePicker,
+  title: 'Forms（フォーム）/WarekiPicker/VRT',
+  component: WarekiPicker,
   render: (args) => {
     const value = '2024/11/06'
     const placeholder = '日付を入力してください'
@@ -31,17 +31,17 @@ export default {
       <Cluster>
         {matrics.map((m) => (
           <>
-            <DatePicker {...args} error={m.error} disabled={m.disabled} />
-            <DatePicker error={m.error} disabled={m.disabled} placeholder={placeholder} />
-            <DatePicker error={m.error} disabled={m.disabled} value={value} />
-            <DatePicker error={m.error} disabled={m.disabled} width={width} />
-            <DatePicker
+            <WarekiPicker {...args} error={m.error} disabled={m.disabled} />
+            <WarekiPicker error={m.error} disabled={m.disabled} placeholder={placeholder} />
+            <WarekiPicker error={m.error} disabled={m.disabled} value={value} />
+            <WarekiPicker error={m.error} disabled={m.disabled} width={width} />
+            <WarekiPicker
               error={m.error}
               disabled={m.disabled}
               value={value}
               showAlternative={showAlternative}
             />
-            <DatePicker
+            <WarekiPicker
               error={m.error}
               disabled={m.disabled}
               value={value}
@@ -56,7 +56,7 @@ export default {
     chromatic: { disableSnapshot: false },
   },
   tags: ['!autodocs'],
-} satisfies Meta<typeof DatePicker>
+} satisfies Meta<typeof WarekiPicker>
 
 export const VRT = {}
 
@@ -68,7 +68,7 @@ export const VRTForcedColors: StoryObj = {
 }
 
 export const VRTExpanded: StoryObj = {
-  render: (args) => <DatePicker {...args} className="shr-min-w-[500px] shr-h-[500px]" />,
+  render: (args) => <WarekiPicker {...args} className="shr-min-w-[500px] shr-h-[500px]" />,
   args: {
     value: '2024/11/06',
   },
@@ -105,7 +105,7 @@ export const VRTExpandedBottom: StoryObj = {
   ...VRTExpanded,
   render: (args) => (
     <div className="shr-w-full shr-h-[100vh] shr-relative">
-      <DatePicker {...args} className="shr-absolute shr-bottom-0" />
+      <WarekiPicker {...args} className="shr-absolute shr-bottom-0" />
     </div>
   ),
 }

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
@@ -17,7 +17,6 @@ export default {
     const value = '2024/11/06'
     const placeholder = '日付を入力してください'
     const width = '100%'
-    const showAlternative = (_: Date | null) => <div>alt</div>
     const formatDate = (date: Date | null) => dayjs(date).format('YYYY年MM月DD')
 
     const matrics = [
@@ -39,12 +38,6 @@ export default {
               error={m.error}
               disabled={m.disabled}
               value={value}
-              showAlternative={showAlternative}
-            />
-            <WarekiPicker
-              error={m.error}
-              disabled={m.disabled}
-              value={value}
               formatDate={formatDate}
             />
           </>
@@ -55,7 +48,7 @@ export default {
   parameters: {
     chromatic: { disableSnapshot: false },
   },
-  tags: ['!autodocs'],
+  tags: ['!autodocs', 'skip-test-runner'],
 } satisfies Meta<typeof WarekiPicker>
 
 export const VRT = {}

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
@@ -3,14 +3,14 @@ import { userEvent, within } from '@storybook/test'
 import dayjs from 'dayjs'
 import React from 'react'
 
-import { DatePicker } from '../DatePicker'
+import { WarekiPicker } from '../WarekiPicker'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
 export default {
-  title: 'Forms（フォーム）/DatePicker（非推奨）',
-  component: DatePicker,
-  render: (args) => <DatePicker {...args} />,
+  title: 'Forms（フォーム）/WarekiPicker',
+  component: WarekiPicker,
+  render: (args) => <WarekiPicker {...args} />,
   args: {},
   argTypes: {
     value: {
@@ -20,48 +20,48 @@ export default {
   parameters: {
     chromatic: { disableSnapshot: true },
   },
-} satisfies Meta<typeof DatePicker>
+} satisfies Meta<typeof WarekiPicker>
 
-export const Playground: StoryObj<typeof DatePicker> = {
+export const Playground: StoryObj<typeof WarekiPicker> = {
   args: {},
 }
 
-export const Value: StoryObj<typeof DatePicker> = {
+export const Value: StoryObj<typeof WarekiPicker> = {
   name: 'value',
   args: {
     value: '2024-11-06',
   },
 }
 
-export const Disabled: StoryObj<typeof DatePicker> = {
+export const Disabled: StoryObj<typeof WarekiPicker> = {
   name: 'disabled',
   args: {
     disabled: true,
   },
 }
 
-export const PlaceHolder: StoryObj<typeof DatePicker> = {
+export const PlaceHolder: StoryObj<typeof WarekiPicker> = {
   name: 'placeholder',
   args: {
     placeholder: '日付を選択してください',
   },
 }
 
-export const Error: StoryObj<typeof DatePicker> = {
+export const Error: StoryObj<typeof WarekiPicker> = {
   name: 'error',
   args: {
     error: true,
   },
 }
 
-export const Width: StoryObj<typeof DatePicker> = {
+export const Width: StoryObj<typeof WarekiPicker> = {
   name: 'width',
   args: {
     width: '500px',
   },
 }
 
-export const From: StoryObj<typeof DatePicker> = {
+export const From: StoryObj<typeof WarekiPicker> = {
   name: 'from',
   args: {
     from: dayjs().subtract(3, 'day').toDate(),
@@ -72,7 +72,7 @@ export const From: StoryObj<typeof DatePicker> = {
   },
 }
 
-export const To: StoryObj<typeof DatePicker> = {
+export const To: StoryObj<typeof WarekiPicker> = {
   name: 'to',
   args: {
     to: dayjs().add(3, 'day').toDate(),
@@ -83,7 +83,7 @@ export const To: StoryObj<typeof DatePicker> = {
   },
 }
 
-export const ParseInput: StoryObj<typeof DatePicker> = {
+export const ParseInput: StoryObj<typeof WarekiPicker> = {
   name: 'parseInput',
   args: {
     value: '2024年11月06日',
@@ -91,19 +91,9 @@ export const ParseInput: StoryObj<typeof DatePicker> = {
   },
 }
 
-export const FormatDate: StoryObj<typeof DatePicker> = {
+export const FormatDate: StoryObj<typeof WarekiPicker> = {
   name: 'formatDate',
   args: {
     formatDate: (date) => dayjs(date).format('YYYY年MM月DD日'),
-  },
-}
-
-export const ShowAlternative: StoryObj<typeof DatePicker> = {
-  name: 'showAlternative',
-  args: {
-    showAlternative: (date) => {
-      const dateSet = ['日', '月', '火', '水', '木', '金', '土']
-      return dateSet[dayjs(date).day()]
-    },
   },
 }

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
@@ -20,6 +20,7 @@ export default {
   parameters: {
     chromatic: { disableSnapshot: true },
   },
+  tags: ['skip-test-runner'],
 } satisfies Meta<typeof WarekiPicker>
 
 export const Playground: StoryObj<typeof WarekiPicker> = {

--- a/packages/smarthr-ui/src/index.ts
+++ b/packages/smarthr-ui/src/index.ts
@@ -91,6 +91,7 @@ export * from './components/Switch'
 export * from './components/Stepper'
 export * from './components/Picker'
 export * from './components/Browser'
+export * from './components/WarekiPicker'
 
 // layout components
 export { Center, Cluster, Reel, Stack, Sidebar } from './components/Layout'

--- a/packages/smarthr-ui/test-runner-jest.config.js
+++ b/packages/smarthr-ui/test-runner-jest.config.js
@@ -32,11 +32,6 @@ module.exports = {
     'ComboBox.stories.tsx',
     'FieldSet.stories.tsx',
     'Switch.stories.tsx',
-    /**
-     * error: "Form elements must have labels"
-     * error: "Elements must only use allowed ARIA attributes"
-     */
-    'DatePicker.stories.tsx',
     'FormControl.stories.tsx', // DatePicker を含むために除外
     /**
      * error: "ARIA attributes must conform to valid values"


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1000

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

DatePicker を和暦に特化させた WarekiPicker を追加しました（厳密に言えば Wareki を pick するわけではない）。
合わせて DatePicker / DateTimeLocalPicker / MonthPicker / TimePicker などを非推奨とし、`<Input type="{date | datetime-local | month | time" />` を使うように促します。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- DatePicker を deprecated
- DatePicker の `showAlternative` で和暦を表示するコンポーネントを WarekiPicker として追加
- DateTimeLocalPicker / MonthPicker / TimePicker を deprecated
- Input の Story の type を拡充

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
Storybook や Chromatic で確認してください。