### PR TITLE
fix(Fieldset): アクセシブルネームの計算にtitle属性を含めるのをやめる

### DIFF
--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
@@ -23,12 +23,20 @@ describe('Fieldset', () => {
   it('子要素が可視ラベルを持たないフォームコントロール要素の場合、アクセシブルネームにlegend文言を追加する', async () => {
     render(
       <form>
+        {/* アクセシブルネームを付けるのにtitleは最適ではないためルール修正まで一時的にdisableにしている */}
+        {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
         <Fieldset title="fieldset-title">
-          <Input name="test" title="input-title" />
+          <Input name="test1" aria-label="input-accessible-name-1" />
+          <Input name="test2" aria-label="input-accessible-name-2" />
         </Fieldset>
       </form>,
     )
 
-    expect(screen.getByRole('textbox', { name: 'fieldset-title input-title' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'input-accessible-name-1 fieldset-title' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'input-accessible-name-2 fieldset-title' }),
+    ).toBeInTheDocument()
   })
 })

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -317,15 +317,12 @@ export const ActualFormControl: FC<Props & ElementProps> = ({
         return
       }
 
-      let accessibleName = ''
-      if (input.hasAttribute('aria-label')) {
-        accessibleName = input.getAttribute('aria-label') || ''
-      } else if (input.hasAttribute('title')) {
-        accessibleName = input.getAttribute('title') || ''
-      }
+      const accessibleName = input.hasAttribute('aria-label')
+        ? input.getAttribute('aria-label')
+        : null
 
-      if (!accessibleName.includes(legendText)) {
-        input.setAttribute('aria-label', `${legendText} ${accessibleName}`.trim())
+      if (accessibleName && !accessibleName.includes(legendText)) {
+        input.setAttribute('aria-label', `${accessibleName} ${legendText} `.trim())
       }
     })
   }, [isFieldset, title])


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL


<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- Fieldset + 可視ラベルを持たない複数のInput のときに、Inputのアクセシブルネームにlegendの文字追加を文末に変更にしました
- 以前はアクセシブルネームの計算に title属性を含めていましたが、title属性には「〇〇してください」といった補足テキストが入ることがあり、文末に legend を追加するとアクセシブルネームが不自然になるため文頭にしていました。
- しかし、title属性は補足テキストをツールチップで表示するのがメインの目的で、アクセシブルネームを設定するための手段としては `aria-label` などより良い手段があるため、title属性は考慮しないことにしました

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
