### PR TITLE
fix(Fieldset): dangerouslyTitleHiddenのFormControlで囲われていた場合の考慮漏れに対応

### DIFF
--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
@@ -20,7 +20,7 @@ describe('Fieldset', () => {
     expect(screen.getByRole('textbox', { name: 'form-control-title' })).toBeInTheDocument()
   })
 
-  it('子要素が可視ラベルを持たないフォームコントロール要素の場合、アクセシブルネームにlegend文言を追加する', async () => {
+  it('子要素が可視ラベルを持たないaria-labelを持つフォームコントロール要素の場合、アクセシブルネームにlegend文言を追加する', async () => {
     render(
       <form>
         {/* アクセシブルネームを付けるのにtitleは最適ではないためルール修正まで一時的にdisableにしている */}
@@ -37,6 +37,28 @@ describe('Fieldset', () => {
     ).toBeInTheDocument()
     expect(
       screen.getByRole('textbox', { name: 'input-accessible-name-2 fieldset-title' }),
+    ).toBeInTheDocument()
+  })
+
+  it('子要素がdangerouslyTitleHidden:trueを持つフォームコントロール要素の場合、アクセシブルネームにlegend文言を追加する', async () => {
+    render(
+      <form>
+        <Fieldset title="fieldset-title">
+          <FormControl title="form-control-title1" dangerouslyTitleHidden>
+            <Input name="test1" />
+          </FormControl>
+          <FormControl title="form-control-title2" dangerouslyTitleHidden>
+            <Input name="test2" />
+          </FormControl>
+        </Fieldset>
+      </form>,
+    )
+
+    expect(
+      screen.getByRole('textbox', { name: 'form-control-title1 fieldset-title' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('textbox', { name: 'form-control-title2 fieldset-title' }),
     ).toBeInTheDocument()
   })
 })

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -307,22 +307,34 @@ export const ActualFormControl: FC<Props & ElementProps> = ({
     const legendText = innerText(title)
     if (!legendText) return
 
-    const labels = new Set(
-      Array.from(document.querySelectorAll('label[for]')).map((label) => label.getAttribute('for')),
+    const labelMap = new Map(
+      Array.from(document.querySelectorAll('label[for]')).map((label) => [
+        label.getAttribute('for'),
+        label,
+      ]),
     )
 
     inputs.forEach((input) => {
       const inputId = input.getAttribute('id')
-      if (inputId && labels.has(inputId)) {
-        return
+      if (inputId && labelMap.has(inputId)) {
+        const label = labelMap.get(inputId)!
+        const isVisuallyHidden = label.closest('.smarthr-ui-VisuallyHiddenText') !== null
+
+        if (!isVisuallyHidden) {
+          return
+        }
       }
 
-      const accessibleName = input.hasAttribute('aria-label')
-        ? input.getAttribute('aria-label')
-        : null
+      let accessibleName = ''
+      if (input.hasAttribute('aria-label')) {
+        accessibleName = input.getAttribute('aria-label') || ''
+      } else if (inputId && labelMap.has(inputId)) {
+        const label = labelMap.get(inputId)!
+        accessibleName = label.textContent || ''
+      }
 
       if (accessibleName && !accessibleName.includes(legendText)) {
-        input.setAttribute('aria-label', `${accessibleName} ${legendText} `.trim())
+        input.setAttribute('aria-label', `${accessibleName} ${legendText}`.trim())
       }
     })
   }, [isFieldset, title])

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
@@ -20,7 +20,7 @@ const ActualVisuallyHiddenText = <T extends ElementType = 'span'>({
     [className],
   )
 
-  return <Component {...props} className={actualClassName} />
+  return <Component {...props} className={`smarthr-ui-VisuallyHiddenText ${actualClassName}`} />
 }
 
 export const VisuallyHiddenText = memo(ActualVisuallyHiddenText) as typeof ActualVisuallyHiddenText


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- https://github.com/kufu/smarthr-ui/pull/5812
- https://github.com/kufu/smarthr-ui/pull/5783

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- `<label>` はあるけど hidden な場合の考慮漏れをしていたのでロジックとテストを追加しました 🙏 

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
