### PR TITLE
ci: npm パッケージプロべナンスの導入

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish_release:
     if: github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'release candidate') && github.event.label.name == 'approve release'
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     env:
       CHANGELOG_PATH: /tmp/CHANGELOG.md
@@ -39,10 +41,12 @@ jobs:
         if: ${{ env.IS_PRERELEASE == 'false' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
       - run: pnpm publish --filter smarthr-ui --tag prerelease --no-git-checks
         if: ${{ env.IS_PRERELEASE == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
       - run: echo NEW_TAG=$(git describe) >> $GITHUB_ENV
       - run: git push origin $NEW_TAG
       - run: npx ts-node ./packages/smarthr-ui/scripts/getLatestChangelog.ts > ${{ env.CHANGELOG_PATH }}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- [Generating provenance statements \| npm Docs](https://docs.npmjs.com/generating-provenance-statements)
- [npmパッケージプロベナンスを導入 - GitHubブログ](https://github.blog/jp/2023-04-26-introducing-npm-package-provenance/)

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

昨今 npm パッケージへの攻撃が頻発しており、サプライチェーンの信頼性を高めるためにもパッケージがどのような経路でビルドされたものかを明確にすることが求められています。

このプルリクエストではNPMパッケージプロべナンスを有効化しています。この変更を取り込むことで、リリースされたパッケージがどのGitHub Actions でビルドされたものかをトレースできるようになります。

技術的な内容については、関連URLを参照してください。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- CIの設定変更

## 確認方法

変更内容の目視チェック

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
