### PR TITLE
fix(Stepper): 縦積みStepperでタイトルが長いときに接続線が途切れるのを修正

### DIFF
--- a/packages/smarthr-ui/src/components/Stepper/StepCounter.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/StepCounter.tsx
@@ -8,7 +8,7 @@ import type { Step } from './types'
 const classNameGenerator = tv({
   slots: {
     // StatusIcon の位置基準となる wrapper
-    wrapper: 'shr-relative',
+    wrapper: 'shr-relative shr-inline-block',
     counter:
       'shr-inline-flex shr-items-center shr-justify-center shr-rounded-full shr-border-shorthand shr-bg-white shr-tabular-nums shr-w-[2em] shr-h-[2em]',
     statusIcon: 'shr-absolute -shr-top-0.25 shr-left-1.5',

--- a/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
@@ -17,7 +17,7 @@ const classNameGenerator = tv({
     heading: 'shr-inline-block',
     body: [
       // (stepCounter + :after) + (body > inner) という構造
-      'shr-flex shr-flex-col',
+      'shr-flex shr-flex-col shr-grow',
       'forced-colors:before:shr-bg-[ButtonBorder]',
     ],
     inner: 'shr-grow shr-pt-0.5 shr-pb-1.5',

--- a/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
@@ -2,7 +2,6 @@ import { type FC, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Heading } from '../Heading'
-import { Sidebar } from '../Layout'
 import { Section } from '../SectioningContent/SectioningContent'
 
 import { StepCounter } from './StepCounter'
@@ -12,6 +11,7 @@ import type { VerticalStep } from './types'
 const classNameGenerator = tv({
   slots: {
     wrapper: 'shr-group/stepItem',
+    section: 'shr-flex shr-gap-1',
     // StepCounterの中心に揃えるため、0.25remとborder分の1px paddingを追加している
     headingWrapper: 'shr-flex shr-items-center shr-gap-1 shr-py-[calc(0.25rem_+_1px)]',
     heading: 'shr-inline-block',
@@ -62,13 +62,15 @@ type Props = VerticalStep & {
 
 export const VerticalStepItem: FC<Props> = ({ stepNumber, label, status, children, current }) => {
   const classNames = useMemo(() => {
-    const { wrapper, headingWrapper, heading, body, inner, stepCounter } = classNameGenerator({
-      status: typeof status === 'object' ? status.type : status,
-      current,
-    })
+    const { wrapper, section, headingWrapper, heading, body, inner, stepCounter } =
+      classNameGenerator({
+        status: typeof status === 'object' ? status.type : status,
+        current,
+      })
 
     return {
       wrapper: wrapper(),
+      section: section(),
       headingWrapper: headingWrapper(),
       heading: heading(),
       body: body(),
@@ -79,20 +81,18 @@ export const VerticalStepItem: FC<Props> = ({ stepNumber, label, status, childre
 
   return (
     <li aria-current={current ? 'step' : undefined} className={classNames.wrapper}>
-      <Section>
-        <Sidebar>
-          <div className={classNames.stepCounter}>
-            <StepCounter status={status} current={current} stepNumber={stepNumber} />
+      <Section className={classNames.section}>
+        <div className={classNames.stepCounter}>
+          <StepCounter status={status} current={current} stepNumber={stepNumber} />
+        </div>
+        <div className={classNames.body}>
+          <div className={classNames.headingWrapper}>
+            <Heading type="sectionTitle" className={classNames.heading}>
+              {label}
+            </Heading>
           </div>
-          <div className={classNames.body}>
-            <div className={classNames.headingWrapper}>
-              <Heading type="sectionTitle" className={classNames.heading}>
-                {label}
-              </Heading>
-            </div>
-            <div className={classNames.inner}>{children}</div>
-          </div>
-        </Sidebar>
+          <div className={classNames.inner}>{children}</div>
+        </div>
       </Section>
     </li>
   )

--- a/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
@@ -1,7 +1,8 @@
-import { type FC, type PropsWithChildren, memo, useMemo } from 'react'
+import { type FC, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Heading } from '../Heading'
+import { Sidebar } from '../Layout'
 import { Section } from '../SectioningContent/SectioningContent'
 
 import { StepCounter } from './StepCounter'
@@ -11,23 +12,26 @@ import type { VerticalStep } from './types'
 const classNameGenerator = tv({
   slots: {
     wrapper: 'shr-group/stepItem',
-    headingWrapper: 'shr-flex shr-items-center shr-gap-1',
+    // StepCounterの中心に揃えるため、0.25remとborder分の1px paddingを追加している
+    headingWrapper: 'shr-flex shr-items-center shr-gap-1 shr-py-[calc(0.25rem_+_1px)]',
     heading: 'shr-inline-block',
     body: [
-      // body > (:before + inner) という構造
-      'shr-flex',
-      // body の before 疑似要素がステップを繋ぐ線
-      'before:shr-block before:shr-content-[""] before:shr-relative before:shr-mx-1 before:shr-bg-border before:shr-w-[theme(borderWidth.2)]',
-      // 最後のステップの線を消す
-      'group-last/stepItem:before:shr-bg-transparent',
+      // (stepCounter + :after) + (body > inner) という構造
+      'shr-flex shr-flex-col',
       'forced-colors:before:shr-bg-[ButtonBorder]',
     ],
-    inner: 'shr-grow shr-ms-1 shr-pt-0.5 shr-pb-1.5',
+    inner: 'shr-grow shr-pt-0.5 shr-pb-1.5',
+    stepCounter: [
+      // stepCounter の after 疑似要素がステップを繋ぐ線
+      'after:shr-block after:shr-content-[""] after:shr-relative after:shr-mx-1 after:shr-bg-border after:shr-w-[theme(borderWidth.2)] after:shr-h-full',
+      // 最後のステップの線を消す
+      'group-last/stepItem:after:shr-bg-transparent',
+    ],
   },
   variants: {
     status: {
       completed: {
-        body: ['before:shr-bg-main', 'forced-colors:before:shr-bg-[Highlight]'],
+        stepCounter: ['after:shr-bg-main', 'forced-colors:after:shr-bg-[Highlight]'],
       },
       closed: {},
     },
@@ -58,7 +62,7 @@ type Props = VerticalStep & {
 
 export const VerticalStepItem: FC<Props> = ({ stepNumber, label, status, children, current }) => {
   const classNames = useMemo(() => {
-    const { wrapper, headingWrapper, heading, body, inner } = classNameGenerator({
+    const { wrapper, headingWrapper, heading, body, inner, stepCounter } = classNameGenerator({
       status: typeof status === 'object' ? status.type : status,
       current,
     })
@@ -69,37 +73,27 @@ export const VerticalStepItem: FC<Props> = ({ stepNumber, label, status, childre
       heading: heading(),
       body: body(),
       inner: inner(),
+      stepCounter: stepCounter(),
     }
   }, [current, status])
 
   return (
     <li aria-current={current ? 'step' : undefined} className={classNames.wrapper}>
       <Section>
-        <StepHeading
-          status={status}
-          current={current}
-          stepNumber={stepNumber}
-          className={classNames.headingWrapper}
-          headingClassName={classNames.heading}
-        >
-          {label}
-        </StepHeading>
-        <div className={classNames.body}>
-          <div className={classNames.inner}>{children}</div>
-        </div>
+        <Sidebar>
+          <div className={classNames.stepCounter}>
+            <StepCounter status={status} current={current} stepNumber={stepNumber} />
+          </div>
+          <div className={classNames.body}>
+            <div className={classNames.headingWrapper}>
+              <Heading type="sectionTitle" className={classNames.heading}>
+                {label}
+              </Heading>
+            </div>
+            <div className={classNames.inner}>{children}</div>
+          </div>
+        </Sidebar>
       </Section>
     </li>
   )
 }
-
-const StepHeading = memo<
-  Pick<Props, 'status' | 'current' | 'stepNumber'> &
-    PropsWithChildren<{ className: string; headingClassName: string }>
->(({ status, current, stepNumber, children, className, headingClassName }) => (
-  <div className={className}>
-    <StepCounter status={status} current={current} stepNumber={stepNumber} />
-    <Heading type="sectionTitle" className={headingClassName}>
-      {children}
-    </Heading>
-  </div>
-))


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1260

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

縦積みのStepperでタイトルが長いときに接続線が途切れるのを修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- 縦積みのStepperでタイトルが長いときに接続線が途切れるのを修正
  - 構造を少し変えています

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

- Story未整理のため、DevToolsで直接長めのタイトルを入れてみてください。

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

| before | after |
| :-- | :-- |
| <img width="1131" alt="image" src="https://github.com/user-attachments/assets/2d3a822d-c12a-44e4-85e9-8fd2d70c1986" /> | <img width="1135" alt="image" src="https://github.com/user-attachments/assets/c90629a3-0992-4c9a-848d-1111eac0ce59" /> |
