### PR TITLE
feat(FileViewer): iOS17.4未満でpdfを開くとエラーを吐くためPolyfill処理を加えた

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -7,12 +7,30 @@ import { ReactPDFStyle } from './generatedReactPDFStyle'
 
 import type { ViewerProps } from './types'
 
-// TODO: バンドラの関係でCDNから読み込んでいるが、smarthr-uiから配信するようにしたい
-// pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-//   'pdfjs-dist/build/pdf.worker.min.mjs',
-//   import.meta.url,
-// ).toString()
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`
+// iOS 17.3以下ではPromise.withResolversが未定義のため、polyfillを適用する
+// @ts-expect-error
+if (typeof Promise.withResolvers === 'undefined') {
+  if (window) {
+    // @ts-expect-error
+    window.Promise.withResolvers = function () {
+      let resolve, reject
+      const promise = new Promise((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      return { promise, resolve, reject }
+    }
+  }
+  // workerもpolyfillする
+  pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`
+} else {
+  // TODO: バンドラの関係でCDNから読み込んでいるが、smarthr-uiから配信するようにしたい
+  // pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  //   'pdfjs-dist/build/pdf.worker.min.mjs',
+  //   import.meta.url,
+  // ).toString()
+  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`
+}
 
 const options = {
   // TODO: バンドラの関係でCDNから読み込んでいるが、smarthr-uiから配信するようにしたい

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -7,10 +7,10 @@ import { ReactPDFStyle } from './generatedReactPDFStyle'
 
 import type { ViewerProps } from './types'
 
-// iOS 17.3以下ではPromise.withResolversが未定義のため、polyfillを適用する
-// @ts-expect-error
-if (typeof Promise.withResolvers === 'undefined') {
-  if (window) {
+if (typeof window !== 'undefined') {
+  // iOS 17.3以下ではPromise.withResolversが未定義のため、polyfillを適用する
+  // @ts-expect-error
+  if (typeof window.Promise.withResolvers === 'undefined') {
     // @ts-expect-error
     window.Promise.withResolvers = function () {
       let resolve, reject
@@ -20,16 +20,16 @@ if (typeof Promise.withResolvers === 'undefined') {
       })
       return { promise, resolve, reject }
     }
+    // web workerもpolyfillされたものを読み込む
+    pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`
+  } else {
+    // TODO: バンドラの関係でCDNから読み込んでいるが、smarthr-uiから配信するようにしたい
+    // pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+    //   'pdfjs-dist/build/pdf.worker.min.mjs',
+    //   import.meta.url,
+    // ).toString()
+    pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
   }
-  // workerもpolyfillする
-  pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`
-} else {
-  // TODO: バンドラの関係でCDNから読み込んでいるが、smarthr-uiから配信するようにしたい
-  // pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  //   'pdfjs-dist/build/pdf.worker.min.mjs',
-  //   import.meta.url,
-  // ).toString()
-  pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`
 }
 
 const options = {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

同様の対応を行っているissue: https://github.com/wojtekmaj/react-pdf/issues/1811#issuecomment-2157866061

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- iOS17.3以下でFileViewerコンポーネントからPDFを開くとエラーが発生するため、修正した。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- PDFViewer内部で利用している`pdf.js`が`Promise.withResolvers`を利用していることが原因であるため、Polyfillを加えた。
  - 現在CDNで読み込んでいるWeb Workerも同じく`Promise.withResolvers`を利用しているため、Promise.withResolversが未定義の場合はPolyfillされているworkerファイルを取りに行くようにした。

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

SimulatorからiOS17.3以下のシミュレータを起動し、SafariでstorybookのFileViewerを開く。
- **修正前**
  - ローディング画面のまま動かず、コンソールを見ると`Promise.withResolvers is not a function.`といったエラーが出力されている。
- **修正後**
  - pdfが表示され、コンソールにもエラーが出力されない。

### キャプチャ
| | 修正前 | 修正後 |
|----|----|----|
|iOS17.3以下の場合(17.2) | <img width="436" alt="normal_old" src="https://github.com/user-attachments/assets/e140cb22-8413-40fd-afed-23f6ea6c7d70" /> | <img width="436" alt="applied_old" src="https://github.com/user-attachments/assets/5c110b5d-3085-4238-9641-f9e40df07194" /> |
|iOS17.3以上の場合(18.5) | <img width="435" alt="normal_latest" src="https://github.com/user-attachments/assets/bd952cf5-0571-46fc-a67c-00bd2653d860" />| <img width="429" alt="applied_latest" src="https://github.com/user-attachments/assets/95e768d4-4028-4726-b596-a44a40ad25a6" /> |

