### PR TITLE
fix!: GoogleDrive 関連のアイコンを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Icon/Icon.tsx
+++ b/packages/smarthr-ui/src/components/Icon/Icon.tsx
@@ -105,7 +105,6 @@ import {
   FaGear,
   FaGears,
   FaGlobe,
-  FaGoogleDrive,
   FaGraduationCap,
   FaGrip,
   FaGripLines,
@@ -307,7 +306,6 @@ export const FaGaugeIcon = /*#__PURE__*/ generateIcon(FaGauge)
 export const FaGearIcon = /*#__PURE__*/ generateIcon(FaGear)
 export const FaGearsIcon = /*#__PURE__*/ generateIcon(FaGears)
 export const FaGlobeIcon = /*#__PURE__*/ generateIcon(FaGlobe)
-export const FaGoogleDriveIcon = /*#__PURE__*/ generateIcon(FaGoogleDrive)
 export const FaGraduationCapIcon = /*#__PURE__*/ generateIcon(FaGraduationCap)
 export const FaGripIcon = /*#__PURE__*/ generateIcon(FaGrip)
 export const FaGripLinesIcon = /*#__PURE__*/ generateIcon(FaGripLines)


### PR DESCRIPTION
Google のロゴ利用ガイドライン違反になる可能性があるため Google Drive のアイコンを消します。

### 関連
- https://github.com/kufu/smarthr-ui/pull/5483
- https://smarthr.atlassian.net/browse/SHRUI-1287