### PR TITLE
fix(Table): fixedHeadのPropsがある場合、キーボード操作の逆タブ操作でフォーカス中のエレメントが被ってしまう

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -3,6 +3,7 @@ import { type VariantProps, tv } from 'tailwind-variants'
 
 import { Base } from '../Base'
 
+import { TableFixedHead } from './TableFixedHead'
 import { TableReel } from './TableReel'
 
 type AbstractProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
@@ -125,8 +126,13 @@ export const Table: FC<Props> = ({
     return { table: table({ className }), wrapper: wrapper() }
   }, [borderType, borderStyle, className, fixedHead, layout, rounded])
   const [Wrapper, wrapperProps] = useMemo(
-    () => (rounded ? [RoundedWrapper, { className: classNames.wrapper }] : [Fragment]),
-    [rounded, classNames.wrapper],
+    () =>
+      rounded
+        ? [RoundedWrapper, { className: classNames.wrapper }]
+        : fixedHead
+          ? [FixedHeadWrapper]
+          : [Fragment],
+    [rounded, classNames.wrapper, fixedHead],
   )
 
   return (
@@ -135,6 +141,10 @@ export const Table: FC<Props> = ({
     </Wrapper>
   )
 }
+
+const FixedHeadWrapper = ({ children }: PropsWithChildren<{ className?: string }>) => (
+  <TableFixedHead>{children}</TableFixedHead>
+)
 
 const RoundedWrapper = ({ children, className }: PropsWithChildren<{ className?: string }>) => (
   <Base className={className} overflow="hidden" layer={0}>

--- a/packages/smarthr-ui/src/components/Table/TableFixedHead.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableFixedHead.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import {
+  type ComponentPropsWithRef,
+  type FC,
+  type PropsWithChildren,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import { tv } from 'tailwind-variants'
+
+import { defaultHtmlFontSize } from '../../themes/createFontSize'
+
+type Props = PropsWithChildren & Omit<ComponentPropsWithRef<'div'>, keyof PropsWithChildren>
+
+const classNameGenerator = tv({
+  slots: {
+    // fixedHead のとき、スクロールインスタンスがTableからWrapperに変わるため、Wrapperに対して高さとoverflowを指定する
+    wrapper: 'shr-h-[inherit] shr-max-h-[inherit] shr-overflow-y-scroll',
+  },
+})
+
+export const TableFixedHead: FC<Props> = ({ className, children, ...props }) => {
+  const tableWrapperRef = useRef<HTMLDivElement>(null)
+  const classNames = useMemo(() => {
+    const { wrapper } = classNameGenerator()
+
+    return {
+      wrapper: wrapper(),
+    }
+  }, [])
+
+  // fixedHead 時に thead の高さ分だけ scroll-padding-top を正しい高さをに設定できるように、Tableのtheadがある場合のみで計算する
+  useLayoutEffect(() => {
+    if (tableWrapperRef.current) {
+      const thead = tableWrapperRef.current.querySelector('thead')
+      if (thead) {
+        const { height } = thead.getBoundingClientRect()
+        tableWrapperRef.current.style.scrollPaddingTop = `${height + defaultHtmlFontSize}px`
+      }
+    }
+  }, [])
+
+  return (
+    <div {...props} ref={tableWrapperRef} className={classNames.wrapper}>
+      {children}
+    </div>
+  )
+}

--- a/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
@@ -91,6 +91,13 @@ export const Layout: StoryObj<typeof Table> = {
 
 export const FixedHead: StoryObj<typeof Table> = {
   name: 'fixedHead',
+  decorators: [
+    (Story) => (
+      <div style={{ height: 'calc(100vh - 32px)' }}>
+        <Story />
+      </div>
+    ),
+  ],
   render: (args) => (
     <Table {...args}>
       <thead>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/C06TPGW9Y4U/p1764723898684169

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

`<Table>`コンポネントの`fixedHead`を`true`にしている場合、`<thead>`が`position: sticky`になるため、`<tr>`にタブ操作可能なエレメント（チェックボックス、リンク、ラジオなど）がある場合、逆タブ（`Shift + Tab`）のキーボード操作で被ってしまう可能性がある。そのために、フォーカス中のエレメントを必ず見えるようにしました。

- [WCAG 2.4.12](https://waic.jp/translations/WCAG22/Understanding/focus-not-obscured-enhanced.html)と[WCAG 2.4.7](https://waic.jp/translations/WCAG21/Understanding/focus-visible.html)に関わる
- https://smarthr.design/accessibility/check-list/keyboard/#h2-4

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- htmlのtableエレメントが基本的にスクロールインスタンスを対応してくれるが、`<thead>`が`position: sticky`にすると、上からどれぐらいのエラーを確保すればいいのが計算出来ない
  - 今回の問題を解決するため、`<thead>`の高さを活かして`scroll-padding-top`を設定する必要がある
  - スクロールインスタンスが`table`に持たずに、テーブルをラップして、コントロール出来るスクロールインスタンスを作るのために、テーブルをdivにラップしている
- `<thead>`の高さを計算するためにJSでやるしかないので、`useLayoutEffect`で計算ロジックを追加している
  - そのために、`fixedHead`のケース以外で`<Table>`のコンポネントがCSRにならないために、分別をして、コンポネント化方針でやりました

#### Storybook
- Storyが正しく表示するために変更しました

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

- `<Table>`の`fixedHead`を使っている場合、`table`のエレメントが更にdivにラップされて、`scroll-padding-top`を`thead`の高さから設定している
- `thead`が`children`に存在しない場合、`scroll-padding-top`を計算しない
- `fixedHead`を設定しているtableが親のコンポネントの`height`と`max-height`と合わせるために、親コンポネントの高さが制限されない場合、全体的なスクロールとなります（これが現在の方針と一緒なはず）
  - _現在の場合、親の高さを固定しないとそもそもスクロールしないのでコードの変更が必要ないはず_

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- [UI Test](https://www.chromatic.com/component?appId=63d0ccabb5d2dd29825524ab&csfId=components-table--fixed-head&buildNumber=13067&k=693fc4c0f8381bdc832e8f58-1200px-interactive-true&h=10&b=-2)で特に変更はないからデグレが発生していないが確認出来る
- このブランチから`pnpm link`をして、ローカルの別のプロジェクトにリンクされたローカルパッケージをインストールすると確認できます
  - テキストリンク・`<TdCheckbox>`・`<TdRadioButton>`があるテーブルで確認するのがおすすめ

## レビュアーへ

- BreakingChangeを起こさない前提で作成しましたので、色々なケースを想像・動作確認をしました。もし問題になりそうなエッジケースがある場合、ご指摘をお願いします 🙇 
