### PR TITLE
fix: Dialog内のresponseStatusメッセージのlive regionが通知されるように修正 SHRUI-1282

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ActionDialog/ActionDialogContentInner.tsx
@@ -5,9 +5,9 @@ import { type FC, type PropsWithChildren, type ReactNode, memo, useCallback, use
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
 import { Button } from '../../Button'
 import { Cluster, Stack } from '../../Layout'
-import { ResponseMessage } from '../../ResponseMessage'
 import { Section } from '../../SectioningContent'
 import { DialogBody, type Props as DialogBodyProps } from '../DialogBody'
+import { DialogContentResponseStatusMessage } from '../DialogContentResponseStatusMessage'
 import { DialogHeader, type Props as DialogHeaderProps } from '../DialogHeader'
 import { dialogContentInner } from '../dialogInnerStyle'
 
@@ -97,13 +97,7 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
             className={styles.buttonArea}
           />
         </Cluster>
-        {calcedResponseStatus.message && (
-          <div className={styles.message}>
-            <ResponseMessage type={calcedResponseStatus.status} role="alert">
-              {calcedResponseStatus.message}
-            </ResponseMessage>
-          </div>
-        )}
+        <DialogContentResponseStatusMessage responseStatus={calcedResponseStatus} />
       </Stack>
     </Section>
   )

--- a/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
@@ -1,0 +1,15 @@
+import { ResponseMessage } from '../ResponseMessage'
+
+import type { useResponseStatus } from '../../hooks/useResponseStatus'
+import type { FC } from 'react'
+
+export const DialogContentResponseStatusMessage: FC<{
+  responseStatus: ReturnType<typeof useResponseStatus>
+  className?: string
+}> = ({ responseStatus, className }) => (
+  <div className={className} role={responseStatus.status === 'error' ? 'alert' : 'status'}>
+    {responseStatus.message && responseStatus.status && (
+      <ResponseMessage type={responseStatus.status}>{responseStatus.message}</ResponseMessage>
+    )}
+  </div>
+)

--- a/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FormDialog/FormDialogContentInner.tsx
@@ -12,9 +12,9 @@ import { tv } from 'tailwind-variants'
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
 import { Button } from '../../Button'
 import { Cluster, Stack } from '../../Layout'
-import { ResponseMessage } from '../../ResponseMessage'
 import { Section } from '../../SectioningContent'
 import { DialogBody, type Props as DialogBodyProps } from '../DialogBody'
+import { DialogContentResponseStatusMessage } from '../DialogContentResponseStatusMessage'
 import { DialogHeader, type Props as DialogHeaderProps } from '../DialogHeader'
 import { dialogContentInner } from '../dialogInnerStyle'
 
@@ -123,13 +123,10 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
               className={styles.buttonArea}
             />
           </Cluster>
-          {calculatedResponseStatus.message && (
-            <div className={styles.message}>
-              <ResponseMessage type={calculatedResponseStatus.status} role="alert">
-                {calculatedResponseStatus.message}
-              </ResponseMessage>
-            </div>
-          )}
+          <DialogContentResponseStatusMessage
+            responseStatus={calculatedResponseStatus}
+            className={styles.message}
+          />
         </Stack>
       </form>
     </Section>

--- a/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialogContentInner.tsx
@@ -14,9 +14,9 @@ import { type DecoratorsType, useDecorators } from '../../../hooks/useDecorators
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
 import { Button } from '../../Button'
 import { Cluster, Stack } from '../../Layout'
-import { ResponseMessage } from '../../ResponseMessage'
 import { Section } from '../../SectioningContent'
 import { DialogBody, type Props as DialogBodyProps } from '../DialogBody'
+import { DialogContentResponseStatusMessage } from '../DialogContentResponseStatusMessage'
 import { DialogHeader, type Props as DialogHeaderProps } from '../DialogHeader'
 import { dialogContentInner } from '../dialogInnerStyle'
 
@@ -198,13 +198,10 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
                 </Button>
               </Cluster>
             </Cluster>
-            {calcedResponseStatus.message && (
-              <div className={classNames.message}>
-                <ResponseMessage type={calcedResponseStatus.status} role="alert">
-                  {calcedResponseStatus.message}
-                </ResponseMessage>
-              </div>
-            )}
+            <DialogContentResponseStatusMessage
+              responseStatus={calcedResponseStatus}
+              className={classNames.message}
+            />
           </Stack>
         </div>
       </form>

--- a/packages/smarthr-ui/src/components/Dialog/dialogInnerStyle.ts
+++ b/packages/smarthr-ui/src/components/Dialog/dialogInnerStyle.ts
@@ -8,6 +8,6 @@ export const dialogContentInner = tv({
       'shr-border-t-shorthand shr-px-1.5 shr-py-1 shr-flex-[0_0_auto] shr-sticky shr-bottom-0 shr-z-1 shr-bg-white shr-rounded-b-m',
     ],
     buttonArea: ['smarthr-ui-Dialog-buttonArea', 'shr-ms-auto'],
-    message: 'shr-text-right',
+    message: 'shr-text-right empty:!shr-mt-0',
   },
 })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

SHRUI-1282

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

StepFormDialog、ActionDialog, FormDialog内のresponseStatusメッセージがライブリージオンで実装されているけど、通知されていない状態

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- StepFormDialog/ActionDialog/FormDialogのresponseStatusメッセージがライブリージオンで支援技術で通知されるように修正

- responseStatusのsuccessとerrorメッセージによって適切なroleを設定
  - success => role="status"
  - error => role="alert"
  
 ### BEFORE
 

https://github.com/user-attachments/assets/f9883c02-c150-411d-a708-1d4095afd746

 ### AFTER
https://github.com/user-attachments/assets/c4d4bc2e-f969-422d-9228-ae0d39a2593a

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
