### PR TITLE
test: vitest 実行時の act() に関する警告への対処

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.test.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { config } from 'react-transition-group'
-import { userEvent } from 'storybook/test'
 
 import { Fieldset } from '../Fieldset'
 import { RadioButton } from '../RadioButton'

--- a/packages/smarthr-ui/src/components/Browser/Browser.test.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { userEvent } from 'storybook/test'
+import userEvent from '@testing-library/user-event'
 
 import { IntlProvider } from '../../intl'
 

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react'
-import { type ComponentProps, act } from 'react'
-import { userEvent } from 'storybook/test'
+import userEvent from '@testing-library/user-event'
 
 import { IntlProvider } from '../../../intl'
 import { FormControl } from '../../FormControl'
 
 import { MultiCombobox } from './MultiCombobox'
+
+import type { ComponentProps } from 'react'
 
 describe('SingleCombobox', () => {
   beforeEach(() => {
@@ -56,14 +57,14 @@ describe('SingleCombobox', () => {
     render(template({ onSelect }))
 
     // コンボボックスをクリックしてリストボックスを表示
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(combobox()).toHaveFocus()
     expect(screen.queryByRole('listbox')).toBeInTheDocument()
 
     // リストボックスからアイテムを2種続けて選択して、選択イベントの発火を確認
-    await act(() => userEvent.click(screen.getByRole('option', { name: 'option 2' })))
+    await userEvent.click(screen.getByRole('option', { name: 'option 2' }))
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2' })
-    await act(() => userEvent.click(screen.getByRole('option', { name: 'option 4' })))
+    await userEvent.click(screen.getByRole('option', { name: 'option 4' }))
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 4', value: 'value-4' })
 
     // リストボックスは開かれたままになっている
@@ -83,9 +84,9 @@ describe('SingleCombobox', () => {
     )
 
     // 削除ボタンをクリックすると、クリックしたアイテムが onDelete で渡される
-    await act(() => userEvent.click(deleteButtons()[0]))
+    await userEvent.click(deleteButtons()[0])
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 1', value: 'value-1' })
-    await act(() => userEvent.click(deleteButtons()[1]))
+    await userEvent.click(deleteButtons()[1])
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 3', value: 'value-3' })
   })
 
@@ -93,19 +94,19 @@ describe('SingleCombobox', () => {
     render(template({}))
 
     // クリックで開く
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).toBeInTheDocument()
 
     // 外側クリックで閉じる
-    await act(() => userEvent.click(document.body))
+    await userEvent.click(document.body)
     expect(listbox()).not.toBeInTheDocument()
 
     // 再度クリックで開く
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).toBeInTheDocument()
 
     // ESCで閉じる
-    await act(() => userEvent.keyboard('{escape}'))
+    await userEvent.keyboard('{escape}')
     expect(listbox()).not.toBeInTheDocument()
   })
 
@@ -114,7 +115,7 @@ describe('SingleCombobox', () => {
     render(template({ onDelete }))
 
     // 選択解除ボタンをクリックしてもリストボックスが表示されないことを確認
-    await act(() => userEvent.click(deleteButtons()[0]))
+    await userEvent.click(deleteButtons()[0])
     expect(listbox()).not.toBeInTheDocument()
   })
 
@@ -123,17 +124,15 @@ describe('SingleCombobox', () => {
     render(template({ onAdd, creatable: true, selectedItems: [] }))
 
     // コンボボックスをクリックしてリストボックスを表示
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).toBeInTheDocument()
 
     // 新しいアイテムを入力する
-    await act(() => userEvent.type(combobox(), '新しいアイテム'))
+    await userEvent.type(combobox(), '新しいアイテム')
     expect(listbox()).toHaveTextContent('「新しいアイテム」を追加')
 
     // 新しいアイテムをクリックして、追加イベントの発火を確認
-    await act(() =>
-      userEvent.click(screen.getByRole('option', { name: '「新しいアイテム」を追加' })),
-    )
+    await userEvent.click(screen.getByRole('option', { name: '「新しいアイテム」を追加' }))
     expect(onAdd).toHaveBeenCalledWith('新しいアイテム')
   })
 
@@ -154,7 +153,7 @@ describe('SingleCombobox', () => {
     expect(deleteButtons()).toHaveLength(1)
 
     // その1つをクリックした場合、deletable なアイテムで onDelete が呼ばれる
-    await act(() => userEvent.click(deleteButtons()[0]))
+    await userEvent.click(deleteButtons()[0])
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2', deletable: true })
   })
 
@@ -163,11 +162,11 @@ describe('SingleCombobox', () => {
     render(template({ onDelete, disabled: true }))
 
     // コンボボックスをクリックしてもリストボックスが表示されないことを確認
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).not.toBeInTheDocument()
 
     // 選択解除ボタンをクリックしても onDelete が呼ばれないことを確認
-    await act(() => userEvent.click(deleteButtons()[0]))
+    await userEvent.click(deleteButtons()[0])
     expect(onDelete).not.toHaveBeenCalled()
   })
 
@@ -175,18 +174,18 @@ describe('SingleCombobox', () => {
     const onSelect = vi.fn()
     render(template({ onSelect, selectedItems: [] }))
 
-    await act(() => userEvent.keyboard('{tab}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{tab}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{enter}')
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 3', value: 'value-3' })
 
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{enter}')
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 4', value: 'value-4' })
   })
 
@@ -204,15 +203,15 @@ describe('SingleCombobox', () => {
     )
 
     // リストボックスを開く
-    await act(() => userEvent.keyboard('{tab}'))
+    await userEvent.keyboard('{tab}')
 
     // 下矢印キーで選択中アイテムに移動し、Enter キーで削除できること
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{enter}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{enter}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{enter}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{enter}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{enter}')
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 1', value: 'value-1' })
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2' })
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 3', value: 'value-3' })
@@ -230,37 +229,37 @@ describe('SingleCombobox', () => {
     )
 
     // リストボックスを開く
-    await act(() => userEvent.keyboard('{tab}'))
+    await userEvent.keyboard('{tab}')
 
     // 適当にキー入力
-    await act(() => userEvent.keyboard('ops'))
+    await userEvent.keyboard('ops')
 
     // カーソルを左に移動をしても、キャレットがテキストの先頭にない間は削除ボタンにフォーカスが移動しないこと
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[2]).not.toHaveFocus()
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[2]).not.toHaveFocus()
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[2]).not.toHaveFocus()
 
     // キャレットが先頭にある状態でカーソルを左に移動すると、末尾の削除ボタンにフォーカスが移動すること
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[2]).toHaveFocus()
 
     // 削除ボタンにフォーカスがある状態でさらに手前の削除ボタンに移動できること
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[1]).toHaveFocus()
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[0]).toHaveFocus()
 
     // 一番手前の削除ボタンにフォーカスがある場合は、左矢印キーを押下してもこれ以上フォーカス移動できないこと
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[0]).toHaveFocus()
 
     // 末尾日の削除ボタンにフォーカスがある場合、右矢印キーを押下すると input いフォーカスが移動すること
