### PR TITLE
fix: LineClampのテキストが上下に見きれないように修正

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -28,7 +28,7 @@ const classNameGenerator = tv({
     maxLines: {
       1: {
         clampedLine:
-          'shr-inline-block shr-w-full shr-overflow-hidden shr-overflow-ellipsis shr-whitespace-nowrap shr-align-middle',
+          'shr-inline-block shr-w-full shr-overflow-ellipsis shr-whitespace-nowrap shr-align-middle shr-overflow-x-clip',
       },
       2: {
         clampedLine: 'shr-line-clamp-[2]',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

SHRUI-1205

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

LineClampのテキストが言語によって上下見切れてしまう
line-clampのcontentが overflow: hidden されているため、element boxに収まらないテキストが切れてしまう


## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

overflow-xだけをhiddenにすると暗黙的に overflow-yのデフォルト値がvisibleからauto として計算されてしまうため、overflow-x: clipでx axisだけを切り取るように修正してみました

https://developer.mozilla.org/ja/docs/Web/CSS/overflow-y

> overflow-x が hidden、scroll、auto のいずれかで、 overflow-y プロパティが visible （既定値）の場合、この値は暗黙的に auto として計算されます。

BEFORE | AFTER
--- | ---
<img width="1133" alt="修正前のLineClamp。ChipとButton内のテキストが上下に見切れてしまっている" src="https://github.com/user-attachments/assets/3d235e2d-48f6-42c8-910d-04a2ecb34b4f" /> | <img width="1115" alt="修正後のLineClamp。ChipとButton内のテキストが上下に見切れてない状態になっている" src="https://github.com/user-attachments/assets/30d6a07a-cd0c-4fa0-8080-17deba952b5e" />



## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Storybook や Chromatic で確認できます。LineClampのButtonの例でテキストを変えて確認しやすいと思います
以下のCodepenでも確認できます
https://codepen.io/Daichi-HASHIMURA/full/wBBvabB
