### PR TITLE
fix(FileViewer): PDFのrotateが考慮されないのを修正した

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -58,7 +58,7 @@ export const FileViewer: FC<Props> = ({
   const ref = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)
   const [loaded, setLoaded] = useState(false)
-  const [rotation, setRotation] = useState(0)
+  const [rotation, setRotation] = useState<number | undefined>(undefined)
   const [width, setWidth] = useState(fixedWidth ?? 0)
 
   const internalScaleStep = useMemo(
@@ -76,12 +76,17 @@ export const FileViewer: FC<Props> = ({
 
   const rotate = useCallback(() => {
     // HINT: react-pdf側のAnnotationLayer.cssではマイナスの回転に対応しておらず、また0, 90, 180, 270度のみ対応しているため、-90度の場合は+270度として扱う
-    const newRotation = rotation === 0 ? 270 : rotation - 90
+    const currentRotation = rotation ?? 0
+    const newRotation = currentRotation === 0 ? 270 : currentRotation - 90
     setRotation(newRotation)
   }, [rotation])
 
   const handleLoaded = useCallback(() => {
     setLoaded(true)
+  }, [])
+
+  const handlePDFLoaded = useCallback((defaultRotation: number) => {
+    setRotation(defaultRotation)
   }, [])
 
   useEffect(() => {
@@ -129,6 +134,7 @@ export const FileViewer: FC<Props> = ({
               file={file}
               width={width}
               onLoad={handleLoaded}
+              onPDFLoaded={handlePDFLoaded}
               onPassword={onPassword}
               onLoadError={onLoadError}
             />

--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -23,7 +23,7 @@ export const ImageViewer: FC<ViewerProps> = memo(
       // 与えられたwidthに対する適切なscaleを算出
       const viewportScale = (width / img.naturalWidth) * scale
 
-      const rad = (rotation * Math.PI) / 180
+      const rad = ((rotation ?? 0) * Math.PI) / 180
       const sin = Math.abs(Math.sin(rad))
       const cos = Math.abs(Math.cos(rad))
 
@@ -63,7 +63,7 @@ export const ImageViewer: FC<ViewerProps> = memo(
           src={file.url}
           alt={file.alt}
           style={{
-            rotate: `${rotation}deg`,
+            rotate: `${rotation ?? 0}deg`,
             scale: `${viewConfig.imgScale}`,
           }}
           onLoad={handleLoad}

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -41,7 +41,7 @@ const options = {
 } satisfies ComponentProps<typeof Document>['options']
 
 export const PDFViewer: FC<ViewerProps> = memo(
-  ({ scale, rotation, file, width, onLoad, onPassword, onLoadError }) => {
+  ({ scale, rotation, file, width, onLoad, onPDFLoaded, onPassword, onLoadError }) => {
     const [pdfNumPages, setPdfNumPages] = useState(1)
 
     const onDocumentLoadSuccess = useCallback<
@@ -51,17 +51,20 @@ export const PDFViewer: FC<ViewerProps> = memo(
     }, [])
 
     const onPageLoad: ComponentProps<typeof Page>['onLoadSuccess'] = useMemo(() => {
-      if (!onLoad) {
+      if (!onLoad && !onPDFLoaded) {
         return undefined
       }
 
       return (page) => {
+        if (onPDFLoaded && rotation === undefined) {
+          onPDFLoaded(page.rotate)
+        }
         // DocumentのLoadだとページごとの読み込みが考慮されないため
-        if (page.pageNumber === pdfNumPages) {
+        if (onLoad && page.pageNumber === pdfNumPages) {
           onLoad()
         }
       }
-    }, [pdfNumPages, onLoad])
+    }, [onLoad, onPDFLoaded, pdfNumPages, rotation])
 
     return (
       <>

--- a/packages/smarthr-ui/src/components/FileViewer/types.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/types.ts
@@ -10,9 +10,10 @@ export type FileForViewer = {
 export type ViewerProps = {
   file: FileForViewer
   scale: number
-  rotation: number
+  rotation: number | undefined
   width: number
   onLoad: () => void
+  onPDFLoaded?: (defaultRotation: number) => void
   /**
    * PDFファイルのパスワード入力を要求されたときに呼ばれるコールバック関数。PdfViewerでのみ使用されます。
    */


### PR DESCRIPTION
## 関連URL

https://kufuinc.slack.com/archives/C04JU8EJN5U/p1774423250015539?thread_ts=1774423190.665169&cid=C04JU8EJN5U

react-pdfの公式ドキュメント: https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#user-guide

## 概要

FileViewerコンポーネントでPDFを表示する際に、rotate属性が考慮されず、常にrotateが0の状態で描画される事象を修正しました。

## 変更内容

### 問題の原因

PDFの各ページにはrotate属性が設定されているものがあるが、react-pdfでDocumentコンポーネントにrotateを渡すと、全てのページのrotateが上書きされることがわかった。
そのため、Documentに渡すrotateは、初期値をundefinedにした上で、読み込みが完了したタイミングで実際のrotateを取得してSetする必要があった。

### 修正内容

FileViewer側で持っているrotationを`<number | undefined>`に変更し、
- PDFViewerではrotate: undefinedとしてPDFを読み込み、onPDFLoadedで再セットする
- ImageViewerでは従来通り0を初期値として描画する（undefinedが渡された場合は0で上書きする）

という処理を加えた。

## 確認方法

1. Storybookで「FileViewer」のストーリーを開く
2. rotate属性を含むPDFファイルを表示
3. rotate属性が反映されていることを確認
4. 回転処理がデグレしていないことを確認

## その他

原因で言及した通り、本来は各ページでそれぞれrotate属性が設定されうる（1Pはrotate:0, 2Pはrotate:90, 3Pはrotate:180みたいなケースがある）のですが、

- rotateが設定されているpdfでも基本的には全ページでrotateが統一されており、エッジケースであること
- 上記ケースをカバーする場合、Documentにrotateを渡すと上記の通り全ページのrotate初期化が行われるため、回転の対象をPDF全体から各Pageごとへ変化させる必要があり、使い勝手は悪化しそうなこと

からカバーしない判断をしています。