### PR TITLE
feat(smarthr-ui-preset): narrow breakpointを追加

### DIFF
--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -2,6 +2,7 @@ import { darken } from 'polished'
 import { defaultConfig } from 'tailwind-variants'
 import plugin from 'tailwindcss/plugin'
 
+import { defaultBreakpoint } from './themes/createBreakpoint'
 import { defaultColor } from './themes/createColor'
 import { defaultFontSize, defaultHtmlFontSize } from './themes/createFontSize'
 import { defaultShadow } from './themes/createShadow/defaultShadow'
@@ -182,6 +183,11 @@ export default {
     },
     outlineColor: {
       DEFAULT: defaultColor.OUTLINE,
+    },
+    screens: {
+      narrow: {
+        max: `${defaultBreakpoint.SP}px`,
+      },
     },
     spacing: {
       px: '1px',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://github.com/kufu/smarthr-ui/pull/4965

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

screensにnarrowを定義し、 `narrow:shr-hoge` でモバイル対応できるようにした

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- screensにnarrowを定義
  - defaultBreakpoint.SPで定義

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

てきとうに `narrow:shr-bg-[red]` などを当てて、横幅を狭めてみる

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