-    await act(() => userEvent.keyboard('{arrowright}'))
-    await act(() => userEvent.keyboard('{arrowright}'))
-    await act(() => userEvent.keyboard('{arrowright}'))
+    await userEvent.keyboard('{arrowright}')
+    await userEvent.keyboard('{arrowright}')
+    await userEvent.keyboard('{arrowright}')
     expect(deleteButtons()[2]).not.toHaveFocus()
     expect(combobox()).toHaveFocus()
   })
@@ -278,14 +277,14 @@ describe('SingleCombobox', () => {
     )
 
     // リストボックスを開く
-    await act(() => userEvent.keyboard('{tab}'))
+    await userEvent.keyboard('{tab}')
 
     // 選択中のアイテムにフォーカスを移動
-    await act(() => userEvent.keyboard('{arrowleft}'))
+    await userEvent.keyboard('{arrowleft}')
     expect(deleteButtons()[1]).toHaveFocus()
 
     // Enter キーで削除
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{enter}')
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2' })
   })
 
@@ -302,10 +301,10 @@ describe('SingleCombobox', () => {
     )
 
     // リストボックスを開く
-    await act(() => userEvent.keyboard('{tab}'))
+    await userEvent.keyboard('{tab}')
 
     // Backspace キーで末尾のアイテムが削除されること
-    await act(() => userEvent.keyboard('{backspace}'))
+    await userEvent.keyboard('{backspace}')
     expect(onDelete).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2' })
 
     // Backspace によって削除した末尾アイテムはテキスト化されること

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
@@ -189,7 +189,7 @@ describe('SingleCombobox', () => {
   })
 })
 
