### PR TITLE
chore(charts): chartsのStoryの整理

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -1,3 +1,5 @@
+import { chartJsOptionsExamples, multiSmall, singleSmall } from '../__stories__/testData'
+
 import { BarChart } from './BarChart'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
@@ -12,51 +14,60 @@ const meta: Meta<typeof BarChart> = {
       </div>
     ),
   ],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 }
 
 export default meta
 
 type Story = StoryObj<typeof BarChart>
 
-const sampleData = {
-  labels: ['1月', '2月', '3月', '4月', '5月', '6月'],
-  datasets: [
-    {
-      label: '売上',
-      data: [12, 19, 3, 5, 2, 3],
+export const Playground: Story = {
+  args: {
+    data: singleSmall,
+    title: 'Bar Chart',
+  },
+  argTypes: {
+    data: {
+      control: 'object',
     },
-  ],
-}
-
-const multiDatasetData = {
-  labels: ['1月', '2月', '3月', '4月', '5月', '6月'],
-  datasets: [
-    {
-      label: '売上',
-      data: [12, 19, 3, 5, 2, 3],
+    title: {
+      control: 'text',
     },
-    {
-      label: '利益',
-      data: [2, 3, 20, 5, 1, 4],
+    options: {
+      control: 'object',
     },
-  ],
+  },
 }
 
 export const Default: Story = {
   args: {
-    data: sampleData,
-    title: '棒グラフ',
+    data: singleSmall,
   },
 }
 
 export const MultipleDatasets: Story = {
   args: {
-    data: multiDatasetData,
-    title: '複数データの棒グラフ',
+    data: multiSmall,
   },
 }
 
-export const WithCustomOptions: Story = {
+export const Title: Story = {
+  name: 'title',
+  args: {
+    data: singleSmall,
+    title: 'Title',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+  },
+}
+
+export const WithChartJsOptions: Story = {
+  name: 'with Chart.js options',
   args: {
     data: {
       labels: [
@@ -79,82 +90,6 @@ export const WithCustomOptions: Story = {
         },
       ],
     },
-    title: 'レベル分布',
-    options: {
-      plugins: {
-        datalabels: {
-          display: true,
-          anchor: 'end',
-          align: 'end',
-          color: '#333',
-          font: {
-            weight: 'bold',
-            size: 12,
-          },
-        },
-      },
-      scales: {
-        y: {
-          ticks: {
-            stepSize: 50,
-          },
-          suggestedMax: 150,
-        },
-      },
-      datasets: {
-        bar: {
-          barPercentage: 0.8,
-          categoryPercentage: 0.9,
-        },
-      },
-    },
-  },
-}
-
-export const WithDataLabels: Story = {
-  args: {
-    data: sampleData,
-    title: 'データラベル付き棒グラフ',
-    options: {
-      plugins: {
-        datalabels: {
-          display: true,
-          anchor: 'end',
-          align: 'end',
-          color: '#333',
-          font: {
-            weight: 'bold',
-            size: 12,
-          },
-        },
-      },
-    },
-  },
-}
-
-export const WithoutTitle: Story = {
-  args: {
-    data: sampleData,
-  },
-}
-
-export const WithOverriddenTooltipAttempt: Story = {
-  name: 'Tooltip上書き試行（内部設定が保護される）',
-  args: {
-    data: sampleData,
-    title: 'Tooltip上書きテスト',
-    options: {
-      plugins: {
-        tooltip: {
-          // これらの設定は無視され、内部のスタイルが使われる
-          backgroundColor: '#ff0000',
-          titleColor: '#00ff00',
-          bodyColor: '#0000ff',
-          borderColor: '#ff00ff',
-          borderWidth: 10,
-          cornerRadius: 20,
-        },
-      },
-    },
+    options: chartJsOptionsExamples.comprehensive,
   },
 }

--- a/packages/charts/src/components/BarChart/VRTBarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/VRTBarChart.stories.tsx
@@ -1,0 +1,79 @@
+import { Stack } from '../../../../smarthr-ui/src/components/Layout'
+import {
+  chartJsOptionsExamples,
+  manyPoints,
+  multiSmall,
+  singleSmall,
+} from '../__stories__/testData'
+
+import { BarChart } from './BarChart'
+
+import type { StoryObj } from '@storybook/react-webpack5'
+
+export default {
+  title: 'BarChart/VRT',
+  render: (args: any) => (
+    <Stack {...args}>
+      {/* パターン1: 単一データセット、タイトルなし、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <BarChart data={singleSmall} />
+      </div>
+
+      {/* パターン2: 単一データセット、タイトルあり、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <BarChart data={singleSmall} title="単一データセット" />
+      </div>
+
+      {/* パターン3: 複数データセット(3個)、タイトルあり、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <BarChart data={multiSmall} title="複数データセット" />
+      </div>
+
+      {/* パターン4: 複数データセット(3個)、タイトルなし、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <BarChart data={multiSmall} />
+      </div>
+
+      {/* パターン5: 単一データセット、タイトルあり、ラベルあり、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <BarChart
+          data={singleSmall}
+          title="データラベル付き"
+          options={chartJsOptionsExamples.datalabels}
+        />
+      </div>
+
+      {/* パターン6: 複数データセット(3個)、タイトルあり、ラベルあり、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <BarChart
+          data={multiSmall}
+          title="複数データ・ラベル付き"
+          options={chartJsOptionsExamples.datalabels}
+        />
+      </div>
+
+      {/* パターン7: 単一データセット、タイトルあり、ラベルなし、小サイズ(300px)、少データ */}
+      <div className="shr-h-[300px]">
+        <BarChart data={singleSmall} title="小サイズ" />
+      </div>
+
+      {/* パターン8: 複数データセット(3個)、タイトルあり、ラベルなし、標準サイズ、多データ(12個) */}
+      <div className="shr-h-[400px]">
+        <BarChart data={manyPoints} title="多データポイント" />
+      </div>
+    </Stack>
+  ),
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+  tags: ['!autodocs'],
+}
+
+export const VRT = {}
+
+export const VRTForcedColors: StoryObj = {
+  ...VRT,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/charts/src/components/Chart/Chart.stories.tsx
+++ b/packages/charts/src/components/Chart/Chart.stories.tsx
@@ -1,3 +1,5 @@
+import { chartJsOptionsExamples, multiSmall, singleSmall } from '../__stories__/testData'
+
 import { Chart } from './Chart'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
@@ -12,241 +14,78 @@ const meta: Meta<typeof Chart> = {
       </div>
     ),
   ],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 }
 
 export default meta
 type Story = StoryObj<typeof Chart>
 
-export const BarChart: Story = {
+export const Playground: Story = {
   args: {
     type: 'bar',
-    title: 'サンプル棒グラフ',
-    data: {
-      labels: ['1月', '2月', '3月', '4月', '5月'],
-      datasets: [
-        {
-          label: '売上',
-          data: [65, 59, 80, 81, 56],
-        },
-      ],
-    },
+    title: 'Chart',
+    data: singleSmall,
   },
-}
-
-export const MultipleDatasets: Story = {
-  args: {
-    type: 'bar',
-    title: '部門別売上比較',
-    data: {
-      labels: ['1月', '2月', '3月', '4月', '5月'],
-      datasets: [
-        {
-          label: '部門A',
-          data: [65, 59, 80, 81, 56],
-        },
-        {
-          label: '部門B',
-          data: [45, 70, 65, 75, 60],
-        },
-      ],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['bar', 'line'],
     },
-  },
-}
-
-export const LineChart: Story = {
-  args: {
-    type: 'line',
-    title: 'サンプル線グラフ',
     data: {
-      labels: ['1月', '2月', '3月', '4月', '5月'],
-      datasets: [
-        {
-          label: '売上',
-          data: [65, 59, 80, 81, 56],
-        },
-      ],
+      control: 'object',
     },
-  },
-}
-
-export const ManyDatasetsBar: Story = {
-  args: {
-    type: 'bar',
-    title: '多データセット棒グラフサンプル',
-    data: {
-      labels: ['Q1', 'Q2', 'Q3', 'Q4'],
-      datasets: [
-        {
-          label: 'データA',
-          data: [20, 35, 40, 30],
-        },
-        {
-          label: 'データB',
-          data: [25, 30, 35, 45],
-        },
-        {
-          label: 'データC',
-          data: [15, 25, 30, 35],
-        },
-        {
-          label: 'データD',
-          data: [30, 40, 25, 20],
-        },
-        {
-          label: 'データE',
-          data: [35, 20, 45, 40],
-        },
-        {
-          label: 'データF',
-          data: [10, 15, 20, 25],
-        },
-        {
-          label: 'データG',
-          data: [45, 50, 35, 30],
-        },
-        {
-          label: 'データH',
-          data: [25, 45, 30, 35],
-        },
-        {
-          label: 'データI',
-          data: [40, 25, 50, 45],
-        },
-        {
-          label: 'データJ',
-          data: [20, 30, 25, 40],
-        },
-      ],
-    },
-  },
-}
-
-export const ManyDatasetsLine: Story = {
-  args: {
-    type: 'line',
-    title: '多データセット線グラフサンプル',
-    data: {
-      labels: ['1月', '2月', '3月', '4月', '5月', '6月'],
-      datasets: [
-        {
-          label: 'データA',
-          data: [10, 20, 15, 25, 30, 35],
-        },
-        {
-          label: 'データB',
-          data: [15, 25, 20, 30, 25, 40],
-        },
-        {
-          label: 'データC',
-          data: [20, 15, 30, 20, 35, 25],
-        },
-        {
-          label: 'データD',
-          data: [25, 30, 25, 35, 20, 30],
-        },
-        {
-          label: 'データE',
-          data: [30, 25, 35, 30, 40, 35],
-        },
-        {
-          label: 'データF',
-          data: [5, 10, 15, 10, 20, 15],
-        },
-        {
-          label: 'データG',
-          data: [35, 40, 30, 45, 35, 50],
-        },
-        {
-          label: 'データH',
-          data: [40, 35, 45, 40, 50, 45],
-        },
-        {
-          label: 'データI',
-          data: [45, 50, 40, 55, 45, 60],
-        },
-        {
-          label: 'データJ',
-          data: [12, 18, 22, 16, 28, 24],
-        },
-      ],
-    },
-  },
-}
-
-export const BarChartWithDataLabels: Story = {
-  args: {
-    type: 'bar',
-    title: 'データラベル付き棒グラフ',
-    data: {
-      labels: ['1月', '2月', '3月', '4月', '5月'],
-      datasets: [
-        {
-          label: '売上',
-          data: [65, 59, 80, 81, 56],
-        },
-      ],
+    title: {
+      control: 'text',
     },
     options: {
-      plugins: {
-        datalabels: {
-          display: true,
-          anchor: 'end',
-          align: 'end',
-          color: '#333',
-          font: {
-            weight: 'bold',
-            size: 12,
-          },
-        },
-      },
+      control: 'object',
     },
   },
 }
 
-export const LineChartWithDataLabels: Story = {
+export const Type: Story = {
+  name: 'type',
   args: {
-    type: 'line',
-    title: 'データラベル付き線グラフ',
-    data: {
-      labels: ['1月', '2月', '3月', '4月', '5月'],
-      datasets: [
-        {
-          label: '売上',
-          data: [65, 59, 80, 81, 56],
-        },
-      ],
-    },
-    options: {
-      plugins: {
-        datalabels: {
-          display: true,
-          backgroundColor: '#fff',
-          borderColor: '#333',
-          borderWidth: 1,
-          borderRadius: 4,
-          color: '#333',
-          font: {
-            weight: 'bold',
-            size: 12,
-          },
-          padding: 4,
-        },
-      },
+    type: 'bar',
+    data: singleSmall,
+  },
+  argTypes: {
+    type: {
+      control: 'radio',
+      options: ['bar', 'line'],
     },
   },
 }
 
-export const BarChartWithoutTitle: Story = {
+export const Title: Story = {
+  name: 'title',
+  args: {
+    type: 'bar',
+    data: singleSmall,
+    title: 'Title',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+  },
+}
+
+export const WithChartJsOptions: Story = {
+  name: 'with Chart.js options',
   args: {
     type: 'bar',
     data: {
-      labels: ['1月', '2月', '3月', '4月', '5月'],
+      labels: ['A', 'B', 'C', 'D', 'E'],
       datasets: [
         {
-          label: '売上',
-          data: [65, 59, 80, 81, 56],
+          label: 'データ',
+          data: [95, 48, 80, 70, 42],
         },
       ],
     },
+    options: chartJsOptionsExamples.comprehensive,
   },
 }

--- a/packages/charts/src/components/Chart/VRTChart.stories.tsx
+++ b/packages/charts/src/components/Chart/VRTChart.stories.tsx
@@ -1,0 +1,46 @@
+import { Stack } from '../../../../smarthr-ui/src/components/Layout'
+import { multiSmall, singleSmall } from '../__stories__/testData'
+
+import { Chart } from './Chart'
+
+import type { StoryObj } from '@storybook/react-webpack5'
+
+export default {
+  title: 'Chart/VRT',
+  render: (args: any) => (
+    <Stack {...args}>
+      {/* Bar型 パターン1: 単一データセット、タイトルあり、標準サイズ */}
+      <div className="shr-h-[400px]">
+        <Chart type="bar" data={singleSmall} title="Bar型 - 単一データセット" />
+      </div>
+
+      {/* Bar型 パターン2: 複数データセット(3個)、タイトルあり、標準サイズ */}
+      <div className="shr-h-[400px]">
+        <Chart type="bar" data={multiSmall} title="Bar型 - 複数データセット" />
+      </div>
+
+      {/* Line型 パターン3: 単一データセット、タイトルあり、標準サイズ */}
+      <div className="shr-h-[400px]">
+        <Chart type="line" data={singleSmall} title="Line型 - 単一データセット" />
+      </div>
+
+      {/* Line型 パターン4: 複数データセット(3個)、タイトルあり、標準サイズ */}
+      <div className="shr-h-[400px]">
+        <Chart type="line" data={multiSmall} title="Line型 - 複数データセット" />
+      </div>
+    </Stack>
+  ),
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+  tags: ['!autodocs'],
+}
+
+export const VRT = {}
+
+export const VRTForcedColors: StoryObj = {
+  ...VRT,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/charts/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/LineChart.stories.tsx
@@ -1,3 +1,5 @@
+import { chartJsOptionsExamples, multiSmall, singleSmall } from '../__stories__/testData'
+
 import { LineChart } from './LineChart'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
@@ -12,51 +14,60 @@ const meta: Meta<typeof LineChart> = {
       </div>
     ),
   ],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 }
 
 export default meta
 
 type Story = StoryObj<typeof LineChart>
 
-const sampleData = {
-  labels: ['1月', '2月', '3月', '4月', '5月', '6月'],
-  datasets: [
-    {
-      label: '売上',
-      data: [12, 19, 3, 5, 2, 3],
+export const Playground: Story = {
+  args: {
+    data: singleSmall,
+    title: 'Line Chart',
+  },
+  argTypes: {
+    data: {
+      control: 'object',
     },
-  ],
-}
-
-const multiDatasetData = {
-  labels: ['1月', '2月', '3月', '4月', '5月', '6月'],
-  datasets: [
-    {
-      label: '売上',
-      data: [12, 19, 3, 5, 2, 3],
+    title: {
+      control: 'text',
     },
-    {
-      label: '利益',
-      data: [2, 3, 20, 5, 1, 4],
+    options: {
+      control: 'object',
     },
-  ],
+  },
 }
 
 export const Default: Story = {
   args: {
-    data: sampleData,
-    title: '線グラフ',
+    data: singleSmall,
   },
 }
 
 export const MultipleDatasets: Story = {
   args: {
-    data: multiDatasetData,
-    title: '複数データの線グラフ',
+    data: multiSmall,
   },
 }
 
-export const WithCustomOptions: Story = {
+export const Title: Story = {
+  name: 'title',
+  args: {
+    data: singleSmall,
+    title: 'Title',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+  },
+}
+
+export const WithChartJsOptions: Story = {
+  name: 'with Chart.js options',
   args: {
     data: {
       labels: [
@@ -79,67 +90,9 @@ export const WithCustomOptions: Story = {
         },
       ],
     },
-    title: 'レベル分布',
     options: {
-      scales: {
-        y: {
-          ticks: {
-            stepSize: 50,
-          },
-          suggestedMax: 150,
-        },
-      },
-    },
-  },
-}
-
-export const WithDataLabels: Story = {
-  args: {
-    data: sampleData,
-    title: 'データラベル付き線グラフ',
-    options: {
-      plugins: {
-        datalabels: {
-          display: true,
-          backgroundColor: '#fff',
-          borderColor: '#333',
-          borderWidth: 1,
-          borderRadius: 4,
-          color: '#333',
-          font: {
-            weight: 'bold',
-            size: 12,
-          },
-          padding: 4,
-        },
-      },
-    },
-  },
-}
-
-export const WithoutTitle: Story = {
-  args: {
-    data: sampleData,
-  },
-}
-
-export const WithOverriddenTooltipAttempt: Story = {
-  name: 'Tooltip上書き試行（内部設定が保護される）',
-  args: {
-    data: sampleData,
-    title: 'Tooltip上書きテスト',
-    options: {
-      plugins: {
-        tooltip: {
-          // これらの設定は無視され、内部のスタイルが使われる
-          backgroundColor: '#ff0000',
-          titleColor: '#00ff00',
-          bodyColor: '#0000ff',
-          borderColor: '#ff00ff',
-          borderWidth: 10,
-          cornerRadius: 20,
-        },
-      },
+      ...chartJsOptionsExamples.customScales,
+      ...chartJsOptionsExamples.datalabelsWithBorder,
     },
   },
 }

--- a/packages/charts/src/components/LineChart/VRTLineChart.stories.tsx
+++ b/packages/charts/src/components/LineChart/VRTLineChart.stories.tsx
@@ -1,0 +1,79 @@
+import { Stack } from '../../../../smarthr-ui/src/components/Layout'
+import {
+  chartJsOptionsExamples,
+  manyPoints,
+  multiSmall,
+  singleSmall,
+} from '../__stories__/testData'
+
+import { LineChart } from './LineChart'
+
+import type { StoryObj } from '@storybook/react-webpack5'
+
+export default {
+  title: 'LineChart/VRT',
+  render: (args: any) => (
+    <Stack {...args}>
+      {/* パターン1: 単一データセット、タイトルなし、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <LineChart data={singleSmall} />
+      </div>
+
+      {/* パターン2: 単一データセット、タイトルあり、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <LineChart data={singleSmall} title="単一データセット" />
+      </div>
+
+      {/* パターン3: 複数データセット(3個)、タイトルあり、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <LineChart data={multiSmall} title="複数データセット" />
+      </div>
+
+      {/* パターン4: 複数データセット(3個)、タイトルなし、ラベルなし、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <LineChart data={multiSmall} />
+      </div>
+
+      {/* パターン5: 単一データセット、タイトルあり、ラベルあり、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <LineChart
+          data={singleSmall}
+          title="データラベル付き"
+          options={chartJsOptionsExamples.datalabelsWithBorder}
+        />
+      </div>
+
+      {/* パターン6: 複数データセット(3個)、タイトルあり、ラベルあり、標準サイズ、少データ */}
+      <div className="shr-h-[400px]">
+        <LineChart
+          data={multiSmall}
+          title="複数データ・ラベル付き"
+          options={chartJsOptionsExamples.datalabelsWithBorder}
+        />
+      </div>
+
+      {/* パターン7: 単一データセット、タイトルあり、ラベルなし、小サイズ(300px)、少データ */}
+      <div className="shr-h-[300px]">
+        <LineChart data={singleSmall} title="小サイズ" />
+      </div>
+
+      {/* パターン8: 複数データセット(3個)、タイトルあり、ラベルなし、標準サイズ、多データ(12個) */}
+      <div className="shr-h-[400px]">
+        <LineChart data={manyPoints} title="多データポイント" />
+      </div>
+    </Stack>
+  ),
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+  tags: ['!autodocs'],
+}
+
+export const VRT = {}
+
+export const VRTForcedColors: StoryObj = {
+  ...VRT,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/charts/src/components/__stories__/testData.ts
+++ b/packages/charts/src/components/__stories__/testData.ts
@@ -1,0 +1,149 @@
+/**
+ * Chart コンポーネント用の共有テストデータ
+ * Playground Story と VRT Story で重複を排除するために使用
+ */
+
+/**
+ * 少データポイント（5個）- 単一データセット
+ */
+export const singleSmall = {
+  labels: ['A', 'B', 'C', 'D', 'E'],
+  datasets: [
+    {
+      label: 'データ1',
+      data: [12, 19, 3, 5, 2],
+    },
+  ],
+}
+
+/**
+ * 少データポイント（5個）- 複数データセット（3個）
+ */
+export const multiSmall = {
+  labels: ['A', 'B', 'C', 'D', 'E'],
+  datasets: [
+    {
+      label: 'データ1',
+      data: [12, 19, 3, 5, 2],
+    },
+    {
+      label: 'データ2',
+      data: [8, 11, 15, 7, 9],
+    },
+    {
+      label: 'データ3',
+      data: [5, 14, 8, 12, 6],
+    },
+  ],
+}
+
+/**
+ * 多データポイント（12個）- 複数データセット（3個）
+ */
+export const manyPoints = {
+  labels: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+  datasets: [
+    {
+      label: 'データ1',
+      data: [12, 19, 3, 5, 2, 18, 7, 15, 8, 11, 4, 14],
+    },
+    {
+      label: 'データ2',
+      data: [8, 11, 15, 7, 9, 5, 13, 6, 17, 9, 12, 10],
+    },
+    {
+      label: 'データ3',
+      data: [5, 14, 8, 12, 6, 11, 9, 18, 4, 13, 7, 16],
+    },
+  ],
+}
+
+/**
+ * chart.js オプションのサンプル
+ */
+export const chartJsOptionsExamples = {
+  /**
+   * データラベル表示設定
+   */
+  datalabels: {
+    plugins: {
+      datalabels: {
+        display: true,
+        anchor: 'end' as const,
+        align: 'end' as const,
+        color: '#333',
+        font: {
+          weight: 'bold' as const,
+          size: 12,
+        },
+      },
+    },
+  },
+
+  /**
+   * データラベル表示設定（線グラフ用：背景・枠線付き）
+   */
+  datalabelsWithBorder: {
+    plugins: {
+      datalabels: {
+        display: true,
+        backgroundColor: '#fff',
+        borderColor: '#333',
+        borderWidth: 1,
+        borderRadius: 4,
+        color: '#333',
+        font: {
+          weight: 'bold' as const,
+          size: 12,
+        },
+        padding: 4,
+      },
+    },
+  },
+
+  /**
+   * スケール・目盛りカスタマイズ
+   */
+  customScales: {
+    scales: {
+      y: {
+        ticks: {
+          stepSize: 50,
+        },
+        suggestedMax: 150,
+      },
+    },
+  },
+
+  /**
+   * 包括的なカスタマイズ例（データラベル + スケール設定）
+   */
+  comprehensive: {
+    plugins: {
+      datalabels: {
+        display: true,
+        anchor: 'end' as const,
+        align: 'end' as const,
+        color: '#333',
+        font: {
+          weight: 'bold' as const,
+          size: 12,
+        },
+      },
+    },
+    scales: {
+      y: {
+        ticks: {
+          stepSize: 50,
+        },
+        suggestedMax: 150,
+      },
+    },
+    datasets: {
+      bar: {
+        barPercentage: 0.8,
+        categoryPercentage: 0.9,
+      },
+    },
+  },
+}

--- a/packages/charts/src/config/chartConfig.ts
+++ b/packages/charts/src/config/chartConfig.ts
@@ -113,6 +113,9 @@ const createBaseChartOptions = <T extends ChartType>({
         labels: internalLegendLabels,
       },
       tooltip: internalTooltipConfig,
+      datalabels: {
+        display: false,
+      },
     },
   }
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

chartsライブラリのStoryをsmarthr-uiの標準パターンに合わせてリファクタリングしました。

今後 charts の Story も smarthr-ui の storybook に乗るようにしたいと考えているんですが、それは別で行おうと思っています。なので現在 charts の preview 環境はありません 🙇 


## 変更内容

### 背景と目的

chartsのStoryは、Playground用とVRT用が混在しており、smarthr-uiの他のコンポーネントと異なるパターンになっていました。
また、datalabelsプラグインがデフォルトで有効になっており、意図せずグラフ内に数値が表示される問題がありました。

### 主な変更

1. **Playground StoryとVRT Storyを分離**
   - Playground Story: `chromatic: { disableSnapshot: true }` でVRT対象外
   - VRT Story: 別ファイル（`VRT*.stories.tsx`）に分離し、網羅的なパターンをテスト

2. **共有テストデータモジュールを作成**
   - 重複していたテストデータを `testData.ts` に集約

3. **smarthr-uiのstory作成ルールに準拠**
   - Story名やprops名の統一、datalabelsのデフォルト非表示化など

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで動作確認:
```bash
cd packages/charts
npm run storybook
```