### PR TITLE
fix: RangeSeparatorを非推奨化する

### DIFF
--- a/packages/smarthr-ui/src/components/RangeSeparator/RangeSeparator.tsx
+++ b/packages/smarthr-ui/src/components/RangeSeparator/RangeSeparator.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react'
 
 import { type DecoratorsType, useDecorators } from '../../hooks/useDecorators'
-import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 type Props = {
   decorators?: DecoratorsType<DecoratorKeyTypes>
@@ -9,19 +8,13 @@ type Props = {
 
 const DECORATOR_DEFAULT_TEXTS = {
   text: '〜',
-  visuallyHiddenText: 'から',
 } as const
 type DecoratorKeyTypes = keyof typeof DECORATOR_DEFAULT_TEXTS
 
+/**
+ * @deprecated このコンポーネントはスクリーンリーダー「NVDA」のバグを迂回するために導入されましたが、当該のバグは解消されているため、今後削除される予定です。代わりにプレーンな文字列 `〜` を使ってください。（[参考: nvdajp/nvdajp#440](https://github.com/nvdajp/nvdajp/issues/440)）
+ */
 export const RangeSeparator = memo<Props>(({ decorators }) => {
   const decorated = useDecorators<DecoratorKeyTypes>(DECORATOR_DEFAULT_TEXTS, decorators)
-
-  return (
-    <>
-      <span aria-hidden="true">{decorated.text}</span>
-      <VisuallyHiddenText className="shr-select-none">
-        {decorated.visuallyHiddenText}
-      </VisuallyHiddenText>
-    </>
-  )
+  return decorated.text
 })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

* https://smarthr.atlassian.net/browse/SHRUI-1331
* https://github.com/nvdajp/nvdajp/issues/440

## 概要

`RangeSeparator`を非推奨化しました。また、`VisuallyHiddenText`の特殊なハンドリングを削除しました。

## 変更内容

TSDocの`@deprecated`を利用して、ユーザーに非推奨である旨と、代替手段を提案するように変更しました。

また、`VisuallyHiddenText`で`〜`が`から`と読まれるような特殊な処理を加えていた部分を削除しました。

## 確認方法

Storybookを確認するほか、下記のスクリーンショットのように、RangeSeparatorのアクセシビリティツリー上の解釈が普通のテキストとなっていれば問題ありません。

* https://63d0ccabb5d2dd29825524ab-dwdskwezmj.chromatic.com/?path=/docs/components-rangeseparator--docs

<img width="989" height="578" alt="image" src="https://github.com/user-attachments/assets/4a2e8c85-e76a-4125-b8d7-7243b42d77c7" />

