### PR TITLE
fix(SegmentedControl): isSquare を指定しなくても使えるように修正

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -35,8 +35,6 @@ type Props = {
   onClickOption?: (value: string) => void
   /** 各ボタンの大きさ */
   size?: 'default' | 's'
-  /** 各ボタンを正方形にするかどうか。アイコンボタンを使用する場合に指定します。 */
-  isSquare?: boolean
   /** コンポーネントに適用するクラス名 */
   className?: string
 }
@@ -48,14 +46,21 @@ const classNameGenerator = tv({
     buttonGroup: '-shr-space-x-px',
     button: [
       'smarthr-ui-SegmentedControl-button',
-      'shr-m-0',
-      'shr-rounded-none',
+      'shr-m-0 shr-rounded-none',
       'focus-visible:shr-focus-indicator',
-      'first:shr-rounded-tl-m',
-      'first:shr-rounded-bl-m',
-      'last:shr-rounded-tr-m',
-      'last:shr-rounded-br-m',
+      'first:shr-rounded-tl-m first:shr-rounded-bl-m',
+      'last:shr-rounded-tr-m last:shr-rounded-br-m',
     ],
+  },
+  variants: {
+    size: {
+      default: {
+        button: '[&:has(>_span_>_.smarthr-ui-Icon:only-child)]:shr-p-0.75',
+      },
+      s: {
+        button: 'shr-p-0.5',
+      },
+    },
   },
 })
 
@@ -64,8 +69,7 @@ export const SegmentedControl: FC<Props & ElementProps> = ({
   value,
   onClickOption,
   size = 'default',
-  isSquare = false,
-  className = '',
+  className,
   ...props
 }) => {
   const [isFocused, setIsFocused] = useState(false)
@@ -76,9 +80,9 @@ export const SegmentedControl: FC<Props & ElementProps> = ({
     return {
       container: container({ className }),
       buttonGroup: buttonGroup(),
-      button: button(),
+      button: button({ size }),
     }
-  }, [className])
+  }, [className, size])
 
   const onFocus = useCallback(() => setIsFocused(true), [])
   const onBlur = useCallback(() => setIsFocused(false), [])
@@ -170,11 +174,10 @@ export const SegmentedControl: FC<Props & ElementProps> = ({
             index={index}
             onClick={actualOnClickOption}
             size={size}
-            isSquare={isSquare}
             value={value}
             isFocused={isFocused}
             excludesSelected={excludesSelected}
-            buttonClassName={classNames.button}
+            className={classNames.button}
           />
         ))}
       </div>
