### PR TITLE
fix(Tooltip): Tooltip trigger外に移動する際にtooltipを非表示にする

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.test.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.test.ts
@@ -8,7 +8,7 @@ describe('dropdownHelper', () => {
       const windowSize = { width: 1000, height: 800 }
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
-        top: '135px', // 140 - 5
+        top: '145px', // 140 - 5 + 10(dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分)
         left: '-5px', // trigger left - 5
         maxHeight: '',
       })
@@ -20,7 +20,7 @@ describe('dropdownHelper', () => {
       const windowSize = { width: 1000, height: 800 }
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
-        top: '205px', // 600 - 400 + 5
+        top: '195px', // 600 - 400 + 5 - 10(dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分)
         left: '-5px', // trigger left - 5
         maxHeight: '',
       })
@@ -32,7 +32,7 @@ describe('dropdownHelper', () => {
       const windowSize = { width: 1000, height: 370 }
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
-        top: '135px', // 140 - 5
+        top: '145px', // 140 - 5 + 10(dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分)
         left: '-5px', // trigger left - 5
         maxHeight: '220px', // 370 - 140 - 10
       })
@@ -44,7 +44,7 @@ describe('dropdownHelper', () => {
       const windowSize = { width: 1000, height: 370 }
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
-        top: '15px', // 0 + 10 + 5
+        top: '5px', // 0 + 10 + 5 - 10(dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分)
         left: '-5px', // trigger left - 5
         maxHeight: '190px', // 200 - 10
       })
