### PR TITLE
chore(TdCheckbox, TdRadioButton): contentWidth={0}ではなくmin-content を指定する

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
@@ -18,7 +18,7 @@ const classNameGenerator = tv({
       'shr-flex shr-justify-center shr-px-1 shr-py-0.75',
       '[&:not(:has([disabled]))]:shr-cursor-pointer',
     ],
-    wrapper: 'shr-p-0',
+    wrapper: 'shr-w-min shr-p-0',
     checkbox: ['shr-leading-[0]', '[&>span]:shr-translate-y-[unset]'],
   },
 })

--- a/packages/smarthr-ui/src/components/Table/TdRadioButton.tsx
+++ b/packages/smarthr-ui/src/components/Table/TdRadioButton.tsx
@@ -19,7 +19,7 @@ const classNameGenerator = tv({
       'shr-flex shr-justify-center shr-px-1 shr-py-0.75',
       '[&:not(:has([disabled]))]:shr-cursor-pointer',
     ],
-    wrapper: 'shr-p-0',
+    wrapper: 'shr-w-min shr-p-0',
     radio: ['shr-leading-[0]', '[&>span]:shr-translate-y-[unset]'],
   },
 })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
https://smarthr.atlassian.net/browse/SHRUI-1328
<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

table が無限スクロールでレンダリングしている場合に、 `<tr>` にabsoluteが付いている場合があり、tableのいい感じのスタイリングがきかなくなる場合がありました。  `contentWidth={0}` が付いていて上書きができなかったため、  checkbox+padding分になる `min-content` に置き換えました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
