### PR TITLE
chore: Revert "fix(Button): テキストのラベルが存在しない場合に自動的にsquareにする"

### DIFF
--- a/packages/smarthr-ui/src/components/Button/Button.tsx
+++ b/packages/smarthr-ui/src/components/Button/Button.tsx
@@ -49,7 +49,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps & P
     {
       type = 'button',
       size = 'default',
-      square,
+      square = false,
       prefix,
       suffix,
       wide = false,
@@ -94,7 +94,7 @@ export const Button = forwardRef<HTMLButtonElement, BaseProps & ElementProps & P
         className={wrapperStyle}
         buttonRef={ref}
         disabled={disabledOnLoading}
-        loading={loading}
+        $loading={loading}
       >
         {
           // `button` 要素内で live region を使うことはできないので、`role="status"` を持つ要素を外側に配置している。 https://github.com/kufu/smarthr-ui/pull/4558

--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -6,17 +6,16 @@ import React, {
   ReactNode,
   useMemo,
 } from 'react'
-import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { Variant } from './types'
 
 type BaseProps = {
   size: 'default' | 's'
-  square?: boolean
+  square: boolean
   wide: boolean
   variant: Variant
-  loading?: boolean
+  $loading?: boolean
   className: string
   children: ReactNode
   elementAs?: ElementType
@@ -39,27 +38,24 @@ export function ButtonWrapper({
   size,
   square,
   wide = false,
-  loading,
+  $loading,
   className,
   ...props
 }: Props) {
-  const actualSquare = useMemo(() => square ?? !innerText(props.children), [props.children, square])
   const { buttonStyle, anchorStyle } = useMemo(() => {
     const { default: defaultButton, anchor } = button({
       variant,
       size,
-      square: actualSquare,
-      loading,
+      square,
+      loading: $loading,
       wide,
     })
 
-    const commonAttr = { className }
-
     return {
-      buttonStyle: defaultButton(commonAttr),
-      anchorStyle: anchor(commonAttr),
+      buttonStyle: defaultButton({ className }),
+      anchorStyle: anchor({ className }),
     }
-  }, [loading, className, size, actualSquare, variant, wide])
+  }, [$loading, className, size, square, variant, wide])
 
   if (props.isAnchor) {
     const { anchorRef, elementAs, isAnchor: _, ...others } = props


### PR DESCRIPTION
react-intlとの組み合わせで期待通りの動作をしないことがわかったのでRevert kufu/smarthr-ui#5294

https://kufuinc.slack.com/archives/CGC58MW01/p1738040458168459?thread_ts=1737541173.404369&cid=CGC58MW01