### PR TITLE
fix: useMediaQueries起因でEnvironmentProviderがSSRエラーが出るため、SSR時にwindowを使わないようにした 

### DIFF
--- a/packages/smarthr-ui/src/hooks/useMediaQueries/useMediaQueries.ts
+++ b/packages/smarthr-ui/src/hooks/useMediaQueries/useMediaQueries.ts
@@ -12,35 +12,42 @@ type MediaQueryMatches<T> = {
 }
 
 export const useMediaQueries = <T extends MediaQueryListMap>(queries: T): MediaQueryMatches<T> => {
-  const matchMediaList = useMemo(
+  const getMatchMediaList = useCallback(
     () => entries(queries).map(([key, query]) => [key, window.matchMedia(query)] as const),
     [queries],
   )
   const lastSnapshotRef = useRef<MediaQueryMatches<T> | null>(null)
 
+  const serverSnapshot = useMemo(
+    () =>
+      fromEntries(entries(queries).map(([key]) => [key, false] as const)) as MediaQueryMatches<T>,
+    [queries],
+  )
+
   const getServerSnapshot = useCallback(
-    (): MediaQueryMatches<T> => fromEntries(matchMediaList.map(([key]) => [key, false] as const)),
-    [matchMediaList],
+    () => serverSnapshot,
+    [serverSnapshot],
   ) satisfies () => MediaQueryMatches<T>
 
   const getSnapshot = useCallback((): MediaQueryMatches<T> => {
     if (typeof window === 'undefined' || !window.matchMedia) {
-      return getServerSnapshot()
+      return serverSnapshot
     }
 
-    const ret = fromEntries(matchMediaList.map(([key, m]) => [key, m.matches] as const))
+    const ret = fromEntries(getMatchMediaList().map(([key, m]) => [key, m.matches] as const))
     if (lastSnapshotRef.current && shallowEqual(lastSnapshotRef.current, ret)) {
       return lastSnapshotRef.current
     }
     lastSnapshotRef.current = ret
     return ret
-  }, [matchMediaList, getServerSnapshot])
+  }, [getMatchMediaList, serverSnapshot])
 
   const subscribe = useCallback(
     (f: () => void) => {
       if (typeof window === 'undefined' || !window.matchMedia) {
         return () => {}
       }
+      const matchMediaList = getMatchMediaList()
       matchMediaList.forEach(([, m]) => {
         m.addEventListener('change', f)
       })
@@ -50,7 +57,7 @@ export const useMediaQueries = <T extends MediaQueryListMap>(queries: T): MediaQ
         })
       }
     },
-    [matchMediaList],
+    [getMatchMediaList],
   )
 
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)


### PR DESCRIPTION

<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

## 概要

`EnvironmentProvider` を使うとSSRで `window is not defined` というエラーになる。
その理由は、 `useMediaQueries` の `matchMediaList` で `window` を参照しているため。

## 変更内容

`useMediaQueries` において、レンダリング時点で `window` を評価しないように調整した。

## プロダクト側で対応が必要な事項

なし

## 確認方法

プロダクト側で修正したsmarthr-uiパッケージをインストールし、SSRエラーが解消していること。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kufu/smarthr-ui/pull/6125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
