### PR TITLE
chore: TimePikcerを拡大表示した場合、文字が途切れてしまう場合がある問題を修正する SHRUI-1075

### DIFF
--- a/packages/smarthr-ui/src/components/Picker/style.ts
+++ b/packages/smarthr-ui/src/components/Picker/style.ts
@@ -17,7 +17,9 @@ export const classNameGenerator = (componentType: string) =>
         'has-[[readonly]]:shr-border-[theme(backgroundColor.background)] has-[[readonly]]:shr-bg-background',
       ],
       inner: [
-        'shr-border-none shr-text-base disabled:shr-text-disabled shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-h-[theme(fontSize.base)] shr-tabular-nums',
+        'shr-border-none shr-text-base shr-h-[theme(fontSize.base)] shr-tabular-nums',
+        'shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-min-w-[5em]',
+        'disabled:shr-text-disabled',
       ],
     },
   })()

--- a/packages/smarthr-ui/src/components/Picker/style.ts
+++ b/packages/smarthr-ui/src/components/Picker/style.ts
@@ -17,8 +17,9 @@ export const classNameGenerator = (componentType: string) =>
         'has-[[readonly]]:shr-border-[theme(backgroundColor.background)] has-[[readonly]]:shr-bg-background',
       ],
       inner: [
-        'shr-border-none shr-text-base shr-h-[theme(fontSize.base)] shr-tabular-nums',
-        'shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-min-w-[5em]',
+        'shr-border-none shr-outline-none shr-outline-0 shr-bg-transparent shr-text-black',
+        'shr-text-base shr-h-[theme(fontSize.base)] shr-tabular-nums',
+        'shr-p-[unset] shr-py-0.75 shr-min-w-[5em]',
         'disabled:shr-text-disabled',
       ],
     },

--- a/packages/smarthr-ui/src/components/Picker/style.ts
+++ b/packages/smarthr-ui/src/components/Picker/style.ts
@@ -17,9 +17,7 @@ export const classNameGenerator = (componentType: string) =>
         'has-[[readonly]]:shr-border-[theme(backgroundColor.background)] has-[[readonly]]:shr-bg-background',
       ],
       inner: [
-        'shr-border-none shr-outline-none shr-outline-0 shr-bg-transparent shr-text-black',
-        'shr-text-base shr-h-[theme(fontSize.base)] shr-tabular-nums',
-        'shr-p-[unset] shr-py-0.75 shr-min-w-[5em]',
+        'shr-border-none shr-text-base shr-bg-transparent shr-text-black shr-outline-none shr-outline-0 shr-p-[unset] shr-py-0.75 shr-h-[theme(fontSize.base)] shr-tabular-nums shr-min-w-[5em]',
         'disabled:shr-text-disabled',
       ],
     },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://smarthr.atlassian.net/browse/SHRUI-1075

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- TimePickerが拡大表示された場合、表示が途切れてしまう場合に対応する

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- timepickerの横幅を調整
  - classに `shr-min-w-[5em]` を追加
  - そもそもの原因は `shr-h-[theme(fontSize.base)]` `shr-tabular-nums` の2つで、文字の横幅が増えることで発生していました
  - 色々試しましたが横幅拡大が最も手軽でした

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- スクショを確認する

<img width="156" alt="スクリーンショット 2025-03-28 13 49 35" src="https://github.com/user-attachments/assets/b8db47c9-2f24-463d-83d4-381e6ea70494" />