### PR TITLE
feat(Table): border の種類とスタイル、角丸を追加

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -1,33 +1,108 @@
-import { type ComponentProps, type FC, type PropsWithChildren, useMemo } from 'react'
+import { type ComponentProps, type FC, Fragment, type PropsWithChildren, useMemo } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
+
+import { Base } from '../Base'
+
+import { TableReel } from './TableReel'
 
 type Props = PropsWithChildren<VariantProps<typeof classNameGenerator>>
 type ElementProps = Omit<ComponentProps<'table'>, keyof Props>
 
 const classNameGenerator = tv({
-  base: [
-    'smarthr-ui-Table',
-    'shr-border-collapse shr-w-full',
-    '[&_tbody]:shr-bg-white',
-    '[&_th]:contrast-more:shr-border-shorthand [&_th]:shr-bg-head [&_th]:contrast-more:shr-border-high-contrast',
-    '[&_td]:contrast-more:shr-border-shorthand [&_td]:contrast-more:shr-border-high-contrast',
-    'contrast-more:shr-border-shorthand contrast-more:shr-border-high-contrast',
-  ],
+  slots: {
+    wrapper: '',
+    table: [
+      'smarthr-ui-Table',
+      'shr-border-collapse shr-w-full',
+      '[&_tbody]:shr-bg-white',
+      '[&_th]:contrast-more:shr-border-shorthand [&_th]:shr-bg-head [&_th]:contrast-more:shr-border-high-contrast',
+      '[&_td]:contrast-more:shr-border-shorthand [&_td]:contrast-more:shr-border-high-contrast',
+      'contrast-more:shr-border-shorthand contrast-more:shr-border-high-contrast',
+    ],
+  },
   variants: {
     borderType: {
-      horizontal: 'shr-table-border-horizontal',
-      both: 'shr-table-border-vertical shr-table-border-horizontal',
+      vertical: {},
+      horizontal: {
+        table: 'shr-table-border-horizontal',
+      },
+      both: {
+        table: 'shr-table-border-horizontal',
+      },
+      outer: {
+        table: 'shr-border-shorthand',
+      },
+      all: {
+        table: 'shr-table-border-horizontal shr-border-shorthand',
+      },
+    },
+    borderStyle: {
+      solid: {
+        table: '[&_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-solid',
+      },
+      dotted: {
+        table: '[&_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-dotted',
+      },
+      dashed: {
+        table: '[&_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-dashed',
+      },
+    },
+    rounded: {
+      true: {},
     },
     layout: {
-      auto: '',
-      fixed: 'shr-table-fixed',
+      auto: {},
+      fixed: {
+        table: 'shr-table-fixed',
+      },
     },
     fixedHead: {
-      true: '[&_thead]:shr-sticky [&_thead]:shr-start-0 [&_thead]:shr-top-0 [&_thead]:shr-z-[2] [&_tbody]:shr-relative [&_tbody]:shr-z-1',
+      true: {
+        table:
+          '[&_thead]:shr-sticky [&_thead]:shr-start-0 [&_thead]:shr-top-0 [&_thead]:shr-z-[2] [&_tbody]:shr-relative [&_tbody]:shr-z-1',
+      },
     },
   },
+  compoundVariants: [
+    {
+      // rounded のとき Wrapper である Base に装飾するため、Table には装飾しない
+      borderType: ['outer', 'all'],
+      rounded: true,
+      className: {
+        table: 'shr-border-none',
+        wrapper: 'shr-border-shorthand',
+      },
+    },
+    {
+      borderType: ['vertical', 'both', 'all'],
+      className: {
+        table: [
+          '[&_:is(.smarthr-ui-Th:not(:first-child),.smarthr-ui-Td:not(:first-child))]:shr-border-l',
+          '[&_:is(.smarthr-ui-Th:not(:first-child),.smarthr-ui-Td:not(:first-child))]:shr-border-l-default',
+        ],
+      },
+    },
+    {
+      borderType: ['horizontal', 'both', 'all'],
+      className: {
+        table: [
+          // thead がある場合は、thead 配下以外の th と td に border-t を適用
+          [
+            '[&:has(thead)_tr:not(:where(thead_tr))_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-t',
+            '[&:has(thead)_tr:not(:where(thead_tr))_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-t-default',
+          ],
+          // thead がない場合は、最初以外の tr 配下の th と td に border-t を適用
+          [
+            '[&:not(:has(thead))_tr:not(:first-of-type)_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-t',
+            '[&:not(:has(thead))_tr:not(:first-of-type)_:is(.smarthr-ui-Th,.smarthr-ui-Td)]:shr-border-t-default',
+          ],
+        ],
+      },
+    },
+  ],
   defaultVariants: {
     borderType: 'horizontal',
+    borderStyle: 'solid',
     layout: 'auto',
     fixedHead: false,
   },
@@ -35,15 +110,38 @@ const classNameGenerator = tv({
 
 export const Table: FC<Props & ElementProps> = ({
   borderType,
+  borderStyle,
   fixedHead,
   layout,
+  rounded,
   className,
-  ...props
+  ...rest
 }) => {
-  const actualClassName = useMemo(
-    () => classNameGenerator({ borderType, fixedHead, layout, className }),
-    [borderType, className, fixedHead, layout],
+  const actualClassName = useMemo(() => {
+    const { table, wrapper } = classNameGenerator({
+      borderType,
+      borderStyle,
+      fixedHead,
+      layout,
+      rounded,
+      className,
+    })
+    return { table: table(), wrapper: wrapper() }
+  }, [borderType, borderStyle, className, fixedHead, layout, rounded])
+  const [Wrapper, wrapperProps] = useMemo(
+    () => (rounded ? [RoundedWrapper, { className: actualClassName.wrapper }] : [Fragment, {}]),
+    [rounded, actualClassName.wrapper],
   )
 
-  return <table {...props} className={actualClassName} />
+  return (
+    <Wrapper {...wrapperProps}>
+      <table {...rest} className={actualClassName.table} />
+    </Wrapper>
+  )
 }
+
+const RoundedWrapper = ({ children, ...rest }: PropsWithChildren) => (
+  <Base {...rest} overflow="hidden" layer={0}>
+    <TableReel>{children}</TableReel>
+  </Base>
+)

--- a/packages/smarthr-ui/src/components/Table/Td.tsx
+++ b/packages/smarthr-ui/src/components/Table/Td.tsx
@@ -52,9 +52,7 @@ export const Td = memo<Props & ElementProps>(
 const classNameGenerator = tv({
   base: [
     'smarthr-ui-Td',
-    'shr-border-solid shr-border-0 shr-px-1 shr-py-0.5 shr-align-middle shr-text-base shr-leading-normal shr-text-black shr-h-[calc(1em_*_theme(lineHeight.normal))]',
-    '[.shr-table-border-horizontal_&]:shr-border-t [.shr-table-border-horizontal_&]:shr-border-t-default',
-    '[.shr-table-border-vertical_&+&]:shr-border-l [.shr-table-border-vertical_&+&]:shr-border-l-default',
+    'shr-border-0 shr-px-1 shr-py-0.5 shr-align-middle shr-text-base shr-leading-normal shr-text-black shr-h-[calc(1em_*_theme(lineHeight.normal))]',
     '[&.fixed]:shr-bg-white',
   ],
   variants: {

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -43,11 +43,7 @@ const SORT_DIRECTION_LABEL = {
 const classNameGenerator = tv({
   base: [
     'smarthr-ui-Th',
-    'shr-border-solid shr-border-0 shr-px-1 shr-py-0.75 shr-text-left shr-align-middle shr-text-sm shr-font-bold shr-leading-tight shr-text-black',
-    [
-      '[.shr-table-border-vertical_&+&]:shr-border-l',
-      '[.shr-table-border-vertical_&+&]:shr-border-l-default',
-    ],
+    'shr-border-0 shr-px-1 shr-py-0.75 shr-text-left shr-align-middle shr-text-sm shr-font-bold shr-leading-tight shr-text-black',
     'aria-[sort]:shr-cursor-pointer',
     'hover:aria-[sort]:shr-bg-head-darken',
     '[&:has(:focus-visible)]:aria-[sort]:shr-focus-indicator',

--- a/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
@@ -44,7 +44,6 @@ export default {
     TableReel,
   },
   render: Template,
-  args: {},
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -56,20 +55,36 @@ export const BorderType: StoryObj<typeof Table> = {
   name: 'borderType',
   render: (args) => (
     <Stack>
-      <Template {...args} />
-      <Template {...args} borderType="horizontal" />
-      <Template {...args} borderType="both" />
+      {[undefined, 'vertical', 'horizontal', 'both', 'outer', 'all'].map((borderType) => (
+        <Template {...args} borderType={borderType as any} />
+      ))}
     </Stack>
   ),
+}
+
+export const BorderStyle: StoryObj<typeof Table> = {
+  name: 'borderStyle',
+  render: (args) => (
+    <Stack>
+      {[undefined, 'solid', 'dashed', 'dotted'].map((borderStyle) => (
+        <Template {...args} borderStyle={borderStyle as any} />
+      ))}
+    </Stack>
+  ),
+}
+
+export const Rounded: StoryObj<typeof Table> = {
+  name: 'rounded',
+  render: (args) => <Template {...args} rounded />,
 }
 
 export const Layout: StoryObj<typeof Table> = {
   name: 'layout',
   render: (args) => (
     <Stack>
-      <Template {...args} />
-      <Template {...args} layout="auto" />
-      <Template {...args} layout="fixed" />
+      {[undefined, 'auto', 'fixed'].map((layout) => (
+        <Template {...args} layout={layout as any} />
+      ))}
     </Stack>
   ),
 }

--- a/packages/smarthr-ui/src/components/Table/stories/VRTTable.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/VRTTable.stories.tsx
@@ -114,6 +114,54 @@ export default {
           )
         }),
       )}
+      {[false, true].map((rounded) =>
+        ['vertical', 'horizontal', 'both', 'outer', 'all'].map((borderType) =>
+          ['solid', 'dashed', 'dotted'].map((borderStyle) => (
+            <>
+              <Table
+                {...args}
+                borderType={borderType as any}
+                borderStyle={borderStyle as any}
+                rounded={rounded}
+              >
+                <thead>
+                  <tr>
+                    <Th>オブジェクト名</Th>
+                    <Th>オブジェクトの情報1</Th>
+                    <Th>オブジェクトの情報2</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <Td>オブジェクト1</Td>
+                    <Td>情報1</Td>
+                    <Td>2024-11-26</Td>
+                  </tr>
+                </tbody>
+              </Table>
+              <Table
+                {...args}
+                borderType={borderType as any}
+                borderStyle={borderStyle as any}
+                rounded={rounded}
+              >
+                <tbody>
+                  <tr>
+                    <Th>オブジェクト1</Th>
+                    <Td>情報1</Td>
+                    <Td>2024-11-26</Td>
+                  </tr>
+                  <tr>
+                    <Th>オブジェクト2</Th>
+                    <Td>情報2</Td>
+                    <Td>2024-11-27</Td>
+                  </tr>
+                </tbody>
+              </Table>
+            </>
+          )),
+        ),
+      )}
     </Stack>
   ),
   parameters: {


### PR DESCRIPTION

<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1265

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

thead がない Table の border が崩れていたのを修正しつつ、border スタイルや角丸を追加しました。

- bordetType に outer と all を追加
  - outer は外側のみ
  - all は vertical, horizontal, outer のすべて
- bordetStyle を追加
  - dashed と dotted
  - 大外の borderStyle を変える需要はまだないので未実装
- rounded を追加
  - 角丸は一旦1サイズで提供
  - 内部的に Base を使っている（構造上 Reel を挟めないので、TableReel も組み込んでいる）

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->