### PR TITLE
fix(StepFormDialog): onPressEscape時にも状態をリセットするように修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialog.tsx
@@ -89,7 +89,7 @@ export const StepFormDialog: FC<Props> = ({
   }, [isOpen, onClickBack])
 
   return createPortal(
-    <StepFormDialogProvider firstStep={firstStep}>
+    <StepFormDialogProvider firstStep={firstStep} isOpen={isOpen}>
       <DialogContentInner
         {...rest}
         isOpen={isOpen}

--- a/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialogContentInner.tsx
@@ -94,12 +94,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
 
   const handleCloseAction = useCallback(() => {
     onClickClose()
-    setTimeout(() => {
-      // HINT: ダイアログが閉じるtransitionが完了してから初期化をしている
-      stepQueue.current = []
-      setCurrentStep(firstStep)
-    }, 300)
-  }, [firstStep, stepQueue, setCurrentStep, onClickClose])
+  }, [onClickClose])
 
   const changeCurrentStep = useCallback(
     (step: Parameters<typeof setCurrentStep>[0]) => {

--- a/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialogProvider.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/StepFormDialog/StepFormDialogProvider.tsx
@@ -33,11 +33,22 @@ export const StepFormDialogContext = createContext<StepFormDialogContextType>({
 type Props = {
   children: ReactNode
   firstStep: StepItem
+  isOpen: boolean
 }
-export const StepFormDialogProvider: FC<Props> = ({ children, firstStep }) => {
+export const StepFormDialogProvider: FC<Props> = ({ children, firstStep, isOpen }) => {
   const [currentStep, setCurrentStep] = useState<StepItem>(firstStep)
   const stepQueue = useRef<StepItem[]>([])
   const scrollerRef = useRef<HTMLDivElement>(null)
+  const prevIsOpen = useRef(isOpen)
+
+  // ダイアログが閉じたときにリセット
+  if (prevIsOpen.current && !isOpen) {
+    setTimeout(() => {
+      stepQueue.current = []
+      setCurrentStep(firstStep)
+    }, 300)
+  }
+  prevIsOpen.current = isOpen
 
   return (
     <StepFormDialogContext.Provider value={{ currentStep, stepQueue, setCurrentStep, scrollerRef }}>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- onPressEscape時にダイアログがリセットされず、2ステップ目から開かれるなどのバグがあったためリセットされるように修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- ダイアログがアニメーション終了して閉じた後にリセットするような処理が入っていたので、共通部分に切り出して修正


<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

ない

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

https://63d0ccabb5d2dd29825524ab-vzhllwcokq.chromatic.com/?path=/story/components-dialog-stepformdialog--async-submit-success
