### PR TITLE
fix!: Tooltipの表示位置の計算ロジックを調整する  SHRUI-573

### DIFF
--- a/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.stories.tsx
@@ -20,6 +20,15 @@ export const All: StoryFn = () => (
       <Balloon horizontal="right" vertical="top">
         <Txt>top right</Txt>
       </Balloon>
+      <Balloon horizontal="left" vertical="top" triggerIcon={true}>
+        <Txt>top left</Txt>
+      </Balloon>
+      <Balloon horizontal="center" vertical="top" triggerIcon={true}>
+        <Txt>top center</Txt>
+      </Balloon>
+      <Balloon horizontal="right" vertical="top" triggerIcon={true}>
+        <Txt>top right</Txt>
+      </Balloon>
     </li>
     <li>
       <Balloon horizontal="left" vertical="bottom">
@@ -29,6 +38,15 @@ export const All: StoryFn = () => (
         <Txt>bottom center</Txt>
       </Balloon>
       <Balloon horizontal="right" vertical="bottom">
+        <Txt>bottom right</Txt>
+      </Balloon>
+      <Balloon horizontal="left" vertical="bottom" triggerIcon={true}>
+        <Txt>bottom left</Txt>
+      </Balloon>
+      <Balloon horizontal="center" vertical="bottom" triggerIcon={true}>
+        <Txt>bottom center</Txt>
+      </Balloon>
+      <Balloon horizontal="right" vertical="bottom" triggerIcon={true}>
         <Txt>bottom right</Txt>
       </Balloon>
     </li>

--- a/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
+++ b/packages/smarthr-ui/src/components/Balloon/Balloon.tsx
@@ -67,6 +67,9 @@ const classNameGenerator = tv({
         'after:-shr-translate-y-[5px]',
       ],
     },
+    triggerIcon: {
+      true: '',
+    },
   },
   compoundVariants: [
     {
@@ -76,8 +79,20 @@ const classNameGenerator = tv({
     },
     {
       vertical: ['top', 'bottom'],
+      horizontal: 'left',
+      triggerIcon: true,
+      className: ['before:shr-left-0.5', 'after:shr-left-0.5'],
+    },
+    {
+      vertical: ['top', 'bottom'],
       horizontal: 'right',
       className: ['before:shr-right-1.5', 'after:shr-right-1.5'],
+    },
+    {
+      vertical: ['top', 'bottom'],
+      horizontal: 'right',
+      triggerIcon: true,
+      className: ['before:shr-right-0.5', 'after:shr-right-0.5'],
     },
     {
       vertical: 'middle',
@@ -120,10 +135,10 @@ type Props = PropsWithChildren<
 type ElementProps = Omit<ComponentPropsWithoutRef<'div'>, keyof Props>
 
 export const Balloon = memo<Props & ElementProps>(
-  ({ horizontal, vertical, className, as: Component = 'div', ...props }) => {
+  ({ horizontal, vertical, triggerIcon, className, as: Component = 'div', ...props }) => {
     const actualClassName = useMemo(
-      () => classNameGenerator({ horizontal, vertical, className }),
-      [horizontal, vertical, className],
+      () => classNameGenerator({ horizontal, vertical, triggerIcon, className }),
+      [horizontal, vertical, className, triggerIcon],
     )
 
     return <Component {...props} className={actualClassName} />

--- a/packages/smarthr-ui/src/components/Button/DisabledDetail.tsx
+++ b/packages/smarthr-ui/src/components/Button/DisabledDetail.tsx
@@ -57,13 +57,7 @@ const TooltipIcon = memo<{
   const DisabledDetailIcon = icon ?? FaCircleInfoIcon
 
   return (
-    <Tooltip
-      message={message}
-      triggerType="icon"
-      horizontal="auto"
-      vertical="auto"
-      className={className}
-    >
+    <Tooltip message={message} triggerType="icon" className={className}>
       <DisabledDetailIcon />
     </Tooltip>
   )

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -112,11 +112,7 @@ export function MultiSelectedItem<T>({
   )
 
   if (needsTooltip) {
-    return (
-      <Tooltip message={item.label} multiLine={true}>
-        {body}
-      </Tooltip>
-    )
+    return <Tooltip message={item.label}>{body}</Tooltip>
   }
 
   return body

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -69,13 +69,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
       <ConditionalWrapper
         shouldWrapContent={tooltip?.show}
         wrapper={({ children: currentChildren }) => (
-          <Tooltip
-            message={tooltip?.message}
-            horizontal="auto"
-            vertical="auto"
-            triggerType="icon"
-            tabIndex={-1}
-          >
+          <Tooltip message={tooltip?.message} triggerType="icon" tabIndex={-1}>
             {currentChildren}
           </Tooltip>
         )}

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -115,9 +115,7 @@ export const LineClamp: FC<Props & ElementProps> = ({
   )
 
   return isTooltipVisible ? (
-    <Tooltip message={children} vertical="auto">
-      {actualLineClamp}
-    </Tooltip>
+    <Tooltip message={children}>{actualLineClamp}</Tooltip>
   ) : (
     actualLineClamp
   )

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -115,7 +115,7 @@ export const LineClamp: FC<Props & ElementProps> = ({
   )
 
   return isTooltipVisible ? (
-    <Tooltip message={children} multiLine vertical="auto">
+    <Tooltip message={children} vertical="auto">
       {actualLineClamp}
     </Tooltip>
   ) : (

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -90,8 +90,6 @@ export const TabItem: FC<Props & ElementProps> = ({
       <Tooltip
         {...tabAttrs}
         message={disabledDetail.message}
-        horizontal="center"
-        vertical="auto"
         ariaDescribedbyTarget="inner"
         aria-disabled={rest.disabled}
         className="focus-visible:shr-focus-indicator--inner"

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -28,8 +28,6 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { TooltipPortal } from './TooltipPortal'
 
-import type { Balloon } from '../Balloon'
-
 const subscribeFullscreenChange = (callback: () => void) => {
   window.addEventListener('fullscreenchange', callback)
 
@@ -45,14 +43,8 @@ type Props = PropsWithChildren<{
   message: ReactNode
   /** ツールチップを表示する対象のタイプ。アイコンの場合は `icon` を指定する */
   triggerType?: 'icon' | 'text'
-  /** ツールチップ内を複数行で表示する場合に `true` を指定する */
-  multiLine?: boolean
   /** `true` のとき、ツールチップを表示する対象が省略されている場合のみツールチップ表示を有効にする */
   ellipsisOnly?: boolean
-  /** 水平方向の位置 */
-  horizontal?: ComponentProps<typeof Balloon>['horizontal'] | 'auto'
-  /** 垂直方向の位置 */
-  vertical?: ComponentProps<typeof Balloon>['vertical'] | 'auto'
   /** ツールチップを表示する対象の tabIndex 値 */
   tabIndex?: number
   /** ツールチップを内包要素に紐付けるかどうか */
@@ -77,10 +69,7 @@ export const Tooltip: FC<Props & ElementProps> = ({
   message,
   children,
   triggerType,
-  multiLine,
   ellipsisOnly,
-  horizontal = 'left',
-  vertical = 'bottom',
   tabIndex = 0,
   ariaDescribedbyTarget = 'wrapper',
   className,
@@ -231,10 +220,6 @@ export const Tooltip: FC<Props & ElementProps> = ({
             isVisible={isVisible}
             parentRect={rect}
             isIcon={isIcon}
-            isMultiLine={multiLine}
-            horizontal={horizontal}
-            vertical={vertical}
-            fullscreenElement={fullscreenElement}
           />,
           portalRoot,
         )}

--- a/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
@@ -20,73 +20,36 @@ const classNameGenerator = tv({
 })
 
 const OUTER_MARGIN = 10
+const SPACING = 5
 
-type ContentBoxStyle = {
-  top: string
-  left?: string
-  right?: string
-  maxHeight: string
-}
-const INITIAL_CONTENT_BOX: ContentBoxStyle = { top: 'auto', maxHeight: '' }
+type HorizontalType = 'left' | 'center' | 'right'
+type VerticalType = 'top' | 'middle' | 'bottom'
 
 export const TooltipPortal: FC<Props> = ({ message, isVisible, parentRect, isIcon }) => {
   const portalRef = useRef<HTMLDivElement>(null)
-  const [contentBox, setContentBox] = useState<ContentBoxStyle>(INITIAL_CONTENT_BOX)
-  const [actualHorizontal, setActualHorizontal] = useState<'left' | 'center' | 'right'>('center')
-  const [actualVertical, setActualVertical] = useState<'top' | 'middle' | 'bottom'>('bottom')
+  const [style, setStyle] = useState<{ [key: string]: undefined | string }>({})
+  const [actualHorizontal, setActualHorizontal] = useState<HorizontalType>('center')
+  const [actualVertical, setActualVertical] = useState<VerticalType>('bottom')
 
   useEffect(() => {
     if (!portalRef.current || !parentRect) {
       return
     }
 
-    const box: ContentBoxStyle = { ...INITIAL_CONTENT_BOX }
+    const portal = portalRef.current
 
-    if (parentRect.top - portalRef.current.offsetHeight >= 0) {
-      // トリガの上側の領域に収まる場合
-      box.top = `${scrollY + parentRect.top - portalRef.current.offsetHeight - 5}px`
-      setActualVertical('bottom')
-    } else if (parentRect.bottom + portalRef.current.offsetHeight <= innerHeight) {
-      // トリガの下側の領域に収まる場合
-      box.top = `${scrollY + parentRect.bottom + 5}px`
-      setActualVertical('top')
-    } else {
-      const triggerHeight = parentRect.bottom - parentRect.top
+    const vertical = calculateVertical(portal.offsetHeight, parentRect)
+    const horizontal = calculateHorizontal(portal.offsetWidth, parentRect)
 
-      if (parentRect.top + triggerHeight / 2 >= innerHeight / 2) {
-        // 上側の領域のほうが広い場合
-        box.top = `${scrollY + OUTER_MARGIN - 5}px`
-        box.maxHeight = `${parentRect.top - OUTER_MARGIN}px`
-        setActualVertical('bottom')
-      } else {
-        // 下側の領域のほうが広い場合
-        box.top = `${scrollY + parentRect.bottom + 5}px`
-        box.maxHeight = `${innerHeight - parentRect.bottom - OUTER_MARGIN}px`
-        setActualVertical('top')
-      }
-    }
-
-    const triggerAlignCenter = parentRect.left + parentRect.width / 2
-    const portalHalfWidth = portalRef.current.offsetWidth / 2
-
-    // トリガを中心に左右に十分な余白がある場合
-    if (
-      triggerAlignCenter - portalHalfWidth > 5 &&
-      triggerAlignCenter + portalHalfWidth < document.body.clientWidth - 5
-    ) {
-      box.left = `${triggerAlignCenter - portalHalfWidth}px`
-      setActualHorizontal('center')
-    } else if (triggerAlignCenter <= document.body.clientWidth / 2) {
-      // トリガが画面左寄りの場合
-      box.left = `${scrollX + parentRect.left - 5}px`
-      setActualHorizontal('left')
-    } else {
-      // トリガが画面右寄りの場合
-      box.right = `${document.body.clientWidth - parentRect.right - scrollX - 5}px`
-      setActualHorizontal('right')
-    }
-
-    setContentBox(box)
+    setStyle({
+      insetBlockStart: vertical.insetBlockStart,
+      insetInlineStart: horizontal.insetInlineStart,
+      insetInlineEnd: horizontal.insetInlineEnd,
+      maxWidth: horizontal.maxWidth,
+      maxHeight: vertical.maxHeight,
+    })
+    setActualVertical(vertical.alignment)
+    setActualHorizontal(horizontal.alignment)
   }, [parentRect])
 
   const classNames = useMemo(() => {
@@ -98,19 +61,6 @@ export const TooltipPortal: FC<Props> = ({ message, isVisible, parentRect, isIco
       balloonText: balloonText(),
     }
   }, [])
-  const style = useMemo(() => {
-    const leftMargin = contentBox.left === undefined ? spacing[0.5] : `max(${contentBox.left}, 0px)`
-    const rightMargin =
-      contentBox.right === undefined ? spacing[0.5] : `max(${contentBox.right}, 0px)`
-
-    return {
-      insetBlockStart: contentBox.top,
-      insetInlineStart: contentBox.left || undefined,
-      insetInlineEnd: contentBox.right || undefined,
-      maxWidth: `calc(100% - ${leftMargin} - ${rightMargin})`,
-      maxHeight: contentBox.maxHeight || undefined,
-    }
-  }, [contentBox])
 
   return (
     <div
@@ -130,4 +80,96 @@ export const TooltipPortal: FC<Props> = ({ message, isVisible, parentRect, isIco
       </Balloon>
     </div>
   )
+}
+
+const calculateVertical = (
+  portalHeight: number,
+  parentRect: DOMRect,
+): { insetBlockStart: string; maxHeight: string | undefined; alignment: VerticalType } => {
+  // トリガの上側の領域に収まる場合
+  if (parentRect.top - portalHeight >= 0) {
+    return {
+      insetBlockStart: `${scrollY + parentRect.top - portalHeight - SPACING}px`,
+      maxHeight: undefined,
+      alignment: 'bottom',
+    }
+  }
+
+  // トリガの下側の領域に収まる場合
+  if (parentRect.bottom + portalHeight <= innerHeight) {
+    return {
+      insetBlockStart: `${scrollY + parentRect.bottom + SPACING}px`,
+      maxHeight: undefined,
+      alignment: 'top',
+    }
+  }
+
+  const triggerHeight = parentRect.bottom - parentRect.top
+
+  // 上側の領域のほうが広い場合
+  if (parentRect.top + triggerHeight / 2 >= innerHeight / 2) {
+    return {
+      insetBlockStart: `${scrollY + OUTER_MARGIN - SPACING}px`,
+      maxHeight: `${parentRect.top - OUTER_MARGIN}px`,
+      alignment: 'bottom',
+    }
+  }
+
+  // 下側の領域のほうが広い場合
+  return {
+    insetBlockStart: `${scrollY + parentRect.bottom + SPACING}px`,
+    maxHeight: `${innerHeight - parentRect.bottom - OUTER_MARGIN}px`,
+    alignment: 'top',
+  }
+}
+
+type ReturnCalculateHorizontalType = {
+  insetInlineStart: string | undefined
+  insetInlineEnd: string | undefined
+  maxWidth: string
+  alignment: HorizontalType
+}
+const calculateHorizontal = (
+  portalWidth: number,
+  parentRect: DOMRect,
+): ReturnCalculateHorizontalType => {
+  const triggerAlignCenter = parentRect.left + parentRect.width / 2
+  const portalHalfWidth = portalWidth / 2
+
+  // トリガを中心に左右に十分な余白がある場合
+  if (
+    triggerAlignCenter - portalHalfWidth > SPACING &&
+    triggerAlignCenter + portalHalfWidth < document.body.clientWidth - SPACING
+  ) {
+    const insetInlineStart = `${triggerAlignCenter - portalHalfWidth}px`
+
+    return {
+      insetInlineStart,
+      insetInlineEnd: undefined,
+      maxWidth: `calc(100% - max(${insetInlineStart}, 0px) - ${spacing[0.5]})`,
+      alignment: 'center',
+    }
+  }
+
+  // トリガが画面左寄りの場合
+  if (triggerAlignCenter <= document.body.clientWidth / 2) {
+    const insetInlineStart = `${scrollX + parentRect.left - SPACING}px`
+
+    return {
+      insetInlineStart,
+      insetInlineEnd: undefined,
+      maxWidth: `calc(100% - max(${insetInlineStart}, 0px) - ${spacing[0.5]})`,
+      alignment: 'left',
+    }
+  }
+
+  // トリガが画面右寄りの場合
+  const insetInlineEnd = `${document.body.clientWidth - parentRect.right - scrollX - SPACING}px`
+
+  return {
+    insetInlineStart: undefined,
+    insetInlineEnd,
+    maxWidth: `calc(100% - ${spacing[0.5]} - max(${insetInlineEnd}, 0px))`,
+    alignment: 'right',
+  }
 }

--- a/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -1,5 +1,4 @@
 import { FaCircleQuestionIcon } from '../../Icon'
-import { Stack } from '../../Layout'
 import { Tooltip } from '../Tooltip'
 
 import type { Meta, StoryObj } from '@storybook/react'

--- a/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -6,8 +6,22 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 const _messages = {
   'テキスト（sting）': 'メッセージ',
+  '複数行（string）':
+    'メッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージ',
   '複数行（ReactNode）': (
     <>
+      複数行
+      <br />
+      メッセージ
+      <br />
+      複数行
+      <br />
+      メッセージ
+      <br />
+      複数行
+      <br />
+      メッセージ
+      <br />
       複数行
       <br />
       メッセージ
@@ -18,7 +32,28 @@ const _messages = {
 export default {
   title: 'Data Display（データ表示）/Tooltip',
   component: Tooltip,
-  render: (args) => <Tooltip {...args} />,
+  render: (args) => (
+    <div className="shr-w-full shr-relative" style={{ height: '250px' }}>
+      <div className="shr-absolute shr-top-0 shr-left-0">
+        <Tooltip {...args} />
+      </div>
+      <div className="shr-absolute shr-top-0 shr-right-0">
+        <Tooltip {...args} />
+      </div>
+      <div className="shr-absolute shr-top-0 shr-right-0">
+        <Tooltip {...args} />
+      </div>
+      <div className="shr-absolute" style={{ top: '40%', left: '40%' }}>
+        <Tooltip {...args} />
+      </div>
+      <div className="shr-absolute shr-bottom-0 shr-left-0">
+        <Tooltip {...args} />
+      </div>
+      <div className="shr-absolute shr-bottom-0 shr-right-0">
+        <Tooltip {...args} />
+      </div>
+    </div>
+  ),
   argTypes: {
     message: {
       control: 'radio',
@@ -47,7 +82,6 @@ export const Message: StoryObj<typeof Tooltip> = {
   },
 }
 
-// なにこれ? いるの?
 export const TriggerType: StoryObj<typeof Tooltip> = {
   name: 'triggerType',
   args: {
@@ -56,16 +90,6 @@ export const TriggerType: StoryObj<typeof Tooltip> = {
   },
 }
 
-// これなんで必要なの?
-export const Multiline: StoryObj<typeof Tooltip> = {
-  name: 'multiLine',
-  args: {
-    multiLine: true,
-    message: _messages['複数行（ReactNode）'],
-  },
-}
-
-// これテキストの場合はデフォルトでいいんじゃないの?
 export const EllipsisOnly: StoryObj<typeof Tooltip> = {
   name: 'ellipsisOnly',
   render: (args) => (
@@ -81,32 +105,6 @@ export const EllipsisOnly: StoryObj<typeof Tooltip> = {
     message: '省略されるメッセージ',
     ellipsisOnly: true,
   },
-}
-
-export const Horizontal: StoryObj<typeof Tooltip> = {
-  name: 'horizontal',
-  render: (args) => (
-    <Stack align="flex-start">
-      {[undefined, 'center', 'left', 'right', 'auto'].map((horizontal) => (
-        <Tooltip {...args} horizontal={horizontal as any} key={horizontal}>
-          horizontal: {horizontal}
-        </Tooltip>
-      ))}
-    </Stack>
-  ),
-}
-
-export const Vertical: StoryObj<typeof Tooltip> = {
-  name: 'vertical',
-  render: (args) => (
-    <Stack align="flex-start">
-      {[undefined, 'top', 'bottom', 'middle', 'auto'].map((vertical) => (
-        <Tooltip {...args} vertical={vertical as any} key={vertical}>
-          vertical: {vertical}
-        </Tooltip>
-      ))}
-    </Stack>
-  ),
 }
 
 export const TabIndex: StoryObj<typeof Tooltip> = {

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, userEvent, within } from '@storybook/test'
+import { userEvent } from '@storybook/test'
 
 import { FaCircleQuestionIcon } from '../../Icon'
 import { Stack } from '../../Layout'

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
@@ -4,7 +4,6 @@ import { FaCircleQuestionIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Tooltip } from '../Tooltip'
 
-
 import type { Meta, StoryObj } from '@storybook/react'
 
 export default {

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, userEvent, within } from '@storybook/test'
 
 import { FaCircleQuestionIcon } from '../../Icon'
-import { Cluster, Stack } from '../../Layout'
+import { Stack } from '../../Layout'
 import { Tooltip } from '../Tooltip'
 
 import { TriggerType } from './Tooltip.stories'
@@ -12,20 +12,6 @@ export default {
   title: 'Data Display（データ表示）/Tooltip/VRT',
   render: (args) => (
     <Stack gap={8} align="flex-start" className="shr-p-4">
-      <Cluster gap={4}>
-        {[undefined, 'center', 'left', 'right', 'auto'].map((horizontal) => (
-          <Tooltip {...args} horizontal={horizontal as any} key={horizontal}>
-            horizontal: {horizontal}
-          </Tooltip>
-        ))}
-      </Cluster>
-      <Cluster gap={4}>
-        {[undefined, 'top', 'bottom', 'middle', 'auto'].map((vertical) => (
-          <Tooltip {...args} vertical={vertical as any} key={vertical}>
-            vertical: {vertical}
-          </Tooltip>
-        ))}
-      </Cluster>
       <Tooltip {...args} triggerType="icon">
         <FaCircleQuestionIcon alt="ツールチップ" />
       </Tooltip>

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
@@ -4,7 +4,6 @@ import { FaCircleQuestionIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Tooltip } from '../Tooltip'
 
-import { TriggerType } from './Tooltip.stories'
 
 import type { Meta, StoryObj } from '@storybook/react'
 


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

SHRUI-573

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- Tooltipの表示位置の計算ロジックを変更します
- これにより、Contentの領域を画面サイズに併せて可変することが可能になり、Tooltipの内容が画面内に収まるようになりました

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
