### PR TITLE
feat: ThCheckbox と TdCheckbox で fixed を渡せるようにしたい

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
@@ -10,7 +10,7 @@ type Props = PropsWithChildren<{
   /** 値を特定するための行 id */
   'aria-labelledby': string
 }> &
-  Pick<ComponentProps<typeof Td>, 'vAlign'>
+  Pick<ComponentProps<typeof Td>, 'vAlign' | 'fixed'>
 
 const classNameGenerator = tv({
   slots: {
@@ -24,7 +24,7 @@ const classNameGenerator = tv({
 })
 
 export const TdCheckbox = forwardRef<HTMLInputElement, Omit<CheckboxProps, keyof Props> & Props>(
-  ({ vAlign, children, className, ...rest }, ref) => {
+  ({ vAlign, fixed, children, className, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, inner, checkbox } = classNameGenerator()
 
@@ -38,7 +38,7 @@ export const TdCheckbox = forwardRef<HTMLInputElement, Omit<CheckboxProps, keyof
     return (
       // Td に必要な属性やイベントは不要
       // contentWidth={0} で td をテーブルの計算上最小幅にする
-      <Td contentWidth={0} vAlign={vAlign} className={classNames.wrapper}>
+      <Td contentWidth={0} vAlign={vAlign} fixed={fixed} className={classNames.wrapper}>
         <label className={classNames.inner}>
           <Checkbox {...rest} ref={ref} className={classNames.checkbox} />
           {children && <VisuallyHiddenText>{children}</VisuallyHiddenText>}

--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -12,7 +12,7 @@ type Props = {
   decorators?: DecoratorsType<'checkAllInvisibleLabel'> & {
     checkColumnName?: (text: string) => string
   }
-} & Pick<ComponentProps<typeof Th>, 'vAlign'>
+} & Pick<ComponentProps<typeof Th>, 'vAlign' | 'fixed'>
 
 const DECORATOR_DEFAULT_TEXTS = {
   checkAllInvisibleLabel: 'すべての項目を選択/解除',
@@ -39,7 +39,7 @@ const classNameGenerator = tv({
 })
 
 export const ThCheckbox = forwardRef<HTMLInputElement, CheckboxProps & Props>(
-  ({ vAlign, decorators, className, ...others }, ref) => {
+  ({ vAlign, fixed, decorators, className, ...others }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, inner, balloon, checkbox } = classNameGenerator()
 
@@ -57,6 +57,7 @@ export const ThCheckbox = forwardRef<HTMLInputElement, CheckboxProps & Props>(
       // Th に必要な属性やイベントは不要
       <Th
         vAlign={vAlign}
+        fixed={fixed}
         className={classNames.wrapper}
         aria-label={decorated.checkColumnName as string}
       >


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

なし

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

プロダクトで、TableReel でラップしたテーブル内で一番左の列にあるチェックボックス(ThCheckbox, TdCheckbox)をスクロール時に固定したい要求があり、それに対応したいです。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

ThCheckbox, TdCheckbox それぞれに props で fixed を受け取れるようにして、受け取った fixed をそのまま Th, Td に渡した

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

👇 `TableReel.stories.tsx` の thead > tr と tbody > tr に ThCheckbox, TdCheckbox を追加した際のキャプチャです。

<img width="634" alt="image" src="https://github.com/user-attachments/assets/b7298ce9-7914-4519-8b89-32b68a6bbddb" />


<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
