### PR TITLE
fix(PageHeading)!: Next.js環境ではページの自動設定を無効にするよう修正

### DIFF
--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable smarthr/a11y-heading-in-sectioning-content */
+import { render } from '@testing-library/react'
+
+import { PageHeading } from './PageHeading'
+
+const waitForAnimationFrame = () => new Promise((resolve) => requestAnimationFrame(resolve))
+
+describe('PageHeading', () => {
+  afterEach(() => {
+    document.title = ''
+  })
+
+  test('ページのタイトルを自動で設定する', async () => {
+    render(<PageHeading>これはタイトルです</PageHeading>)
+
+    await waitForAnimationFrame()
+    expect(document.title).toBe('これはタイトルです｜SmartHR（スマートHR）')
+    expect(document.querySelector(`*[aria-live="polite"]`)).toHaveTextContent(
+      'これはタイトルです｜SmartHR（スマートHR）',
+    )
+  })
+
+  test('autoPageTitle=falseではページのタイトルを設定しない', async () => {
+    render(<PageHeading autoPageTitle={false}>これはタイトルです</PageHeading>)
+
+    await waitForAnimationFrame()
+    expect(document.title).toBe('')
+    expect(document.querySelector(`*[aria-live="polite"]`)).toBeNull()
+  })
+
+  test('Next.js環境ではページのタイトルを設定しない', async () => {
+    vi.resetModules()
+    vi.doMock('../../../libs/nextjs', () => ({ IS_NEXT_JS: true }))
+
+    const { PageHeading: MockedPageHeading } = await import('./PageHeading')
+    render(<MockedPageHeading>これはタイトルです</MockedPageHeading>)
+
+    await waitForAnimationFrame()
+    expect(document.title).toBe('')
+    expect(document.querySelector(`*[aria-live="polite"]`)).toBeNull()
+  })
+})

--- a/packages/smarthr-ui/src/libs/nextjs.ts
+++ b/packages/smarthr-ui/src/libs/nextjs.ts
@@ -1,0 +1,2 @@
+// https://stackoverflow.com/a/74462617
+export const IS_NEXT_JS = typeof window !== 'undefined' && 'next' in window


### PR DESCRIPTION
## 関連URL

* https://kufuinc.slack.com/archives/C06TPGW9Y4U/p1768454287931339

## 概要

#5855 で `PageHeading` のchildrenとして指定したテキストが自動的に `document.title` に設定されるようになりました。これに加えて、`aria-live="polite"`をもつlive regionも挿入されるようになりました。

ところが、live regionについては、Next.jsやGatsbyなどのReact Frameworksでも同様の機能を実装しています。そのため、そのまま組み合わせて使う場合には、live regionがページ上に二重に挿入されます。

- **Architecture: Accessibility | Next.js**
  https://nextjs.org/docs/architecture/accessibility#route-announcements
- **Accessibility Improvements to Client Side Routing in Gatsby – Available in 2.19.8**
  https://www.gatsbyjs.com/blog/2020-02-10-accessible-client-side-routing-improvements/

複数のlive regionが挿入された場合のスクリーンリーダの挙動は厳密に定義されていませんが、NVDAやJAWSでは、優先度の順番ですべてを読み上げます。

> […] because with JAWS and NVDA, even multiple live regions that are updated at the same time are output properly one after the other.
> https://github.com/w3c/aria/issues/1689

したがって、Next.jsによって挿入されたlive regionと`PageHeading`によって挿入されたlive regionとで、二重にページタイトルを読み上げるおそれがあり、これを修正したいです。

## 変更内容

Next.jsでは、自動でページタイトルを設定する挙動を無効にするように変更しました。これにより、Next.jsではつねに `autoPageTitle=false` 相当の挙動になります。

`document.tilte`に文字列を代入するだけでは、サーバーサイドレンダリング時にはタイトルが設定されなかった（HTMLに `<title>` タグが含まれなかった）ため、従来から利用には問題点がありましたが、この変更で自動設定が使えなくなります。

これにより、開発者はページから `metadata` などの定数をエクスポートすることによって、タイトルを設定する必要があります。

## プロダクト側で対応が必要な事項

なし

## 確認方法

以下の挙動が確認できれば問題ありません。ユニットテストも書いています。

**従来の挙動**（[再現コード](https://github.com/neetlab/repro-smarthr-ui-6047)）： Next.jsで実行すると `PageTitleの値 | SmartHR（スマートHR）` がtitleになる
<img width="1278" height="451" alt="image" src="https://github.com/user-attachments/assets/4bb89a3e-ffe2-4d41-ab93-9807f2b3bcd3" />


**このPRの挙動：** Next.jsで実行すると、PageTitleの文字列ではなく、metadataに設定したタイトルがtitleになる。
<img width="1279" height="532" alt="image" src="https://github.com/user-attachments/assets/226936cc-1a85-4be9-bfc3-fc70b8787604" />
