### PR TITLE
fix!: color.ORANGE と color.GREEN を見直し

### DIFF
--- a/packages/smarthr-ui/src/components/Chip/Chip.tsx
+++ b/packages/smarthr-ui/src/components/Chip/Chip.tsx
@@ -15,10 +15,8 @@ export const classNameGenerator = tv({
     color: {
       grey: 'shr-border-grey-20',
       blue: 'shr-border-main',
-      /* green がトークン化されたら置き換える */
-      green: 'shr-border-[#0f7f85]',
-      /* oragen がトークン化されたら置き換える */
-      orange: 'shr-border-[#ff8800]',
+      green: 'shr-border-green',
+      orange: 'shr-border-orange',
       red: 'shr-border-danger',
     },
     size: {

--- a/packages/smarthr-ui/src/components/Chip/stories/Chip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Chip/stories/Chip.stories.tsx
@@ -11,6 +11,10 @@ export default {
     size: {
       control: 'select',
     },
+    color: {
+      control: 'select',
+      options: Object.keys(classNameGenerator.variants.color),
+    },
   },
   args: {
     children: 'ラベル',
@@ -20,9 +24,7 @@ export default {
   },
 } satisfies Meta<typeof Chip>
 
-export const Playground: StoryObj<typeof Chip> = {
-  args: {},
-}
+export const Playground: StoryObj<typeof Chip> = {}
 
 export const Size: StoryObj<typeof Chip> = {
   name: 'size',

--- a/packages/smarthr-ui/src/components/Chip/stories/VRTChip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Chip/stories/VRTChip.stories.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '../../Layout'
-import { Chip } from '../Chip'
+import { Chip, classNameGenerator } from '../Chip'
 
 import type { Meta } from '@storybook/react'
 
@@ -7,9 +7,11 @@ export default {
   title: 'Components/Chip/VRT',
   render: (args) => (
     <Stack align="flex-start">
-      {[undefined, true].map((disabled) => (
-        <Chip {...args} disabled={disabled} key={String(disabled)} />
-      ))}
+      {[undefined, true].map((disabled) =>
+        Object.keys(classNameGenerator.variants.color).map((color) => (
+          <Chip {...args} disabled={disabled} key={`${disabled}${color}`} color={color as any} />
+        )),
+      )}
     </Stack>
   ),
   args: {

--- a/packages/smarthr-ui/src/components/StatusLabel/StatusLabel.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/StatusLabel.tsx
@@ -22,7 +22,7 @@ export const classNameGenerator = tv({
       blue: 'shr-text-main',
       /* SmartHR 基本色の Aqua04。StatusLabel 以外では使いません。
        * https://smarthr.design/basics/colors/#h4-1 */
-      green: 'shr-text-[#0f7f85]',
+      green: 'shr-text-green',
       red: 'shr-text-danger',
       warning: 'shr-border-warning-yellow shr-bg-warning-yellow shr-text-black',
       error: 'shr-bg-danger shr-border-danger shr-text-white',
@@ -47,7 +47,7 @@ export const classNameGenerator = tv({
       bold: true,
       /* SmartHR 基本色の Aqua04。StatusLabel 以外では使いません。
        * https://smarthr.design/basics/colors/#h4-1 */
-      class: 'shr-border-[#0f7f85] shr-bg-[#0f7f85]',
+      class: 'shr-border-green shr-bg-green',
     },
     {
       type: 'red',

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -95,6 +95,7 @@ export default {
       'warning-yellow-darken': theme('colors.warning-yellow-darken'),
       overlay: defaultColor.OVERLAY,
       scrim: defaultColor.SCRIM,
+      green: theme('colors.green'),
       grey: {
         9: theme('colors.grey.9'),
         '9-darken': darkenColor(theme('colors.grey.9')),
@@ -134,6 +135,9 @@ export default {
       'danger-darken': darkenColor(defaultColor.DANGER),
       'warning-yellow': defaultColor.WARNING_YELLOW,
       'warning-yellow-darken': darkenColor(defaultColor.WARNING_YELLOW),
+      // 色トークン周りの整理が必要（GREEN_100 と ORANGE_100 は primitive にしかない。）
+      green: '#0f7f85',
+      orange: '#f56121',
       grey: {
         DEFAULT: defaultColor.GREY_65,
         5: defaultColor.GREY_5,
@@ -206,6 +210,7 @@ export default {
       'link-darken': darkenColor(theme('colors.link'), 0.062),
       grey: theme('colors.grey.65'),
       danger: theme('colors.danger'),
+      green: theme('colors.green'),
       'color-inherit': 'inherit',
       transparent: 'transparent',
     }),
@@ -234,6 +239,8 @@ export default {
         darken: darkenColor(theme('colors.grey.20')),
         'high-contrast': theme('colors.grey.100'),
         link: theme('colors.link'),
+        orange: theme('colors.orange'),
+        green: theme('colors.green'),
       }),
       strokeWidth: {
         '0.5': '0.5',

--- a/packages/smarthr-ui/src/themes/__tests__/createColor.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createColor.ts
@@ -15,7 +15,6 @@ describe('createColor', () => {
       BASE_GREY: '#777',
       MAIN: '#888',
       DANGER: '#999',
-      WARNING: '#aaa',
       SCRIM: '#bbb',
       OVERLAY: '#ccc',
     })
@@ -31,7 +30,6 @@ describe('createColor', () => {
     expect(actual.BASE_GREY).toBe('#777')
     expect(actual.MAIN).toBe('#888')
     expect(actual.DANGER).toBe('#999')
-    expect(actual.WARNING).toBe('#aaa')
     expect(actual.SCRIM).toBe('#bbb')
     expect(actual.OVERLAY).toBe('#ccc')
   })

--- a/packages/smarthr-ui/src/themes/__tests__/createTheme.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createTheme.ts
@@ -1,9 +1,5 @@
 import { defaultBorder } from '../createBorder'
-import { defaultBreakpoint } from '../createBreakpoint'
-import { defaultColor } from '../createColor'
-import { defaultFontSize } from '../createFontSize'
 import { defaultLeading } from '../createLeading'
-import { defaultRadius } from '../createRadius'
 import { createTheme } from '../createTheme'
 
 describe('createTheme', () => {
@@ -25,7 +21,6 @@ describe('createTheme', () => {
         BASE_GREY: '#011',
         MAIN: '#012',
         DANGER: '#013',
-        WARNING: '#014',
         SCRIM: '#015',
         OVERLAY: '#016',
         OUTLINE: '#017',
@@ -46,7 +41,6 @@ describe('createTheme', () => {
     expect(actual.color.BASE_GREY).toBe('#011')
     expect(actual.color.MAIN).toBe('#012')
     expect(actual.color.DANGER).toBe('#013')
-    expect(actual.color.WARNING).toBe('#014')
     expect(actual.color.SCRIM).toBe('#015')
     expect(actual.color.OVERLAY).toBe('#016')
     expect(actual.color.OUTLINE).toBe('#017')

--- a/packages/smarthr-ui/src/themes/createColor.ts
+++ b/packages/smarthr-ui/src/themes/createColor.ts
@@ -33,8 +33,9 @@ const primitiveTokens = {
   WHITE: '#fff',
   BLUE_100: '#0077c7',
   BLUE_101: '#0071c1',
+  GREEN_100: '#0f7f85',
+  ORANGE_100: '#f56121',
   RED_100: '#e01e5a',
-  ORANGE_100: '#ff8800',
   YELLOW_100: '#ffcc17',
   SMARTHR_BLUE: '#00c4cc',
 }
@@ -56,7 +57,6 @@ const semanticTokens = {
   MAIN: primitiveTokens.BLUE_100,
   OUTLINE: primitiveTokens.BLUE_100,
   DANGER: primitiveTokens.RED_100,
-  WARNING: primitiveTokens.ORANGE_100,
   WARNING_YELLOW: primitiveTokens.YELLOW_100,
   OVERLAY: transparencyScale.TRANSPARENCY_15,
   SCRIM: transparencyScale.TRANSPARENCY_50,


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1225

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

orange と green を preset に定義しました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- primitive トークンの ORANGE_100 を [Sunlight_04](https://smarthr.design/basics/colors/#h4-4) に差し替え
- primitive トークンに GREEN_100 を追加
- ベタ書きたった orange と green を置き換え
- WARNING はどこでも使えないはずなので削除（すでにデザインシステムサイトからは消えている）
  - WARNING が消えるため BREAKING CHANGE です

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
