### PR TITLE
docs: iframe内のコンテンツの高さを100%で表示できるように修正

### DIFF
--- a/packages/smarthr-ui/.storybook/preview-head.html
+++ b/packages/smarthr-ui/.storybook/preview-head.html
@@ -3,4 +3,7 @@
   code {
     font-family: 'Courier New', Courier, monospace;
   }
+  html, body {
+    height: 100%;
+  }
 </style>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/C079SGNTSGN/p1737529135300159?thread_ts=1737337547.918989&cid=C079SGNTSGN

https://kufuinc.slack.com/archives/C079SGNTSGN/p1737529430502409?thread_ts=1737337547.918989&cid=C079SGNTSGN

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

Storybookの高さが不十分なことで、Dropdown等の外をクリックしたら閉じる系のものの挙動が勘違いされやすいので修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- Storybookのiframeのhtml, bodyをheight: 100%に修正

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

before

https://github.com/user-attachments/assets/2eae5818-a1c0-4d9a-8194-322ccf10a549

after

https://github.com/user-attachments/assets/b607a4bc-9774-42b7-9d9f-6cb3d1bf7d32

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
