### PR TITLE
refactor: aria-haspopup の値をtrueからdialogに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger.tsx
@@ -37,7 +37,7 @@ export const RemoteDialogTrigger: React.FC<
     () =>
       cloneElement(children as ReactElement, {
         onClick: actualOnClick,
-        'aria-haspopup': 'true',
+        'aria-haspopup': 'dialog',
         'aria-controls': targetId,
         variant,
         ...rest,


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

JIRAなし、アクセシビリティ簡易チェックをした際に見つけた課題です

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

`aria-haspopup="dialog"` のサポート状況が広がったため、正しい読み上げになる dialog に変えたい
根拠: [Test: aria-haspopup attribute | Accessibility Support](https://a11ysupport.io/tests/tech__aria__aria-haspopup-attribute)

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容
- RemoteTriggerButton の `aria-haspopup="true"` を `aria-haspopup="dialog"` へ変更 
<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

- [x] VoiceOver
- [x] PC-Talker
- [x] NVDA


PC-Talker は dialog の対応なしみたいで読み上げは変わりませんでした！（開発版のみ確認）
しかし読み上げないようは true,dialog で変わらなかったので問題ない認識です！
<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
