### PR TITLE
fix: CIのTypo Checkerで落ちているタイポを修正する

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.test.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/dropdownHelper.test.ts
@@ -1,7 +1,7 @@
 import { getContentBoxStyle } from './dropdownHelper'
 
 describe('dropdownHelper', () => {
-  describe('getConetentBoxStyle', () => {
+  describe('getContentBoxStyle', () => {
     it('returns bottom style when the bottom side of the trigger has enough space to display content', () => {
       const triggerRect = { top: 100, bottom: 140, left: 0, right: 120 }
       const contentSize = { width: 300, height: 400 }

--- a/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
@@ -13,13 +13,13 @@ export default {
   argTypes: {
     file: {
       control: 'select',
-      options: ['Japanese PDF', 'English PDF (long, multuple pages)', 'JPEG', 'PNG'],
+      options: ['Japanese PDF', 'English PDF (long, multiple pages)', 'JPEG', 'PNG'],
       mapping: {
         'Japanese PDF': {
           url: '/fixtures/sample-japanese-pdf.pdf',
           contentType: 'application/pdf',
         },
-        'English PDF (long, multuple pages)': {
+        'English PDF (long, multiple pages)': {
           url: '/fixtures/sample-english-pdf.pdf',
           contentType: 'application/pdf',
         },

--- a/packages/smarthr-ui/src/components/FileViewer/stories/VRTFileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/VRTFileViewer.stories.tsx
@@ -48,13 +48,13 @@ export default {
   argTypes: {
     file: {
       control: 'select',
-      options: ['Japanese PDF', 'English PDF (long, multuple pages)', 'JPEG', 'PNG'],
+      options: ['Japanese PDF', 'English PDF (long, multiple pages)', 'JPEG', 'PNG'],
       mapping: {
         'Japanese PDF': {
           url: '/fixtures/sample-japanese-pdf.pdf',
           contentType: 'application/pdf',
         },
-        'English PDF (long, multuple pages)': {
+        'English PDF (long, multiple pages)': {
           url: '/fixtures/sample-english-pdf.pdf',
           contentType: 'application/pdf',
         },


### PR DESCRIPTION
下記PRでエラー出ている箇所を修正しました。
https://github.com/kufu/smarthr-ui/actions/runs/18188552708/job/51778243675?pr=5859