### PR TITLE
fix: imageViewerの初期読み込み時、画像サイズの計算処理でゼロ除算によるエラーが発生していたため修正

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -14,7 +14,7 @@ export const ImageViewer: FC<ViewerProps> = memo(({ scale, rotation, file, width
 
   // CSSのみではscale, transformの値を親に適用してスクロールするようにできないため、計算している
   const updateViewConfig = useCallback(() => {
-    if (!imageRef.current) {
+    if (!imageRef.current || !imageRef.current.complete) {
       return
     }
 


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

FileViewerコンポーネントで画像を表示したところ、コンソール上で以下のエラーが発生することを確認した。
```
`NaN` is an invalid value for the `width` css style property.
```

実装を確認したところ、FileViewerの内部実装であるImageViewerにおいて、画像ファイルの読み込みが完了する前に下記のscale計算処理が走るタイミングが存在することがわかった。

```
// 与えられたwidthに対する適切なscaleを算出
const viewportScale = (width / img.naturalWidth) * scale
```

[Web APIsの公式リファレンス](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/naturalWidth#value)を見ると、naturalWidthプロパティは正常に読み込めなかった場合に0を返す仕様になっているため、`viewportScale`の計算にてゼロ除算が発生し、widthにNaNが渡されてしまいエラーが発生することがわかった。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

`img`が正常に読み込めていれば問題ないため、ガード節に`!imageRef.current.complete`の条件を追記した。

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->


