### PR TITLE
perf: storiesディレクトリをバンドルから削除した

### DIFF
--- a/packages/smarthr-ui/rollup.esm.config.js
+++ b/packages/smarthr-ui/rollup.esm.config.js
@@ -1,13 +1,13 @@
-import typescript from '@rollup/plugin-typescript';
-import preserveDirectives from "rollup-plugin-preserve-directives";
-import renameNodeModules from "rollup-plugin-rename-node-modules";
-import replace from '@rollup/plugin-replace';
-import commonjs from '@rollup/plugin-commonjs';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import { globSync } from 'glob';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import packageJson from './package.json' with { type: "json" }
+import typescript from '@rollup/plugin-typescript'
+import preserveDirectives from 'rollup-plugin-preserve-directives'
+import renameNodeModules from 'rollup-plugin-rename-node-modules'
+import replace from '@rollup/plugin-replace'
+import commonjs from '@rollup/plugin-commonjs'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+import { globSync } from 'glob'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import packageJson from './package.json' with { type: 'json' }
 
 const peerDependencies = packageJson.peerDependencies
   ? Object.keys(packageJson.peerDependencies)
@@ -16,6 +16,7 @@ const peerDependencies = packageJson.peerDependencies
 const entryPoints = globSync('src/**/*.{ts,tsx}', {
   ignore: [
     '**/*.stories.{ts,tsx}',
+    '**/stories/*.{ts,tsx}',
     '**/*.test.{ts,tsx}',
     '**/__tests__/*.{ts,tsx}',
   ],
@@ -23,16 +24,16 @@ const entryPoints = globSync('src/**/*.{ts,tsx}', {
 
 /** @type {import('rollup').RollupOptions} */
 export default {
-	input: Object.fromEntries(
-		entryPoints.map(file => [
-			path.relative(
-				'src',
+  input: Object.fromEntries(
+    entryPoints.map((file) => [
+      path.relative(
+        'src',
         // 拡張子を除去し書き出し時に正しいファイル名になるようにしている
-				file.slice(0, file.length - path.extname(file).length)
-			),
-			fileURLToPath(new URL(file, import.meta.url))
-		])
-	),
+        file.slice(0, file.length - path.extname(file).length),
+      ),
+      fileURLToPath(new URL(file, import.meta.url)),
+    ]),
+  ),
   output: {
     format: 'es',
     sourcemap: true,
@@ -57,7 +58,7 @@ export default {
     commonjs(),
     nodeResolve(),
     // node_modulesのままだとimportできないケースがあったので、vendorにrenameしている
-    renameNodeModules("vendor"),
+    renameNodeModules('vendor'),
     // reactの影響でprocess is not definedになってしまうので、"production"に置き換えている
     // import.meta.env等に置き換えるほうが本当は好ましいが、あまり良い方法がない
     replace({
@@ -69,9 +70,9 @@ export default {
     // picocolorsのみprocessをglobalThis.processに置き換えて、process is not definedを回避する
     replace({
       values: {
-        'process': 'globalThis.process',
+        process: 'globalThis.process',
       },
-      include: "**/picocolors.*",
+      include: '**/picocolors.*',
       delimiters: ['\\s', '\\s(?!\\.)'],
       preventAssignment: true,
     }),

--- a/packages/smarthr-ui/tsconfig.build.json
+++ b/packages/smarthr-ui/tsconfig.build.json
@@ -5,18 +5,14 @@
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/*.stories.tsx",
+    "src/**/stories/*.tsx",
     "src/**/__tests__"
   ],
   "compilerOptions": {
     // stories.tsx で発生する下記のエラーを避けるため、tsconfig.json ではなくこちらで `"declaration": true` を指定
     // https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189
     "declaration": true,
-    "types": [
-      "node",
-      "react"
-    ]
+    "types": ["node", "react"]
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/packages/smarthr-ui/tsconfig.esm.build.json
+++ b/packages/smarthr-ui/tsconfig.esm.build.json
@@ -6,12 +6,10 @@
     "moduleResolution": "bundler",
     "target": "esnext"
   },
-  "include": [
-    "src/**/*.tsx",
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.tsx", "src/**/*.ts"],
   "exclude": [
     "src/**/*.stories.tsx",
+    "src/**/stories/*.tsx",
     "src/**/*.test.tsx",
     "src/**/*.test.ts",
     "src/**/__tests__/*.ts"


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- [stories/args.tsx](https://github.com/kufu/smarthr-ui/blob/6f46385f2030fececaa9b0b8ee05fa4bcf77ffcb/packages/smarthr-ui/src/components/AppHeader/stories/args.tsx)のようなstories関連のファイルがビルドの結果に含まれていた。たぶん意図していないと思うのでビルドの結果から除外したい。

## 変更内容

- ESMとCJSのビルド成果物から `stories` ディレクトリを除外。

## 確認方法

- masterブランチでビルド結果のesmとlibディレクトリに対してstories/args.tsxに含まれる文字列（例：「株式会社テストテナント壱」）を検索し、ヒットする。
- 本ブランチでビルド結果のesmとlibディレクトリに対してstories/args.tsxに含まれる文字列（例：「株式会社テストテナント壱」）を検索し、ヒットしない。
- StackBlitzのパッケージをローカルでインストールし、プラスアプリが問題なく動いている。

## その他

- CJSの方はあんまりビルド結果のサイズ変わらなかったのですが、ESMの方は3分の1のサイズ削減。

変更前

```bash
% du -sh esm
 18M    esm
```

変更後

```bash
% du -sh esm                            
 12M    esm
```

- Slackでお話したようにpicocolorsに関するビルドの設定も削除できると思ったのですが、ビルド結果にpicocolorsが含まれていた(含まれていたけど空のオブジェクトぽかった)ため、一旦対応を見送りました。たぶん削除できると思ってるのですが、時間に余裕があったら別途PR出します。