### PR TITLE
feat: DateFormatterをクライアントコンポーネントとして扱うように修正

### DIFF
--- a/packages/smarthr-ui/src/intl/DateFormatter.tsx
+++ b/packages/smarthr-ui/src/intl/DateFormatter.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { useIntl } from './useIntl'
 
 import type { FormatDateProps } from './useIntl'

--- a/sandbox/next/e2e/rsc.test.ts
+++ b/sandbox/next/e2e/rsc.test.ts
@@ -113,6 +113,7 @@ const CLIENT_COMPONENTS: string[] = [
   'Textarea',       // オートフォーカスや文字数カウントのための状態管理
   'ThCheckbox',     // 多言語化対応のため
   'Tooltip',        // 開閉状態の管理
+  'DateFormatter',  // 多言語化対応のため
 ]
 
 /**

--- a/sandbox/next/src/app/rsc_test/DateFormatter/page.tsx
+++ b/sandbox/next/src/app/rsc_test/DateFormatter/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { DateFormatter } from 'smarthr-ui'
+
+import { RSCChecker } from '../components/RSCChecker'
+export default function DateFormatterPage() {
+  return (
+    <>
+      <RSCChecker actualComponent={DateFormatter} />
+      <DateFormatter date={new Date(2024, 10, 15)} />
+    </>
+  )
+}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://github.com/kufu/smarthr-ui/pull/5889 を参考

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- DateFormatterが `useIntl` のhookを使っており、事実上クライアントコンポーネントとして運用されている状態だったため、'use client'を追加します

## 変更内容

- 'use client' ディレクティブをDateFormatterに追加
- rsc.testにDateFormatterがなかったので追加

## 確認方法

- プラスアプリ側でDateFormatterに `'use client'` つけて問題なく動いていることは確認済。
