### PR TITLE
fix: AppLauncherのmain要素をdiv要素に置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -187,7 +187,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
           translated={translated}
           classNames={classNames}
         />
-        <main className={classNames.main}>
+        <div className={classNames.main}>
           <Section className={classNames.mainInner}>
             <Cluster className={classNames.contentHead} align="center" justify="space-between">
               <MemoizedSubSubBlockHeading>
@@ -203,7 +203,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
               <AppLauncherFeatures features={features} page={page} />
             </div>
           </Section>
-        </main>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## 概要

支援技術ユーザーに不便をかけるリスクがあるため、AppLauncherの中の不要な[ランドマーク](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Reference/Roles/landmark_role)を消しました。

## 変更内容

ページの主要コンテンツを意味する [`main`](https://developer.mozilla.org/ja/docs/Web/HTML/Reference/Elements/main) 要素がAppLauncherの中に使われていたので、divに置き換えました。

## プロダクト側で対応が必要な事項

プロダクト側の対応不要

## 確認方法

ローカルStorybookで、AppLauncherが問題なく使えることを確認する
http://localhost:6006/?path=/docs/components-appheader--docs&globals=locale:en-us