### PR TITLE
fix: SpreadsheetTableのthのコントラスト比を改善

### DIFF
--- a/packages/smarthr-ui/src/components/SpreadsheetTable/SpreadsheetTable.tsx
+++ b/packages/smarthr-ui/src/components/SpreadsheetTable/SpreadsheetTable.tsx
@@ -19,7 +19,7 @@ const classNameGenerator = tv({
   base: [
     'smarthr-ui-SpreadsheetTable shr-border-shorthand shr-border-collapse shr-bg-head',
     // th
-    '[&_th]:shr-p-0.25 [&_th]:shr-text-sm [&_th]:shr-font-normal [&_th]:shr-text-grey',
+    '[&_th]:shr-p-0.25 [&_th]:shr-text-sm [&_th]:shr-font-normal [&_th]:shr-text-black',
     // th + th
     '[&_th_+_th]:shr-border-l-shorthand [&_th_+_th]:shr-border-[theme(backgroundColor[head-darken])]',
     // 左上の角： tr:first-child th:first-child


### PR DESCRIPTION
## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1338

## 概要

SpreadsheetTableコンポーネントにおける表の見出し要素で、前景色と背景色（`TEXT_GREY` と `HEAD`）のコントラスト比が4.34:1と十分でない問題を修正したい。

## 変更内容

前景色を `TEXT_BLACK` に修正した

## 確認方法

https://www.chromatic.com/test?appId=63d0ccabb5d2dd29825524ab&id=68ca243f084f19ad25fe5e57
