### PR TITLE
fix(Textarea): autoResize時にvalue, defaultValueの初期値でも高さを反映するように修正

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -101,7 +101,7 @@ const textarea = tv({
 
 const calculateIdealRows = (
   element?: HTMLTextAreaElement | null,
-  maxRows: number = Infinity,
+  maxRows: number = Number.MAX_SAFE_INTEGER,
 ): number => {
   if (!element) {
     return 0

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, {
+  ChangeEvent,
   ComponentPropsWithRef,
   ReactNode,
   forwardRef,
@@ -98,6 +99,20 @@ const textarea = tv({
   },
 })
 
+const calculateIdealRows = (
+  element?: HTMLTextAreaElement | null,
+  maxRows: number = Infinity,
+): number => {
+  if (!element) {
+    return 0
+  }
+  // 現在の入力値に応じた行数
+  const currentInputValueRows = Math.floor(
+    element.scrollHeight / (defaultHtmlFontSize * Number(lineHeight.normal)),
+  )
+  return currentInputValueRows < maxRows ? currentInputValueRows : maxRows
+}
+
 export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
   (
     {
@@ -189,12 +204,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
       () => textareaRef.current,
     )
 
-    useEffect(() => {
-      if (autoFocus && textareaRef && textareaRef.current) {
-        textareaRef.current.focus()
-      }
-    }, [autoFocus])
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const debouncedUpdateCount = useCallback(
       debounce((value: string) => {
@@ -221,49 +230,54 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
     )
 
     const handleChange = useCallback(
-      (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        if (onChange) {
-          onChange(event)
-        }
-
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         if (maxLetters) {
-          const inputValue = event.currentTarget.value
+          const inputValue = e.currentTarget.value
           debouncedUpdateCount(inputValue)
           debouncedUpdateSrCounterMessage(inputValue)
         }
+
+        onChange?.(e)
       },
       [debouncedUpdateCount, maxLetters, onChange, debouncedUpdateSrCounterMessage],
     )
 
+    // autoFocus時に、フォーカスを当てる
+    useEffect(() => {
+      if (autoFocus && textareaRef && textareaRef.current) {
+        textareaRef.current.focus()
+      }
+    }, [autoFocus])
+
+    // autoResize時に、初期値での高さを指定
+    useEffect(() => {
+      if (!autoResize) {
+        return
+      }
+      if (!textareaRef.current) {
+        return
+      }
+
+      setInterimRows(calculateIdealRows(textareaRef.current, maxRows))
+    }, [setInterimRows, maxRows, autoResize])
+
     const handleInput = useCallback(
-      (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        if (!autoResize) {
-          return onInput && onInput(e)
-        }
+      (e: ChangeEvent<HTMLTextAreaElement>) => {
+        // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
+        e.target.rows = 0
 
-        const previousRows = e.target.rows
-        // 消したことを検知できないので必ず初期化
-        e.target.rows = rows
-
-        const currentRows = Math.floor(
-          e.target.scrollHeight / (defaultHtmlFontSize * Number(lineHeight.normal)),
-        )
-
-        if (previousRows === currentRows) {
+        if (autoResize) {
+          const currentRows = calculateIdealRows(e.target, maxRows)
+          // rowsを直接反映 Textareaのrows propsが状態を変更しても反映されないため
           e.target.rows = currentRows
-        } else if (maxRows < currentRows) {
-          // 最大まで達したとき高さが潰れないように代入
-          e.target.rows = maxRows
+          setInterimRows(currentRows)
         }
 
-        setInterimRows(currentRows < maxRows ? currentRows : maxRows)
-
-        if (onInput) {
-          onInput(e)
-        }
+        onInput?.(e)
       },
-      [autoResize, maxRows, onInput, rows],
+      [autoResize, maxRows, onInput],
     )
+
     const { textareaStyleProps, counterStyle, counterTextStyle } = useMemo(() => {
       const { textareaEl, counter, counterText } = textarea()
       return {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/C06KVP5PL23/p1737614015187009

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

autoResize時にvalue, defaultValueの初期値でも高さを反映するように修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- autoResize時にvalue, defaultValueの初期値でも高さを反映するように修正
- 軽微なリファクタリング

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

- 複数行のvalue または defaultValue と autoResize を設定した状態で初期レンダリング時に高さが反映されていることを確認

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
