### PR TITLE
fix(Select)!: hasBlankのデフォルトの選択肢を空にする

### DIFF
--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -13,8 +13,6 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { type DecoratorsType, useDecorators } from '../../hooks/useDecorators'
-import { useIntl } from '../../intl'
 import { isIOS, isMobileSafari } from '../../libs/ua'
 import { genericsForwardRef } from '../../libs/util'
 import { FaAngleDownIcon } from '../Icon'
@@ -40,14 +38,12 @@ type AbstractProps<T extends string> = {
   size?: 'default' | 's'
   /** 空の選択肢を表示するかどうか */
   hasBlank?: boolean
-  /** コンポーネント内の文言を変更するための関数を設定 */
-  decorators?: DecoratorsType<DecoratorKeyTypes>
+  /** 空の選択肢のラベル */
+  blankLabel?: string
 }
 
 type Props<T extends string> = AbstractProps<T> &
   Omit<ComponentPropsWithoutRef<'select'>, keyof AbstractProps<string> | 'children'>
-
-type DecoratorKeyTypes = 'blankLabel'
 
 const classNameGenerator = tv({
   slots: {
@@ -96,7 +92,7 @@ const ActualSelect = <T extends string>(
     error,
     width,
     hasBlank,
-    decorators,
+    blankLabel,
     size,
     className,
     disabled,
@@ -105,8 +101,6 @@ const ActualSelect = <T extends string>(
   }: Props<T>,
   ref: ForwardedRef<HTMLSelectElement>,
 ) => {
-  const { localize } = useIntl()
-
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       onChange?.(e)
@@ -145,17 +139,8 @@ const ActualSelect = <T extends string>(
     }),
     [width],
   )
-  const decoratorDefaultTexts = useMemo(
-    () => ({
-      blankLabel: localize({
-        id: 'smarthr-ui/Select/blankLabel',
-        defaultText: '選択してください',
-      }),
-    }),
-    [localize],
-  )
 
-  const decorated = useDecorators<DecoratorKeyTypes>(decoratorDefaultTexts, decorators)
+  const actualBlankLabel = blankLabel ?? ''
 
   return (
     <span className={classNames.wrapper} style={wrapperStyle}>
@@ -175,7 +160,7 @@ const ActualSelect = <T extends string>(
         ref={ref}
         className={classNames.select}
       >
-        <BlankOption hasBlank={hasBlank}>{decorated.blankLabel}</BlankOption>
+        <BlankOption hasBlank={hasBlank}>{actualBlankLabel}</BlankOption>
         {options.map((option, index) => (
           <Option {...option} key={index} />
         ))}

--- a/packages/smarthr-ui/src/intl/locales/en_us.ts
+++ b/packages/smarthr-ui/src/intl/locales/en_us.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': 'Pagination',
   'smarthr-ui/RequiredLabel/text': 'Required',
   'smarthr-ui/SearchInput/iconAlt': 'Search',
-  'smarthr-ui/Select/blankLabel': 'Select',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': 'Clear',
   'smarthr-ui/SortDropdown/applyText': 'Apply',

--- a/packages/smarthr-ui/src/intl/locales/id_id.ts
+++ b/packages/smarthr-ui/src/intl/locales/id_id.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': 'Navigasi halaman',
   'smarthr-ui/RequiredLabel/text': 'Wajib',
   'smarthr-ui/SearchInput/iconAlt': 'Cari',
-  'smarthr-ui/Select/blankLabel': 'Silakan pilih',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': 'Bersihkan',
   'smarthr-ui/SortDropdown/applyText': 'Terapkan',

--- a/packages/smarthr-ui/src/intl/locales/ja.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja.ts
@@ -79,7 +79,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': 'ページネーション',
   'smarthr-ui/RequiredLabel/text': '必須',
   'smarthr-ui/SearchInput/iconAlt': '検索',
-  'smarthr-ui/Select/blankLabel': '選択してください',
   'smarthr-ui/SideMenu/navigationLabel': 'サイドメニュー',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': 'クリア',
   'smarthr-ui/SortDropdown/applyText': '適用',

--- a/packages/smarthr-ui/src/intl/locales/ja_easy.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja_easy.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': '',
   'smarthr-ui/RequiredLabel/text': '',
   'smarthr-ui/SearchInput/iconAlt': '',
-  'smarthr-ui/Select/blankLabel': '',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': '',
   'smarthr-ui/SortDropdown/applyText': '',

--- a/packages/smarthr-ui/src/intl/locales/ko_kr.ts
+++ b/packages/smarthr-ui/src/intl/locales/ko_kr.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': '페이지네이션',
   'smarthr-ui/RequiredLabel/text': '필수',
   'smarthr-ui/SearchInput/iconAlt': '검색',
-  'smarthr-ui/Select/blankLabel': '선택해 주세요',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': '지우기',
   'smarthr-ui/SortDropdown/applyText': '적용',

--- a/packages/smarthr-ui/src/intl/locales/pt_br.ts
+++ b/packages/smarthr-ui/src/intl/locales/pt_br.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': 'Paginação',
   'smarthr-ui/RequiredLabel/text': 'Obrigatório',
   'smarthr-ui/SearchInput/iconAlt': 'Pesquisar',
-  'smarthr-ui/Select/blankLabel': 'Selecione',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': 'Limpar',
   'smarthr-ui/SortDropdown/applyText': 'Aplicar',

--- a/packages/smarthr-ui/src/intl/locales/vi_vn.ts
+++ b/packages/smarthr-ui/src/intl/locales/vi_vn.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': 'Phân trang',
   'smarthr-ui/RequiredLabel/text': 'Bắt buộc',
   'smarthr-ui/SearchInput/iconAlt': 'Tìm',
-  'smarthr-ui/Select/blankLabel': 'Hãy chọn',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': 'Xóa',
   'smarthr-ui/SortDropdown/applyText': 'Áp dụng',

--- a/packages/smarthr-ui/src/intl/locales/zh_hans_cn.ts
+++ b/packages/smarthr-ui/src/intl/locales/zh_hans_cn.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': '分页',
   'smarthr-ui/RequiredLabel/text': '必填',
   'smarthr-ui/SearchInput/iconAlt': '搜索',
-  'smarthr-ui/Select/blankLabel': '请选择',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': '清除',
   'smarthr-ui/SortDropdown/applyText': '启用',

--- a/packages/smarthr-ui/src/intl/locales/zh_hant_tw.ts
+++ b/packages/smarthr-ui/src/intl/locales/zh_hant_tw.ts
@@ -81,7 +81,6 @@ export const locale = {
   'smarthr-ui/Pagination/navigationLabel': '分頁',
   'smarthr-ui/RequiredLabel/text': '必填',
   'smarthr-ui/SearchInput/iconAlt': '搜尋',
-  'smarthr-ui/Select/blankLabel': '請選擇',
   'smarthr-ui/SideMenu/navigationLabel': '',
   'smarthr-ui/SingleCombobox/destroyButtonIconAlt': '清除',
   'smarthr-ui/SortDropdown/applyText': '套用',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/CDG1XRPTP/p1773801277836809

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

Select[hasBlank]のデフォルトを、「選択してください」から空テキストにした。

参考： https://smarthr.design/products/components/select/#h3-3

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

- Selectのdecoratorsは廃止されました。置き換える場合は `blankLabel` propsを使ってください。
  - そもそも空の場合のラベルは必要ない可能性が高いので、ただ消すだけという対応も検討してください。

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
