### PR TITLE
fix: SideMenu のグループタイトルの type を `blockTitle` から `subBlockTitle` に変更する

### DIFF
--- a/packages/smarthr-ui/src/components/SideMenu/SideMenuGroup.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/SideMenuGroup.tsx
@@ -63,7 +63,7 @@ export const SideMenuGroup = <TitleElement extends ElementType = 'span'>({
 
 const GroupHeading = memo<PropsWithChildren<{ titleElementAs?: ElementType; className: string }>>(
   ({ titleElementAs: Inner, children, className }) => (
-    <Heading type="blockTitle" className={className}>
+    <Heading type="subBlockTitle" className={className}>
       {Inner ? <Inner>{children}</Inner> : children}
     </Heading>
   ),


### PR DESCRIPTION
## 概要
![スクリーンショット 2025-05-27 21 21 56](https://github.com/user-attachments/assets/2762d1b1-d6bc-4d76-86b0-02a6f7a1dd86)

グループタイトルは現状 TEXT_BLACK の bold ですが、SideMenuItem の current スタイルも同様に TEXT_BLACK の bold で、テキストサイズの違いしかなく、クリッカブルエリアが判別しづらいです。

DropdownContent のグルーピングタイトルに合わせて、TEXT_GRAY になるようにしたいです。

![スクリーンショット 2025-05-27 21 28 36](https://github.com/user-attachments/assets/864280cf-744a-4f32-803d-743536c98a6f)

## 変更内容

`<SideMenuGroup />` 内 `<Heading />` の type props の値を、 `blockTitle` から `subBlockTitle` に変更しました。

## 確認方法

https://63d0ccabb5d2dd29825524ab-orfetcmnze.chromatic.com/?path=/story/navigation%EF%BC%88%E3%83%8A%E3%83%93%E3%82%B2%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%EF%BC%89-sidemenu--grouped
