### PR TITLE
fix(SortDropdown): 適用ボタンが正しく動作するように修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/SortDropdown/SortDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/SortDropdown/SortDropdown.tsx
@@ -3,6 +3,7 @@
 import {
   type ComponentPropsWithRef,
   type FC,
+  type FormEvent,
   type MouseEventHandler,
   type OptionHTMLAttributes,
   type PropsWithChildren,
@@ -48,6 +49,10 @@ type Props = {
 }
 type ElementProps = Omit<ComponentPropsWithRef<'button'>, keyof Props>
 
+const ON_SUBMIT = (e: FormEvent) => {
+  e.preventDefault()
+}
+
 export const SortDropdown: FC<Props & ElementProps> = ({
   sortFields,
   defaultOrder,
@@ -78,7 +83,7 @@ export const SortDropdown: FC<Props & ElementProps> = ({
         </Button>
       </DropdownTrigger>
       <DropdownContent controllable>
-        <form onSubmit={handleApply}>
+        <form onSubmit={ON_SUBMIT}>
           <Stack className={classNames.body}>
             <FormControl title={labels.sortFieldLabel}>
               <Select
@@ -110,6 +115,7 @@ export const SortDropdown: FC<Props & ElementProps> = ({
             </Fieldset>
           </Stack>
           <Footer
+            onApply={handleApply}
             onCancel={onCancel}
             cancelButtonLabel={labels.cancelButtonLabel}
             applyButtonLabel={labels.applyButtonLabel}
@@ -123,14 +129,15 @@ export const SortDropdown: FC<Props & ElementProps> = ({
 
 const Footer = memo<
   Pick<Props, 'onCancel'> & {
+    onApply: MouseEventHandler<HTMLButtonElement>
     className: string
     cancelButtonLabel: ReactNode
     applyButtonLabel: ReactNode
   }
->(({ className, onCancel, cancelButtonLabel, applyButtonLabel }) => (
+>(({ className, onApply, onCancel, cancelButtonLabel, applyButtonLabel }) => (
   <Cluster gap={1} align="center" justify="flex-end" as="footer" className={className}>
     <CancelButton onClick={onCancel}>{cancelButtonLabel}</CancelButton>
-    <ApplyButton>{applyButtonLabel}</ApplyButton>
+    <ApplyButton onClick={onApply}>{applyButtonLabel}</ApplyButton>
   </Cluster>
 ))
 
@@ -142,10 +149,12 @@ const CancelButton = memo<PropsWithChildren<{ onClick: Props['onCancel'] }>>(
   ),
 )
 
-const ApplyButton = memo<PropsWithChildren>(({ children }) => (
-  <DropdownCloser>
-    <Button type="submit" variant="primary">
-      {children}
-    </Button>
-  </DropdownCloser>
-))
+const ApplyButton = memo<PropsWithChildren<{ onClick: MouseEventHandler<HTMLButtonElement> }>>(
+  ({ onClick, children }) => (
+    <DropdownCloser>
+      <Button variant="primary" onClick={onClick}>
+        {children}
+      </Button>
+    </DropdownCloser>
+  ),
+)

--- a/packages/smarthr-ui/src/components/Dropdown/SortDropdown/useSortDropdown.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/SortDropdown/useSortDropdown.ts
@@ -1,7 +1,7 @@
 import {
   type ChangeEventHandler,
   type ComponentProps,
-  type FormEventHandler,
+  type MouseEventHandler,
   useCallback,
   useEffect,
   useMemo,
@@ -126,7 +126,7 @@ export const useSortDropdown = ({ sortFields, defaultOrder, onApply, decorators 
     },
     [innerFields],
   )
-  const handleApply = useCallback<FormEventHandler<HTMLFormElement>>(() => {
+  const handleApply = useCallback<MouseEventHandler<HTMLButtonElement>>(() => {
     setSelectedLabel(innerSelectedField)
     setCheckedOrder(innerCheckedOrder)
     onApply({ field: innerSelectedField || '', order: innerCheckedOrder, newfields: innerFields })


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

`SortDropdown`の［適用］ボタンを推しても`onApply`が発火しないので修正

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

[`FilterDropdown`を参考に](https://github.com/kufu/smarthr-ui/pull/5152/files)してformがなくならないようにしました

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- storybookのplaygroundで［適用］ボタンを押したときに`Actions`タブにapplyのログが出ること
- https://63d0ccabb5d2dd29825524ab-mwiqyxswwp.chromatic.com/?path=/story/components-dropdown-sortdropdown--playground
