### PR TITLE
fix(IntlProvider): 複数のIntlProviderをネストできるように修正

### DIFF
--- a/packages/smarthr-ui/src/intl/IntlProvider.tsx
+++ b/packages/smarthr-ui/src/intl/IntlProvider.tsx
@@ -1,17 +1,22 @@
 'use client'
 
-import { IntlProvider as ReactIntlProvider } from 'react-intl'
+import { type FC, type PropsWithChildren, useContext, useMemo } from 'react'
+import { IntlContext, IntlProvider as ReactIntlProvider } from 'react-intl'
 
 import * as locales from './locales'
-
-import type { FC, PropsWithChildren } from 'react'
 
 type Props = PropsWithChildren<{
   locale: keyof typeof locales
 }>
 
-export const IntlProvider: FC<Props> = ({ locale, children }) => (
-  <ReactIntlProvider locale={locale} messages={locales[locale]}>
-    {children}
-  </ReactIntlProvider>
-)
+export const IntlProvider: FC<Props> = ({ locale, children }) => {
+  // プロダクト側でIntlProviderを使っている場合、プロダクト側のmessagesとマージして提供するためにContextから取得している
+  const intl = useContext(IntlContext)
+  const actualMessages = useMemo(() => ({ ...intl?.messages, ...locales[locale] }), [intl, locale])
+
+  return (
+    <ReactIntlProvider locale={locale} messages={actualMessages}>
+      {children}
+    </ReactIntlProvider>
+  )
+}

--- a/packages/smarthr-ui/src/intl/useIntl.test.tsx
+++ b/packages/smarthr-ui/src/intl/useIntl.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react'
-import { IntlProvider } from 'react-intl'
+import { IntlProvider as ReactIntlProvider, useIntl as useReactIntl } from 'react-intl'
 
-import { useIntl } from './useIntl'
+import { IntlProvider, useIntl } from '.'
 
 import type { FC, PropsWithChildren } from 'react'
 
@@ -24,5 +24,17 @@ describe('useIntl', () => {
     const date = new Date(2025, 1 - 1, 1)
     const ret = formatDate(date)
     expect(ret).toBe('1/1/2025')
+  })
+
+  it('returns all messages even if provider is nested', async () => {
+    const wrapper: FC<PropsWithChildren> = ({ children }) => (
+      <ReactIntlProvider locale="ja" messages={{ test: 'テスト' }}>
+        <IntlProvider locale="ja">{children}</IntlProvider>
+      </ReactIntlProvider>
+    )
+    const { localize } = renderHook(() => useIntl(), { wrapper }).result.current
+    expect(localize({ id: 'smarthr-ui/common/language', defaultText: '日本語' })).toBe('日本語')
+    const { formatMessage } = renderHook(() => useReactIntl(), { wrapper }).result.current
+    expect(formatMessage({ id: 'test' })).toBe('テスト')
   })
 })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

#5569 

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

#5569 でlocalesはexportしたが、AppHeaderなどIntlProviderをネストできると便利なケースがあったり、そもそもプロダクト側でも気にせずIntlProviderだけを差し込めば良いと便利なため

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- react-intlのIntlProviderをネストできるようにした

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

- テストがあるのでそちらの妥当性で判断いただければ！

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
