### PR TITLE
fix(charts): strictモードでキーボード操作時にエラーが発生する問題を修正

### DIFF
--- a/packages/charts/src/plugins/keyboardNavigationPlugin.ts
+++ b/packages/charts/src/plugins/keyboardNavigationPlugin.ts
@@ -4,12 +4,16 @@ export type KeyboardNavigationOptions = {
   liveRegionId?: string
 }
 
+type ChartWithKeyboardHandler = {
+  _keyboardNavigationHandler?: (event: KeyboardEvent) => void
+} & Chart
+
 export const keyboardNavigationPlugin = {
   id: 'keyboardNavigation',
   defaults: {
     liveRegionId: undefined,
   },
-  afterInit: (chart: Chart, args: any, options: KeyboardNavigationOptions) => {
+  afterInit: (chart: ChartWithKeyboardHandler, args: any, options: KeyboardNavigationOptions) => {
     const { canvas } = chart
 
     let liveRegionElement: HTMLElement | null = null
@@ -95,5 +99,14 @@ export const keyboardNavigationPlugin = {
     }
 
     canvas.addEventListener('keydown', handleKeyDown)
+
+    chart._keyboardNavigationHandler = handleKeyDown
+  },
+
+  beforeDestroy: (chart: ChartWithKeyboardHandler) => {
+    const { canvas } = chart
+    if (chart._keyboardNavigationHandler && canvas) {
+      canvas.removeEventListener('keydown', chart._keyboardNavigationHandler)
+    }
   },
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

React Strict Mode環境でチャートコンポーネントのキーボード操作を行うと、コンソールにエラーが発生する問題を修正しました。

## 変更内容

`keyboardNavigationPlugin` に `beforeDestroy` フックを追加し、チャートが破棄される際にイベントリスナーを適切にクリーンアップするようにしました。

### 原因

- `afterInit` フックで `keydown` イベントリスナーを追加していたが、チャート破棄時にリスナーを削除していなかった
- React Strict Modeではコンポーネントが2回マウントされるため、古いイベントリスナーが残り、削除されたcanvas要素にアクセスしようとしてエラーが発生していた

### 修正内容

1. `ChartWithKeyboardHandler` 型を追加し、イベントハンドラの参照を保存できるようにした
2. `afterInit` で `handleKeyDown` 関数の参照を `chart._keyboardNavigationHandler` に保存
3. `beforeDestroy` フックを追加し、保存したイベントリスナーを削除

## プロダクト側で対応が必要な事項

なし（内部実装の修正のみで、APIの変更はありません）

## 確認方法

### エラーの再現方法

`packages/charts/src/components/BarChart/BarChart.stories.tsx` に以下のStoryを追加することでエラーを再現できます：

```tsx
import { useEffect, useRef, useState } from 'react'

…

const ChartWithCanvasReuse = () => {
  const [chartKey, setChartKey] = useState(0)
  const containerRef = useRef<HTMLDivElement>(null)

  useEffect(() => {
    const timer = setTimeout(() => setChartKey(1), 100)
    return () => clearTimeout(timer)
  }, [])

  return (
    <div ref={containerRef} style={{ height: '500px' }}>
      <input type="text" />
      <BarChart key={chartKey} data={sampleData} title="再マウントテスト" />
      <input type="text" />
    </div>
  )
}

export const KeyboardNavigationError: StoryObj = {
  render: () => <ChartWithCanvasReuse />,
}
```

### 確認手順

1. 上記Storyを追加してStorybookを起動
2. 最初のinputにフォーカス → Tabキーでチャートにフォーカス → Tabキーで次のinputにフォーカス
3. **修正前**: コンソールに `Cannot read properties of null (reading 'parentNode')` エラーが発生
4. **修正後**: エラーが発生しない
