### PR TITLE
fix(twMerge): leading-[0] も leading 扱いになるように修正

### DIFF
--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -35,14 +35,14 @@ defaultConfig.twMergeConfig = {
       'border-b-shorthand',
       'border-l-shorthand',
     ],
-    'font-size': [
+    fontSize: [
       {
         text: ['2xs', 'xs', 'sm', 'base', 'lg', 'xl', '2xl', 'inherit'],
       },
     ],
     lineHeight: [
       {
-        leading: ['none', 'tight', 'normal', 'loose'],
+        leading: ['none', 'tight', 'normal', 'loose', '[0]'],
       },
     ],
     zIndex: [


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1300

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

`<StatusLabel />` の `className` に `shr-text-base` を設定すると StatusLabel に設定された `leading-[0]` も消えてしまう不具合がありました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

tailwind-merge の設定を見直し、`leading-[0]` も leading 扱いになるように修正しました。

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

StatusLabel など `leading-[0]` を使ったコンポーネントの Story で `className="shr-text-hoge"` を指定しても `leading-[0]` が消えないことを確認。 

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