@@ -183,25 +186,15 @@ export const SegmentedControl: FC<Props & ElementProps> = ({
 }
 
 const SegmentedControlButton: FC<
-  Pick<Props, 'size' | 'isSquare' | 'value'> & {
+  Pick<Props, 'size' | 'value'> & {
     onClick: undefined | ((e: MouseEvent<HTMLButtonElement>) => void)
     option: Props['options'][number]
     index: number
     isFocused: boolean
     excludesSelected: boolean
-    buttonClassName: string
+    className: string
   }
-> = ({
-  onClick,
-  size,
-  isSquare,
-  value,
-  option,
-  index,
-  isFocused,
-  excludesSelected,
-  buttonClassName,
-}) => {
+> = ({ onClick, size, value, option, index, isFocused, excludesSelected, className }) => {
   const checked = value === option.value
   const tabIndex = useMemo(() => {
     if (isFocused) {
@@ -226,8 +219,7 @@ const SegmentedControlButton: FC<
       value={option.value}
       onClick={onClick}
       size={size}
-      square={isSquare}
-      className={buttonClassName}
+      className={className}
     >
       {option.content}
     </Button>

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -35,8 +35,8 @@ type Props = {
   onClickOption?: (value: string) => void
   /** 各ボタンの大きさ */
   size?: 'default' | 's'
-  /** コンポーネントに適用するクラス名 */
-  className?: string
+  /** 各ボタンを正方形にするかどうか */
+  isSquare?: boolean
 }
 type ElementProps = Omit<ComponentProps<'div'>, keyof Props>
 
@@ -69,6 +69,7 @@ export const SegmentedControl: FC<Props & ElementProps> = ({
   value,
   onClickOption,
   size = 'default',
+  isSquare,
   className,
   ...props
 }) => {
@@ -186,7 +187,7 @@ export const SegmentedControl: FC<Props & ElementProps> = ({
 }
 
 const SegmentedControlButton: FC<
-  Pick<Props, 'size' | 'value'> & {
+  Pick<Props, 'size' | 'isSquare' | 'value'> & {
     onClick: undefined | ((e: MouseEvent<HTMLButtonElement>) => void)
     option: Props['options'][number]
     index: number
@@ -194,7 +195,7 @@ const SegmentedControlButton: FC<
     excludesSelected: boolean
     className: string
   }
-> = ({ onClick, size, value, option, index, isFocused, excludesSelected, className }) => {
+> = ({ onClick, size, value, option, index, isFocused, excludesSelected, isSquare, className }) => {
   const checked = value === option.value
   const tabIndex = useMemo(() => {
     if (isFocused) {
@@ -219,6 +220,7 @@ const SegmentedControlButton: FC<
       value={option.value}
       onClick={onClick}
       size={size}
+      square={isSquare}
       className={className}
     >
       {option.content}

--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
@@ -31,7 +31,6 @@ export default {
     value: 'departments',
     onClickOption: (value) => action('onClickOption')(value),
     size: 'default',
-    isSquare: false,
     className: '',
   },
   parameters: {
@@ -66,7 +65,6 @@ export const Options: StoryObj<typeof SegmentedControl> = {
       />
       <SegmentedControl
         {...args}
-        isSquare={true}
         options={[
           { value: 'table', ariaLabel: 'テーブル', content: tableIcon },
           { value: 'chartBar', ariaLabel: 'バーチャート', content: chartBarIcon },
@@ -97,34 +95,6 @@ export const Size: StoryObj<typeof SegmentedControl> = {
     <Stack>
       <SegmentedControl {...args} size="default" />
       <SegmentedControl {...args} size="s" />
-    </Stack>
-  ),
-}
-
-export const IsSquare: StoryObj<typeof SegmentedControl> = {
-  name: 'isSquare',
-  render: (args) => (
-    <Stack>
-      <SegmentedControl
-        {...args}
-        options={[
-          { value: 'table', ariaLabel: 'テーブル', content: tableIcon },
-          { value: 'chartBar', ariaLabel: 'バーチャート', content: chartBarIcon },
-          { value: 'chartArea', ariaLabel: 'エリアチャート', content: chartAreaIcon },
-          { value: 'chartLine', ariaLabel: 'ラインチャート', content: chartLineIcon },
-          { value: 'chartPie', ariaLabel: 'パイチャート', content: chartPieIcon },
-        ]}
-        isSquare={false}
-      />
-      <SegmentedControl
-        {...args}
-        options={[
-          { value: 'departments', content: '部署', disabled: true },
-          { value: 'crew', content: '従業員', disabled: true },
-          { value: 'both', content: '部署と従業員', disabled: true },
-        ]}
-        isSquare={true}
-      />
     </Stack>
   ),
 }

--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/VRTSegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/VRTSegmentedControl.stories.tsx
@@ -25,23 +25,23 @@ const iconOptions = (disabled: boolean): Option[] => [
 export default {
   title: 'Buttons（ボタン）/SegmentedControl/VRT',
   /* ペアワイズ法による網羅 */
-  // options.content options.disabled        value   size    isSquare
-  // icon            true                    null    default true
-  // text            false                   null    s       false
-  // text            true                    3       s       true
-  // text            false                   1       default false
-  // icon            false                   3       default false
-  // icon            true                    1       s       false
-  // icon            false                   1       s       true
+  // options.content options.disabled        value   size
+  // icon            true                    null    default
+  // text            false                   null    s
+  // text            true                    3       s
+  // text            false                   1       default
+  // icon            false                   3       default
+  // icon            true                    1       s
+  // icon            false                   1       s
   render: (args: any) => (
     <Stack>
-      <SegmentedControl options={iconOptions(true)} value={null} size="default" isSquare={true} />
-      <SegmentedControl options={textOptions(false)} value={null} size="s" isSquare={false} />
-      <SegmentedControl options={textOptions(true)} value="3" size="s" isSquare={true} />
-      <SegmentedControl options={textOptions(false)} value="1" size="default" isSquare={false} />
-      <SegmentedControl options={iconOptions(false)} value="3" size="default" isSquare={false} />
-      <SegmentedControl options={iconOptions(true)} value="1" size="s" isSquare={false} />
-      <SegmentedControl options={iconOptions(false)} value="1" size="s" isSquare={true} />
+      <SegmentedControl options={iconOptions(true)} value={null} size="default" />
+      <SegmentedControl options={textOptions(false)} value={null} size="s" />
+      <SegmentedControl options={textOptions(true)} value="3" size="s" />
+      <SegmentedControl options={textOptions(false)} value="1" size="default" />
+      <SegmentedControl options={iconOptions(false)} value="3" size="default" />
+      <SegmentedControl options={iconOptions(true)} value="1" size="s" />
+      <SegmentedControl options={iconOptions(false)} value="1" size="s" />
     </Stack>
   ),
   parameters: {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1179

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

アイコンのみの場合に `Button[square]` 相当のスタイリングをするために、`isSquare` を渡していた。
開発者は `isSquare` を気にせず使えるようになるため削除します。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

Chromatic の差分がでていますが、標準サイズで isSquare が効いていなかったので修正されています。確認して accept してください。