### PR TITLE
fix: SegmentedControl内の選択済み項目でButton[variant=primary]を利用する

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -49,11 +49,6 @@ const segmentedControl = tv({
       'smarthr-ui-SegmentedControl-button',
       'shr-m-0',
       'shr-rounded-none',
-      'aria-checked:shr-border-main',
-      'aria-checked:shr-bg-main',
-      'aria-checked:shr-text-white',
-      'aria-checked:hover:shr-border-main/50',
-      'aria-checked:hover:shr-bg-main/50',
       'focus-visible:shr-focus-indicator',
       'first:shr-rounded-tl-m',
       'first:shr-rounded-bl-m',
@@ -226,6 +221,7 @@ const SegmentedControlButton: FC<
     <Button
       role="radio"
       aria-label={option.ariaLabel}
+      variant={checked ? 'primary' : 'secondary'}
       aria-checked={checked && !!value}
       disabled={option.disabled}
       tabIndex={tabIndex}


### PR DESCRIPTION
## 関連URL

* https://smarthr.atlassian.net/browse/SHRUI-1218

## 概要

`SegmentedControl` コンポーネントにおいて、チェック済みの項目をホバーしたときの背景色と前景色のカラーコントラスト比が不十分でした。そのため、選択済みの場合は、内部で利用されている `Button` コンポーネントで `variant=primary` を利用するように変更しました。

これによって、選択済み項目で `shr-bg-main-darken` が当たるようになり、十分なコントラスト比が確保されます。

## 変更内容

| before | after |
| :-: | :-: |
| <img width="689" alt="image" src="https://github.com/user-attachments/assets/c2c387c3-0acb-4cf2-97d2-35a4d7d68d70" /> | <img width="689" alt="image" src="https://github.com/user-attachments/assets/b83c178d-8ba0-4a01-8fa2-192e91d133ad" /> |


## 確認方法

https://www.chromatic.com/build?appId=63d0ccabb5d2dd29825524ab&number=10084
