### PR TITLE
feat(FileViewer): 読み込みエラー時のハンドラーを追加した

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -33,10 +33,6 @@ import type { FileForViewer } from './types'
 const defaultScaleStep = new Decimal(0.2)
 const defaultScaleSteps = [0.2, 0.6, 1, 1.6, 2, 3]
 
-const defaultOnLoadError = () => {
-  alert('読み込みに失敗しました。ファイルが破損している可能性があります。')
-}
-
 type Props = {
   file: FileForViewer
   width?: number
@@ -57,7 +53,7 @@ export const FileViewer: FC<Props> = ({
   scaleSteps,
   width: fixedWidth,
   onPassword,
-  onLoadError = defaultOnLoadError,
+  onLoadError,
 }) => {
   const ref = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -33,6 +33,10 @@ import type { FileForViewer } from './types'
 const defaultScaleStep = new Decimal(0.2)
 const defaultScaleSteps = [0.2, 0.6, 1, 1.6, 2, 3]
 
+const defaultOnLoadError = () => {
+  alert('読み込みに失敗しました。ファイルが破損している可能性があります。')
+}
+
 type Props = {
   file: FileForViewer
   width?: number
@@ -44,6 +48,7 @@ type Props = {
 
   scaleStep?: number
   onPassword?: ComponentProps<typeof PDFViewer>['onPassword']
+  onLoadError?: () => void
 }
 
 export const FileViewer: FC<Props> = ({
@@ -52,6 +57,7 @@ export const FileViewer: FC<Props> = ({
   scaleSteps,
   width: fixedWidth,
   onPassword,
+  onLoadError = defaultOnLoadError,
 }) => {
   const ref = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)
@@ -126,6 +132,7 @@ export const FileViewer: FC<Props> = ({
               width={width}
               onLoad={handleLoaded}
               onPassword={onPassword}
+              onLoadError={onLoadError}
             />
           ) : file.contentType.startsWith('image/') ? (
             <ImageViewer
@@ -134,6 +141,7 @@ export const FileViewer: FC<Props> = ({
               file={file}
               width={width}
               onLoad={handleLoaded}
+              onLoadError={onLoadError}
             />
           ) : (
             <Text>

--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -4,69 +4,72 @@ import { type FC, memo, useCallback, useEffect, useRef, useState } from 'react'
 
 import type { ViewerProps } from './types'
 
-export const ImageViewer: FC<ViewerProps> = memo(({ scale, rotation, file, width, onLoad }) => {
-  const imageRef = useRef<HTMLImageElement>(null)
-  const [viewConfig, setViewConfig] = useState({
-    wrapperWidth: 0,
-    wrapperHeight: 0,
-    imgScale: 1,
-  })
-
-  // CSSのみではscale, transformの値を親に適用してスクロールするようにできないため、計算している
-  const updateViewConfig = useCallback(() => {
-    if (!imageRef.current?.complete) {
-      return
-    }
-
-    const img = imageRef.current
-    // 与えられたwidthに対する適切なscaleを算出
-    const viewportScale = (width / img.naturalWidth) * scale
-
-    const rad = (rotation * Math.PI) / 180
-    const sin = Math.abs(Math.sin(rad))
-    const cos = Math.abs(Math.cos(rad))
-
-    // imgをwidth: 100%で表示したときと同等の値を算出
-    const scaledWidth = img.naturalWidth * viewportScale
-    const scaledHeight = img.naturalHeight * viewportScale
-
-    setViewConfig({
-      wrapperWidth: scaledWidth * cos + scaledHeight * sin,
-      wrapperHeight: scaledWidth * sin + scaledHeight * cos,
-      imgScale: viewportScale,
+export const ImageViewer: FC<ViewerProps> = memo(
+  ({ scale, rotation, file, width, onLoad, onLoadError }) => {
+    const imageRef = useRef<HTMLImageElement>(null)
+    const [viewConfig, setViewConfig] = useState({
+      wrapperWidth: 0,
+      wrapperHeight: 0,
+      imgScale: 1,
     })
-  }, [scale, rotation, width])
 
-  const handleLoad = useCallback(() => {
-    updateViewConfig()
-    onLoad?.()
-  }, [updateViewConfig, onLoad])
+    // CSSのみではscale, transformの値を親に適用してスクロールするようにできないため、計算している
+    const updateViewConfig = useCallback(() => {
+      if (!imageRef.current?.complete) {
+        return
+      }
 
-  useEffect(() => {
-    updateViewConfig()
-  }, [updateViewConfig])
+      const img = imageRef.current
+      // 与えられたwidthに対する適切なscaleを算出
+      const viewportScale = (width / img.naturalWidth) * scale
 
-  return (
-    <div
-      style={{
-        width: viewConfig.wrapperWidth,
-        height: viewConfig.wrapperHeight,
-      }}
-      className="shr-relative shr-h-full shr-w-full"
-    >
-      {/* imgのload完了時にupdateViewConfigを呼び出さないと適切なサイズが取得できないため */}
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <img
-        className="shr-absolute shr-left-[50%] shr-top-[50%] shr-origin-top-left -shr-translate-x-1/2 -shr-translate-y-1/2"
-        ref={imageRef}
-        src={file.url}
-        alt={file.alt}
+      const rad = (rotation * Math.PI) / 180
+      const sin = Math.abs(Math.sin(rad))
+      const cos = Math.abs(Math.cos(rad))
+
+      // imgをwidth: 100%で表示したときと同等の値を算出
+      const scaledWidth = img.naturalWidth * viewportScale
+      const scaledHeight = img.naturalHeight * viewportScale
+
+      setViewConfig({
+        wrapperWidth: scaledWidth * cos + scaledHeight * sin,
+        wrapperHeight: scaledWidth * sin + scaledHeight * cos,
+        imgScale: viewportScale,
+      })
+    }, [scale, rotation, width])
+
+    const handleLoad = useCallback(() => {
+      updateViewConfig()
+      onLoad?.()
+    }, [updateViewConfig, onLoad])
+
+    useEffect(() => {
+      updateViewConfig()
+    }, [updateViewConfig])
+
+    return (
+      <div
         style={{
-          rotate: `${rotation}deg`,
-          scale: `${viewConfig.imgScale}`,
+          width: viewConfig.wrapperWidth,
+          height: viewConfig.wrapperHeight,
         }}
-        onLoad={handleLoad}
-      />
-    </div>
-  )
-})
+        className="shr-relative shr-h-full shr-w-full"
+      >
+        {/* imgのload完了時にupdateViewConfigを呼び出さないと適切なサイズが取得できないため */}
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+        <img
+          className="shr-absolute shr-left-[50%] shr-top-[50%] shr-origin-top-left -shr-translate-x-1/2 -shr-translate-y-1/2"
+          ref={imageRef}
+          src={file.url}
+          alt={file.alt}
+          style={{
+            rotate: `${rotation}deg`,
+            scale: `${viewConfig.imgScale}`,
+          }}
+          onLoad={handleLoad}
+          onError={onLoadError}
+        />
+      </div>
+    )
+  },
+)

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -41,7 +41,7 @@ const options = {
 } satisfies ComponentProps<typeof Document>['options']
 
 export const PDFViewer: FC<ViewerProps> = memo(
-  ({ scale, rotation, file, width, onLoad, onPassword }) => {
+  ({ scale, rotation, file, width, onLoad, onPassword, onLoadError }) => {
     const [pdfNumPages, setPdfNumPages] = useState(1)
 
     const onDocumentLoadSuccess = useCallback<
@@ -72,6 +72,7 @@ export const PDFViewer: FC<ViewerProps> = memo(
           options={options}
           file={file.url}
           onLoadSuccess={onDocumentLoadSuccess}
+          onLoadError={onLoadError}
           rotate={rotation}
           className="shr-flex shr-h-full shr-w-fit shr-flex-col shr-items-center shr-gap-1 shr-overflow-auto"
           externalLinkTarget="_blank"

--- a/packages/smarthr-ui/src/components/FileViewer/types.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/types.ts
@@ -17,4 +17,5 @@ export type ViewerProps = {
    * PDFファイルのパスワード入力を要求されたときに呼ばれるコールバック関数。PdfViewerでのみ使用されます。
    */
   onPassword?: ComponentProps<typeof Document>['onPassword']
+  onLoadError?: () => void
 }


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- https://kufuinc.slack.com/archives/CGC58MW01/p1752573350694899

## 概要

- FileViewerに破損したファイルが渡された際のエラー処理が設定されていないため、ユーザー側からエラーであることが確認しづらくなっている。
- エラー時のハンドラーをPropsとして渡せるようにすることで、読み込みエラー時の挙動をユーザー側でカスタマイズできるようにした。

## 変更内容

- `onLoadError`を新しくFileViewerのPropsとして生やした。
  - PDFViewerでは、内部的に使われている[react-pdfのonLoadError](https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#document)にそのまま渡すようにした。
  - ImageViewerでは、HTMLImageElementのonErrorハンドラーに渡すようにした。

## 確認方法
下記のような実装をして適当なファイルを渡し、動作していることを確認する。
```tsx
<FileViewer
  file={...}
  onError={ () => { alert('読み込みに失敗しました。ファイルが破損している可能性があります。') } }
```

## その他
インデントによる変更が多く出ているため、URLに `?w=1` をつけた方が差分見やすそうです！