### PR TITLE
fix: v69 から SideMenuGroup, SideMenuItem が export されなくなってしまったので export する

### DIFF
--- a/packages/smarthr-ui/src/index.ts
+++ b/packages/smarthr-ui/src/index.ts
@@ -87,7 +87,7 @@ export {
 export { PageCounter } from './components/PageCounter'
 export { Article, Aside, Nav, Section } from './components/SectioningContent'
 export { VisuallyHiddenText } from './components/VisuallyHiddenText'
-export { SideMenu } from './components/SideMenu'
+export * from './components/SideMenu'
 export * from './components/SpreadsheetTable'
 export * from './components/ResponseMessage'
 export * from './components/Badge'

--- a/sandbox/next/e2e/rsc.test.ts
+++ b/sandbox/next/e2e/rsc.test.ts
@@ -35,6 +35,7 @@ const SERVER_COMPONENTS = [
   'RangeSeparator',
   'ResponseMessage',
   'SearchInput',
+  'SideMenu',
   'SideNav',
   'SmartHRLogo',
   'SpreadsheetTable',

--- a/sandbox/next/src/app/rsc_test/SideMenu/page.tsx
+++ b/sandbox/next/src/app/rsc_test/SideMenu/page.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { SideMenu, SideMenuGroup, SideMenuItem } from 'smarthr-ui'
+
+import { RSCChecker } from '../components/RSCChecker'
+
+export default function SideMenuPage() {
+  return (
+    <>
+      <RSCChecker actualComponent={SideMenu} />
+
+      <SideMenu>
+        <SideMenuGroup title="個人設定">
+          <SideMenuItem href="#">アカウント</SideMenuItem>
+          <SideMenuItem href="#" current>
+            認証設定
+          </SideMenuItem>
+        </SideMenuGroup>
+
+        <SideMenuGroup title="共通設定">
+          <SideMenuItem href="#">評価項目の表示設定</SideMenuItem>
+          <SideMenuItem href="#">評価対象者の入力必須項目設定</SideMenuItem>
+        </SideMenuGroup>
+      </SideMenu>
+    </>
+  )
+}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://github.com/kufu/smarthr-ui/pull/5521
<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->
関連 URL に記載の PR で SideMenu を experimental から移動しているが、その際に export 対象から SideMenuGroup, SideMenuItem が消えてしまい import できなくなってしまったので修正したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- `{ SideMenu }` で export していた箇所を `*` に変更
- SideMenu を RSC テストがなかったので追加

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

fmfm で
