### PR TITLE
fix(Textarea): スクロール可能領域内で日本語入力中にスクロール位置が先頭に戻る問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -10,7 +10,6 @@ import {
   useEffect,
   useId,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -296,7 +295,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props & ElementProps>(
     }, [autoFocus])
 
     // autoResize時に、初期値での高さを指定
-    useLayoutEffect(() => {
+    useEffect(() => {
       if (autoResize && textareaRef.current) {
         setInterimRows(calculateIdealRows(textareaRef.current, maxRows))
       }


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- https://kufuinc.slack.com/archives/C06KVP5PL23/p1761121215640099
- https://kufuinc.slack.com/archives/CGC58MW01/p1761122788288959

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

スクロール可能な領域にあるTextareaが、日本語入力中に入力を確定するとスクロールがトップに戻ってしまう問題を修正

挙動の参考: https://kufuinc.slack.com/archives/C07LGLBA003/p1761119087457359?thread_ts=1761118826.463929&cid=C07LGLBA003

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- onInputとonChangeに分かれている部分をonChangeにまとめた
  - onInputは入力内容確定のenterでも発火するため、そのタイミングで再レンダリングが起きていることが原因だった

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

以下のようなStorybookを作成してみて、日本語を複数行入力してスクロール位置が保持されることを確認する

```tsx
export const T = () => {
  const [value, setValue] = useState('')
  return (
    <div className="shr-h-[100px] shr-overflow-auto">
      <Textarea value={value} onChange={(e) => setValue(e.target.value)} autoResize />
    </div>
  )
}
```

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
