### PR TITLE
fix: a11y担保のためDropZone内のinput要素をdisplay:noneではなくvisually hiddenで非表示にする

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -20,6 +20,7 @@ import { useDecorators } from '../../hooks/useDecorators'
 import { useIntl } from '../../intl'
 import { Button } from '../Button'
 import { FaFolderOpenIcon } from '../Icon'
+import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import type { DecoratorsType } from '../../hooks/useDecorators'
 
@@ -29,7 +30,6 @@ const classNameGenerator = tv({
       'smarthr-ui-DropZone',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
     ],
-    input: 'shr-hidden',
     button: '',
   },
   variants: {
@@ -89,10 +89,9 @@ export const DropZone = forwardRef<HTMLInputElement, DropZoneProps & ElementProp
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
     const classNames = useMemo(() => {
-      const { wrapper, input, button } = classNameGenerator({ filesDraggedOver, disabled, error })
+      const { wrapper, button } = classNameGenerator({ filesDraggedOver, disabled, error })
       return {
         wrapper: wrapper(),
-        input: input(),
         button: button(),
       }
     }, [disabled, error, filesDraggedOver])
@@ -152,18 +151,19 @@ export const DropZone = forwardRef<HTMLInputElement, DropZoneProps & ElementProp
           className={classNames.button}
           decorators={decorators}
         />
-        {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
-        <input
-          {...props}
-          data-smarthr-ui-input="true"
-          ref={fileRef}
-          type="file"
-          multiple={multiple}
-          disabled={disabled}
-          aria-invalid={error || undefined}
-          onChange={onChange}
-          className={classNames.input}
-        />
+        <VisuallyHiddenText>
+          {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
+          <input
+            {...props}
+            data-smarthr-ui-input="true"
+            ref={fileRef}
+            type="file"
+            multiple={multiple}
+            disabled={disabled}
+            aria-invalid={error || undefined}
+            onChange={onChange}
+          />
+        </VisuallyHiddenText>
       </div>
     )
   },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- display: noneではなく、visually hidden パターンでinputを不可視にすることでa11y的な対応を行いやすい状態にしたい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- shr-hidden classではなく、VisuallyHiddenTextでinputをラップすることで不可視にするように変更

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- diffをみてfmfmする
