### PR TITLE
fix: FormControle, FieldsetのstatusLabels propsを指定するとキーが付与されていないwarnが出る問題の修正

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -5,10 +5,10 @@ import {
   type ComponentPropsWithoutRef,
   type ComponentType,
   type FC,
+  Fragment,
   type FunctionComponentElement,
   type PropsWithChildren,
   type ReactNode,
-  cloneElement,
   memo,
   useEffect,
   useMemo,
@@ -188,10 +188,7 @@ export const ActualFormControl: FC<Props & ElementProps> = ({
   const actualStatusLabels = useMemo(() => {
     if (statusLabels) {
       return (Array.isArray(statusLabels) ? statusLabels : [statusLabels]).map(
-        (statusLabel, index) =>
-          cloneElement(statusLabel, {
-            key: index,
-          }),
+        (statusLabel, index) => <Fragment key={index}>{statusLabel}</Fragment>,
       )
     }
 

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -8,6 +8,7 @@ import {
   type FunctionComponentElement,
   type PropsWithChildren,
   type ReactNode,
+  cloneElement,
   memo,
   useEffect,
   useMemo,
@@ -186,7 +187,12 @@ export const ActualFormControl: FC<Props & ElementProps> = ({
 
   const actualStatusLabels = useMemo(() => {
     if (statusLabels) {
-      return Array.isArray(statusLabels) ? statusLabels : [statusLabels]
+      return (Array.isArray(statusLabels) ? statusLabels : [statusLabels]).map(
+        (statusLabel, index) =>
+          cloneElement(statusLabel, {
+            key: index,
+          }),
+      )
     }
 
     if (!statusLabelProps) {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://kufuinc.slack.com/archives/CGC58MW01/p1743752214631679

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->
FormControle, FieldsetのstatusLabels propsにStatusLabelを指定すると、`Warning: Each child in a list should have a unique "key" prop.`のwarnが出てしまうので解消したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->
statusLabelsに渡されたコンポーネントにkeyを付与するようにした

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
- ChromaticでstatusLabelsのページを開いた際に、コンソールログにwarnが表示されないこと
  - http://localhost:6006/?path=/story/forms%EF%BC%88%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%EF%BC%89-formcontrol--status-labels
