### PR TITLE
fix(Fieldset): innerMarginとして0.5を受け取れるように修正

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -112,12 +112,12 @@ const childrenWrapper = tv({
   },
   compoundVariants: [
     {
-      innerMargin: 0.5,
+      innerMargin: undefined,
       isFieldset: true,
       className: '[:not([hidden])_~_&&&]:shr-mt-1',
     },
     {
-      innerMargin: 0.5,
+      innerMargin: undefined,
       isFieldset: false,
       className: '[:not([hidden])_~_&&&]:shr-mt-0.5',
     },
@@ -133,7 +133,7 @@ export const ActualFormControl: React.FC<Props & ElementProps> = ({
   dangerouslyTitleHidden = false,
   htmlFor,
   labelId,
-  innerMargin = 0.5,
+  innerMargin,
   statusLabelProps,
   helpMessage,
   exampleMessage,
@@ -184,6 +184,8 @@ export const ActualFormControl: React.FC<Props & ElementProps> = ({
 
     return Array.isArray(errorMessages) ? errorMessages : [errorMessages]
   }, [errorMessages])
+
+  const actualInnerMargin = useMemo(() => innerMargin ?? 0.5, [innerMargin])
 
   const { wrapperStyle, labelStyle, errorListStyle, errorIconStyle, underTitleStackStyle } =
     useMemo(() => {
@@ -307,7 +309,7 @@ export const ActualFormControl: React.FC<Props & ElementProps> = ({
   if (dangerouslyTitleHidden) {
     body = (
       // eslint-disable-next-line smarthr/best-practice-for-layouts
-      <Stack gap={innerMargin} className={underTitleStackStyle}>
+      <Stack gap={actualInnerMargin} className={underTitleStackStyle}>
         {body}
       </Stack>
     )
@@ -317,7 +319,7 @@ export const ActualFormControl: React.FC<Props & ElementProps> = ({
     <Stack
       {...props}
       as={as}
-      gap={innerMargin}
+      gap={actualInnerMargin}
       aria-describedby={isFieldset && describedbyIds ? describedbyIds : undefined}
       className={wrapperStyle}
     >


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/CGC58MW01/p1740726417428149

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

Fieldsetが innerMarginとして`0.5` を受け取れなくなっていたので修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- props経由のinnerMarginのデフォルト値指定を削除
- innerMarginの値がundefinedのときだけ `1` を指定するように修正

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- FieldsetのinnerMargin未指定時に`1`であることを確認 https://63d0ccabb5d2dd29825524ab-yjibkvwsnc.chromatic.com/?path=/story/forms%EF%BC%88%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%EF%BC%89-fieldset--playground (VRTでOK)
- FieldsetのinnerMarginを0.5に指定してあたることを確認 https://63d0ccabb5d2dd29825524ab-yjibkvwsnc.chromatic.com/?path=/story/forms%EF%BC%88%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%EF%BC%89-fieldset--inner-margin (https://story.smarthr-ui.dev では当たらないことも確認)
- FormControlの表示が変わっていないことを確認(VRT)
