### PR TITLE
fix(Input): disabled 時に、prefix/suffix もグレーアウトさせる

### DIFF
--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -75,6 +75,13 @@ const innerClassNameGenerator = tv({
     ],
     affix: 'shr-flex shr-shrink-0 shr-items-center shr-text-grey',
   },
+  variants: {
+    disabled: {
+      true: {
+        affix: 'shr-text-disabled shr-opacity-100',
+      },
+    },
+  },
 })
 
 export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
@@ -134,14 +141,14 @@ export const Input = forwardRef<HTMLInputElement, Props & ElementProps>(
     }, [width, bgColor])
 
     const innerClassNames = useMemo(() => {
-      const { input, affix } = innerClassNameGenerator()
+      const { input, affix } = innerClassNameGenerator({ disabled })
 
       return {
         input: input(),
         prefix: affix({ className: 'smarthr-ui-Input-prefix' }),
         suffix: affix({ className: 'smarthr-ui-Input-suffix' }),
       }
-    }, [])
+    }, [disabled])
 
     return (
       <span


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

N/A (プロダクト開発中に気になった次第です)

## 概要

Input コンポーネントでは disabled 時に入力要素及び入力中のテキストがグレーアウトする仕様だが、prefix/suffix が設定されている場合、そちらのスタイルは変更されないため、浮いて見えてしまっているのが気になりました。

## 変更内容

Input コンポーネントに disabled 指定時は、prefix/suffix についても同様にグレーアウトするようにしました。

## 確認方法

以下のように変わることを、Storybook 上でも確認可能です。

|before|after|
|---|---|
|![CleanShot 2025-05-02 at 22 47 00](https://github.com/user-attachments/assets/0bb8dff4-151a-4fb9-bcc8-6c21cac982da)|![CleanShot 2025-05-02 at 22 45 59](https://github.com/user-attachments/assets/82854b0a-8e8e-4d6e-afe4-c8bb487fbd1c)

