### PR TITLE
feat: AppNaviDropdownMenuButton コンポーネントに onOpen/onClose オプションを追加する

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
@@ -16,6 +16,8 @@ import { DropdownMenuButton } from '../Dropdown/DropdownMenuButton/DropdownMenuB
 type Props = PropsWithChildren<{
   /** 引き金となるボタンラベル */
   label: ReactNode
+  onOpen?: () => void
+  onClose?: () => void
 }>
 
 const classNameGenerator = tv({
@@ -71,7 +73,7 @@ const renderItemList = (children: ReactNode) =>
     })
   })
 
-export const AppNaviDropdownMenuButton: FC<Props> = ({ label, children }) => (
+export const AppNaviDropdownMenuButton: FC<Props> = ({ label, onOpen, onClose, children }) => (
   <DropdownMenuButton
     label={
       <>
@@ -80,6 +82,8 @@ export const AppNaviDropdownMenuButton: FC<Props> = ({ label, children }) => (
         <span hidden>{children}</span>
       </>
     }
+    onOpen={onOpen}
+    onClose={onClose}
     className={trigger()}
   >
     {renderItemList(children)}

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
@@ -15,12 +15,6 @@ export default {
   ),
   args: {
     label: 'ボタン',
-    onOpen: () => {
-      console.log('open')
-    },
-    onClose: () => {
-      console.log('close')
-    },
   },
   parameters: {
     backgrounds: {

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
@@ -15,6 +15,12 @@ export default {
   ),
   args: {
     label: 'ボタン',
+    onOpen: () => {
+      console.log('open')
+    },
+    onClose: () => {
+      console.log('close')
+    },
   },
   parameters: {
     backgrounds: {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -48,6 +48,10 @@ type Props = {
   onlyIconTrigger?: boolean
   /** 引き金となるアイコンを差し替えたい場合（onlyIconTrigger=true の場合のみ有効） */
   triggerIcon?: ComponentType<ComponentProps<typeof FaCaretDownIcon>>
+  /** ドロップダウンメニューが開かれた際のイベント */
+  onOpen?: () => void
+  /** ドロップダウンメニューが閉じられた際のイベント */
+  onClose?: () => void
 }
 type ElementProps = Omit<ComponentPropsWithRef<'button'>, keyof Props>
 
@@ -81,6 +85,8 @@ export const DropdownMenuButton: FC<Props & ElementProps> = ({
   triggerSize,
   onlyIconTrigger,
   triggerIcon,
+  onOpen,
+  onClose,
   className,
   ...rest
 }) => {
@@ -98,7 +104,7 @@ export const DropdownMenuButton: FC<Props & ElementProps> = ({
   )
 
   return (
-    <Dropdown>
+    <Dropdown onOpen={onOpen} onClose={onClose}>
       <MemoizedTriggerButton
         {...rest}
         label={label}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

N/A

## 概要

`AppNaviDropdownMenuButton` コンポーネントに onOpen/onClose オプションを追加したいです。

`FilterDropdown` には既にあるオプションで、プロダクト側でこのオプションを使った調整を、`AppNaviDropdownMenuButton` を使ってる箇所でも行おうとしたら onOpen/onClose がないことに気づき困ってるため追加したいです。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

`AppNaviDropdownMenuButton` -> `DropdownMenuButton` -> `Dropdown` に props を伝搬します。

## 確認方法

- 適当に Storybook 上で onClick/onClose を適用して動作確認しました。
- pkg-pr-new を使ってプロダクト側で問題解決できることも確認しました。