### PR TITLE
fix: AppHeader内のAppNaviCustomTagのスタイル修正

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/common/CommonButton.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/common/CommonButton.tsx
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants'
 
 export const commonButtonClassNameGenerator = tv({
   base: [
-    '[&&]:shr-box-border [&&]:shr-flex [&&]:shr-w-full [&&]:shr-cursor-pointer [&&]:shr-items-center [&&]:shr-rounded-m [&&]:shr-border-none [&&]:shr-bg-transparent [&&]:shr-px-1 [&&]:shr-py-0.5 [&&]:shr-text-base [&&]:shr-leading-normal [&&]:shr-text-black [&&]:shr-no-underline',
+    '[&&]:shr-box-border [&&]:shr-flex [&&]:shr-w-full [&&]:shr-cursor-pointer [&&]:shr-items-center [&&]:shr-border-none [&&]:shr-bg-transparent [&&]:shr-px-1 [&&]:shr-py-0.5 [&&]:shr-text-base [&&]:shr-leading-normal [&&]:shr-text-black [&&]:shr-no-underline',
     '[&&]:hover:shr-bg-white-darken',
     '[&&]:focus-visible:shr-bg-white-darken',
   ],
@@ -18,6 +18,10 @@ export const commonButtonClassNameGenerator = tv({
       true: null,
       false: ['[&&]:shr-font-normal'],
     },
+    rounded: {
+      true: ['[&&]:shr-rounded-m'],
+      false: ['[&&]:shr-rounded-none'],
+    },
   },
   compoundVariants: [
     {
@@ -26,6 +30,9 @@ export const commonButtonClassNameGenerator = tv({
       className: ['[&&]:shr-font-bold'],
     },
   ],
+  defaultVariants: {
+    rounded: true,
+  },
 })
 
 type AnchorProps = Omit<ComponentPropsWithoutRef<'a'>, 'prefix'>

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/Navigation.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/Navigation.tsx
@@ -116,6 +116,7 @@ const DropdownCustomTag = memo<NavigationCustomTag>(
         commonButtonClassNameGenerator({
           current,
           className,
+          rounded: false,
         }),
       [current, className],
     )


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

https://smarthr.atlassian.net/browse/SHRUI-1357


## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

`AppHeader`のドロップダウンメニュー内でカスタムタグを使用した際に、意図せず角丸（`border-radius`）が適用されてしまう問題を修正。


## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

1. `commonButtonClassNameGenerator`に`rounded`バリアントを追加
   - デフォルトは`true`（角丸あり）で既存の動作を維持
   - `false`を指定すると角丸なしになる

2. `Navigation.tsx`の`DropdownCustomTag`で`rounded: false`を指定
   - デスクトップのドロップダウンメニュー内のカスタムタグのみ角丸を無効化
   - モバイルは従来通り角丸あり

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

なし

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

Storybookで確認
