### PR TITLE
refactor(InformationPanel): useIdを1つに統合

### DIFF
--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -125,8 +125,9 @@ export const InformationPanel: FC<Props> = ({
   ...props
 }) => {
   const [active, setActive] = useState(activeProps)
-  const titleId = useId()
-  const contentId = useId()
+  const id = useId()
+  const titleId = `${id}-title`
+  const contentId = `${id}-content`
 
   useEffect(() => {
     setActive(activeProps)


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- useIdは1つにしてほしいと書いてあるので
  - https://ja.legacy.reactjs.org/docs/hooks-reference.html#useid
  - でも新しいドキュメント https://react.dev/reference/react/useId#generating-ids-for-several-related-elements だと書きっぷりが少し変わってて、実はそうでもないのか…？となってる
  - 挙動としては複数書いても違うidが当たるようにはなってる

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
