### PR TITLE
feat(DropdownMenuButton)!: label, trigger関連の属性をtrigger属性一つにまとめる

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/UserInfo.tsx
@@ -158,7 +158,7 @@ export const ActualUserInfo: FC<Omit<Props, 'arbitraryDisplayName'> & { displayN
     return (
       <DropdownMenuButton
         className={classNames.dropdownMenuButton}
-        label={
+        trigger={
           <DropdownMenuLabel
             firstName={firstName}
             lastName={lastName}

--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
@@ -75,7 +75,7 @@ const renderItemList = (children: ReactNode) =>
 
 export const AppNaviDropdownMenuButton: FC<Props> = ({ label, onOpen, onClose, children }) => (
   <DropdownMenuButton
-    label={
+    trigger={
       <>
         {label}
         {/* has([aria-current="page"]) を書くために複製 */}

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -38,17 +38,24 @@ type ActionItem =
   | ReactElement<ComponentProps<typeof RemoteDialogTrigger>>
   | ReactNode
 
-type AbstractProps = {
+type ObjectTriggerType = {
   /** 引き金となるボタンラベル */
-  label: ReactNode
+  children: ReactNode
+  /** 引き金となるボタンの大きさ */
+  size?: ButtonProps['size']
+  /** 引き金となるボタンをアイコンのみとするかどうか */
+  onlyIcon?:
+    | boolean
+    | {
+        /** 引き金となるアイコンを差し替えたい場合（onlyIcon=true の場合のみ有効） */
+        component?: ComponentType<ComponentProps<typeof FaCaretDownIcon>>
+      }
+}
+type AbstractProps = {
+  /** 引き金となるボタン */
+  trigger: ReactNode | ObjectTriggerType
   /** 操作群 */
   children: Actions
-  /** 引き金となるボタンの大きさ */
-  triggerSize?: ButtonProps['size']
-  /** 引き金となるボタンをアイコンのみとするかどうか */
-  onlyIconTrigger?: boolean
-  /** 引き金となるアイコンを差し替えたい場合（onlyIconTrigger=true の場合のみ有効） */
-  triggerIcon?: ComponentType<ComponentProps<typeof FaCaretDownIcon>>
   /** ドロップダウンメニューが開かれた際のイベント */
   onOpen?: () => void
   /** ドロップダウンメニューが閉じられた際のイベント */
@@ -82,16 +89,26 @@ const classNameGenerator = tv({
 const { triggerWrapper, triggerButton, actionList, actionListItemButton } = classNameGenerator()
 
 export const DropdownMenuButton: FC<Props> = ({
-  label,
+  trigger,
   children,
-  triggerSize,
-  onlyIconTrigger,
-  triggerIcon,
   onOpen,
   onClose,
   className,
   ...rest
 }) => {
+  // HINT: ReactNodeとObjectのどちらかを判定
+  // typeofはnullの場合もobject判定されてしまうため念の為falsyで判定
+  // ReactNodeの一部であるReactElementもobjectとして判定されてしまうためisValidElementで判定
+  const {
+    children: triggerChildren,
+    size: triggerSize,
+    onlyIcon: onlyIconTrigger,
+  }: ObjectTriggerType = !trigger || typeof trigger !== 'object' || isValidElement(trigger)
+    ? {
+        children: trigger as ReactNode,
+      }
+    : (trigger as ObjectTriggerType)
+
   const containerRef = useRef<HTMLUListElement>(null)
 
   useKeyboardNavigation(containerRef)
@@ -109,9 +126,8 @@ export const DropdownMenuButton: FC<Props> = ({
     <Dropdown onOpen={onOpen} onClose={onClose}>
       <MemoizedTriggerButton
         {...rest}
-        label={label}
+        children={triggerChildren}
         onlyIconTrigger={onlyIconTrigger}
-        triggerIcon={triggerIcon}
         triggerSize={triggerSize}
         classNames={classNames}
       />
@@ -125,22 +141,22 @@ export const DropdownMenuButton: FC<Props> = ({
 }
 
 const MemoizedTriggerButton = memo<
-  Pick<Props, 'onlyIconTrigger' | 'triggerSize' | 'label' | 'triggerIcon'> &
-    ElementProps & {
-      classNames: {
-        triggerWrapper: string
-        triggerButton: string
-      }
+  ElementProps & {
+    onlyIconTrigger: ObjectTriggerType['onlyIcon']
+    triggerSize: ObjectTriggerType['size']
+    children: ObjectTriggerType['children']
+    classNames: {
+      triggerWrapper: string
+      triggerButton: string
     }
->(({ onlyIconTrigger, triggerSize, label, triggerIcon, classNames, ...rest }) => {
+  }
+>(({ onlyIconTrigger, triggerSize, children, classNames, ...rest }) => {
   const { localize } = useIntl()
 
   const { active } = useContext(DropdownContext)
 
-  const tooltip = useMemo(
-    () => ({ show: onlyIconTrigger, message: label }),
-    [label, onlyIconTrigger],
-  )
+  const showTooltip = !!onlyIconTrigger
+  const tooltip = useMemo(() => ({ show: showTooltip, message: children }), [children, showTooltip])
 
   return (
     <DropdownTrigger className={classNames.triggerWrapper} tooltip={tooltip}>
@@ -166,27 +182,24 @@ const MemoizedTriggerButton = memo<
         size={triggerSize}
         className={classNames.triggerButton}
       >
-        <TriggerLabelText
-          label={label}
-          onlyIconTrigger={onlyIconTrigger}
-          triggerIcon={triggerIcon}
-        />
+        <TriggerLabelText children={children} onlyIconTrigger={onlyIconTrigger} />
       </Button>
     </DropdownTrigger>
   )
 })
 
-const TriggerLabelText = memo<Pick<Props, 'label' | 'onlyIconTrigger' | 'triggerIcon'>>(
-  ({ label, onlyIconTrigger, triggerIcon }) => {
-    if (!onlyIconTrigger) {
-      return label
-    }
+const TriggerLabelText = memo<{
+  onlyIconTrigger: ObjectTriggerType['onlyIcon']
+  children: ObjectTriggerType['children']
+}>(({ children, onlyIconTrigger }) => {
+  if (!onlyIconTrigger) {
+    return children
+  }
 
-    const Icon = triggerIcon || FaEllipsisIcon
+  const Icon = (typeof onlyIconTrigger === 'object' && onlyIconTrigger.component) || FaEllipsisIcon
 
-    return <Icon alt={typeof label === 'string' ? label : innerText(label)} />
-  },
-)
+  return <Icon alt={typeof children === 'string' ? children : innerText(children)} />
+})
 
 export const renderButtonList = (children: Actions) =>
   Children.map(children, (item): ReactNode => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuButton.stories.tsx
@@ -29,15 +29,8 @@ export default {
       </Button>
     </DropdownMenuButton>
   ),
-  argTypes: {
-    triggerIcon: {
-      control: 'radio',
-      options: Object.keys(_sampleTriggerIcons),
-      mapping: _sampleTriggerIcons,
-    },
-  },
   args: {
-    label: 'その他の操作',
+    trigger: 'その他の操作',
   },
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -46,37 +39,49 @@ export default {
 
 export const Playground: StoryObj<typeof DropdownMenuButton> = {
   args: {
-    triggerSize: 'default',
-    onlyIconTrigger: false,
+    trigger: {
+      children: 'その他の操作',
+      size: 'default',
+    },
   },
 }
 
-export const Label: StoryObj<typeof DropdownMenuButton> = {
-  name: 'label',
+export const Trigger: StoryObj<typeof DropdownMenuButton> = {
+  name: 'trigger',
   args: {
-    label: 'ドロップダウンメニューボタンラベル',
+    trigger: 'ドロップダウンメニューボタンラベル',
   },
 }
 
 export const TriggerSize: StoryObj<typeof DropdownMenuButton> = {
-  name: 'triggerSize',
+  name: 'trigger.size',
   args: {
-    triggerSize: 's',
+    trigger: {
+      children: 'ドロップダウンメニューボタンラベル',
+      size: 's',
+    },
   },
 }
 
-export const OnlyIconTrigger: StoryObj<typeof DropdownMenuButton> = {
-  name: 'onlyIconTrigger',
+export const TriggerOnlyIcon: StoryObj<typeof DropdownMenuButton> = {
+  name: 'trigger.onlyIcon',
   args: {
-    onlyIconTrigger: true,
+    trigger: {
+      children: 'ドロップダウンメニューボタンラベル',
+      // onlyIcon が falsy の時は、開閉を示唆する FaCaretDownIcon が表示されます
+      onlyIcon: true,
+    },
   },
 }
 
-export const TriggerIcon: StoryObj<typeof DropdownMenuButton> = {
-  name: 'triggerIcon',
+export const TriggerOnlyIconComponent: StoryObj<typeof DropdownMenuButton> = {
+  name: 'trigger.onlyIcon.component',
   args: {
-    // onlyIconTrigger が false の時は、開閉を示唆する FaCaretDownIcon が表示されます
-    onlyIconTrigger: true,
-    triggerIcon: FaGearIcon,
+    trigger: {
+      children: 'ドロップダウンメニューボタンラベル',
+      onlyIcon: {
+        component: FaGearIcon,
+      },
+    },
   },
 }

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuGroup.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuGroup.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/Dropdown/DropdownMenuButton/DropdownMenuGroup',
   component: DropdownMenuGroup,
   render: (args) => (
-    <DropdownMenuButton label="その他の操作">
+    <DropdownMenuButton trigger="その他の操作">
       <DropdownMenuGroup {...args} name="グループ1">
         <Button>操作1</Button>
         <Button>操作2</Button>
@@ -38,7 +38,7 @@ export const Playground: StoryObj<typeof DropdownMenuGroup> = {}
 export const Name: StoryObj<typeof DropdownMenuGroup> = {
   name: 'name',
   render: (args) => (
-    <DropdownMenuButton label="その他の操作">
+    <DropdownMenuButton trigger="その他の操作">
       <Button>操作1</Button>
       <Button>操作2</Button>
       <DropdownMenuGroup {...args}>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
@@ -20,15 +20,13 @@ import type { Meta, StoryObj } from '@storybook/react'
  * default     false           undefined
  * default     true            指定あり
  */
-const _cases: Array<
-  Pick<ComponentProps<typeof DropdownMenuButton>, 'triggerSize' | 'onlyIconTrigger' | 'triggerIcon'>
-> = [
-  { triggerSize: 's', onlyIconTrigger: true, triggerIcon: undefined },
-  { triggerSize: 's', onlyIconTrigger: false, triggerIcon: undefined },
-  { triggerSize: 'default', onlyIconTrigger: true, triggerIcon: undefined },
-  { triggerSize: 's', onlyIconTrigger: true, triggerIcon: FaGearIcon },
-  { triggerSize: 'default', onlyIconTrigger: false, triggerIcon: undefined },
-  { triggerSize: 'default', onlyIconTrigger: true, triggerIcon: FaGearIcon },
+const _cases: Array<Pick<ComponentProps<typeof DropdownMenuButton>, 'trigger'>> = [
+  { trigger: { children: 'その他の操作', size: 's', onlyIcon: true } },
+  { trigger: { children: 'その他の操作', size: 's' } },
+  { trigger: { children: 'その他の操作', onlyIcon: true } },
+  { trigger: { children: 'その他の操作', size: 's', onlyIcon: { component: FaGearIcon } } },
+  { trigger: 'その他の操作' },
+  { trigger: { children: 'その他の操作', onlyIcon: { component: FaGearIcon } } },
 ]
 
 export default {
@@ -55,9 +53,6 @@ export default {
       ))}
     </Cluster>
   ),
-  args: {
-    label: 'その他の操作',
-  },
   parameters: {
     chromatic: { disableSnapshot: false },
   },

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -186,7 +186,7 @@ const Controller: FC<ControllerProps> = memo(
             />
           </Button>
           <DropdownMenuButton
-            label={
+            trigger={
               <Text>
                 <VisuallyHiddenText>
                   <Localizer id="smarthr-ui/FileViewer/scaleRateLabel" defaultText="拡大率" />

--- a/packages/smarthr-ui/src/components/Header/Header.tsx
+++ b/packages/smarthr-ui/src/components/Header/Header.tsx
@@ -170,7 +170,7 @@ const TenantSwitcher = memo<
       <div className={classNames.tenantInfo}>
         {tenants && tenants.length > 1 ? (
           <MultiTenantDropdownMenuButton
-            label={currentTenantName}
+            trigger={currentTenantName}
             tenants={tenants}
             onTenantSelect={onTenantSelect}
           />
@@ -185,8 +185,8 @@ const TenantSwitcher = memo<
 })
 
 const MultiTenantDropdownMenuButton = memo<
-  Pick<Required<Props>, 'tenants'> & Pick<Props, 'onTenantSelect'> & { label: ReactNode }
->(({ label, tenants, onTenantSelect }) => {
+  Pick<Required<Props>, 'tenants'> & Pick<Props, 'onTenantSelect'> & { trigger: ReactNode }
+>(({ trigger, tenants, onTenantSelect }) => {
   const onClick = useMemo(
     () =>
       onTenantSelect
@@ -198,7 +198,7 @@ const MultiTenantDropdownMenuButton = memo<
   )
 
   return (
-    <HeaderDropdownMenuButton label={label}>
+    <HeaderDropdownMenuButton trigger={trigger}>
       {tenants.map(({ id, name }) => (
         <Button key={id} value={id} onClick={onClick}>
           {name}


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- DropdownMenuButtonのlabel, tirggerに関連する属性をtrigger属性一つにまとめます

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- labelをtriggerに変更
- triggerSizeをtrigger.sizeに変更
- onlyIconTriggerをtrigger.onlyIconに変更
- triggerIconをtrigger.onlyIcon.componentに変更

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

- labelをtriggerに変更
- triggerSizeを `trigger={{ children: 'ラベル', size: 's' }}` のように指定する方法に変更
- 同様にonlyIconTriggerを `trigger={{ children: 'ラベル', onlyIcon: true }}` のように変更
- triggerIconはonlyIconTriggerがtrueの場合のみ指定出来たため、仕様に合わせて `trigger={{ children: 'ラベル', onlyIcon: { compnent: FaGearIcon } }}` のように指定する方法に変更

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- diffとCIを確認
