### PR TITLE
fix: ドロップダウンナビゲーションボタンで current が false の場合は aria-current を undefined にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
       "nanoid": "3.3.11",
       "esbuild@<=0.24.2": ">=0.25.5",
       "@babel/runtime@<7.26.10": ">=7.27.6",
-      "@babel/helpers@<7.26.10": ">=7.27.6"
+      "@babel/helpers@<7.26.10": ">=7.27.6",
+      "brace-expansion@<1.1.12": "^1.1.12",
+      "brace-expansion@<2.0.2": "^2.0.2"
     }
   }
 }

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/Navigation.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/Navigation.tsx
@@ -124,8 +124,8 @@ const DropdownCustomTag = memo<NavigationCustomTag>(
   },
 )
 const DropdownMenuAnchorButton = memo<NavigationLink>(({ current, ...rest }) => (
-  <AnchorButton {...rest} aria-current={current && 'page'} />
+  <AnchorButton {...rest} aria-current={current ? 'page' : undefined} />
 ))
 const DropdownNavigationButton = memo<NavigationButton>(({ current, ...rest }) => (
-  <Button {...rest} aria-current={current && 'page'} />
+  <Button {...rest} aria-current={current ? 'page' : undefined} />
 ))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,8 @@ overrides:
   esbuild@<=0.24.2: '>=0.25.5'
   '@babel/runtime@<7.26.10': '>=7.27.6'
   '@babel/helpers@<7.26.10': '>=7.27.6'
+  brace-expansion@<1.1.12: ^1.1.12
+  brace-expansion@<2.0.2: ^2.0.2
 
 importers:
 
@@ -2766,11 +2768,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3052,9 +3051,6 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -10251,12 +10247,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.11:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.1:
+  brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -10539,8 +10530,6 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
-
-  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -13303,15 +13292,15 @@ snapshots:
 
   minimatch@10.0.1:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimatch@3.1.2:
     dependencies:
-      brace-expansion: 1.1.11
+      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimist-options@4.1.0:
     dependencies:


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- https://kufuinc.slack.com/archives/C069HF218UW/p1749549861451029
- https://github.com/kufu/smarthr-ui/pull/5659
  - 上の PR で `aria-current=page` だったのが `aria-current` になったことが原因そう

## 概要 

- ドロップダウンナビゲーション（`AppNaviDropdownMenuButton` 配下）の子アイテムで  
  `current=false` の場合でも `aria-current="false"` が DOM に出力されるため、  
- 目的は、**本当にアクティブなページのみ**親ボタンに下線が付くようにすること。

## 変更内容 

| 対象コンポーネント | 変更前 | 変更後 |
|-------------------|--------|--------|
| `DropdownMenuAnchorButton` | `aria-current={current && 'page'}` | `aria-current={current ? 'page' : undefined}` |
| `DropdownNavigationButton` | `aria-current={current && 'page'}` | `aria-current={current ? 'page' : undefined}` |

### 挙動の違い
| 状態 | 修正前 | 修正後 |
|------|--------|--------|
| `current = false` | `<a aria-current="false">` が出力され、親に下線が付く | `aria-current` が出力されず、親に下線が付かない |
| `current = true`  | `<a aria-current="page">` が出力され、親に下線がつく | `<a aria-current="page">` が出力され、親に下線 |

- 親ボタンの CSS は https://github.com/kufu/smarthr-ui/blob/5798cf4c71e7779262fb152e0b30ae1e4cda2309/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx#L27-L45

## 確認方法

![image](https://github.com/user-attachments/assets/98b0cc57-0b62-47a2-b750-73045a554f20)

![image](https://github.com/user-attachments/assets/941e088b-0f77-4a8e-a688-04b50e373c84)

