### PR TITLE
fix: Textareaの文字数カウントテキストの生成時、ReactComponentが利用される場合があることの考慮漏れを対応

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -2,6 +2,7 @@
 
 import React, {
   ComponentPropsWithRef,
+  ReactNode,
   forwardRef,
   startTransition,
   useCallback,
@@ -123,7 +124,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
     const currentValue = props.defaultValue || props.value
     const [interimRows, setInterimRows] = useState(rows)
     const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
-    const [srCounterMessage, setSrCounterMessage] = useState('')
+    const [srCounterMessage, setSrCounterMessage] = useState<ReactNode>('')
 
     const {
       afterMaxLettersCount,
@@ -160,11 +161,23 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
 
         if (counterValue > maxLetters) {
           // {count}文字オーバー
-          return `${counterValue - maxLetters}${afterMaxLettersCount}${maxLettersCountExceeded}`
+          return (
+            <>
+              {counterValue - maxLetters}
+              {afterMaxLettersCount}
+              {maxLettersCountExceeded}
+            </>
+          )
         }
 
         // あと{count}文字
-        return `${beforeMaxLettersCount}${maxLetters - counterValue}${afterMaxLettersCount}`
+        return (
+          <>
+            {beforeMaxLettersCount}
+            {maxLetters - counterValue}
+            {afterMaxLettersCount}
+          </>
+        )
       },
       [maxLetters, maxLettersCountExceeded, afterMaxLettersCount, beforeMaxLettersCount],
     )


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- Textareaのdecoratorsの実行結果が意図しない文字列になる場合があるため調整したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- decoratorsの実行結果が、ReactNodeになる場合を考慮し、Fragmentで結合するように修正する
  - decoratorsは文字列に対してタグなどを差し込めるようにするための属性であるため、それを考慮したロジックに変更しました

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
