### PR TITLE
fix(Button): テキストのラベルが存在しない場合に自動的にsquareにする

### DIFF
--- a/packages/smarthr-ui/src/components/Button/Button.tsx
+++ b/packages/smarthr-ui/src/components/Button/Button.tsx
@@ -49,7 +49,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps & P
     {
       type = 'button',
       size = 'default',
-      square = false,
+      square,
       prefix,
       suffix,
       wide = false,
@@ -94,7 +94,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps & P
         className={wrapperStyle}
         buttonRef={ref}
         disabled={disabledOnLoading}
-        $loading={loading}
+        loading={loading}
       >
         {
           // `button` 要素内で live region を使うことはできないので、`role="status"` を持つ要素を外側に配置している。 https://github.com/kufu/smarthr-ui/pull/4558

--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -6,16 +6,17 @@ import React, {
   ReactNode,
   useMemo,
 } from 'react'
+import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { Variant } from './types'
 
 type BaseProps = {
   size: 'default' | 's'
-  square: boolean
+  square?: boolean
   wide: boolean
   variant: Variant
-  $loading?: boolean
+  loading?: boolean
   className: string
   children: ReactNode
   elementAs?: ElementType
@@ -38,16 +39,17 @@ export function ButtonWrapper({
   size,
   square,
   wide = false,
-  $loading,
+  loading,
   className,
   ...props
 }: Props) {
   const { buttonStyle, anchorStyle } = useMemo(() => {
+    const _square = square ?? !innerText(props.children)
     const { default: defaultButton, anchor } = button({
       variant,
       size,
-      square,
-      loading: $loading,
+      square: _square,
+      loading,
       wide,
     })
 
@@ -55,7 +57,7 @@ export function ButtonWrapper({
       buttonStyle: defaultButton({ className }),
       anchorStyle: anchor({ className }),
     }
-  }, [$loading, className, size, square, variant, wide])
+  }, [loading, className, size, square, variant, wide, props.children])
 
   if (props.isAnchor) {
     const { anchorRef, elementAs, isAnchor: _, ...others } = props

--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -43,21 +43,23 @@ export function ButtonWrapper({
   className,
   ...props
 }: Props) {
+  const actualSquare = useMemo(() => square ?? !innerText(props.children), [props.children, square])
   const { buttonStyle, anchorStyle } = useMemo(() => {
-    const _square = square ?? !innerText(props.children)
     const { default: defaultButton, anchor } = button({
       variant,
       size,
-      square: _square,
+      square: actualSquare,
       loading,
       wide,
     })
 
+    const commonAttr = { className }
+
     return {
-      buttonStyle: defaultButton({ className }),
-      anchorStyle: anchor({ className }),
+      buttonStyle: defaultButton(commonAttr),
+      anchorStyle: anchor(commonAttr),
     }
-  }, [loading, className, size, square, variant, wide, props.children])
+  }, [loading, className, size, actualSquare, variant, wide])
 
   if (props.isAnchor) {
     const { anchorRef, elementAs, isAnchor: _, ...others } = props


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

```tsx
<Button>
  <FaHogeIcon alt="hoge" />
</Button>
```

のようなボタンを作る時に、 `square` を指定しなくてもsquareになるように修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- ButtonWrapperの `$loading` を `loading` に修正
- `react-innertext` でchildrenを見て、ラベルが空 かつ square propsがundefinedなら自動的にsquareになるようにした
  - VisuallyHiddenTextでの指定などもあるが、square propsは残してあるので概ね対応できれば、でいいと考えた

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
