### PR TITLE
feat(FormControl): 内部の入力要素に対してidを指定した場合でもlabelと正しく紐づくように修正

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -14,6 +14,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import { useId } from 'react'
 import innerText from 'react-innertext'
@@ -175,7 +176,8 @@ export const ActualFormControl: FC<Props> = ({
 
   const defaultHtmlFor = useId()
   const defaultLabelId = useId()
-  const managedHtmlFor = label.htmlFor || defaultHtmlFor
+  const [childInputId, setChildInputId] = useState<string>('')
+  const managedHtmlFor = label.htmlFor || childInputId || defaultHtmlFor
   const managedLabelId = label.id || defaultLabelId
   const inputWrapperRef = useRef<HTMLDivElement>(null)
   const isFieldset = as === 'fieldset'
@@ -257,7 +259,11 @@ export const ActualFormControl: FC<Props> = ({
       return
     }
 
-    if (!input.getAttribute('id')) {
+    const inputId = input.getAttribute('id')
+
+    if (inputId) {
+      setChildInputId(inputId)
+    } else {
       input.setAttribute('id', managedHtmlFor)
     }
 

--- a/packages/smarthr-ui/src/components/FormControl/stories/FormControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/stories/FormControl.stories.tsx
@@ -123,6 +123,17 @@ export const HtmlFor: StoryObj<typeof FormControl> = {
   },
 }
 
+export const AutoRelation: StoryObj<typeof FormControl> = {
+  name: '子要素にidを指定した場合でもlabelと正しく紐づく',
+  args: {
+    label: {
+      text: '子要素にidを指定した場合でもlabelと正しく紐づく',
+    },
+    children: <Input name="formcontrol_input" id="auto-relation-test" />,
+    supplementaryMessage: '入力要素に紐づく補足メッセージ',
+  },
+}
+
 export const LabelId: StoryObj<typeof FormControl> = {
   name: 'label.id',
   args: {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- FormControl内にid属性を指定した入力要素を設置するとlabel要素とinputが正しく紐づかないロジックになっていた
- そのためこれまではlabel.htmlFor属性を明示的に指定する必要があった
- この仕様ではよく設定忘れが発生し、a11yの問題になっていたため対応したい

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- FormControl内のinput要素を取得、id属性が設定されている場合、label要素と紐づくように修正

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

- 基本的に何もしなくても改善しかしないため、対応しなくてもOK
  - htmlForを明示的に指定している場合、優先的に利用されるため
  - ロジック的に再レンダリングも減るため無駄コードにはならない
- コードとしての見やすさ・一貫性などを重視する場合は以下の対応を行う
  - smarthr-uiの入力要素を利用しているFormControl、かつ内部のinputに指定しているidをhtmlForに明示的に指定している場合、削除する

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- diffを確認
- storybookで問題なくlabelとinputが紐づいていることを確認する
  - (storybookとして提供する必要はなさそうなので確認が済んだらstorybookからは消す予定です)
