### PR TITLE
fix: AppHeaderの表示モードの判定をSSRでも最適に行えるようにする

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -9,12 +9,17 @@ import type { HeaderProps } from './types'
 import type { FC } from 'react'
 
 export const AppHeader: FC<HeaderProps> = ({ locale, children, ...props }) => {
+  // NOTE: ヘッダーの出し分けは CSS によって行われているので、useMediaQuery による children の出し分けは本来不要ですが、
+  //  wovn の言語切替カスタム UI の挿入対象となる DOM ("wovn-embedded-widget-anchor" クラスを持った div) が複数描画されていると、
+  //  wovn のスクリプトの仕様上1つ目の DOM にしか UI が挿入されないため、やむを得ず children のみ React のレンダリングレベルでの出し分けをしています。
   const isDesktop = useMediaQuery(mediaQuery.desktop)
-  const Header = isDesktop ? DesktopHeader : MobileHeader
 
+  // HINT: Desktop,Mobileの両ヘッダーは常にHTML上に存在し、cssでvisibleを切り替えることでSSR環境でのレイアウトシフトが発生しないようにしています
+  // 表示切替は画面幅によって決まり、SSR環境では判定出来ないためです
   return (
     <LocaleContextProvider locale={locale}>
-      <Header {...props}>{children}</Header>
+      <DesktopHeader {...props}>{isDesktop ? children : undefined}</DesktopHeader>
+      <MobileHeader {...props}>{isDesktop ? undefined : children}</MobileHeader>
     </LocaleContextProvider>
   )
 }

--- a/packages/smarthr-ui/src/components/AppHeader/hooks/useMediaQuery.ts
+++ b/packages/smarthr-ui/src/components/AppHeader/hooks/useMediaQuery.ts
@@ -1,8 +1,7 @@
 import { useMemo, useSyncExternalStore } from 'react'
 
 export const mediaQuery = {
-  desktop: 'min-width: 752px',
-  mobile: 'max-width: 751px',
+  desktop: '(min-width: 752px)',
 } as const
 
 const NOOP = () => undefined
@@ -10,7 +9,7 @@ const RETURN_FALSE = () => false
 
 export const useMediaQuery = (query: string) => {
   const mediaQueryList = useMemo(
-    () => (typeof window === 'undefined' ? null : matchMedia(`(${query})`)),
+    () => (typeof window === 'undefined' ? null : matchMedia(query)),
     [query],
   )
 


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- AppHeaderの表示モードの判定が、SSRの場合レイアウトシフトを引き起こしてしまう
- ロジックを修正したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- 常にdesktop, mobileの両モードがhtml上に存在するように修正
  - cssでの表示出し分けにすることでレイアウトシフトが発生しない状態にする
- なぜこのようなロジックにしているのか？をコメントとして明記

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- 実プロダクトにて動作確認済み
