### PR TITLE
fix: SideNavItemAnchorをエクスポートに追加

### DIFF
--- a/packages/smarthr-ui/src/index.ts
+++ b/packages/smarthr-ui/src/index.ts
@@ -71,7 +71,7 @@ export { SegmentedControl, type SegmentedControlOption } from './components/Segm
 export { FormControl } from './components/FormControl'
 export { Fieldset } from './components/Fieldset'
 export { MultiCombobox, SingleCombobox } from './components/Combobox'
-export { SideNav, SideNavItemButton } from './components/SideNav'
+export { SideNav, SideNavItemButton, SideNavItemAnchor } from './components/SideNav'
 export { Text } from './components/Text'
 export { LineClamp } from './components/LineClamp'
 export { NotificationBar } from './components/NotificationBar'


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->
https://github.com/kufu/smarthr-ui/pull/6094

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->
`SideNavItemAnchor` コンポーネントがエクスポートされていなかったため、外部から利用できない状態でした。
このコンポーネントを公開APIとして利用できるようにしました。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->
`packages/smarthr-ui/src/index.ts` に `SideNavItemAnchor` のエクスポートを追加しました。

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->
なし

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
