### PR TITLE
feat!: RadioButtonPanelに説明テキストをdescriptionとして提供できるようにした

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -14,10 +14,11 @@ import { tv } from 'tailwind-variants'
 
 import { Base } from '../Base'
 import { RadioButton } from '../RadioButton'
+import { Text } from '../Text'
 
 type Props = ComponentProps<typeof RadioButton> & {
   as?: string | ComponentType<any>
-  description?: ReactNode
+  label: string
 }
 
 const NONE_ROLE_TAG_REGEX = /^(div|span)$/
@@ -48,17 +49,18 @@ export const RadioButtonPanel: FC<Props> = ({
   onClick,
   as,
   className,
-  description,
+  children,
+  label,
   'aria-describedby': ariaDescribedbyProp,
   ...props
 }) => {
   const classNames = useMemo(() => {
     const { base, description: descriptionStyle } = classNameGenerator({
       className,
-      hasDescription: !!description,
+      hasDescription: !!children,
     })
     return { base: base(), description: descriptionStyle() }
-  }, [className, description])
+  }, [className, children])
   const role = useMemo(
     () => (typeof as === 'string' && NONE_ROLE_TAG_REGEX.test(as) ? 'presentation' : undefined),
     [as],
@@ -72,17 +74,19 @@ export const RadioButtonPanel: FC<Props> = ({
 
   const descriptionId = useId()
   const ariaDescribedby = useMemo(
-    () => [description && descriptionId, ariaDescribedbyProp].filter(Boolean).join(' '),
-    [description, descriptionId, ariaDescribedbyProp],
+    () => [children && descriptionId, ariaDescribedbyProp].filter(Boolean).join(' '),
+    [children, descriptionId, ariaDescribedbyProp],
   )
 
   return (
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
     <Base padding={1} role={role} onClick={handleOuterClick} as={as} className={classNames.base}>
-      <RadioButton {...props} ref={innerRef} aria-describedby={ariaDescribedby} />
-      {description && (
+      <RadioButton {...props} ref={innerRef} aria-describedby={ariaDescribedby}>
+        <Text weight="bold">{label}</Text>
+      </RadioButton>
+      {children && (
         <span id={descriptionId} className={classNames.description}>
-          {description}
+          {children}
         </span>
       )}
     </Base>

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -40,7 +40,6 @@ const classNameGenerator = tv({
   variants: {
     hasDescription: {
       true: 'shr-flex shr-flex-col',
-      false: '',
     },
   },
 })
@@ -51,7 +50,7 @@ export const RadioButtonPanel: FC<Props> = ({
   className,
   children,
   label,
-  'aria-describedby': ariaDescribedbyProp,
+  'aria-describedby': ariaDescribedby,
   ...props
 }) => {
   const classNames = useMemo(() => {
@@ -73,16 +72,22 @@ export const RadioButtonPanel: FC<Props> = ({
   }, [])
 
   const descriptionId = useId()
-  const ariaDescribedby = useMemo(
-    () => [children && descriptionId, ariaDescribedbyProp].filter(Boolean).join(' '),
-    [children, descriptionId, ariaDescribedbyProp],
+  const actualAriaDescribedby = useMemo(
+    () =>
+      [children && descriptionId, ariaDescribedby].reduce((acc: string, str) => {
+        if (!str) {
+          return acc
+        }
+        return `${acc} ${str}`
+      }, ''),
+    [children, descriptionId, ariaDescribedby],
   )
 
   return (
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
     <Base padding={1} role={role} onClick={handleOuterClick} as={as} className={classNames.base}>
-      <RadioButton {...props} ref={innerRef} aria-describedby={ariaDescribedby}>
-        <Text weight="bold">{label}</Text>
+      <RadioButton {...props} ref={innerRef} aria-describedby={actualAriaDescribedby}>
+        <Text styleType="blockTitle">{label}</Text>
       </RadioButton>
       {children && (
         <span id={descriptionId} className={classNames.description}>

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -81,16 +81,6 @@ export const RadioButtonPanel: FC<Props> = ({
   }, [])
 
   const descriptionId = useId()
-  const actualAriaDescribedby = useMemo(
-    () =>
-      [children && descriptionId, ariaDescribedby].reduce((acc: string, str) => {
-        if (!str) {
-          return acc
-        }
-        return `${acc} ${str}`
-      }, ''),
-    [children, descriptionId, ariaDescribedby],
-  )
 
   return (
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
@@ -98,10 +88,10 @@ export const RadioButtonPanel: FC<Props> = ({
       <RadioButton
         {...props}
         ref={innerRef}
-        aria-describedby={actualAriaDescribedby}
+        aria-describedby={`${descriptionId} ${ariaDescribedby ?? ''}`}
         className={classNames.radio}
       >
-        <Cluster as="span">
+        <Cluster align="center" as="span">
           {label}
           {labelSuffix}
         </Cluster>

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -13,12 +13,14 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { Base } from '../Base'
+import { Cluster } from '../Layout'
 import { RadioButton } from '../RadioButton'
 import { Text } from '../Text'
 
 type Props = ComponentProps<typeof RadioButton> & {
   as?: string | ComponentType<any>
   label: ReactNode
+  labelSuffix?: ReactNode
 }
 
 const NONE_ROLE_TAG_REGEX = /^(div|span)$/
@@ -50,6 +52,7 @@ export const RadioButtonPanel: FC<Props> = ({
   className,
   children,
   label,
+  labelSuffix,
   'aria-describedby': ariaDescribedby,
   ...props
 }) => {
@@ -87,7 +90,10 @@ export const RadioButtonPanel: FC<Props> = ({
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
     <Base padding={1} role={role} onClick={handleOuterClick} as={as} className={classNames.base}>
       <RadioButton {...props} ref={innerRef} aria-describedby={actualAriaDescribedby}>
-        <Text styleType="blockTitle">{label}</Text>
+        <Cluster as="span">
+          {children ? <Text styleType="blockTitle">{label}</Text> : label}
+          {labelSuffix}
+        </Cluster>
       </RadioButton>
       {children && (
         <span id={descriptionId} className={classNames.description}>

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -32,17 +32,22 @@ const classNameGenerator = tv({
       'shr-border-shorthand shr-list-none shr-shadow-none',
       // FIX: なぜか storybook 上で :has が動作しないので重ねて書いている
       'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
+      'has-[:disabled]:[&_.smarthr-ui-RadioButtonPanel-description]:shr-text-disabled [&:has(:disabled)]:shr-text-disabled',
+    ],
+    radio: [
       '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
       '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
       'shr-cursor-pointer has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer',
       'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
-      'has-[:disabled]:[&_.smarthr-ui-RadioButtonPanel-description]:shr-text-disabled [&:has(:disabled)]:shr-text-disabled',
     ],
     description: ['smarthr-ui-RadioButtonPanel-description', 'shr-ms-[1.75em] shr-mt-0.5'],
   },
   variants: {
     hasDescription: {
-      true: 'shr-flex shr-flex-col',
+      true: {
+        base: 'shr-flex shr-flex-col',
+        radio: 'shr-font-bold',
+      },
     },
   },
 })
@@ -58,11 +63,11 @@ export const RadioButtonPanel: FC<Props> = ({
   ...props
 }) => {
   const classNames = useMemo(() => {
-    const { base, description: descriptionStyle } = classNameGenerator({
+    const { base, description, radio } = classNameGenerator({
       className,
       hasDescription: !!children,
     })
-    return { base: base(), description: descriptionStyle() }
+    return { base: base(), description: description(), radio: radio() }
   }, [className, children])
   const role = useMemo(
     () => (typeof as === 'string' && NONE_ROLE_TAG_REGEX.test(as) ? 'presentation' : undefined),
@@ -90,16 +95,21 @@ export const RadioButtonPanel: FC<Props> = ({
   return (
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
     <Base padding={1} role={role} onClick={handleOuterClick} as={as} className={classNames.base}>
-      <RadioButton {...props} ref={innerRef} aria-describedby={actualAriaDescribedby}>
+      <RadioButton
+        {...props}
+        ref={innerRef}
+        aria-describedby={actualAriaDescribedby}
+        className={classNames.radio}
+      >
         <Cluster as="span">
-          {children ? <Text styleType="blockTitle">{label}</Text> : label}
+          {label}
           {labelSuffix}
         </Cluster>
       </RadioButton>
       {children && (
-        <span id={descriptionId} className={classNames.description}>
+        <div id={descriptionId} className={classNames.description}>
           {children}
-        </span>
+        </div>
       )}
     </Base>
   )

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -15,7 +15,6 @@ import { tv } from 'tailwind-variants'
 import { Base } from '../Base'
 import { Cluster } from '../Layout'
 import { RadioButton } from '../RadioButton'
-import { Text } from '../Text'
 
 type Props = ComponentProps<typeof RadioButton> & {
   as?: string | ComponentType<any>

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -4,7 +4,6 @@ import {
   type ComponentProps,
   type ComponentType,
   type FC,
-  type ReactNode,
   useCallback,
   useId,
   useMemo,

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -36,8 +36,9 @@ const classNameGenerator = tv({
       '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
       'shr-cursor-pointer has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer',
       'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
+      'has-[:disabled]:[&_.smarthr-ui-RadioButtonPanel-description]:shr-text-disabled [&:has(:disabled)]:shr-text-disabled',
     ],
-    description: 'shr-ms-[1.75em] shr-mt-0.5',
+    description: ['smarthr-ui-RadioButtonPanel-description', 'shr-ms-[1.75em] shr-mt-0.5'],
   },
   variants: {
     hasDescription: {

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -4,7 +4,9 @@ import {
   type ComponentProps,
   type ComponentType,
   type FC,
+  type ReactNode,
   useCallback,
+  useId,
   useMemo,
   useRef,
 } from 'react'
@@ -15,25 +17,48 @@ import { RadioButton } from '../RadioButton'
 
 type Props = ComponentProps<typeof RadioButton> & {
   as?: string | ComponentType<any>
+  description?: ReactNode
 }
 
 const NONE_ROLE_TAG_REGEX = /^(div|span)$/
 
 const classNameGenerator = tv({
-  base: [
-    'smarthr-ui-RadioButtonPanel',
-    'shr-border-shorthand shr-list-none shr-shadow-none',
-    // なぜか :has が動作しないので重ねて書いている
-    'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
-    '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
-    '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
-    'shr-cursor-pointer has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer',
-    'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
-  ],
+  slots: {
+    base: [
+      'smarthr-ui-RadioButtonPanel',
+      'shr-border-shorthand shr-list-none shr-shadow-none',
+      // なぜか :has が動作しないので重ねて書いている
+      'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
+      '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
+      '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
+      'shr-cursor-pointer has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer',
+      'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
+    ],
+    description: 'shr-ms-[1.75em] shr-mt-0.5',
+  },
+  variants: {
+    hasDescription: {
+      true: 'shr-flex shr-flex-col',
+      false: '',
+    },
+  },
 })
 
-export const RadioButtonPanel: FC<Props> = ({ onClick, as, className, ...props }) => {
-  const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
+export const RadioButtonPanel: FC<Props> = ({
+  onClick,
+  as,
+  className,
+  description,
+  'aria-describedby': ariaDescribedbyProp,
+  ...props
+}) => {
+  const classNames = useMemo(() => {
+    const { base, description: descriptionStyle } = classNameGenerator({
+      className,
+      hasDescription: !!description,
+    })
+    return { base: base(), description: descriptionStyle() }
+  }, [className, description])
   const role = useMemo(
     () => (typeof as === 'string' && NONE_ROLE_TAG_REGEX.test(as) ? 'presentation' : undefined),
     [as],
@@ -45,10 +70,21 @@ export const RadioButtonPanel: FC<Props> = ({ onClick, as, className, ...props }
     innerRef.current?.click()
   }, [])
 
+  const descriptionId = useId()
+  const ariaDescribedby = useMemo(
+    () => [description && descriptionId, ariaDescribedbyProp].filter(Boolean).join(' '),
+    [description, descriptionId, ariaDescribedbyProp],
+  )
+
   return (
     // eslint-disable-next-line smarthr/a11y-delegate-element-has-role-presentation
-    <Base padding={1} role={role} onClick={handleOuterClick} as={as} className={actualClassName}>
-      <RadioButton {...props} ref={innerRef} />
+    <Base padding={1} role={role} onClick={handleOuterClick} as={as} className={classNames.base}>
+      <RadioButton {...props} ref={innerRef} aria-describedby={ariaDescribedby} />
+      {description && (
+        <span id={descriptionId} className={classNames.description}>
+          {description}
+        </span>
+      )}
     </Base>
   )
 }

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -4,6 +4,7 @@ import {
   type ComponentProps,
   type ComponentType,
   type FC,
+  type ReactNode,
   useCallback,
   useId,
   useMemo,
@@ -17,7 +18,7 @@ import { Text } from '../Text'
 
 type Props = ComponentProps<typeof RadioButton> & {
   as?: string | ComponentType<any>
-  label: string
+  label: ReactNode
 }
 
 const NONE_ROLE_TAG_REGEX = /^(div|span)$/

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -39,6 +39,7 @@ const classNameGenerator = tv({
       'shr-cursor-pointer has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer',
       'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
     ],
+    // RadioButtonPanel で指定している shr-ms-0.75 + RadioButton のボタンの shr-w-em を足して shr-ms-[1.75em] にしている
     description: ['smarthr-ui-RadioButtonPanel-description', 'shr-ms-[1.75em] shr-mt-0.5'],
   },
   variants: {

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -27,7 +27,7 @@ const classNameGenerator = tv({
     base: [
       'smarthr-ui-RadioButtonPanel',
       'shr-border-shorthand shr-list-none shr-shadow-none',
-      // なぜか :has が動作しないので重ねて書いている
+      // FIX: なぜか storybook 上で :has が動作しないので重ねて書いている
       'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
       '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
       '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
@@ -1,3 +1,4 @@
+import { StatusLabel } from '../../StatusLabel'
 import { RadioButtonPanel } from '../RadioButtonPanel'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -56,5 +57,12 @@ export const Description: StoryObj<typeof RadioButtonPanel> = {
   name: 'description',
   args: {
     children: '説明のテキストです。',
+  },
+}
+
+export const LabelSuffix: StoryObj<typeof RadioButtonPanel> = {
+  name: 'labelSuffix',
+  args: {
+    labelSuffix: <StatusLabel>ステータスラベル</StatusLabel>,
   },
 }

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
@@ -15,6 +15,9 @@ export default {
       options: Object.keys(_asOptions),
       mapping: _asOptions,
     },
+    children: {
+      control: 'text',
+    },
   },
   args: {
     label: 'ラジオボタンパネル',

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
@@ -48,3 +48,10 @@ export const As: StoryObj<typeof RadioButtonPanel> = {
     as: 'span',
   },
 }
+
+export const Description: StoryObj<typeof RadioButtonPanel> = {
+  name: 'description',
+  args: {
+    description: '説明のテキストです。',
+  },
+}

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
@@ -17,7 +17,7 @@ export default {
     },
   },
   args: {
-    children: 'ラジオボタンパネル',
+    label: 'ラジオボタンパネル',
   },
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -52,6 +52,6 @@ export const As: StoryObj<typeof RadioButtonPanel> = {
 export const Description: StoryObj<typeof RadioButtonPanel> = {
   name: 'description',
   args: {
-    description: '説明のテキストです。',
+    children: '説明のテキストです。',
   },
 }

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
@@ -11,6 +11,12 @@ export default {
   // eslint-disable-next-line smarthr/a11y-input-in-form-control
   render: (args) => <RadioButtonPanel {...args} />,
   argTypes: {
+    checked: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
     as: {
       control: 'radio',
       options: Object.keys(_asOptions),
@@ -53,8 +59,8 @@ export const As: StoryObj<typeof RadioButtonPanel> = {
   },
 }
 
-export const Description: StoryObj<typeof RadioButtonPanel> = {
-  name: 'description',
+export const Children: StoryObj<typeof RadioButtonPanel> = {
+  name: 'children',
   args: {
     children: '説明のテキストです。',
   },

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
@@ -7,21 +7,31 @@ export default {
   title: 'Forms（フォーム）/RadioButtonPanel/VRT',
   render: (args) => (
     <Stack>
-      {[undefined, 'hover', 'focus-visible'].map((id) => (
-        <Cluster gap={2} id={id} key={id}>
-          {[false, true].map((checked) =>
-            [false, true].map((disabled) => (
-              // eslint-disable-next-line smarthr/a11y-input-in-form-control
-              <RadioButtonPanel
-                {...args}
-                checked={checked}
-                disabled={disabled}
-                key={`${id}-${checked}-${disabled}`}
-              />
-            )),
-          )}
-        </Cluster>
-      ))}
+      {[undefined, 'hover', 'focus-visible'].map((id) =>
+        [false, true].map((checked) => (
+          <Cluster gap={2} id={id} key={id}>
+            {[false, true].map((disabled) => (
+              <>
+                {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
+                <RadioButtonPanel
+                  {...args}
+                  checked={checked}
+                  disabled={disabled}
+                  key={`${id}-${checked}-${disabled}`}
+                />
+                <RadioButtonPanel
+                  {...args}
+                  checked={checked}
+                  disabled={disabled}
+                  key={`${id}-${checked}-${disabled}`}
+                >
+                  説明テキスト
+                </RadioButtonPanel>
+              </>
+            ))}
+          </Cluster>
+        )),
+      )}
     </Stack>
   ),
   args: {

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
@@ -13,20 +13,24 @@ export default {
             {[false, true].map((disabled) => (
               <>
                 {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
-                <RadioButtonPanel
-                  {...args}
-                  checked={checked}
-                  disabled={disabled}
-                  key={`${id}-${checked}-${disabled}`}
-                />
-                <RadioButtonPanel
-                  {...args}
-                  checked={checked}
-                  disabled={disabled}
-                  key={`${id}-${checked}-${disabled}`}
-                >
-                  説明テキスト
-                </RadioButtonPanel>
+                <div>
+                  <RadioButtonPanel
+                    {...args}
+                    checked={checked}
+                    disabled={disabled}
+                    key={`${id}-${checked}-${disabled}`}
+                  />
+                </div>
+                <div>
+                  <RadioButtonPanel
+                    {...args}
+                    checked={checked}
+                    disabled={disabled}
+                    key={`${id}-${checked}-${disabled}`}
+                  >
+                    説明テキスト
+                  </RadioButtonPanel>
+                </div>
               </>
             ))}
           </Cluster>

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
@@ -25,7 +25,7 @@ export default {
     </Stack>
   ),
   args: {
-    children: 'ラジオボタンパネル',
+    label: 'ラジオボタンパネル',
   },
   parameters: {
     chromatic: { disableSnapshot: false },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- [SHRUI-1251](https://smarthr.atlassian.net/browse/SHRUI-1251)

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

RadioButtonPanel の説明テキストはラジオボタンのアクセシブルネームではなく、 説明文として登録できるようにしたい

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- RadioButton のラベルとして提供したい文字列を `label` propsで渡すようにしました
- `labelSuffix` を追加しました
- 説明文を `children` で渡すようにして、children がある場合 label に bold のスタイルが当たるように変更しました変更しました

![説明テキストとステータスラベルがあるRadioButtonPanelのStory](https://github.com/user-attachments/assets/ac97f5e6-5c38-448d-9033-bfae55149432)

![説明テキストがradioのDescriptionとして登録されている](https://github.com/user-attachments/assets/476bc8c5-9093-4d6a-917e-2db85502f40f)


<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->


[SHRUI-1251]: https://smarthr.atlassian.net/browse/SHRUI-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