### PR TITLE
fix(smarthr-ui-preset): width 周りのマージ設定を修正

### DIFF
--- a/packages/smarthr-ui/package.json
+++ b/packages/smarthr-ui/package.json
@@ -85,6 +85,7 @@
     "storybook-addon-pseudo-states": "9.0.12",
     "style-loader": "^4.0.0",
     "styled-components": "^5.3.11",
+    "tailwind-merge": "^3.3.1",
     "ts-loader": "^9.5.2",
     "ttypescript": "^1.5.15",
     "typescript-plugin-styled-components": "^3.0.0",

--- a/packages/smarthr-ui/src/smarthr-ui-preset.test.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.test.ts
@@ -1,0 +1,160 @@
+import { tv } from 'tailwind-variants'
+
+// smarthr-ui-presetをimportして設定を適用
+import './smarthr-ui-preset'
+
+describe('twMergeConfig', () => {
+  describe('classGroups', () => {
+    describe('width', () => {
+      it('width関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-w-col1 shr-w-px',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-w-[20em]',
+        })
+
+        // 最後に指定されたクラスが優先されることを確認
+        expect(result).toContain('shr-w-[20em]')
+
+        // twMergeConfigが効いている場合、古いクラスは削除される
+        if (
+          result.includes('shr-w-col1') &&
+          result.includes('shr-w-px') &&
+          result.includes('shr-w-[20em]')
+        ) {
+          console.warn('❌ twMergeConfigが効いていない: width classGroup')
+          // テストを失敗させる
+          expect(result).not.toContain('shr-w-col1')
+        }
+      })
+    })
+
+    describe('flexBasis', () => {
+      it('flex-basis関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-basis-col6 shr-basis-px',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-basis-[300px]',
+        })
+
+        // 最後に指定されたクラスが優先されることを確認
+        expect(result).toContain('shr-basis-[300px]')
+
+        if (
+          result.includes('shr-basis-px') &&
+          result.includes('shr-basis-col6') &&
+          result.includes('shr-basis-[300px]')
+        ) {
+          console.warn('❌ twMergeConfigが効いていない: flexBasis classGroup')
+          expect(result).not.toContain('shr-basis-col6')
+        }
+      })
+    })
+
+    describe('boxShadow', () => {
+      it('shadow関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-shadow-none',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-shadow-layer-2',
+        })
+
+        // 最後に指定されたクラスが優先されることを確認
+        expect(result).toContain('shr-shadow-layer-2')
+
+        if (result.includes('shr-shadow-none') && result.includes('shr-shadow-layer-2')) {
+          console.warn('❌ twMergeConfigが効いていない: boxShadow classGroup')
+          expect(result).not.toContain('shr-shadow-none')
+        }
+      })
+    })
+
+    describe('borderShorthand', () => {
+      it('border-shorthand関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-border-t-shorthand shr-border-r-shorthand',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-border-b-shorthand',
+        })
+
+        expect(result).toContain('shr-border-b-shorthand')
+      })
+    })
+
+    describe('fontSize', () => {
+      it('text-size関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-text-sm',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-text-inherit',
+        })
+
+        // 最後に指定されたクラスが優先されることを確認
+        expect(result).toContain('shr-text-inherit')
+
+        if (result.includes('shr-text-sm') && result.includes('shr-text-inherit')) {
+          console.warn('❌ twMergeConfigが効いていない: fontSize classGroup')
+          expect(result).not.toContain('shr-text-sm')
+        }
+      })
+    })
+
+    describe('lineHeight', () => {
+      it('line-height関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-leading-none',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-leading-tight shr-leading-[0]',
+        })
+
+        expect(result).toContain('shr-leading-[0]')
+      })
+    })
+
+    describe('zIndex', () => {
+      it('z-index関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-z-0',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-z-overlap',
+        })
+
+        // 最後に指定されたクラスが優先されることを確認
+        expect(result).toContain('shr-z-overlap')
+
+        if (result.includes('shr-z-0') && result.includes('shr-z-overlap')) {
+          console.warn('❌ twMergeConfigが効いていない: zIndex classGroup')
+          expect(result).not.toContain('shr-z-0')
+        }
+      })
+    })
+
+    describe('focus', () => {
+      it('focus関連のクラスが正しくマージされること', () => {
+        const testClassNameGenerator = tv({
+          base: 'shr-focus-indicator',
+        })
+
+        const result = testClassNameGenerator({
+          className: 'shr-focus-indicator--inner',
+        })
+
+        expect(result).toContain('shr-focus-indicator--inner')
+      })
+    })
+  })
+})

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -1,4 +1,5 @@
 import { darken } from 'polished'
+import { validators } from 'tailwind-merge'
 import { defaultConfig } from 'tailwind-variants'
 import plugin from 'tailwindcss/plugin'
 
@@ -14,6 +15,7 @@ import type { Config } from 'tailwindcss'
 defaultConfig.twMergeConfig = {
   prefix: 'shr-',
   classGroups: {
+    w: [{ w: [...Object.keys(defaultWidth), validators.isArbitraryValue] }],
     boxShadow: [
       {
         shadow: [

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -16,6 +16,7 @@ defaultConfig.twMergeConfig = {
   prefix: 'shr-',
   classGroups: {
     w: [{ w: [...Object.keys(defaultWidth), validators.isArbitraryValue] }],
+    basis: [{ basis: [...Object.keys(defaultWidth), validators.isArbitraryValue] }],
     boxShadow: [
       {
         shadow: [
@@ -230,6 +231,9 @@ export default {
         'current-page': 'current="page"',
       },
       width: {
+        ...defaultWidth,
+      },
+      flexBasis: {
         ...defaultWidth,
       },
       minHeight: ({ theme }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       styled-components:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
       ts-loader:
         specifier: ^9.5.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.5)(esbuild@0.25.5))
@@ -6868,6 +6871,9 @@ packages:
 
   tailwind-merge@2.5.4:
     resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
+
+  tailwind-merge@3.3.1:
+    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
   tailwind-variants@0.3.1:
     resolution: {integrity: sha512-krn67M3FpPwElg4FsZrOQd0U26o7UDH/QOkK8RNaiCCrr052f6YJPBUfNKnPo/s/xRzNPtv1Mldlxsg8Tb46BQ==}
@@ -15122,6 +15128,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   tailwind-merge@2.5.4: {}
+
+  tailwind-merge@3.3.1: {}
 
   tailwind-variants@0.3.1(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.12.5)(@types/node@20.19.1)(typescript@5.8.3))):
     dependencies:


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

Container コンポーネントで `shr-w-full` と `shr-w-[hoge]` がマージされていない不具合がありました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- width のクラスが正しくマージされるように修正
- flex-basis にも幅トークンを追加
- テストを追加

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
