### PR TITLE
feat!: FocusIndicator を inset にしつつ outline を使用する方法に変更する

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelContent.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelContent.tsx
@@ -26,7 +26,7 @@ const classNameGenerator = tv({
     '[&.entered]:shr-visible [&.entered]:shr-max-h-[revert] [&.entered]:shr-opacity-100',
     // HINT: flexなどで囲まれると、非表示だが内容分高さが出てしまい、スクロール領域が不自然に伸びてしまう現象が起きる場合がある
     // 非表示の場合、visually hiddenを適用することで、内容としては残しつつ、高さを0にすることで回避する
-    'aria-[hidden]:shr-absolute aria-[hidden]:shr-h-px aria-[hidden]:shr-overflow-hidden',
+    'aria-[hidden]:shr-overflow-hidden aria-[hidden]:shr-absolute aria-[hidden]:shr-h-px',
   ],
 })
 

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/Navigation.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/Navigation.tsx
@@ -27,7 +27,7 @@ import type {
 
 const classNameGenerator = tv({
   base: [
-    'shr-min-w-[auto] shr-overflow-x-auto',
+    'shr-overflow-x-auto shr-min-w-[auto]',
     'max-[751px]:!shr-hidden',
     'data-[with-releasenote="true"]:shr-pe-0',
   ],

--- a/packages/smarthr-ui/src/components/AppNavi/itemClassNameGenerator.ts
+++ b/packages/smarthr-ui/src/components/AppNavi/itemClassNameGenerator.ts
@@ -5,7 +5,7 @@ export const itemClassNameGenerator = tv({
     wrapper: [
       'shr-box-border shr-inline-flex shr-cursor-pointer shr-items-center shr-gap-0.5 shr-whitespace-nowrap shr-px-0.5 shr-py-0.75 shr-text-base shr-font-bold shr-leading-none shr-text-grey shr-no-underline',
       'hover:shr-bg-white-darken',
-      'focus-visible:shr-focus-indicator--inner',
+      'focus-visible:shr-focus-indicator',
     ],
     icon: 'shr-fill-grey',
   },

--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -40,13 +40,13 @@ type DayJsType = ReturnType<typeof dayjs>
 const classNameGenerator = tv({
   slots: {
     container:
-      'smarthr-ui-Calendar shr-inline-block shr-overflow-hidden shr-rounded-m shr-bg-white shr-text-black shr-shadow-layer-3 forced-colors:shr-border-shorthand forced-colors:shr-shadow-none',
+      'smarthr-ui-Calendar shr-overflow-hidden shr-inline-block shr-rounded-m shr-bg-white shr-text-black shr-shadow-layer-3 forced-colors:shr-border-shorthand forced-colors:shr-shadow-none',
     header: 'smarthr-ui-Calendar-header shr-border-b-shorthand shr-flex shr-items-center shr-p-1',
     yearMonth: 'smarthr-ui-Calendar-yearMonth shr-me-0.5 shr-text-base shr-font-bold',
     monthButtons: 'smarthr-ui-Calendar-monthButtons shr-ms-auto shr-flex',
     tableLayout: 'shr-relative',
     yearSelectButton:
-      'smarthr-ui-Calendar-selectingYear [&[aria-expanded="true"]_.smarthr-ui-Icon]:shr-rotate-180',
+      'smarthr-ui-Calendar-selectingYear focus-visible:shr-focus-indicator--outer [&[aria-expanded="true"]_.smarthr-ui-Icon]:shr-rotate-180',
   },
 })
 
@@ -261,7 +261,7 @@ const MonthDirectionCluster = memo<{
         disabled={isSelectingYear || prev.isBefore(from, 'month')}
         onClick={onClickMonthPrev}
         size="s"
-        className="smarthr-ui-Calendar-monthButtonPrev"
+        className="smarthr-ui-Calendar-monthButtonPrev focus-visible:shr-focus-indicator--outer"
       >
         <FaChevronLeftIcon alt={previousMonthAltText} />
       </Button>
@@ -269,7 +269,7 @@ const MonthDirectionCluster = memo<{
         disabled={isSelectingYear || next.isAfter(to, 'month')}
         onClick={onClickMonthNext}
         size="s"
-        className="smarthr-ui-Calendar-monthButtonNext"
+        className="smarthr-ui-Calendar-monthButtonNext focus-visible:shr-focus-indicator--outer"
       >
         <FaChevronRightIcon alt={nextMonthAltText} />
       </Button>

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -35,11 +35,11 @@ const classNameGenerator = tv({
   slots: {
     overlay: 'smarthr-ui-YearPicker shr-absolute shr-inset-0 shr-bg-white',
     container:
-      'shr-box-border shr-flex shr-h-full shr-w-full shr-flex-wrap shr-items-start shr-overflow-y-auto shr-px-0.25 shr-py-0.5',
+      'shr-overflow-y-auto shr-box-border shr-flex shr-h-full shr-w-full shr-flex-wrap shr-items-start shr-px-0.25 shr-py-0.5',
     yearButton:
-      'smarthr-ui-YearPicker-selectYear shr-group shr-flex shr-w-1/4 shr-items-center shr-justify-center shr-px-0 shr-py-0.5 shr-leading-none',
+      'smarthr-ui-YearPicker-selectYear shr-group shr-flex shr-w-1/4 shr-items-center shr-justify-center shr-px-0 shr-py-0.5 shr-leading-none focus-visible:shr-outline-none',
     yearWrapper: [
-      'shr-box-border shr-inline-block shr-rounded-full shr-px-0.75 shr-py-0.5 shr-text-base shr-leading-none group-hover:shr-bg-base-grey group-hover:shr-text-black',
+      'shr-box-border shr-inline-block shr-rounded-full shr-px-0.75 shr-py-0.5 shr-text-base shr-leading-none group-focus-visible:shr-focus-indicator group-hover:shr-bg-base-grey group-hover:shr-text-black',
       '[[data-this-year="true"]>&]:shr-border-shorthand',
       '[[aria-pressed="true"]>&]:shr-bg-main [[aria-pressed="true"]>&]:shr-text-white',
     ],

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -100,7 +100,7 @@ const classNameGenerator = tv({
       'contrast-more:shr-border-high-contrast',
       'has-[[aria-invalid]]:shr-border-danger',
     ],
-    inputArea: 'shr-flex shr-flex-1 shr-flex-wrap shr-gap-0.5 shr-overflow-y-auto',
+    inputArea: 'shr-overflow-y-auto shr-flex shr-flex-1 shr-flex-wrap shr-gap-0.5',
     selectedList:
       'smarthr-ui-MultiCombobox-selectedList shr-contents shr-list-none [&_li]:shr-min-w-0',
     inputWrapper: 'shr-flex shr-flex-1 shr-items-center',

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -42,10 +42,9 @@ const classNameGenerator = tv({
       'smarthr-ui-MultiCombobox-deleteButton',
       'shr-group/deleteButton',
       'shr-shrink shr-rounded-full shr-leading-[0] shr-text-black',
-      'focus-visible:shr-shadow-[unset]',
     ],
     deleteButtonIcon:
-      'group-focus-visible/deleteButton:shr-focus-indicator group-focus-visible/deleteButton:shr-rounded-full',
+      'group-focus-visible/deleteButton:shr-focus-indicator--outer group-focus-visible/deleteButton:shr-rounded-full',
   },
   variants: {
     enableEllipsis: {

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -54,7 +54,7 @@ const classNameGenerator = tv({
     wrapper: 'shr-absolute',
     dropdownList: [
       'smarthr-ui-Combobox-dropdownList',
-      'shr-absolute shr-z-overlap shr-box-border shr-min-w-full shr-overflow-y-auto shr-rounded-m shr-bg-white shr-py-0.5 shr-shadow-layer-3',
+      'shr-overflow-y-auto shr-absolute shr-z-overlap shr-box-border shr-min-w-full shr-rounded-m shr-bg-white shr-py-0.5 shr-shadow-layer-3',
       /* 縦スクロールに気づきやすくするために8個目のアイテムが半分見切れるように max-height を算出
       = (アイテムのフォントサイズ + アイテムの上下padding) * 7.5 + コンテナの上padding */
       'shr-max-h-[calc((theme(fontSize.base)_+_theme(spacing[0.5])_*_2)_*_7.5_+_theme(spacing[0.5]))]',

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -103,7 +103,7 @@ const classNameGenerator = tv({
       'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5 hover:shr-bg-white-darken',
     dialogHandler: [
       'smarthr-ui-ModelessDialog-handle shr-absolute shr-inset-x-0 shr-bottom-0 shr-top-[2px] shr-m-auto shr-flex shr-justify-center shr-rounded-tl-s shr-rounded-tr-s shr-text-grey shr-transition-colors shr-duration-100 shr-ease-in-out',
-      'focus-visible:shr-bg-white-darken focus-visible:shr-shadow-outline focus-visible:shr-outline-none',
+      'focus-visible:shr-shadow-outline focus-visible:shr-bg-white-darken focus-visible:shr-outline-none',
     ],
     titleEl: [
       'shr-my-1 shr-me-1',

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -17,7 +17,7 @@ import { type ContentBoxStyle, type Rect, getContentBoxStyle } from './dropdownH
 import { useKeyboardNavigation } from './useKeyboardNavigation'
 
 const classNameGenerator = tv({
-  base: 'smarthr-ui-Dropdown-content shr-absolute shr-z-overlap-base shr-overflow-y-auto shr-break-words shr-rounded-m shr-bg-white shr-shadow-layer-3',
+  base: 'smarthr-ui-Dropdown-content shr-overflow-y-auto shr-absolute shr-z-overlap-base shr-break-words shr-rounded-m shr-bg-white shr-shadow-layer-3',
   variants: {
     isActive: {
       true: 'shr-visible',

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -73,7 +73,7 @@ const classNameGenerator = tv({
     ],
     actionListItemButton: [
       'shr-justify-start shr-rounded-none shr-border-none shr-py-0.5 shr-font-normal',
-      'focus-visible:shr-focus-indicator--inner',
+      'focus-visible:shr-focus-indicator',
     ],
   },
 })

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -175,7 +175,7 @@ const Controller: FC<ControllerProps> = memo(
   }) => (
     <div className="shr-sticky shr-flex shr-w-full shr-items-center shr-justify-center shr-justify-items-center shr-gap-0.5 shr-bg-scrim shr-p-0.5 shr-shadow-layer-1">
       <Cluster gap={0.5}>
-        <div className="shr-border-shorthand shr-flex shr-divide-x shr-divide-solid shr-overflow-hidden shr-rounded-m">
+        <div className="shr-overflow-hidden shr-border-shorthand shr-flex shr-divide-x shr-divide-solid shr-rounded-m">
           <Button
             onClick={onClickScaleDownButton}
             disabled={scale <= scaleSteps[0]}

--- a/packages/smarthr-ui/src/components/Layout/Reel/Reel.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Reel/Reel.tsx
@@ -21,7 +21,7 @@ type Props = VariantProps<typeof classNameGenerator> &
 
 const classNameGenerator = tv({
   base: [
-    'shr-flex shr-overflow-x-auto shr-overflow-y-hidden',
+    'shr-overflow-y-hidden shr-overflow-x-auto shr-flex',
     '[&_>_*]:shr-flex- [&_>_*]:shr-flex-shrink-0 [&_>_*]:shr-basis-auto',
     /*
       Chromeで空の要素にflex-gapがあると印刷時にレイアウトが崩れるので gap の値を0にする

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -21,14 +21,14 @@ const classNameGenerator = tv({
     base: 'smarthr-ui-LineClamp shr-relative',
     clampedLine: 'shr-w-full',
     shadowElementWrapper:
-      'shr-invisible shr-absolute shr-left-0 shr-top-0 shr-h-full shr-w-full shr-overflow-hidden shr-whitespace-normal shr-opacity-0',
+      'shr-overflow-hidden shr-invisible shr-absolute shr-left-0 shr-top-0 shr-h-full shr-w-full shr-whitespace-normal shr-opacity-0',
     shadowElement: 'shr-absolute shr-left-0 shr-top-0 shr-w-full',
   },
   variants: {
     maxLines: {
       1: {
         clampedLine:
-          'shr-inline-block shr-w-full shr-overflow-x-clip shr-overflow-ellipsis shr-whitespace-nowrap shr-align-middle',
+          'shr-overflow-x-clip shr-inline-block shr-w-full shr-overflow-ellipsis shr-whitespace-nowrap shr-align-middle',
       },
       2: {
         clampedLine: 'shr-line-clamp-[2]',

--- a/packages/smarthr-ui/src/components/Loader/Loader.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.tsx
@@ -17,7 +17,7 @@ type ElementProps = Omit<ComponentProps<'span'>, keyof Props>
 
 const classNameGenerator = tv({
   slots: {
-    wrapper: ['smarthr-ui-Loader', 'shr-inline-block shr-overflow-hidden'],
+    wrapper: ['smarthr-ui-Loader', 'shr-overflow-hidden shr-inline-block'],
     textSlot: ['shr-block', 'shr-mt-1', 'shr-text-base', 'shr-text-center'],
   },
   variants: {

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -21,7 +21,7 @@ const classNameGenerator = tv({
       'shr-group/tabitem',
       'shr-relative shr-inline-flex shr-items-center shr-gap-0.5 shr-px-1 shr-py-0.75',
       'hover:shr-bg-white-darken',
-      'focus-visible:shr-focus-indicator--inner focus-visible:shr-z-1',
+      'focus-visible:shr-focus-indicator focus-visible:shr-z-1',
       'disabled:shr-cursor-not-allowed disabled:shr-bg-transparent',
       'aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-z-1 aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-content-[""]',
       'forced-colors:aria-selected:before:shr-bg-[Highlight]',
@@ -84,7 +84,7 @@ export const TabItem: FC<Props & ElementProps> = ({
         message={disabledDetail.message}
         ariaDescribedbyTarget="inner"
         aria-disabled={rest.disabled}
-        className="focus-visible:shr-focus-indicator--inner"
+        className="focus-visible:shr-focus-indicator"
       >
         <TabButton {...rest} suffix={Icon} />
       </Tooltip>

--- a/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -94,7 +94,7 @@ export const EllipsisOnly: StoryObj<typeof Tooltip> = {
   render: (args) => (
     <div className="shr-w-[5em]">
       <Tooltip {...args}>
-        <span className="shr-inline-block shr-max-w-full shr-overflow-hidden shr-text-ellipsis shr-text-nowrap">
+        <span className="shr-overflow-hidden shr-inline-block shr-max-w-full shr-text-ellipsis shr-text-nowrap">
           省略されるメッセージ
         </span>
       </Tooltip>

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
@@ -25,7 +25,7 @@ export default {
       />
       <div className="shr-w-[5em]">
         <Tooltip {...args} ellipsisOnly>
-          <span className="shr-inline-block shr-max-w-full shr-overflow-hidden shr-text-ellipsis shr-text-nowrap">
+          <span className="shr-overflow-hidden shr-inline-block shr-max-w-full shr-text-ellipsis shr-text-nowrap">
             省略されるメッセージ
           </span>
         </Tooltip>

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
@@ -2,7 +2,7 @@ import { type ComponentProps, type ElementType, type PropsWithChildren, memo, us
 import { tv } from 'tailwind-variants'
 
 export const visuallyHiddenTextClassNameGenerator = tv({
-  base: 'shr-absolute shr-h-px shr-w-px shr-overflow-hidden shr-whitespace-nowrap shr-border-0 shr-p-0 [clip-path:inset(100%)] [clip:rect(0_0_0_0)]',
+  base: 'shr-overflow-hidden shr-absolute shr-h-px shr-w-px shr-whitespace-nowrap shr-border-0 shr-p-0 [clip-path:inset(100%)] [clip:rect(0_0_0_0)]',
 })
 
 type Props<T extends ElementType> = PropsWithChildren<{

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -410,6 +410,28 @@ export default {
          */
         '.focus-indicator': {
           outline: `2px solid ${theme('colors.outline')}`,
+          outlineOffset: '2px',
+          isolation: 'isolate',
+          boxShadow: `0 0 0 2px ${theme('colors.white')}`,
+
+          /** overflow する可能性がある場合はフォーカスインジケーターを内側に設定する */
+          '.overflow-hidden &, .overflow-y-hidden &, .overflow-x-hidden &, .overflow-y-clip &, .overflow-x-clip &, .overflow-y-auto &, .overflow-x-auto &':
+            {
+              outline: `2px solid ${theme('colors.outline')}`,
+              outlineOffset: '-2px',
+              isolation: 'isolate',
+              /** outline は border の外側から生えるが、box-shadow は border の内側から生えるため、border の幅を引いている */
+              boxShadow: `inset 0 0 0 3px ${theme('colors.white')}`,
+            },
+        },
+        '.focus-indicator--outer': {
+          outline: `2px solid ${theme('colors.outline')}`,
+          outlineOffset: '2px',
+          isolation: 'isolate',
+          boxShadow: `0 0 0 2px ${theme('colors.white')}`,
+        },
+        '.focus-indicator--inner': {
+          outline: `2px solid ${theme('colors.outline')}`,
           outlineOffset: '-2px',
           isolation: 'isolate',
           /** outline は border の外側から生えるが、box-shadow は border の内側から生えるため、border の幅を引いている */

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -27,7 +27,6 @@ defaultConfig.twMergeConfig = {
           'layer-2',
           'layer-3',
           'layer-4',
-          'outline',
           'underline',
           'input-hover',
           'none',
@@ -64,7 +63,7 @@ defaultConfig.twMergeConfig = {
         ],
       },
     ],
-    focus: ['focus-indicator', 'focus-indicator--inner'],
+    focus: ['focus-indicator'],
   },
 }
 
@@ -122,7 +121,6 @@ export default {
       'layer-2': defaultShadow.LAYER2,
       'layer-3': defaultShadow.LAYER3,
       'layer-4': defaultShadow.LAYER4,
-      outline: defaultShadow.OUTLINE,
       underline: defaultShadow.UNDERLINE,
       'input-hover': defaultShadow.INPUT_HOVER,
       none: 'none',
@@ -411,14 +409,10 @@ export default {
          * via https://github.com/tailwindlabs/tailwindcss/issues/10226
          */
         '.focus-indicator': {
-          outline: 'none',
+          outline: `2px solid ${theme('colors.outline')}`,
+          outlineOffset: '-2px',
           isolation: 'isolate',
-          boxShadow: `0 0 0 2px ${theme('colors.white')}, 0 0 0 4px ${theme('colors.outline')}`,
-        },
-        '.focus-indicator--inner': {
-          outline: 'none',
-          isolation: 'isolate',
-          boxShadow: `inset 0 0 0 2px ${theme('colors.outline')}, inset 0 0 0 4px ${theme('colors.white')}`,
+          boxShadow: `inset 0 0 0 2px ${theme('colors.white')}`,
         },
         '.border-shorthand': {
           borderWidth: theme('borderWidth.DEFAULT'),

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -408,7 +408,7 @@ export default {
          * box-shadow や ring を使った仕組みでは Firefox で欠陥があるため、独自定義している
          * via https://github.com/tailwindlabs/tailwindcss/issues/10226
          */
-        '.focus-indicator': {
+        ':where(.focus-indicator)': {
           outline: `2px solid ${theme('colors.outline')}`,
           outlineOffset: '2px',
           isolation: 'isolate',

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -412,7 +412,8 @@ export default {
           outline: `2px solid ${theme('colors.outline')}`,
           outlineOffset: '-2px',
           isolation: 'isolate',
-          boxShadow: `inset 0 0 0 2px ${theme('colors.white')}`,
+          /** outline は border の外側から生えるが、box-shadow は border の内側から生えるため、border の幅を引いている */
+          boxShadow: `inset 0 0 0 3px ${theme('colors.white')}`,
         },
         '.border-shorthand': {
           borderWidth: theme('borderWidth.DEFAULT'),

--- a/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
@@ -11,9 +11,9 @@ describe('createOutline', () => {
     const expectedOutline = replaceSpaces(css`
       /* stylelint-disable no-invalid-position-declaration */
       outline: 2px solid ${userOutlineColor};
-      outline-offset: -2px;
+      outline-offset: 2px;
       isolation: isolate;
-      box-shadow: inset 0 0 0 2px white;
+      box-shadow: 0 0 0 2px white;
       /* stylelint-enable no-invalid-position-declaration */
     `)
 
@@ -23,9 +23,9 @@ describe('createOutline', () => {
     const expectedFocusIndicator = replaceSpaces(css`
       /* stylelint-disable no-invalid-position-declaration */
       outline: 2px solid ${userOutlineColor};
-      outline-offset: -2px;
+      outline-offset: 2px;
       isolation: isolate;
-      box-shadow: inset 0 0 0 2px white;
+      box-shadow: 0 0 0 2px white;
       /* stylelint-enable no-invalid-position-declaration */
     `)
 

--- a/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
@@ -9,18 +9,22 @@ describe('createOutline', () => {
     const userOutlineColor = 'black'
     const actual = createOutline({ OUTLINE: userOutlineColor })
     const expectedOutline = replaceSpaces(css`
+      /* stylelint-disable no-invalid-position-declaration */
       outline: 2px solid ${userOutlineColor};
       outline-offset: -2px;
       box-shadow: inset 0 0 0 2px white;
+      /* stylelint-enable no-invalid-position-declaration */
     `)
 
     expect(replaceSpaces(actual.OUTLINE)).toBe(expectedOutline)
 
     const actualFocusIndicator = replaceSpaces(actual.focusIndicatorStyles)
     const expectedFocusIndicator = replaceSpaces(css`
+      /* stylelint-disable no-invalid-position-declaration */
       outline: 2px solid ${userOutlineColor};
       outline-offset: -2px;
       box-shadow: inset 0 0 0 2px white;
+      /* stylelint-enable no-invalid-position-declaration */
     `)
 
     expect(actualFocusIndicator).toBe(expectedFocusIndicator)

--- a/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
@@ -1,0 +1,24 @@
+import { type FlattenSimpleInterpolation, css } from 'styled-components'
+
+import { createOutline } from '../createOutline'
+
+const replaceSpaces = (str: FlattenSimpleInterpolation) => String(str).replace(/\s/g, '')
+
+describe('createOutline', () => {
+  it('ユーザー指定の OUTLINE がフォーカススタイルに反映されること', () => {
+    const userOutlineColor = 'black'
+    const actual = createOutline({ OUTLINE: userOutlineColor })
+    const expectedOutline = `0 0 0 2px white, 0 0 0 4px ${userOutlineColor}`
+
+    expect(actual.OUTLINE).toBe(expectedOutline)
+
+    const actualFocusIndicator = replaceSpaces(actual.focusIndicatorStyles)
+    const expectedFocusIndicator = replaceSpaces(css`
+      outline: 2px solid ${userOutlineColor};
+      outline-offset: -2px;
+      box-shadow: inset 0 0 0 2px white;
+    `)
+
+    expect(actualFocusIndicator).toBe(expectedFocusIndicator)
+  })
+})

--- a/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
@@ -8,9 +8,13 @@ describe('createOutline', () => {
   it('ユーザー指定の OUTLINE がフォーカススタイルに反映されること', () => {
     const userOutlineColor = 'black'
     const actual = createOutline({ OUTLINE: userOutlineColor })
-    const expectedOutline = `0 0 0 2px white, 0 0 0 4px ${userOutlineColor}`
+    const expectedOutline = replaceSpaces(css`
+      outline: 2px solid ${userOutlineColor};
+      outline-offset: -2px;
+      box-shadow: inset 0 0 0 2px white;
+    `)
 
-    expect(actual.OUTLINE).toBe(expectedOutline)
+    expect(replaceSpaces(actual.OUTLINE)).toBe(expectedOutline)
 
     const actualFocusIndicator = replaceSpaces(actual.focusIndicatorStyles)
     const expectedFocusIndicator = replaceSpaces(css`

--- a/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createOutline.ts
@@ -12,6 +12,7 @@ describe('createOutline', () => {
       /* stylelint-disable no-invalid-position-declaration */
       outline: 2px solid ${userOutlineColor};
       outline-offset: -2px;
+      isolation: isolate;
       box-shadow: inset 0 0 0 2px white;
       /* stylelint-enable no-invalid-position-declaration */
     `)
@@ -23,6 +24,7 @@ describe('createOutline', () => {
       /* stylelint-disable no-invalid-position-declaration */
       outline: 2px solid ${userOutlineColor};
       outline-offset: -2px;
+      isolation: isolate;
       box-shadow: inset 0 0 0 2px white;
       /* stylelint-enable no-invalid-position-declaration */
     `)

--- a/packages/smarthr-ui/src/themes/__tests__/createShadow.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createShadow.ts
@@ -1,26 +1,12 @@
-import { type FlattenSimpleInterpolation, css } from 'styled-components'
-
 import { createShadow } from '../createShadow'
 
-const replaceSpaces = (str: FlattenSimpleInterpolation) => String(str).replace(/\s/g, '')
-
 describe('createShadow', () => {
-  it('ユーザー指定の OUTLINE がフォーカススタイルに反映されること', () => {
-    const userOutlineColor = 'black'
-    const actual = createShadow(undefined, { OUTLINE: userOutlineColor })
-    const expectedOutline = `0 0 0 2px white, 0 0 0 4px ${userOutlineColor}`
-
-    expect(actual.OUTLINE).toBe(expectedOutline)
-
-    const actualFocusIndicator = replaceSpaces(actual.focusIndicatorStyles)
-    const expectedFocusIndicator = replaceSpaces(css`
-      /* stylelint-disable no-invalid-position-declaration */
-      outline: none;
-      isolation: isolate;
-      box-shadow: ${expectedOutline};
-      /* stylelint-enable no-invalid-position-declaration */
-    `)
-
-    expect(actualFocusIndicator).toBe(expectedFocusIndicator)
+  it('デフォルトのシャドウが返されること', () => {
+    const actual = createShadow()
+    expect(actual.LAYER0).toBe('none')
+    expect(actual.LAYER1).toBe('0 1px 2px 0 rgba(3,3,2,0.3)')
+    expect(actual.LAYER2).toBe('0 2px 4px 1px rgba(3,3,2,0.3)')
+    expect(actual.LAYER3).toBe('0 4px 8px 2px rgba(3,3,2,0.3)')
+    expect(actual.LAYER4).toBe('0 8px 16px 4px rgba(3,3,2,0.3)')
   })
 })

--- a/packages/smarthr-ui/src/themes/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/createOutline.ts
@@ -13,19 +13,23 @@ export type CreatedOutlineTheme = {
 }
 
 const createOuterOutlineStyles = (color: string) => css`
+  /* stylelint-disable no-invalid-position-declaration */
   outline: 2px solid ${color};
   outline-offset: 2px;
   isolation: isolate;
   box-shadow: 0 0 0 2px white;
+  /* stylelint-enable no-invalid-position-declaration */
 `
 
 const createInnerOutlineStyles = (color: string) => css`
+  /* stylelint-disable no-invalid-position-declaration */
   outline: 2px solid ${color};
   outline-offset: -2px;
   isolation: isolate;
 
   /** outline は border の外側から生えるが、box-shadow は border の内側から生えるため、border の幅を引いている */
   box-shadow: inset 0 0 0 3px white;
+  /* stylelint-enable no-invalid-position-declaration */
 `
 
 export const createOutline = (userOutline?: OutlineProperty): CreatedOutlineTheme => {

--- a/packages/smarthr-ui/src/themes/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/createOutline.ts
@@ -1,40 +1,30 @@
 import { type FlattenSimpleInterpolation, css } from 'styled-components'
 
-import { merge } from '../libs/lodash'
-
 import { defaultColor } from './createColor'
 
 export type OutlineProperty = {
   OUTLINE?: string
-  OUTLINE_MARGIN?: string
 }
 
 export type CreatedOutlineTheme = {
-  OUTLINE: string
-  OUTLINE_MARGIN: string
+  OUTLINE: FlattenSimpleInterpolation
   focusIndicatorStyles: FlattenSimpleInterpolation
 }
 
-const createFocusIndicatorStyles = (color: string) => css`
+const createOutlineStyles = (color: string) => css`
   outline: 2px solid ${color};
   outline-offset: -2px;
   box-shadow: inset 0 0 0 2px white;
 `
 
 export const defaultOutline = {
-  OUTLINE: defaultColor.OUTLINE,
-  OUTLINE_MARGIN: '4px',
+  OUTLINE: createOutlineStyles(defaultColor.OUTLINE),
 }
 
 export const createOutline = (userOutline?: OutlineProperty): CreatedOutlineTheme => {
-  const outlineColor = userOutline?.OUTLINE || defaultColor.OUTLINE
-  const outline = {
-    ...defaultOutline,
-    focusIndicatorStyles: createFocusIndicatorStyles(outlineColor),
+  const outline = userOutline?.OUTLINE || defaultColor.OUTLINE
+  return {
+    OUTLINE: createOutlineStyles(outline),
+    focusIndicatorStyles: createOutlineStyles(outline),
   }
-  if (!userOutline) {
-    return outline
-  }
-
-  return merge({ ...outline }, userOutline)
 }

--- a/packages/smarthr-ui/src/themes/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/createOutline.ts
@@ -14,7 +14,10 @@ export type CreatedOutlineTheme = {
 const createOutlineStyles = (color: string) => css`
   outline: 2px solid ${color};
   outline-offset: -2px;
-  box-shadow: inset 0 0 0 2px white;
+  isolation: isolate;
+
+  /** outline は border の外側から生えるが、box-shadow は border の内側から生えるため、border の幅を引いている */
+  box-shadow: inset 0 0 0 3px white;
 `
 
 export const defaultOutline = {

--- a/packages/smarthr-ui/src/themes/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/createOutline.ts
@@ -1,0 +1,40 @@
+import { type FlattenSimpleInterpolation, css } from 'styled-components'
+
+import { merge } from '../libs/lodash'
+
+import { defaultColor } from './createColor'
+
+export type OutlineProperty = {
+  OUTLINE?: string
+  OUTLINE_MARGIN?: string
+}
+
+export type CreatedOutlineTheme = {
+  OUTLINE: string
+  OUTLINE_MARGIN: string
+  focusIndicatorStyles: FlattenSimpleInterpolation
+}
+
+const createFocusIndicatorStyles = (color: string) => css`
+  outline: 2px solid ${color};
+  outline-offset: -2px;
+  box-shadow: inset 0 0 0 2px white;
+`
+
+export const defaultOutline = {
+  OUTLINE: defaultColor.OUTLINE,
+  OUTLINE_MARGIN: '4px',
+}
+
+export const createOutline = (userOutline?: OutlineProperty): CreatedOutlineTheme => {
+  const outlineColor = userOutline?.OUTLINE || defaultColor.OUTLINE
+  const outline = {
+    ...defaultOutline,
+    focusIndicatorStyles: createFocusIndicatorStyles(outlineColor),
+  }
+  if (!userOutline) {
+    return outline
+  }
+
+  return merge({ ...outline }, userOutline)
+}

--- a/packages/smarthr-ui/src/themes/createOutline.ts
+++ b/packages/smarthr-ui/src/themes/createOutline.ts
@@ -9,9 +9,17 @@ export type OutlineProperty = {
 export type CreatedOutlineTheme = {
   OUTLINE: FlattenSimpleInterpolation
   focusIndicatorStyles: FlattenSimpleInterpolation
+  innerFocusIndicatorStyles: FlattenSimpleInterpolation
 }
 
-const createOutlineStyles = (color: string) => css`
+const createOuterOutlineStyles = (color: string) => css`
+  outline: 2px solid ${color};
+  outline-offset: 2px;
+  isolation: isolate;
+  box-shadow: 0 0 0 2px white;
+`
+
+const createInnerOutlineStyles = (color: string) => css`
   outline: 2px solid ${color};
   outline-offset: -2px;
   isolation: isolate;
@@ -20,14 +28,12 @@ const createOutlineStyles = (color: string) => css`
   box-shadow: inset 0 0 0 3px white;
 `
 
-export const defaultOutline = {
-  OUTLINE: createOutlineStyles(defaultColor.OUTLINE),
-}
-
 export const createOutline = (userOutline?: OutlineProperty): CreatedOutlineTheme => {
-  const outline = userOutline?.OUTLINE || defaultColor.OUTLINE
+  const outlineColor = userOutline?.OUTLINE || defaultColor.OUTLINE
   return {
-    OUTLINE: createOutlineStyles(outline),
-    focusIndicatorStyles: createOutlineStyles(outline),
+    OUTLINE: createOuterOutlineStyles(outlineColor),
+    focusIndicatorStyles: createOuterOutlineStyles(outlineColor),
+    innerFocusIndicatorStyles: createInnerOutlineStyles(outlineColor),
   }
 }
+export const defaultOutline = createOutline()

--- a/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
+++ b/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
@@ -1,7 +1,4 @@
-import { type FlattenSimpleInterpolation, css } from 'styled-components'
-
 import { merge } from '../../libs/lodash'
-import { type ColorProperty, defaultColor } from '../createColor'
 
 import { defaultShadow } from './defaultShadow'
 
@@ -11,8 +8,6 @@ export type ShadowProperty = {
   LAYER2?: string
   LAYER3?: string
   LAYER4?: string
-  OUTLINE?: string
-  OUTLINE_MARGIN?: string
   UNDERLINE?: string
 }
 
@@ -22,36 +17,13 @@ export type CreatedShadowTheme = {
   LAYER2?: string
   LAYER3?: string
   LAYER4?: string
-  OUTLINE: string
-  OUTLINE_MARGIN: string
   UNDERLINE: string
-  focusIndicatorStyles: FlattenSimpleInterpolation
 }
 
-const createOutline = (color: string) => `0 0 0 2px white, 0 0 0 4px ${color}`
-
-const createFocusIndicatorStyles = (outline: string) => css`
-  /* stylelint-disable no-invalid-position-declaration */
-  outline: none;
-  isolation: isolate;
-  box-shadow: ${outline};
-  /* stylelint-enable no-invalid-position-declaration */
-`
-
-export const createShadow = (
-  userShadow?: ShadowProperty,
-  userColor?: ColorProperty,
-): CreatedShadowTheme => {
-  const outline = createOutline(userColor?.OUTLINE || defaultColor.OUTLINE)
-  const shadows = {
-    ...defaultShadow,
-    OUTLINE: outline,
-    focusIndicatorStyles: createFocusIndicatorStyles(outline),
-  }
-
+export const createShadow = (userShadow?: ShadowProperty): CreatedShadowTheme => {
   if (!userShadow) {
-    return shadows
+    return defaultShadow
   }
 
-  return merge(shadows, userShadow)
+  return merge({ ...defaultShadow }, userShadow)
 }

--- a/packages/smarthr-ui/src/themes/createShadow/defaultShadow.ts
+++ b/packages/smarthr-ui/src/themes/createShadow/defaultShadow.ts
@@ -2,10 +2,6 @@ import { transparentize } from 'polished'
 
 import { defaultColor } from '../createColor'
 
-const createOutline = (color: string) => `0 0 0 2px white, 0 0 0 4px ${color}`
-const defaultOutline = createOutline(defaultColor.OUTLINE)
-const defaultOutlineMargin = '4px'
-
 const createLayerShadow = (depth: number) =>
   depth === 0
     ? 'none'
@@ -21,8 +17,6 @@ export const defaultShadow = {
   LAYER2: createLayerShadow(2),
   LAYER3: createLayerShadow(3),
   LAYER4: createLayerShadow(4),
-  OUTLINE: defaultOutline,
-  OUTLINE_MARGIN: defaultOutlineMargin,
   UNDERLINE: '0 1px 0 0',
   INPUT_HOVER: `0 0 0 2px ${transparentize(0.78, defaultColor.MAIN)}`,
 }

--- a/packages/smarthr-ui/src/themes/createTheme.ts
+++ b/packages/smarthr-ui/src/themes/createTheme.ts
@@ -12,6 +12,7 @@ import {
   createInteraction,
 } from './createInteraction'
 import { type CreatedLeading, type LeadingProperty, createLeading } from './createLeading'
+import { type CreatedOutlineTheme, createOutline } from './createOutline'
 import { type CreatedRadiusTheme, type RadiusProperty, createRadius } from './createRadius'
 import { type CreatedShadowTheme, type ShadowProperty, createShadow } from './createShadow'
 import {
@@ -48,6 +49,7 @@ export type CreatedTheme = {
   radius: CreatedRadiusTheme
   interaction: CreatedInteractionTheme
   shadow: CreatedShadowTheme
+  outline: CreatedOutlineTheme
   zIndex: CreatedZindexTheme
 }
 
@@ -67,7 +69,8 @@ export const createTheme = (theme: ThemeProperty = {}): CreatedTheme => {
     border: createBorder(theme.border, colorProperty),
     radius: createRadius(theme.radius),
     interaction: createInteraction(theme.interaction),
-    shadow: createShadow(theme.shadow, colorProperty),
+    shadow: createShadow(theme.shadow),
+    outline: createOutline(colorProperty),
     zIndex: createZIndex(theme.zIndex),
   }
 }


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->


## 関連URL
https://smarthr.atlassian.net/browse/A11Y2-68
https://smarthr.atlassian.net/browse/A11Y2-47
<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

### やりたいこと

- `box-shadow` ではなく `outline` を使用してフォーカスインジケーターを作りたい
  - box-shadow は矯正カラーモードで表示されないため
- アウトラインが途切れる可能性がある箇所は、intent(内側) にフォーカスインジケーターを表示させたい


<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- OUTLINEの生成箇所として `createOutline.ts` を作成し、 `createShadow.ts` から削除
- `smarthr-ui-presets.ts` の `focus-indicator` に、祖先に `overflow` がいる場合は内側になるように処理を追加
   - 上書きできるように `:where` で詳細度を 0 に 
- 内側になるもののうちおかしいものを個別に対応

変化があったもの↓

|before|after|
|---|---|
|<img width="981" height="191" alt="image" src="https://github.com/user-attachments/assets/64078a4e-1f4e-44d2-8937-61ecfe998b8f" />|<img width="979" height="186" alt="image" src="https://github.com/user-attachments/assets/17b54434-a15c-44fd-b82e-c9194659b644" />|
|<img width="388" height="391" alt="image" src="https://github.com/user-attachments/assets/6333a392-94f2-425b-85eb-a02bd82ace93" />|<img width="389" height="378" alt="image" src="https://github.com/user-attachments/assets/c67572a0-1eaa-44e7-9815-af0756e81871" />|
|<img width="361" height="369" alt="image" src="https://github.com/user-attachments/assets/6975cbdb-505b-41cc-b67f-0d9bde49a592" /> |<img width="369" height="384" alt="image" src="https://github.com/user-attachments/assets/268b1777-ac24-4d35-aa33-a64d86918759" />|

※ WarekiPicker の年を選ぶカレンダーは元のフォーカスインジケーターが hover などと違っていて違和感があったので一緒に変更を入れました
<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

### ⚠️ 大きな懸念 ⚠️ 

inset にしている条件が、「祖先に `offset-*` が当たっているかどうか 」で判定しているため、ほとんどの要素が inset になる可能性があります。

また、ダイアログあり/なしで同じ要素だけどfocusの当たり方が変わるといった可能性があります。

そのため、基本insetにしつつ、insetであるとわかりにくくなる一部の要素だけouterにするという実装を考えています。

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
