### PR TITLE
feat: TextLink の size プロパティに XS を追加する

### DIFF
--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -49,6 +49,9 @@ const classNameGenerator = tv({
   },
   variants: {
     size: {
+      XS: {
+        anchor: 'shr-text-xs',
+      },
       S: {
         anchor: 'shr-text-sm',
       },

--- a/packages/smarthr-ui/src/components/TextLink/stories/TextLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/stories/TextLink.stories.tsx
@@ -98,7 +98,7 @@ export const Size: StoryObj<typeof TextLink> = {
   name: 'size',
   render: (args) => (
     <>
-      {([undefined, 'M', 'S'] as const).map((size) => (
+      {([undefined, 'M', 'S', 'XS'] as const).map((size) => (
         <p>
           <TextLink {...args} size={size}>
             {size || 'size未指定'}


### PR DESCRIPTION
TextLink の size プロパティに XS を追加しました。

## 概要

FigmaのSmartHR UIコンポーネントでは XS があるので、実装側にも追加しました。

<img width="624" height="325" alt="スクリーンショット 2025-10-02 22 46 16" src="https://github.com/user-attachments/assets/4c477025-21a3-42de-a6e5-edf8fec080ce" />

## 確認方法

AsIs: https://story.smarthr-ui.dev/?path=/story/components-textlink--size

ToBe: https://63d0ccabb5d2dd29825524ab-smutouonqn.chromatic.com/?path=/story/components-textlink--size