### PR TITLE
fix: DefinitionListでFragmentの子要素を適切に処理するよう修正

### DIFF
--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.tsx
@@ -5,6 +5,7 @@ import {
   Fragment,
   type PropsWithChildren,
   type ReactElement,
+  type ReactNode,
   cloneElement,
   isValidElement,
   useMemo,
@@ -36,6 +37,38 @@ const classNameGenerator = tv({
   base: 'smarthr-ui-DefinitionList shr-my-[initial]',
 })
 
+// children のうち DefinitionListItem にだけ maxColumns / termStyleType を注入して返す
+function childrenToItems(
+  children: ReactNode,
+  extra: Pick<ItemType, 'maxColumns' | 'termStyleType'>,
+): ReactNode[] {
+  const out: ReactNode[] = []
+
+  const walk = (nodes: ReactNode) => {
+    Children.forEach(nodes, (child) => {
+      if (!isValidElement(child)) {
+        out.push(child)
+        return
+      }
+
+      if (child.type === Fragment) {
+        walk(child.props.children) // Fragment は再帰的に展開
+        return
+      }
+
+      // DefinitionListItem にだけ追加 props を注入
+      if (child.type === DefinitionListItem) {
+        out.push(cloneElement(child, extra))
+      } else {
+        out.push(child) // 他の要素はそのまま
+      }
+    })
+  }
+
+  walk(children)
+  return out
+}
+
 export const DefinitionList: FC<Props & ElementProps> = ({
   items,
   maxColumns,
@@ -56,21 +89,7 @@ export const DefinitionList: FC<Props & ElementProps> = ({
             termStyleType={termStyleType}
           />
         ))}
-      {Children.toArray(children)
-        .flatMap((child) => {
-          if (isValidElement(child) && child.type === Fragment) {
-            return Children.toArray(child.props.children)
-          }
-          return child
-        })
-        .map((child) =>
-          isValidElement(child)
-            ? cloneElement(child as ReactElement, {
-                maxColumns,
-                termStyleType,
-              })
-            : child,
-        )}
+      {childrenToItems(children, { maxColumns, termStyleType })}
     </Cluster>
   )
 }

--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionList.tsx
@@ -2,6 +2,7 @@ import {
   Children,
   type ComponentProps,
   type FC,
+  Fragment,
   type PropsWithChildren,
   type ReactElement,
   cloneElement,
@@ -55,15 +56,21 @@ export const DefinitionList: FC<Props & ElementProps> = ({
             termStyleType={termStyleType}
           />
         ))}
-      {Children.map(
-        children,
-        (child) =>
-          isValidElement(child) &&
-          cloneElement(child as ReactElement, {
-            maxColumns,
-            termStyleType,
-          }),
-      )}
+      {Children.toArray(children)
+        .flatMap((child) => {
+          if (isValidElement(child) && child.type === Fragment) {
+            return Children.toArray(child.props.children)
+          }
+          return child
+        })
+        .map((child) =>
+          isValidElement(child)
+            ? cloneElement(child as ReactElement, {
+                maxColumns,
+                termStyleType,
+              })
+            : child,
+        )}
     </Cluster>
   )
 }


### PR DESCRIPTION
## 関連URL

None

## 概要

Deprecatedなitems propsから置き換えようとしたらうまく動作しないケースが有ることに気が付きました。
以下のように条件分岐で`DefinitionListItem`を複数セットしたいケースがありますがこの場合にうまく動作しません。
```
			<DefinitionListItem term="入社日">
				{enteredDate}
			</DefinitionListItem>
			<DefinitionListItem term="退職日">
				{resignedDate}
			</DefinitionListItem>
			{isActive && (
				<>
					<DefinitionListItem term="加入者口座コード（21桁）">
						{hoge}
					</DefinitionListItem>
					<DefinitionListItem term="部店コード">
						{fuga}
					</DefinitionListItem>
				</>
			)}
```

## 変更内容

Fragmentか確認してchildrenを取り出して今までの処理を通すようにしました

## 備考
以下ならこのままでも動きます
```
			<DefinitionListItem term="入社日">
				{enteredDate}
			</DefinitionListItem>
			<DefinitionListItem term="退職日">
				{resignedDate}
			</DefinitionListItem>
			{isActive && (
				<DefinitionListItem term="口座コード">
					{hoge}
				</DefinitionListItem>
			)}
			{isActive && (
				<DefinitionListItem term="部店コード">
					{fuga}
				</DefinitionListItem>
			)}
```
