### PR TITLE
fix: Tableで<table>タグにpropsのclassNameが渡されなくなっている不具合修正

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -122,7 +122,7 @@ export const Table: FC<Props & ElementProps> = ({
       rounded,
       className,
     })
-    return { table: table({ class: className }), wrapper: wrapper() }
+    return { table: table({ className }), wrapper: wrapper() }
   }, [borderType, borderStyle, className, fixedHead, layout, rounded])
   const [Wrapper, wrapperProps] = useMemo(
     () => (rounded ? [RoundedWrapper, { className: classNames.wrapper }] : [Fragment]),

--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -122,7 +122,7 @@ export const Table: FC<Props & ElementProps> = ({
       rounded,
       className,
     })
-    return { table: table(), wrapper: wrapper() }
+    return { table: table({ class: className }), wrapper: wrapper() }
   }, [borderType, borderStyle, className, fixedHead, layout, rounded])
   const [Wrapper, wrapperProps] = useMemo(
     () => (rounded ? [RoundedWrapper, { className: classNames.wrapper }] : [Fragment]),


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

プロダクト側でsmarthr-ui v72.1.0に更新しようとしたが、Table周りでデグレがありそうだったので修正したい。
具体的に書くと、以下のPRの変更によって、Tableコンポーネントのpropsに渡したclassNameがtableタグに設定されなくなっており、styled-componentsで当てているスタイルが効かなくなっていた。

- https://github.com/kufu/smarthr-ui/pull/5622

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

Tableのpropsに渡したclassNameがtableタグに設定されるように修正しました。


<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

- Tableに渡したclassNameがtableタグに正しく設定されていること

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
