### PR TITLE
fix!: RemoteDialogTriggerからvariant属性を削除し、Button自体に持つ形で修正する SHRUI-1275

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import {
-  type ComponentProps,
   type FC,
   type MouseEvent,
   type ReactElement,
@@ -12,8 +11,6 @@ import {
 
 import { TRIGGER_EVENT } from '../useRemoteTrigger'
 
-import type { Button } from '../../Button'
-
 const onClickRemoteDialogTrigger = (e: MouseEvent<HTMLElement>) => {
   document.dispatchEvent(
     new CustomEvent(TRIGGER_EVENT, {
@@ -22,13 +19,11 @@ const onClickRemoteDialogTrigger = (e: MouseEvent<HTMLElement>) => {
   )
 }
 
-export const RemoteDialogTrigger: FC<
-  Pick<ComponentProps<typeof Button>, 'variant'> & {
-    targetId: string
-    onClick?: (open: () => void) => void
-    children: Omit<ReactElement, 'onClick' | 'aria-haspopup' | 'aria-controls' | 'variant'>
-  }
-> = ({ targetId, children, onClick, variant, ...rest }) => {
+export const RemoteDialogTrigger: FC<{
+  targetId: string
+  onClick?: (open: () => void) => void
+  children: Omit<ReactElement, 'onClick' | 'aria-haspopup' | 'aria-controls'>
+}> = ({ targetId, children, onClick, ...rest }) => {
   const actualOnClick = useCallback(
     (e: MouseEvent<HTMLElement>) => {
       if (onClick) {
@@ -47,10 +42,9 @@ export const RemoteDialogTrigger: FC<
         onClick: actualOnClick,
         'aria-haspopup': 'dialog',
         'aria-controls': targetId,
-        variant,
         ...rest,
       }),
-    [children, actualOnClick, targetId, variant, rest],
+    [children, actualOnClick, targetId, rest],
   )
 
   return actualTrigger

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -68,7 +68,7 @@ const classNameGenerator = tv({
         /* unset した Button の右 padding 分 */
         '[&_.smarthr-ui-Button-disabledWrapper]:shr-pe-1',
         '[&_.smarthr-ui-Button-disabledWrapper]:shr-gap-x-0.5',
-        '[&_.smarthr-ui-Button-disabledWrapper_>_.smarthr-ui-Button]:shr-w-[unset] [&_.smarthr-ui-Button-disabledWrapper_>_.smarthr-ui-Button]:shr-pe-[unset]',
+        '[&_.smarthr-ui-Button-disabledWrapper_>_.smarthr-ui-Button]:shr-w-[unset] [&_.smarthr-ui-Button-disabledWrapper_>_.smarthr-ui-Button]:shr-pe-[unset] [&_.smarthr-ui-Button-disabledWrapper_>_.smarthr-ui-Button]:shr-bg-transparent',
       ],
     ],
     actionListItemButton: [
@@ -204,7 +204,6 @@ export const renderButtonList = (children: Actions) =>
       <li role="presentation">
         <DropdownCloser>
           {cloneElement(item as ReactElement, {
-            variant: 'text',
             wide: true,
             role: 'menuitem',
             className: actionListItemButton({ className: item.props.className }),


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://smarthr.atlassian.net/browse/SHRUI-1275

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- 歴史的経緯により、RemoteDialogTriggerがvariantを持ち、childrenに設定されるButtonにはvariantを持てない状態だった
- これらの仕様はRemoteDialogTrigger内にRemoteDialogTriggerを設置するための処置であったため、整理したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- RemoteDialogTriggerからvariant属性を削除し、childrenのButtonで設定できるように修正
- DropdownMenuButtonのstyleを調整し、表示崩れが起きないように修正

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- storybookなどで表示を確認する
