### PR TITLE
feat: headerの背景色をカスタムできるようにした

### DIFF
--- a/packages/smarthr-ui/src/components/Header/Header.tsx
+++ b/packages/smarthr-ui/src/components/Header/Header.tsx
@@ -10,7 +10,7 @@ import { AppLauncher, HeaderDropdownMenuButton } from '.'
 
 const header = tv({
   slots: {
-    wrapper: ['smarthr-ui-Header', 'shr-bg-brand shr-px-1.25', 'max-md:shr-px-0.75'],
+    wrapper: ['smarthr-ui-Header', 'shr-px-1.25', 'max-md:shr-px-0.75', 'shr-bg-brand'],
     logoLink: [
       'smarthr-ui-Header-logoLink',
       /* ロゴが持つ padding 分だけ調整 */
@@ -58,6 +58,10 @@ type Props = {
   onTenantSelect?: (id: string) => void
   /** @deprecated internal-ui から利用するので使わないでください。 */
   enableNew?: boolean
+  /** ヘッダーの背景色を指定します */
+  headerColor?: string
+  /** ヘッダーの文字色を指定します */
+  textColor?: 'inherit' | 'TEXT_BLACK' | 'TEXT_WHITE' | 'TEXT_GREY' | 'TEXT_DISABLED' | 'TEXT_LINK'
 } & VariantProps<typeof header>
 
 type ElementProps = Omit<ComponentProps<'header'>, keyof Props>
@@ -73,6 +77,8 @@ export const Header: React.FC<PropsWithChildren<Props> & ElementProps> = ({
   onTenantSelect,
   children,
   className,
+  headerColor,
+  textColor = 'TEXT_WHITE',
 }) => {
   const {
     wrapper,
@@ -92,7 +98,7 @@ export const Header: React.FC<PropsWithChildren<Props> & ElementProps> = ({
   const tenantInfo = useMemo(
     () =>
       tenants && tenants.length > 1 ? (
-        <HeaderDropdownMenuButton label={currentTenantName}>
+        <HeaderDropdownMenuButton label={currentTenantName} textColor={textColor}>
           {tenants.map(({ id, name }) => (
             <Button key={id} onClick={() => onTenantSelect && onTenantSelect(id)}>
               {name}
@@ -100,11 +106,11 @@ export const Header: React.FC<PropsWithChildren<Props> & ElementProps> = ({
           ))}
         </HeaderDropdownMenuButton>
       ) : (
-        <Text color="TEXT_WHITE" className={tenantNameText()}>
+        <Text color={textColor} className={tenantNameText()}>
           {currentTenantName}
         </Text>
       ),
-    [currentTenantName, onTenantSelect, tenants, tenantNameText],
+    [currentTenantName, onTenantSelect, tenants, tenantNameText, textColor],
   )
 
   return (
@@ -113,6 +119,7 @@ export const Header: React.FC<PropsWithChildren<Props> & ElementProps> = ({
       justify="space-between"
       gap={{ column: 0.25, row: 0 }}
       className={wrapper({ className })}
+      style={headerColor ? { backgroundColor: headerColor } : undefined}
     >
       <Cluster align="center" gap={{ column: 0.25, row: 0 }}>
         <a href={logoHref} className={logoLink()}>

--- a/packages/smarthr-ui/src/components/Header/HeaderDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Header/HeaderDropdownMenuButton.tsx
@@ -5,19 +5,36 @@ import { DropdownMenuButton } from '../Dropdown'
 
 const headerDropdownMenuButton = tv({
   base: [
-    '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-border-transparent [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-bg-transparent [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-px-0.25 [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-font-normal [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-white',
+    '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-border-transparent [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-bg-transparent [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-px-0.25 [&>.smarthr-ui-DropdownMenuButton-trigger]:shr-font-normal',
     // ボタンの余白分だけ微調整
     '[&>.smarthr-ui-DropdownMenuButton-trigger]:last-of-type:-shr-me-0.25',
   ],
+  variants: {
+    textColor: {
+      TEXT_WHITE: '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-white',
+      TEXT_BLACK: '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-black',
+      TEXT_GREY: '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-grey',
+      TEXT_DISABLED: '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-disabled',
+      TEXT_LINK: '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-link',
+      inherit: '[&>.smarthr-ui-DropdownMenuButton-trigger]:shr-text-inherit',
+    },
+  },
 })
 
-export const HeaderDropdownMenuButton: React.FC<ComponentProps<typeof DropdownMenuButton>> = ({
-  className,
-  ...rest
-}) => {
+export const HeaderDropdownMenuButton: React.FC<
+  ComponentProps<typeof DropdownMenuButton> & {
+    textColor?:
+      | 'inherit'
+      | 'TEXT_BLACK'
+      | 'TEXT_WHITE'
+      | 'TEXT_GREY'
+      | 'TEXT_DISABLED'
+      | 'TEXT_LINK'
+  }
+> = ({ className, textColor = 'TEXT_WHITE', ...rest }) => {
   const headerDropdownMenuButtonStyle = useMemo(
-    () => headerDropdownMenuButton({ className }),
-    [className],
+    () => headerDropdownMenuButton({ className, textColor }),
+    [className, textColor],
   )
 
   return <DropdownMenuButton {...rest} className={headerDropdownMenuButtonStyle} />

--- a/packages/smarthr-ui/src/components/Header/HeaderLink.tsx
+++ b/packages/smarthr-ui/src/components/Header/HeaderLink.tsx
@@ -3,24 +3,48 @@ import { VariantProps, tv } from 'tailwind-variants'
 
 import { TextLink } from '../TextLink'
 
-type Props = Omit<ComponentProps<typeof TextLink>, 'suffix'> & VariantProps<typeof headerLink>
+type Props = Omit<ComponentProps<typeof TextLink>, 'suffix'> &
+  VariantProps<typeof headerLink> & {
+    textColor?:
+      | 'inherit'
+      | 'TEXT_BLACK'
+      | 'TEXT_WHITE'
+      | 'TEXT_GREY'
+      | 'TEXT_DISABLED'
+      | 'TEXT_LINK'
+  }
 
 const headerLink = tv({
   base: [
     'shr-inline-flex shr-items-center',
-    'shr-px-0.25 shr-text-white shr-shadow-none',
+    'shr-px-0.25 shr-shadow-none',
     'focus-visible:shr-focus-indicator',
     '[&_.smarthr-ui-Icon]:shr-block',
   ],
   variants: {
     enableNew: {
       true: ['shr-px-0.5 shr-text-black', 'hover:shr-shadow-underline'],
-      false: 'hover:shr-text-white',
+      false: [],
+    },
+    textColor: {
+      TEXT_WHITE: 'shr-text-white hover:shr-text-white',
+      TEXT_BLACK: 'shr-text-black hover:shr-text-black',
+      TEXT_GREY: 'shr-text-grey hover:shr-text-grey',
+      TEXT_DISABLED: 'shr-text-disabled hover:shr-text-disabled',
+      TEXT_LINK: 'shr-text-link hover:shr-text-link',
+      inherit: 'shr-text-inherit hover:shr-text-inherit',
     },
   },
+  compoundVariants: [
+    {
+      enableNew: false,
+      textColor: undefined,
+      className: 'shr-text-white hover:shr-text-white',
+    },
+  ],
 })
 
-export const HeaderLink: React.FC<Props> = ({ enableNew, className, ...props }) => {
-  const style = headerLink({ enableNew, className })
+export const HeaderLink: React.FC<Props> = ({ enableNew, className, textColor, ...props }) => {
+  const style = headerLink({ enableNew, className, textColor })
   return <TextLink {...props} target="_blank" suffix={null} className={style} />
 }

--- a/packages/smarthr-ui/src/components/Header/stories/Header.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/Header.stories.tsx
@@ -114,6 +114,11 @@ export default {
       mapping: _childrenOptions,
     },
     enableNew: { control: false },
+    headerColor: { control: 'color' },
+    textColor: {
+      control: 'select',
+      options: ['inherit', 'TEXT_BLACK', 'TEXT_WHITE', 'TEXT_GREY', 'TEXT_DISABLED', 'TEXT_LINK'],
+    },
   },
   args: {},
   parameters: {


### PR DESCRIPTION
## 関連URL


## 概要

- こんにちは！ヘッダーカラーをカスタマイズしたいケースに出くわしたので、PRを出しました（プロポーザルになります）
    - `Header`コンポーネントの背景色と文字色をpropsで変更できるようにしたいです
    - 本質的には、ヘッダーカラーに合わせてテキストカラー（DropdownMenuのテキストカラーなど）を変えたいです

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- `Header`コンポーネントに背景色を変更するための `headerColor` props を追加
- `Header`コンポーネントおよび関連する `HeaderLink`、`HeaderDropdownMenuButton` コンポーネントに文字色を変更するための `textColor` props を追加
- `Header`コンポーネントの `wrapper` の `tv` から `shr-bg-brand` を削除し、背景色のデフォルト設定を削除
- `Header`コンポーネントで `headerColor` propsから渡された場合、その値を背景色として適用するように修正
- `Text` コンポーネントの `color` props に `textColor` props の値を渡すように変更
- `HeaderDropdownMenuButton` に `textColor` props を渡すように変更

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Storybookで、HeaderコンポーネントのPropsを変更して背景と文字色が変更できることを確認してください。

![Storybookのキャプチャ](https://github.com/user-attachments/assets/9efc35e7-1ff4-4fd2-9d76-21b441fba14d)