### PR TITLE
fix(Table): fixedHeadのPropsがある場合、キーボード操作の逆タブ操作でフォーカス中のエレメントが被ってしまう

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -3,6 +3,7 @@ import { type VariantProps, tv } from 'tailwind-variants'
 
 import { Base } from '../Base'
 
+import { TableFixedHead } from './TableFixedHead'
 import { TableReel } from './TableReel'
 
 type AbstractProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
@@ -125,8 +126,13 @@ export const Table: FC<Props> = ({
     return { table: table({ className }), wrapper: wrapper() }
   }, [borderType, borderStyle, className, fixedHead, layout, rounded])
   const [Wrapper, wrapperProps] = useMemo(
-    () => (rounded ? [RoundedWrapper, { className: classNames.wrapper }] : [Fragment]),
-    [rounded, classNames.wrapper],
+    () =>
+      rounded
+        ? [RoundedWrapper, { className: classNames.wrapper }]
+        : fixedHead
+          ? [FixedHeadWrapper]
+          : [Fragment],
+    [rounded, classNames.wrapper, fixedHead],
   )
 
   return (
@@ -135,6 +141,10 @@ export const Table: FC<Props> = ({
     </Wrapper>
   )
 }
+
+const FixedHeadWrapper = ({ children }: PropsWithChildren<{ className?: string }>) => (
+  <TableFixedHead>{children}</TableFixedHead>
+)
 
 const RoundedWrapper = ({ children, className }: PropsWithChildren<{ className?: string }>) => (
   <Base className={className} overflow="hidden" layer={0}>

--- a/packages/smarthr-ui/src/components/Table/TableFixedHead.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableFixedHead.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import {
+  type ComponentPropsWithRef,
+  type FC,
+  type PropsWithChildren,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react'
+import { tv } from 'tailwind-variants'
+
+import { defaultHtmlFontSize } from '../../themes/createFontSize'
+
+type Props = PropsWithChildren & Omit<ComponentPropsWithRef<'div'>, keyof PropsWithChildren>
+
+const classNameGenerator = tv({
+  slots: {
+    // fixedHead のとき、スクロールインスタンスがTableからWrapperに変わるため、Wrapperに対して高さとoverflowを指定する
+    wrapper: 'shr-h-[inherit] shr-max-h-[inherit] shr-overflow-y-scroll',
+  },
+})
+
+export const TableFixedHead: FC<Props> = ({ className, children, ...rest }) => {
+  const tableWrapperRef = useRef<HTMLDivElement>(null)
+  const classNames = useMemo(() => {
+    const { wrapper } = classNameGenerator()
+
+    return {
+      wrapper: wrapper(),
+    }
+  }, [])
+
+  // fixedHead 時に thead の高さ分だけ scroll-padding-top を正しい高さをに設定できるように、Tableのtheadがある場合のみで計算する
+  useLayoutEffect(() => {
+    if (tableWrapperRef.current) {
+      const thead = tableWrapperRef.current.querySelector('thead')
+      if (thead) {
+        const { height } = thead.getBoundingClientRect()
+        tableWrapperRef.current.style.scrollPaddingTop = `${height + defaultHtmlFontSize}px`
+      }
+    }
+  }, [])
+
+  return (
+    <div {...rest} ref={tableWrapperRef} className={classNames.wrapper}>
+      {children}
+    </div>
+  )
+}

--- a/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
@@ -91,6 +91,13 @@ export const Layout: StoryObj<typeof Table> = {
 
 export const FixedHead: StoryObj<typeof Table> = {
   name: 'fixedHead',
+  decorators: [
+    (Story) => (
+      <div style={{ height: 'calc(100vh - 32px)' }}>
+        <Story />
+      </div>
+    ),
+  ],
   render: (args) => (
     <Table {...args}>
       <thead>


### PR DESCRIPTION
Reverts kufu/smarthr-ui#6051