### PR TITLE
fix: AppHeaderの言語切替ボタンでの矢印キーの動作を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
@@ -43,6 +43,16 @@ type DecoratorKeyTypes = 'checkIconAlt' | keyof typeof DECORATOR_DEFAULT_TEXTS
 const ARROW_KEY_REGEX = /^Arrow(Up|Down|Left|Right)$/
 const ARROW_UPS_REGEX = /^Arrow(Up|Left)$/
 
+// 配列のインデックスを循環的に移動する（最初→最後、最後→最初）
+const getCircularIndex = (currentIndex: number, direction: 'up' | 'down', arrayLength: number) => {
+  if (direction === 'up') {
+    // 負の数を避けるため arrayLength を加算してから剰余を取る
+    return (currentIndex - 1 + arrayLength) % arrayLength
+  }
+  // 次の要素へ移動（最後の場合は 0 に戻る）
+  return (currentIndex + 1) % arrayLength
+}
+
 const onKeyDownContent = (e: KeyboardEvent<HTMLDivElement>) => {
   if (!ARROW_KEY_REGEX.test(e.key)) {
     return
@@ -51,16 +61,11 @@ const onKeyDownContent = (e: KeyboardEvent<HTMLDivElement>) => {
   e.preventDefault()
 
   const buttons = tabbable(e.currentTarget)
-  const i = buttons.indexOf(e.target as HTMLElement)
-  let buttonAt = 0
+  const currentIndex = buttons.indexOf(e.target as HTMLElement)
+  const direction = ARROW_UPS_REGEX.test(e.key) ? 'up' : 'down'
+  const nextIndex = getCircularIndex(currentIndex, direction, buttons.length)
 
-  if (ARROW_UPS_REGEX.test(e.key)) {
-    buttonAt = i - 1
-  } else if (i + 1 === buttons.length) {
-    buttonAt = i + 1
-  }
-
-  buttons.at(buttonAt)?.focus()
+  buttons[nextIndex]?.focus()
 }
 
 const classNameGenerator = tv({


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://smarthr.atlassian.net/browse/SHRUI-1367

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

`AppHeader`内の`LanguageSwitcher`コンポーネントで、矢印キー↓を押してもフォーカスが次の言語オプションに移動しない不具合を修正。

最初/最後の要素から循環的にフォーカス移動できるようにした。


## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- 矢印キー↓（ArrowDown）を押した際、常に最初の要素にフォーカスが戻ってしまう問題を修正
  - 原因: 条件分岐のロジックミスで、最後の要素以外では常に `buttonAt = 0` のままになっていた

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

なし

## 確認方法
Storybookで確認
<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
