### PR TITLE
fix: RemoteDialogTriggerがasync-awaitなど非同期処理と併用されると正常動作しない可能性があるため修正する

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -11,10 +11,10 @@ import {
 
 import { TRIGGER_EVENT } from '../useRemoteTrigger'
 
-const onClickRemoteDialogTrigger = (e: MouseEvent<HTMLElement>) => {
+const onClickRemoteDialogTrigger = (ariaControls: string) => {
   document.dispatchEvent(
     new CustomEvent(TRIGGER_EVENT, {
-      detail: { id: e.currentTarget.getAttribute('aria-controls') as string },
+      detail: { id: ariaControls },
     }),
   )
 }
@@ -26,13 +26,17 @@ export const RemoteDialogTrigger: FC<{
 }> = ({ targetId, children, onClick, ...rest }) => {
   const actualOnClick = useCallback(
     (e: MouseEvent<HTMLElement>) => {
+      // HINT: onClick内で非同期処理される場合、e.currentTargetがnullになってしまう可能性があるため
+      // 先にariaControlsを取得しておく
+      const ariaControls = e.currentTarget.getAttribute('aria-controls') as string
+
       if (onClick) {
         return onClick(() => {
-          onClickRemoteDialogTrigger(e)
+          onClickRemoteDialogTrigger(ariaControls)
         })
       }
 
-      onClickRemoteDialogTrigger(e)
+      onClickRemoteDialogTrigger(ariaControls)
     },
     [onClick],
   )


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- RemoteDialogTriggerのonClickTriggerに対してasync-awaitなど、非同期処理の関数を設定した場合、event.currentTargetの取得時点でnullになってしまう可能性があることがわかったため対応したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- 非同期処理となる可能性がある前にcurrentTarget絡みの処理を完了させるように修正

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- コードをみてfmfmする
