### PR TITLE
fix(FileViewer): pdf回転時にハイパーリンクが正常に動作しないのを修正

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -75,8 +75,10 @@ export const FileViewer: FC<Props> = ({
   }, [internalScaleStep])
 
   const rotate = useCallback(() => {
-    setRotation((currentRotation) => currentRotation - 90)
-  }, [])
+    // HINT: react-pdf側のAnnotationLayer.cssではマイナスの回転に対応しておらず、また0, 90, 180, 270度のみ対応しているため、-90度の場合は+270度として扱う
+    const newRotation = rotation === 0 ? 270 : rotation - 90
+    setRotation(newRotation)
+  }, [rotation])
 
   const handleLoaded = useCallback(() => {
     setLoaded(true)


### PR DESCRIPTION
## 関連URL

なし

## 概要

FileViewerコンポーネントでPDFを回転表示した際に、PDF内のハイパーリンクがクリックできなくなる不具合を修正しました。

## 変更内容

### 問題の原因

PDFの回転処理において、`rotation`の値がマイナスになるロジックが実装されていましたが、[react-pdf（PDF.js）側の`AnnotationLayer.css`](https://github.com/wojtekmaj/react-pdf/blob/384e2abb4279f9f2b6e3274dbdbfc4268c3526c2/packages/react-pdf/src/Page/AnnotationLayer.css#L55-L63)とのズレにより以下の問題がありました：

1. **マイナスの回転角度に対応していない**
   - react-pdf（PDF.js）側のCSSでは`data-main-rotation='0'`, `'90'`, `'180'`, `'270'`のみが定義されている
   - そのため、`-90`, `-180`, `-270`などの値には対応するCSSが存在しない

2. **上記のCSS未対応によりAnnotationLayerが回転されない**
   - `data-main-rotation`属性に対応しない値が設定されると、AnnotationLayer（ハイパーリンクなどの注釈要素）がページの回転に追従せず、リンクの位置がずれてクリックできなくなる

### 修正内容

回転ロジックを変更し、常に`0`, `90`, `180`, `270`の正の値のみを使用するように修正：

- **変更前**: `setRotation((currentRotation) => currentRotation - 90)` 
  - 回転するたびに-90ずつ減算（0 → -90 → -180 → -270 → ...）
  
- **変更後**: `rotation === 0 ? 270 : rotation - 90`
  - 0度の時は270度に、それ以外は90度減算（0 → 270 → 180 → 90 → 0）
  - 常に0, 90, 180, 270のいずれかの値を保持

これにより、react-pdfのCSSで定義された回転スタイルが正しく適用され、AnnotationLayerがページの回転に追従するようになり、ハイパーリンクが正常にクリックできるようになりました。

## 確認方法

1. Storybookで「FileViewer」のストーリーを開く
2. ハイパーリンクを含むPDFファイルを表示
3. 回転ボタンをクリックしてPDFを回転
4. 各回転角度（90度、180度、270度、0度）でハイパーリンクがクリック可能であることを確認