@@ -56,7 +56,7 @@ describe('dropdownHelper', () => {
       const windowSize = { width: 1000, height: 800 }
       const scroll = { top: 0, left: 0 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
-        top: '135px', // 140 - 5
+        top: '145px', // 140 - 5 + 10(dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分)
         right: '375px', // window width - trigger right - 5
         maxHeight: '',
       })
@@ -68,7 +68,7 @@ describe('dropdownHelper', () => {
       const windowSize = { width: 1000, height: 800 }
       const scroll = { top: 500, left: 600 }
       expect(getContentBoxStyle(triggerRect, contentSize, windowSize, scroll)).toEqual({
-        top: '635px', // 140 - 5 + 500
+        top: '645px', // 140 - 5 + 500 + 10(dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分)
         left: '595px', // trigger left + scroll left - 5
         maxHeight: '',
       })

--- a/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.ts
@@ -45,11 +45,9 @@ export function getContentBoxStyle(
   if (triggerRect.bottom + contentSize.height <= windowSize.height) {
     // ドロップダウンのサイズがトリガの下側の領域に収まる場合
     contentBox.top = `${scroll.top + triggerRect.bottom + DROPDOWN_MENU_GAP - 5}px`
-    console.log('test 下側')
   } else if (triggerRect.top - contentSize.height >= 0) {
     // ドロップダウンのサイズがトリガの上側の領域に収まる場合
     contentBox.top = `${scroll.top + triggerRect.top - contentSize.height - DROPDOWN_MENU_GAP + 5}px`
-    console.log('test 上側')
   } else {
     const padding = 10
     const triggerHeight = triggerRect.bottom - triggerRect.top
@@ -58,12 +56,10 @@ export function getContentBoxStyle(
       // 下側の領域のほうが広い場合
       contentBox.top = `${scroll.top + triggerRect.bottom + DROPDOWN_MENU_GAP - 5}px`
       contentBox.maxHeight = `${windowSize.height - triggerRect.bottom - padding}px`
-      console.log('test 下側が広い')
     } else {
       // 上側の領域のほうが広い場合
       contentBox.top = `${scroll.top + padding - DROPDOWN_MENU_GAP + 5}px`
       contentBox.maxHeight = `${triggerRect.top - padding}px`
-      console.log('test 上側が広い')
     }
   }
 

--- a/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.ts
@@ -23,6 +23,11 @@ export function isEventFromChild(e: Event, parent: Element | null): boolean {
   return path.includes(parent)
 }
 
+/**
+ * dropdown menu buttonとdropdown menu contentの間にスペースがあくための10px分
+ */
+const DROPDOWN_MENU_GAP = 10
+
 export function getContentBoxStyle(
   triggerRect: Rect,
   contentSize: Size,
@@ -39,22 +44,26 @@ export function getContentBoxStyle(
 
   if (triggerRect.bottom + contentSize.height <= windowSize.height) {
     // ドロップダウンのサイズがトリガの下側の領域に収まる場合
-    contentBox.top = `${scroll.top + triggerRect.bottom - 5}px`
+    contentBox.top = `${scroll.top + triggerRect.bottom + DROPDOWN_MENU_GAP - 5}px`
+    console.log('test 下側')
   } else if (triggerRect.top - contentSize.height >= 0) {
-    // ドロップダウンのサイズがトリガの上川の領域に収まる場合
-    contentBox.top = `${scroll.top + triggerRect.top - contentSize.height + 5}px`
+    // ドロップダウンのサイズがトリガの上側の領域に収まる場合
+    contentBox.top = `${scroll.top + triggerRect.top - contentSize.height - DROPDOWN_MENU_GAP + 5}px`
+    console.log('test 上側')
   } else {
     const padding = 10
     const triggerHeight = triggerRect.bottom - triggerRect.top
 
     if (triggerRect.top + triggerHeight / 2 < windowSize.height / 2) {
       // 下側の領域のほうが広い場合
-      contentBox.top = `${scroll.top + triggerRect.bottom - 5}px`
+      contentBox.top = `${scroll.top + triggerRect.bottom + DROPDOWN_MENU_GAP - 5}px`
       contentBox.maxHeight = `${windowSize.height - triggerRect.bottom - padding}px`
+      console.log('test 下側が広い')
     } else {
       // 上側の領域のほうが広い場合
-      contentBox.top = `${scroll.top + padding + 5}px`
+      contentBox.top = `${scroll.top + padding - DROPDOWN_MENU_GAP + 5}px`
       contentBox.maxHeight = `${triggerRect.top - padding}px`
+      console.log('test 上側が広い')
     }
   }
 

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -114,7 +114,7 @@ export const Tooltip: FC<Props & ElementProps> = ({
         setRect(ref.current.getBoundingClientRect())
 
         // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)に移動されたらtooltipを表示しない
-        if (!ref.current?.contains(document.activeElement)) {
+        if (!ref.current.contains(document.activeElement)) {
           return
         }
 

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -111,10 +111,8 @@ export const Tooltip: FC<Props & ElementProps> = ({
           return
         }
 
-        setRect(ref.current.getBoundingClientRect())
-
         // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)に移動されたらtooltipを表示しない
-        if (!ref.current.contains(document.activeElement)) {
+        if (!ref.current.contains((e as React.BaseSyntheticEvent).target)) {
           return
         }
 
@@ -133,6 +131,7 @@ export const Tooltip: FC<Props & ElementProps> = ({
           }
         }
 
+        setRect(ref.current.getBoundingClientRect())
         setIsVisible(true)
       },
     [ellipsisOnly],
@@ -161,24 +160,6 @@ export const Tooltip: FC<Props & ElementProps> = ({
         : children,
     [children, isInnerTarget, messageId],
   )
-
-  // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)にpointerで移動されたときのtooltipの表示・非表示の処理
-  useEffect(() => {
-    const pointerHandler = (e: PointerEvent) => {
-      if (!(e.target instanceof HTMLElement) || !ref.current) return
-
-      if (!ref.current.contains(document.activeElement)) {
-        setIsVisible(false)
-      }
-
-      if (ref.current.contains(e.target)) {
-        setIsVisible(true)
-      }
-    }
-
-    document.addEventListener('pointerenter', pointerHandler, true)
-    return () => document.removeEventListener('pointerenter', pointerHandler, true)
-  }, [])
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions,smarthr/a11y-delegate-element-has-role-presentation

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -111,8 +111,10 @@ export const Tooltip: FC<Props & ElementProps> = ({
           return
         }
 
+        setRect(ref.current.getBoundingClientRect())
+
         // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)に移動されたらtooltipを表示しない
-        if (!ref.current?.contains((e as React.BaseSyntheticEvent).target)) {
+        if (!ref.current?.contains(document.activeElement)) {
           return
         }
 
@@ -131,28 +133,10 @@ export const Tooltip: FC<Props & ElementProps> = ({
           }
         }
 
-        setRect(ref.current.getBoundingClientRect())
         setIsVisible(true)
       },
     [ellipsisOnly],
   )
-
-  useEffect(() => {
-    const pointerHandler = (e: FocusEvent) => {
-      if (!(e.target instanceof HTMLElement) || !ref.current) return
-
-      if (!ref.current.contains(document.activeElement)) {
-        setIsVisible(false)
-      }
-
-      if (ref.current.contains(e.target)) {
-        setIsVisible(true)
-      }
-    }
-
-    document.addEventListener('pointerenter', pointerHandler, true)
-    return () => document.removeEventListener('pointerenter', pointerHandler, true)
-  }, [])
 
   const getHandlerToHide = useCallback(
     <T,>(handler?: (e: T) => void) =>
@@ -177,6 +161,24 @@ export const Tooltip: FC<Props & ElementProps> = ({
         : children,
     [children, isInnerTarget, messageId],
   )
+
+  // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)にpointerで移動されたときのtooltipの表示・非表示の処理
+  useEffect(() => {
+    const pointerHandler = (e: PointerEvent) => {
+      if (!(e.target instanceof HTMLElement) || !ref.current) return
+
+      if (!ref.current.contains(document.activeElement)) {
+        setIsVisible(false)
+      }
+
+      if (ref.current.contains(e.target)) {
+        setIsVisible(true)
+      }
+    }
+
+    document.addEventListener('pointerenter', pointerHandler, true)
+    return () => document.removeEventListener('pointerenter', pointerHandler, true)
+  }, [])
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions,smarthr/a11y-delegate-element-has-role-presentation

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,6 @@ import React, {
   ReactElement,
   ReactNode,
   useCallback,
-  useEffect,
   useId,
   useMemo,
   useRef,

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -111,7 +111,7 @@ export const Tooltip: FC<Props & ElementProps> = ({
           return
         }
 
-        // Tooltipのtriggerではない要素(Dropwdown menu buttonで開いたmenu contentとか)に移動されたらtooltipを表示しない
+        // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)に移動されたらtooltipを表示しない
         if (!ref.current?.contains((e as React.BaseSyntheticEvent).target)) {
           return
         }
@@ -141,32 +141,17 @@ export const Tooltip: FC<Props & ElementProps> = ({
     const pointerHandler = (e: FocusEvent) => {
       if (!(e.target instanceof HTMLElement) || !ref.current) return
 
-      const currentPointerTarget = e.target
-
-      if (!ref.current.contains(currentPointerTarget)) {
+      if (!ref.current.contains(document.activeElement)) {
         setIsVisible(false)
       }
 
-      if (ref.current.contains(currentPointerTarget)) {
+      if (ref.current.contains(e.target)) {
         setIsVisible(true)
       }
     }
 
     document.addEventListener('pointerenter', pointerHandler, true)
     return () => document.removeEventListener('pointerenter', pointerHandler, true)
-  }, [])
-
-  useEffect(() => {
-    const focusHandler = (e: FocusEvent) => {
-      if (!(e.target instanceof HTMLElement) || !ref.current) return
-
-      if (!ref.current.contains(e.target)) {
-        setIsVisible(false)
-      }
-    }
-
-    document.addEventListener('focus', focusHandler, true)
-    return () => document.removeEventListener('focus', focusHandler, true)
   }, [])
 
   const getHandlerToHide = useCallback(


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1209

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

Dropdown menuを表示/非表示の操作のtrigger buttonなどにtooltipでラベル表示のためラップすると、menu内操作中でもtooltipが表示されたままになるので、tooltip trigger外に移動する際にはtooltipを非表示にする

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- pointerenter時のeventListenerで現在の操作中要素がtooltip trigger内の要素なのかをチェックしてから、tooltipを表示/非表示にする

### BEFORE - dropdown menu開いてTooltip trigger buttonから別の要素に移動するとtooltipが表示されたまま

https://github.com/user-attachments/assets/e7e1d9ad-d762-409c-9fb9-610b20baf7fa

https://github.com/user-attachments/assets/516f8667-188a-4d3e-94f5-27865fbb279e

### AFTER- dropdown menu開いてTooltip trigger buttonから別の要素に移動するとtooltipが非表示になる

https://github.com/user-attachments/assets/67ecd38c-08ae-4888-8450-a03630e8f425

https://github.com/user-attachments/assets/c735ff03-3ec0-4508-96a4-cf0e3cedc9d1





## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

ローカルでstorybookで確認できますが、dropdown menuのStoryにtooltipを追加する必要があります.
以下のcomponentのstoryに追加すると確認しやすいかと思います。こちらの問題がおきたプロダクト側ではinstallして検証済みです

-  DropdownMenuButton
  - packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuButton.stories.tsx 
```tsx
render: (args) => (
    <Tooltip
      message={'その他の操作'}
      horizontal="auto"
      vertical="bottom"
      triggerType="icon"
      tabIndex={-1}
    >
      <DropdownMenuButton {...args}>
        <Button>操作1</Button>
        <AnchorButton href="#">操作2</AnchorButton>
        <RemoteDialogTrigger targetId="remoteDialog" onClick={action('open-remote-dialog')}>
          <Button>操作3</Button>
        </RemoteDialogTrigger>
      </DropdownMenuButton>
    </Tooltip>
  ),
```

-  SortDropdown
  - packages/smarthr-ui/src/components/Dropdown/SortDropdown/stories/SortDropdown.stories.tsx 
``` tsx
 render: (args) => (
    <Tooltip message={'その他の操作'} horizontal="auto" triggerType="icon" tabIndex={-1}>
      <SortDropdown {...args} />
    </Tooltip>
  ),
 ```