### PR TITLE
fix: RadioButtonPanel に cursor: pointer; がつくように修正 SHRUI-1285

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -28,7 +28,8 @@ const classNameGenerator = tv({
   slots: {
     base: [
       'smarthr-ui-RadioButtonPanel',
-      'shr-border-shorthand shr-list-none shr-shadow-none',
+      'shr-border-shorthand shr-list-none shr-shadow-none shr-cursor-pointer',
+      'has-[:disabled]:shr-cursor-default',
       // FIX: なぜか storybook 上で :has が動作しないので重ねて書いている
       'has-[:focus-visible]:shr-focus-indicator [&:has(:focus-visible)]:shr-focus-indicator',
       'has-[:disabled]:[&_.smarthr-ui-RadioButtonPanel-description]:shr-text-disabled [&:has(:disabled)]:shr-text-disabled',
@@ -36,8 +37,6 @@ const classNameGenerator = tv({
     radio: [
       '[&_.smarthr-ui-RadioButton-radioButton:focus-visible_+_span]:shr-shadow-none',
       '[&_.smarthr-ui-RadioButton-label]:shr-ms-0.75',
-      'shr-cursor-pointer has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer',
-      'has-[:disabled]:shr-cursor-default has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default',
     ],
     // RadioButtonPanel で指定している shr-ms-0.75 + RadioButton のボタンの shr-w-em を足して shr-ms-[1.75em] にしている
     description: ['smarthr-ui-RadioButtonPanel-description', 'shr-ms-[1.75em] shr-mt-0.5'],


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

SHRUI-1285

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

https://github.com/kufu/smarthr-ui/pull/5556/files での変更により、RadioButtonPanel にホバーしてもマウスカーソルが pointer にならなくなってしまっていたので直しました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- `shr-cursor-pointer` と `has-[:disabled]:shr-cursor-default` のクラスが base から radio に移動してしまっていたので戻した
- 下記の2つのクラスは不要そうだったので削除した
  - `has-[:not(:disabled)]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-pointer`
  - `has-[:disabled]:[&_.smarthr-ui-RadioButton-label]:shr-cursor-default`

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

Storybook で RadioButtonPanel を開き、マウスカーソルが pointer になること、また disabled 状態のときは default となることを確認してください。

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
