### PR TITLE
chore: actionのpnpm version定義をomitする

### DIFF
--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
n/a

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

package.jsonとactionでpnpmのバージョン定義されているとえらーになってしまう

## 変更内容

ので、package.jsonのバージョン優先するためにaction側の定義をomitします

関連リンク
https://github.com/pnpm/action-setup/pull/134
https://github.com/pnpm/action-setup?tab=readme-ov-file#install-only-pnpm-with-packagemanager

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
