### PR TITLE
fix(Th): ソートアイコンが左寄せになっていたのを修正

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -148,10 +148,10 @@ export const Th: FC<Props & ElementProps> = ({
 }
 
 const sortButton = tv({
-  base: '-shr-mx-1 -shr-my-0.75 shr-inline-flex shr-w-full shr-gap-x-0.5 shr-px-1 shr-py-0.75 shr-font-bold shr-items-center',
+  base: '-shr-mx-1 -shr-my-0.75 shr-inline-flex shr-w-full shr-gap-x-0.5 shr-px-1 shr-py-0.75 shr-font-bold shr-items-center shr-justify-between',
   variants: {
     align: {
-      left: 'shr-justify-between',
+      left: '',
       right: 'shr-justify-end',
     },
   },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

#5144 で紛れ込んでしまった不具合を修正します。ソート付き Th のアイコンが両端揃えではなく左に依ってしまっていました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

両端揃えになるように調整。

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
Storybook や Chromatic で確認してください。