### PR TITLE
fix: AppHeader を Server Component から呼べるようにする

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { FC } from 'react'
 
 import { DesktopHeader } from './components/desktop/DesktopHeader'

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
@@ -5,7 +5,6 @@ import { Button } from '../../../Button'
 import { Dropdown, DropdownContent, DropdownTrigger } from '../../../Dropdown'
 import { Header, HeaderLink, LanguageSwitcher } from '../../../Header'
 import {
-  FaCaretDownIcon,
   FaCircleQuestionIcon,
   FaGraduationCapIcon,
   FaRegCircleQuestionIcon,
@@ -84,11 +83,7 @@ export const DesktopHeader: FC<HeaderProps> = ({
               {features && features.length > 0 && (
                 <Dropdown>
                   <DropdownTrigger>
-                    <Button
-                      prefix={enableNew ?? <FaToolboxIcon />}
-                      suffix={enableNew ?? <FaCaretDownIcon />}
-                      className={appsButton()}
-                    >
+                    <Button prefix={enableNew ?? <FaToolboxIcon />} className={appsButton()}>
                       <Translate>
                         {translate('DesktopHeader/DesktopHeader/appLauncherLabel')}
                       </Translate>

--- a/sandbox/next/e2e/rsc.test.ts
+++ b/sandbox/next/e2e/rsc.test.ts
@@ -65,6 +65,7 @@ const CLIENT_COMPONENTS: string[] = [
   'AccordionPanelContent', // 開いているパネル名を共有するためのuseContext
   'AccordionPanelItem',    // 開いているパネル名を共有するためのuseContext
   'AccordionPanelTrigger', // 開いているパネル名を共有するためのuseContext
+  'AppHeader',      // ドロップダウンやダイアログを表示するためのuseStateなど
   'Article',        // 見出しレベルの自動生成のため
   'Aside',          // 見出しレベルの自動生成のため
   'Base',           // 見出しレベルの自動生成のため

--- a/sandbox/next/src/app/rsc_test/AppHeader/page.tsx
+++ b/sandbox/next/src/app/rsc_test/AppHeader/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { AppHeader } from 'smarthr-ui'
+
+import { RSCChecker } from '../components/RSCChecker'
+export default function AppHeaderPage() {
+  return (
+    <>
+      <RSCChecker actualComponent={AppHeader} />
+      <AppHeader />
+    </>
+  )
+}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

🍐 

## 概要

AppHeader を Server Component から呼び出すとエラーが発生してしまったので、`'use client'` をつけたい

## 変更内容

- `'use client'` をつけた
- ドロップダウンの不要な suffix アイコンを削除

## 確認方法

fmfm で大丈夫です
<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
