### PR TITLE
fix: Comboboxにgroupロールを追加し、削除ボタンとの関係を明らかにする

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { type ComponentProps, act } from 'react'
 import { userEvent } from 'storybook/test'
 
@@ -17,7 +17,7 @@ describe('SingleCombobox', () => {
 
   const combobox = () => screen.getByRole('combobox', { name: 'コンボボックス' })
   const listbox = () => screen.queryByRole('listbox')
-  const clearButton = () => screen.getByRole('button', { name: '削除' })
+  const clearButton = () => screen.getByRole('button', { name: 'クリア' })
 
   const template = ({
     name,
@@ -188,4 +188,29 @@ describe('SingleCombobox', () => {
     await act(() => userEvent.keyboard('{enter}'))
     expect(onSubmit).not.toHaveBeenCalled()
   })
+})
+
+test('groupロールが付与されている', () => {
+  const onClearClick = vi.fn()
+
+  render(
+    <IntlProvider locale="ja">
+      <form>
+        <FormControl label="コンボボックス">
+          <SingleCombobox
+            name="default"
+            items={[
+              { label: 'option 1', value: 'value-1' },
+              { label: 'option 2', value: 'value-2' },
+            ]}
+            selectedItem={{ label: 'option 1', value: 'value-1' }}
+            onClearClick={onClearClick}
+          />
+        </FormControl>
+      </form>
+    </IntlProvider>,
+  )
+
+  within(screen.getByRole('group')).getByRole('button', { name: 'クリア' }).click()
+  expect(onClearClick).toBeCalled()
 })

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -375,7 +375,7 @@ const ActualSingleCombobox = <T,>(
     () => ({
       destroyButtonIconAlt: localize({
         id: 'smarthr-ui/SingleCombobox/destroyButtonIconAlt',
-        defaultText: '削除',
+        defaultText: 'クリア',
       }),
     }),
     [localize],
@@ -384,7 +384,7 @@ const ActualSingleCombobox = <T,>(
   const decorated = useDecorators<DecoratorKeyTypes>(decoratorDefaultTexts, decorators)
 
   return (
-    <div className={classNames.wrapper} style={wrapperStyle} ref={outerRef}>
+    <div role="group" className={classNames.wrapper} style={wrapperStyle} ref={outerRef}>
       <Input
         {...rest}
         ref={inputRef}

--- a/packages/smarthr-ui/src/intl/locales/ja.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja.ts
@@ -78,7 +78,7 @@ export const locale = {
   'smarthr-ui/RequiredLabel/text': '必須',
   'smarthr-ui/SearchInput/iconAlt': '検索',
   'smarthr-ui/Select/blankLabel': '選択してください',
-  'smarthr-ui/SingleCombobox/destroyButtonIconAlt': '削除',
+  'smarthr-ui/SingleCombobox/destroyButtonIconAlt': 'クリア',
   'smarthr-ui/SortDropdown/applyButtonLabel': '適用',
   'smarthr-ui/SortDropdown/ascLabel': '昇順',
   'smarthr-ui/SortDropdown/cancelButtonLabel': 'キャンセル',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
- [Comboboxの「削除」ボタンと入力欄の関連を機械で判別できるようにする](https://www.notion.so/Combobox-28f37b6398eb807d9a37c112618cd23d?source=copy_link)

## 概要

「組織図」で以下のような画面がありました。ここで、コンボボックスの中の「X」ボタンは選択した結果をクリアするもので、コンボボックスの外の「削除」ボタンはコンボボックス自体を削除するものです。

> <img width="400" alt="" src="https://github.com/user-attachments/assets/45e90c53-6a97-4787-b091-3d87791eb601" />
>
> 組織図のスクリーンショット

この画面のアクセシビリティーツリーを考えると、以下のようにコンボボックスの次に２つのボタンが並列であらわれます。２つのボタンはいずれも「削除」というアクセシブルネームを持ちます。よって、支援技術からはどちらの削除ボタンがどちらの役割をするものなのか推測できません。

> <img width="400" alt="" src="https://github.com/user-attachments/assets/3ea4b09c-b4c2-4c67-b2f0-503bc4e22d83" />
>
> Chromeの開発者ツールのスクリーンショット。comboboxロールを持つノードと同列に「削除」というラベルを持つbuttonが２つある

これはWCAG 2.1の[1.3.1 情報及び関係性](https://waic.jp/translations/WCAG21/#info-and-relationships)を達成していません。視覚的には入力欄とクリアのためのボタンを囲うボーダー `shr-border-shorthand` によって両者の関係性が示されているものの、それについて[プログラムによる解釈](https://waic.jp/translations/WCAG21/#dfn-programmatically-determinable)を行うことができないためです。

## 変更内容

`SingleCombobox` コンポーネントについて、全体を `group` ロールでラップするように変更しました。

加えて、コンボボックスのクリアボタンのラベルを「削除」から「クリア」に改めました。こちらの修正は本質的ではありませんが、「削除」にくらべてアクションの対象が限定的であり、プロダクト側の文言と衝突するおそれも小さいと考えたためです。

`Input` で `prefix` または `suffix` が設定されている場合に `group` ロールでラップする変更を加えれば、他のケースでも一挙に修正できますが、内部のスタイルの兼ね合いで中間にさらにひとつコンテナーを追加すると変更が大きくなってしまい、見送りました。類似の問題が見つかったら再検討すべきでしょう。

## 確認方法

テストを書いたので、妥当性を確認してください。
