### PR TITLE
feat(SingleCombobox, MultipleCombobox): 選択肢を選んだ際、onChangeInputを空文字で発火する処理を追加

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -92,6 +92,11 @@ const ARROW_LEFT_KEY_REGEX = /^(Arrow)?Left$/
 const ARROW_RIGHT_KEY_REGEX = /^(Arrow)?Right/
 const ARROW_UP_AND_DOWN_KEY_REGEX = /^(Arrow)?(Up|Down)$/
 
+const EMPTY_INPUT_CHANGE_EVENT = {
+  currentTarget: { value: '' },
+  target: { value: '' },
+} as ChangeEvent<HTMLInputElement>
+
 const classNameGenerator = tv({
   slots: {
     wrapper: [
@@ -231,12 +236,15 @@ const ActualMultiCombobox = <T,>(
         if (matchedSelectedItem === undefined) {
           onSelect?.(selected)
           onChangeSelected?.(selectedItems.concat(selected))
+
+          // 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
+          onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
         } else if (matchedSelectedItem.deletable !== false) {
           actualOnDelete(selected)
         }
       })
     },
-    [selectedItems, actualOnDelete, onChangeSelected, onSelect],
+    [selectedItems, actualOnDelete, onChangeSelected, onSelect, onChangeInput],
   )
 
   const { renderListBox, activeOption, onKeyDownListBox, listBoxId, listBoxRef } = useListbox({

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -80,6 +80,11 @@ const NOOP = () => undefined
 const ESCAPE_KEY_REGEX = /^Esc(ape)?$/
 const ARROW_UP_DOWN_REGEX = /^(Arrow)?(Up|Down)$/
 
+const EMPTY_INPUT_CHANGE_EVENT = {
+  currentTarget: { value: '' },
+  target: { value: '' },
+} as ChangeEvent<HTMLInputElement>
+
 const classNameGenerator = tv({
   slots: {
     wrapper: 'smarthr-ui-SingleCombobox shr-inline-block',
@@ -180,6 +185,9 @@ const ActualSingleCombobox = <T,>(
         onSelect?.(selected)
         onChangeSelected?.(selected)
 
+        // 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
+        onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
+
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
         requestAnimationFrame(() => {
@@ -188,7 +196,7 @@ const ActualSingleCombobox = <T,>(
 
         setIsEditing(false)
       },
-      [onChangeSelected, onSelect],
+      [onChangeSelected, onSelect, onChangeInput],
     ),
     isExpanded,
     isLoading,


### PR DESCRIPTION
## 関連URL

https://kufuinc.slack.com/archives/C06KVP5PL23/p1772680498316019

## 概要

制御コンポーネントで `inputValue` を使用している場合、選択時に親側で `inputValue` を更新できるように、`onChangeInput` を空文字の `ChangeEvent` で発火するように変更しました。

これまで、制御コンポーネントの場合に選択時にsmarthr-ui内部でinputをクリアしても、親側のuseStateの値はそのままになってしまい、齟齬が発生していました。

## 変更内容

### SingleCombobox

- 選択時に `onChangeInput` を空文字の `ChangeEvent` で発火するように変更
- `EMPTY_INPUT_CHANGE_EVENT` を定数として定義

### MultiCombobox

- 選択時（新規選択の場合）に `onChangeInput` を空文字の `ChangeEvent` で発火するように変更
- `EMPTY_INPUT_CHANGE_EVENT` を定数として定義

これにより、制御・非制御に関わらず、選択時に親コンポーネント側で `inputValue` を空にすることができます。

## プロダクト側で対応が必要な事項

`inputValue` を制御している場合、`onChangeInput` のハンドラで選択時に発火される空文字のイベントを受け取り、`inputValue` の状態を更新してください。

```tsx
const [inputValue, setInputValue] = useState('')

<SingleCombobox
  inputValue={inputValue}
  onChangeInput={(e) => setInputValue(e.currentTarget.value)}
  // ...
/>
```

## 確認方法

- テスト: `pnpm ui test` ですべてのテストが通過することを確認
- Lint: `pnpm ui lint` ですべてのlintチェックが通過することを確認