-test('groupロールが付与されている', () => {
+test('groupロールが付与されている', async () => {
   const onClearClick = vi.fn()
 
   render(
@@ -210,6 +210,6 @@ test('groupロールが付与されている', () => {
     </IntlProvider>,
   )
 
-  within(screen.getByRole('group')).getByRole('button', { name: 'クリア' }).click()
+  await userEvent.click(within(screen.getByRole('group')).getByRole('button', { name: 'クリア' }))
   expect(onClearClick).toBeCalled()
 })

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen, within } from '@testing-library/react'
-import { type ComponentProps, act } from 'react'
-import { userEvent } from 'storybook/test'
+import userEvent from '@testing-library/user-event'
 
 import { IntlProvider } from '../../../intl'
 import { FormControl } from '../../FormControl'
 
 import { SingleCombobox } from './SingleCombobox'
+
+import type { ComponentProps } from 'react'
 
 describe('SingleCombobox', () => {
   beforeEach(() => {
@@ -54,12 +55,12 @@ describe('SingleCombobox', () => {
     render(template({ onSelect }))
 
     // コンボボックスをクリックしてリストボックスを表示
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(combobox()).toHaveFocus()
     expect(screen.queryByRole('listbox')).toBeInTheDocument()
 
     // リストボックスからアイテムを選択して、選択イベントの発火を確認
-    await act(() => userEvent.click(screen.getByRole('option', { name: 'option 2' })))
+    await userEvent.click(screen.getByRole('option', { name: 'option 2' }))
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2' })
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
@@ -69,7 +70,7 @@ describe('SingleCombobox', () => {
     render(template({ onClear }))
 
     // 削除ボタンをクリックして削除イベントの発火を確認
-    await act(() => userEvent.click(clearButton()))
+    await userEvent.click(clearButton())
     expect(onClear).toHaveBeenCalledWith()
   })
 
@@ -77,19 +78,19 @@ describe('SingleCombobox', () => {
     render(template({}))
 
     // クリックで開く
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).toBeInTheDocument()
 
     // 外側クリックで閉じる
-    await act(() => userEvent.click(document.body))
+    await userEvent.click(document.body)
     expect(listbox()).not.toBeInTheDocument()
 
     // 再度クリックで開く
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).toBeInTheDocument()
 
     // ESCで閉じる
-    await act(() => userEvent.keyboard('{escape}'))
+    await userEvent.keyboard('{escape}')
     expect(listbox()).not.toBeInTheDocument()
   })
 
@@ -98,7 +99,7 @@ describe('SingleCombobox', () => {
     render(template({ onClear }))
 
     // 選択解除ボタンをクリックしてリストボックスが表示されることを確認
-    await act(() => userEvent.click(clearButton()))
+    await userEvent.click(clearButton())
     expect(listbox()).toBeInTheDocument()
   })
 
@@ -107,17 +108,15 @@ describe('SingleCombobox', () => {
     render(template({ onAdd, creatable: true, selectedItem: null }))
 
     // コンボボックスをクリックしてリストボックスを表示
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).toBeInTheDocument()
 
     // 新しいアイテムを入力する
-    await act(() => userEvent.type(combobox(), '新しいアイテム'))
+    await userEvent.type(combobox(), '新しいアイテム')
     expect(listbox()).toHaveTextContent('「新しいアイテム」を追加')
 
     // 新しいアイテムをクリックして、追加イベントの発火を確認
-    await act(() =>
-      userEvent.click(screen.getByRole('option', { name: '「新しいアイテム」を追加' })),
-    )
+    await userEvent.click(screen.getByRole('option', { name: '「新しいアイテム」を追加' }))
     expect(onAdd).toHaveBeenCalledWith('新しいアイテム')
   })
 
@@ -126,7 +125,7 @@ describe('SingleCombobox', () => {
     render(template({ onClear, disabled: true }))
 
     // コンボボックスをクリックしてもリストボックスが表示されないことを確認
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).not.toBeInTheDocument()
 
     // 選択解除ボタンが表示されていない(非表示用のクラスが付与されている)
@@ -138,7 +137,7 @@ describe('SingleCombobox', () => {
     render(template({ onClear, readOnly: true }))
 
     // コンボボックスをクリックしてもリストボックスが表示されないことを確認
-    await act(() => userEvent.click(combobox()))
+    await userEvent.click(combobox())
     expect(listbox()).not.toBeInTheDocument()
 
     // 選択解除ボタンが表示されていない(非表示用のクラスが付与されている)
@@ -149,18 +148,18 @@ describe('SingleCombobox', () => {
     const onSelect = vi.fn()
     render(template({ onSelect, selectedItem: null }))
 
-    await act(() => userEvent.keyboard('{tab}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{arrowdown}'))
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{tab}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{arrowdown}')
+    await userEvent.keyboard('{enter}')
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 3', value: 'value-3' })
 
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{arrowup}'))
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{arrowup}')
+    await userEvent.keyboard('{enter}')
     expect(onSelect).toHaveBeenCalledWith({ label: 'option 2', value: 'value-2' })
   })
 
@@ -184,8 +183,8 @@ describe('SingleCombobox', () => {
       </IntlProvider>,
     )
 
-    await act(() => userEvent.keyboard('{tab}'))
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.keyboard('{tab}')
+    await userEvent.keyboard('{enter}')
     expect(onSubmit).not.toHaveBeenCalled()
   })
 })

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { act } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { IntlProvider } from '../../intl'
 import { FormControl } from '../FormControl'
@@ -53,7 +53,7 @@ describe('DatePicker', () => {
       </form>,
     )
     const textbox = screen.getByRole('textbox', { name: 'DatePicker' })
-    await act(() => userEvent.type(textbox, '平成4年5月29日{tab}'))
+    await userEvent.type(textbox, '平成4年5月29日{tab}')
     expect(textbox).toHaveProperty('value', '1992/05/29')
   })
 })

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type FC, useState } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { IntlProvider } from '../../../intl'
 import { Button } from '../../Button'
@@ -31,12 +31,12 @@ describe('ControlledActionDialog', () => {
     render(<DialogTemplate />)
 
     expect(screen.queryByRole('dialog', { name: 'ControlledActionDialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: 'ControlledActionDialog' })).toBeVisible()
 
-    await act(() => userEvent.tab({ shift: true }))
-    await act(() => userEvent.keyboard('{ }'))
+    await userEvent.tab({ shift: true })
+    await userEvent.keyboard('{ }')
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog', { name: 'ControlledActionDialog' })).toBeNull()

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type FC, useRef, useState } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { IntlProvider } from '../../../intl'
 import { Button } from '../../Button'
@@ -36,12 +36,12 @@ describe('ControlledFormDialog', () => {
     render(<DialogTemplate />)
 
     expect(screen.queryByRole('dialog', { name: 'ControlledFormDialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: 'ControlledFormDialog' })).toBeVisible()
 
-    await act(() => userEvent.tab({ shift: true }))
-    await act(() => userEvent.keyboard('{ }'))
+    await userEvent.tab({ shift: true })
+    await userEvent.keyboard('{ }')
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog', { name: 'ControlledFormDialog' })).toBeNull()
@@ -90,16 +90,16 @@ describe('ControlledFormDialog', () => {
     render(<DialogTemplateWithFocusTrap />)
 
     expect(screen.queryByRole('dialog', { name: '開いた状態で投入されたダイアログ' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: '開いた状態で投入されたダイアログ' })).toBeVisible()
 
     expect(
       screen.getByRole('textbox', { name: 'isOpen=true の状態で DOM に投入した場合のダイアログ' }),
     ).toHaveFocus()
 
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{ }'))
+    await userEvent.tab()
+    await userEvent.keyboard('{ }')
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog', { name: 'ControlledFormDialog' })).toBeNull()

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type FC, useState } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { IntlProvider } from '../../../intl'
 import { Button } from '../../Button'
@@ -27,12 +27,12 @@ describe('ControlledMessageDialog', () => {
     render(<DialogTemplate />)
 
     expect(screen.queryByRole('dialog', { name: 'ControlledMessageDialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: 'ControlledMessageDialog' })).toBeVisible()
 
-    await act(() => userEvent.tab({ shift: true }))
-    await act(() => userEvent.keyboard('{ }'))
+    await userEvent.tab({ shift: true })
+    await userEvent.keyboard('{ }')
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog', { name: 'ControlledMessageDialog' })).toBeNull()

--- a/packages/smarthr-ui/src/components/Dialog/Dialog.PortalParent.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.PortalParent.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useRef, useState } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { Button } from '../Button'
 import { Heading } from '../Heading'
@@ -37,12 +37,12 @@ describe('Dialog (Portal Parent)', () => {
     render(<DialogTemplate />)
 
     expect(screen.queryByRole('dialog', { name: 'Dialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: 'Dialog' })).toBeVisible()
 
-    await act(() => userEvent.tab({ shift: true }))
-    await act(() => userEvent.keyboard('{ }'))
+    await userEvent.tab({ shift: true })
+    await userEvent.keyboard('{ }')
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog', { name: 'Dialog' })).toBeNull()

--- a/packages/smarthr-ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type FC, useRef, useState } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { IntlProvider } from '../../intl'
 import { Button } from '../Button'
@@ -69,12 +69,12 @@ describe('Dialog', () => {
     renderWithIntl(<DialogTemplate />)
 
     expect(screen.queryByRole('dialog', { name: 'Dialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: 'Dialog' })).toBeVisible()
 
-    await act(() => userEvent.tab({ shift: true }))
-    await act(() => userEvent.keyboard('{ }'))
+    await userEvent.tab({ shift: true })
+    await userEvent.keyboard('{ }')
     await waitFor(
       () => {
         expect(screen.queryByRole('dialog', { name: 'Dialog' })).toBeNull()
@@ -111,13 +111,13 @@ describe('Dialog', () => {
     renderWithIntl(<DialogTemplate />)
 
     expect(screen.queryByRole('dialog', { name: 'Dialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: 'Dialog' })).toBeVisible()
 
-    await act(() => userEvent.tab({ shift: true }))
+    await userEvent.tab({ shift: true })
     expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
-    await act(() => userEvent.tab())
+    await userEvent.tab()
     expect(screen.getByRole('textbox', { name: 'dialog_datepicker' })).toHaveFocus()
   })
 
@@ -151,8 +151,8 @@ describe('Dialog', () => {
     expect(
       screen.queryByRole('dialog', { name: '特定の要素をフォーカスするダイアログ' }),
     ).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(
       screen.getByRole('dialog', { name: '特定の要素をフォーカスするダイアログ' }),
     ).toBeVisible()

--- a/packages/smarthr-ui/src/components/Dialog/DialogWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogWrapper.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
-import { userEvent } from 'storybook/test'
+import userEvent from '@testing-library/user-event'
 
 import { IntlProvider } from '../../intl'
 import { Button } from '../Button'
@@ -36,12 +36,12 @@ describe('DialogWrapper', () => {
       render(<DialogContentTemplate />)
 
       expect(screen.queryByRole('dialog', { name: 'DialogContent' })).toBeNull()
-      await act(() => userEvent.tab())
-      await act(() => userEvent.keyboard('{enter}'))
+      await userEvent.tab()
+      await userEvent.keyboard('{enter}')
       expect(screen.getByRole('dialog', { name: 'DialogContent' })).toBeVisible()
 
-      await act(() => userEvent.tab({ shift: true }))
-      await act(() => userEvent.keyboard('{ }'))
+      await userEvent.tab({ shift: true })
+      await userEvent.keyboard('{ }')
       await waitFor(
         () => {
           expect(screen.queryByRole('dialog', { name: 'DialogContent' })).toBeNull()

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type FC, useState } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { IntlProvider } from '../../../intl'
 import { Button } from '../../Button'
@@ -28,12 +28,12 @@ describe('ModelessDialog', () => {
 
     // トリガ押下でダイアログが開くこと
     expect(screen.queryByRole('dialog', { name: 'ModelessDialog' })).toBeNull()
-    await act(() => userEvent.tab())
-    await act(() => userEvent.keyboard('{enter}'))
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
     expect(screen.getByRole('dialog', { name: '座標指定表示' })).toBeVisible()
 
     // 裏側をクリックしてもダイアログが閉じないこと
-    await act(() => userEvent.click(document.body))
+    await userEvent.click(document.body)
     await waitFor(
       () => {
         expect(screen.getByRole('dialog', { name: '座標指定表示' })).toBeVisible()

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { act } from 'react'
-import { userEvent } from 'storybook/test'
 
 import { Button } from '../Button'
 import { Stack } from '../Layout'

--- a/packages/smarthr-ui/src/components/InputFile/InputFile.test.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFile.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { userEvent } from 'storybook/test'
+import userEvent from '@testing-library/user-event'
 
 import { IntlProvider } from '../../intl'
 import { FormControl } from '../FormControl'


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- CircleCI の実行結果 https://app.circleci.com/pipelines/github/kufu/smarthr-ui/26586/workflows/6d63b726-347e-4a71-a8bc-468af01469af/jobs/97631/parallel-runs/0/steps/0-107

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

vitest を実行すると、以下の警告が出ています。

```
When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
An update to null inside a test was not wrapped in act(...).
```


<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

大部分については、`storybook/test` の `userEvent` を import していたのが原因のようです。
` @testing-library/user-event` の `userEvent` であれば自動的に act(...) してくれるので（なによりどれもストーリーブックではないので）、こちらを利用するよう変更します。 53ba3d881b7c7547b4acec2a0f18217efbe008d3
 
`SingleCombobox.test.tsx`  については書き方に問題があったので修正しています。 07fdc69c2600f842fd5a8c4b3b6ca15ea80595c4

### やっていないこと

Testing Library v14 以降で推奨される userEvent の書き方が変わっているのですが、この変更には含めていません。

[Writing tests with userEvent](https://testing-library.com/docs/user-event/intro/#writing-tests-with-userevent)

> 

``` 
# Testing Library v14 以降で推奨される書き方
user = userEvent.setup()
user.click(...)
```

`storybook/test` の userEvent が使われていた件については、eslint で弾いてもいいかもしれませんね。

``` javascript
 diff --git i/eslint.config.mjs w/eslint.config.mjs
index c6c9d9f1f..b117d3e51 100644
--- i/eslint.config.mjs
+++ w/eslint.config.mjs
@@ -52,6 +52,23 @@ export default [
       '@typescript-eslint/no-import-type-side-effects': 'error',
     },
   },
+  {
+    files: ['**/*.test.tsx', '!**/*.stories.tsx'],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "storybook/test",
+              importNames: ["userEvent"],
+              message: "Please import userEvent from @testing-library/user-event."
+            }
+          ]
+        }
+      ]
+    },
+  },
   {
     ignores: [
       '**/*.{mjs,js}',
 ```
 


<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## 確認方法

CircleCI の実行結果を確認

※ テストコードの変更だけで、動作に影響はありません

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kufu/smarthr-ui/pull/5969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
