### PR TITLE
fix!: AppHeader から arbitraryDisplayName props を削除

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/UserInfo.tsx
@@ -61,7 +61,6 @@ type Props = UserInfoProps &
   Pick<HeaderProps, 'desktopAdditionalContent' | 'tenants' | 'currentTenantId'>
 
 export const UserInfo: FC<Props> = ({
-  arbitraryDisplayName,
   email,
   empCode,
   firstName,
@@ -72,14 +71,13 @@ export const UserInfo: FC<Props> = ({
 }) => {
   const displayName = useMemo(
     () =>
-      arbitraryDisplayName ??
       buildDisplayName({
         email,
         empCode,
         firstName,
         lastName,
       }),
-    [arbitraryDisplayName, email, empCode, firstName, lastName],
+    [email, empCode, firstName, lastName],
   )
 
   if (!displayName) {
@@ -104,7 +102,7 @@ export const UserInfo: FC<Props> = ({
   )
 }
 
-export const ActualUserInfo: FC<Omit<Props, 'arbitraryDisplayName'> & { displayName: string }> = ({
+export const ActualUserInfo: FC<Props & { displayName: string }> = ({
   email,
   empCode,
   firstName,

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
@@ -28,17 +28,16 @@ const classNameGenerator = tv({
 type Props = UserInfoProps & Pick<HeaderProps, 'locale'>
 
 export const UserInfo = memo<Props>(
-  ({ arbitraryDisplayName, email, empCode, firstName, lastName, accountUrl, locale }) => {
+  ({ email, empCode, firstName, lastName, accountUrl, locale }) => {
     const displayName = useMemo(
       () =>
-        arbitraryDisplayName ??
         buildDisplayName({
           email,
           empCode,
           firstName,
           lastName,
         }),
-      [arbitraryDisplayName, email, empCode, firstName, lastName],
+      [email, empCode, firstName, lastName],
     )
 
     return displayName ? (

--- a/packages/smarthr-ui/src/components/AppHeader/types.ts
+++ b/packages/smarthr-ui/src/components/AppHeader/types.ts
@@ -7,8 +7,6 @@ export type LocaleProps = {
 }
 
 export type UserInfoProps = {
-  /** @deprecated 書式の統一のために、可能な限り使用しないでください */
-  arbitraryDisplayName?: string | null
   email?: string | null
   empCode?: string | null
   firstName?: string | null


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

AppHeader コンポーネントの arbitraryDisplayName はマイグレーションをしやすくするための props でしたが、使っているプロダクトがなくなったので削除しました。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

arbitraryDisplayName 関連のコードを削除しました。

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

arbitraryDisplayName の代わりに email, empCode, firstName, lastName の props を使うようにしてください。

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

コード削除だけなので、差分を見て問題なさそうなら大丈夫です！

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
