### PR TITLE
fix: target="_blank"を指定していてもprefixがあればOpenInNewTabIconを表示しない

### DIFF
--- a/packages/smarthr-ui/src/components/Button/AnchorButton.tsx
+++ b/packages/smarthr-ui/src/components/Button/AnchorButton.tsx
@@ -59,12 +59,12 @@ const AnchorButton = forwardRef(
     const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
     const actualSuffix = useMemo(() => {
-      if (target === '_blank' && !suffix) {
+      if (target === '_blank' && !prefix && !suffix) {
         return <OpenInNewTabIcon />
       }
 
       return suffix
-    }, [suffix, target])
+    }, [prefix, suffix, target])
 
     const button = (
       <ButtonWrapper

--- a/packages/smarthr-ui/src/components/Header/HeaderLink.tsx
+++ b/packages/smarthr-ui/src/components/Header/HeaderLink.tsx
@@ -27,5 +27,5 @@ export const HeaderLink = memo<Props>(({ enableNew, className, ...props }) => {
     [enableNew, className],
   )
 
-  return <TextLink {...props} target="_blank" suffix={null} className={actualClassName} />
+  return <TextLink {...props} target="_blank" className={actualClassName} />
 })

--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -84,12 +84,12 @@ const ActualTextLink: TextLinkComponent = forwardRef(
   ) => {
     const Anchor = elementAs || 'a'
     const actualSuffix = useMemo(() => {
-      if (target === '_blank' && !suffix) {
+      if (target === '_blank' && !prefix && !suffix) {
         return <OpenInNewTabIcon />
       }
 
       return suffix
-    }, [suffix, target])
+    }, [prefix, suffix, target])
     const actualHref = useMemo(() => {
       if (href) {
         return href


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
- https://kufuinc.slack.com/archives/CGC58MW01/p1761627695898699

## 概要

AnchorButtonの対応 #5879 について `prefix` が指定されていた場合には当該の処理をスキップするように変更しました。

## 変更内容

PRの内容に付随して、TextLinkで`OpenInNewTab`アイコンを表示する条件を「suffixがundefinedであること」から「falsyであること」へと変えたことが原因でした
https://github.com/kufu/smarthr-ui/pull/5879#discussion_r2418674510

HeaderLinkでは、変更前の条件を迂回して`OpenInNewTab`のアイコンを非表示にするために、おそらく意図的にnullを渡していました。この処理は削除しました。
https://github.com/kufu/smarthr-ui/blob/master/packages/smarthr-ui/src/components/Header/HeaderLink.tsx#L30


## 確認方法

Chromaticをご確認ください。
https://www.chromatic.com/build?appId=63d0ccabb5d2dd29825524ab&number=12767

