### PR TITLE
fix(Textarea): rows指定が正しく動かないのを修正

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -237,7 +237,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
     const handleInput = useCallback(
       (e: ChangeEvent<HTMLTextAreaElement>) => {
         // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
-        e.target.rows = 0
+        e.target.rows = rows
 
         if (autoResize) {
           const currentRows = calculateIdealRows(e.target, maxRows)
@@ -248,7 +248,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
 
         onInput?.(e)
       },
-      [autoResize, maxRows, onInput],
+      [autoResize, maxRows, onInput, rows],
     )
 
     const { textareaStyleProps, counterStyle, counterTextStyle } = useMemo(() => {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://kufuinc.slack.com/archives/CGC58MW01/p1739845995732009

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

propsで渡されるrowsの初期値が入力後にブラウザの初期値に戻ってしまうのを修正

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

propsで渡されるrowsの初期値が反映されないのを修正

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

StorybookのTextarea/rowsで入力して高さが縮まないことを確認