### PR TITLE
chore: Dialogのscroll部分をStackではなくSection、かつ必要なflex系styleのみ設定することで余計な処理をskipする

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -6,6 +6,7 @@ import { type DecoratorsType } from '../../../hooks/useDecorators'
 import { Button } from '../../Button'
 import { Cluster, Stack } from '../../Layout'
 import { ResponseMessage } from '../../ResponseMessage'
+import { Section } from '../../SectioningContent'
 import { DialogBody, type Props as DialogBodyProps } from '../DialogBody'
 import { DialogHeader, type Props as DialogHeaderProps } from '../DialogHeader'
 import { dialogContentInner } from '../dialogInnerStyle'
@@ -98,9 +99,8 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
   }, [])
 
   return (
-    // HINT: bodyをスクロールできるようにするため、Sectionではなく、Stack[as="section"][gap=0]を使用する必要がある
-    // eslint-disable-next-line smarthr/best-practice-for-layouts, smarthr/a11y-heading-in-sectioning-content
-    <Stack as="section" gap={0} className={styles.wrapper}>
+    // eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content
+    <Section className={styles.wrapper}>
       <DialogHeader title={title} subtitle={subtitle} titleTag={titleTag} titleId={titleId} />
       <DialogBody contentPadding={contentPadding} contentBgColor={contentBgColor}>
         {children}
@@ -128,7 +128,7 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
           </div>
         )}
       </Stack>
-    </Stack>
+    </Section>
   )
 }
 

--- a/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -12,6 +12,7 @@ import { type DecoratorsType } from '../../../hooks/useDecorators'
 import { Button } from '../../Button'
 import { Cluster, Stack } from '../../Layout'
 import { ResponseMessage } from '../../ResponseMessage'
+import { Section } from '../../SectioningContent'
 import { DialogBody, Props as DialogBodyProps } from '../DialogBody'
 import { DialogHeader, type Props as DialogHeaderProps } from '../DialogHeader'
 import { dialogContentInner } from '../dialogInnerStyle'
@@ -123,9 +124,8 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   }, [])
 
   return (
-    // HINT: bodyをスクロールできるようにするため、Sectionではなく、Stack[as="section"][gap=0]を使用する必要がある
-    // eslint-disable-next-line smarthr/best-practice-for-layouts, smarthr/a11y-heading-in-sectioning-content, smarthr/a11y-prohibit-sectioning-content-in-form
-    <Stack as="section" gap={0} className={styles.wrapper}>
+    // eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content, smarthr/a11y-prohibit-sectioning-content-in-form
+    <Section className={styles.wrapper}>
       <DialogHeader title={title} subtitle={subtitle} titleTag={titleTag} titleId={titleId} />
       <form onSubmit={handleSubmitAction} className={styles.form}>
         <DialogBody contentPadding={contentPadding} contentBgColor={contentBgColor}>
@@ -154,7 +154,7 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
           )}
         </Stack>
       </form>
-    </Stack>
+    </Section>
   )
 }
 

--- a/packages/smarthr-ui/src/components/Dialog/dialogInnerStyle.ts
+++ b/packages/smarthr-ui/src/components/Dialog/dialogInnerStyle.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants'
 
 export const dialogContentInner = tv({
   slots: {
-    wrapper: 'shr-max-h-[calc(100dvh-theme(spacing.2))]',
+    wrapper: 'shr-flex shr-flex-col shr-max-h-[calc(100dvh-theme(spacing.2))]',
     actionArea: [
       'smarthr-ui-Dialog-actionArea',
       'shr-border-t-shorthand shr-px-1.5 shr-py-1 shr-flex-[0_0_auto] shr-sticky shr-bottom-0 shr-z-1 shr-bg-white shr-rounded-b-m',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- DialogのScroll部分の処理がStackで設定されるflex系のclassNameに依存している記述になっている
- 依存関係が分かりづらく、かつ一見Stackが不要に見える記述になってしまうこと、Stack内のロジックの大半が本質的に不要であることから、必要なflex系のclassNameをDialog側で設定することでバグらせづらいコードにしたい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- DialogContentInner系からスクロール部分のStackの使用をやめ、`shr-flex shr-flex-col` だけ指定するように修正

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- ActionDialog, FormDialogで画面縦幅が短い場合でも問題なくbodyがscrollできることを確認する
