### PR TITLE
fix: pin minimatch@3.x for eslint-plugin-import compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "cross-spawn@<7.0.5": ">=7.0.6",
       "nanoid": "3.3.11",
       "esbuild@<=0.24.2": ">=0.27.3",
+      "eslint-plugin-import>minimatch": "^3.1.2",
       "@babel/runtime@<7.26.10": ">=7.28.6",
       "@babel/helpers@<7.26.10": ">=7.28.6",
       "brace-expansion@<1.1.12": "^5.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   cross-spawn@<7.0.5: '>=7.0.6'
   nanoid: 3.3.11
   esbuild@<=0.24.2: '>=0.27.3'
+  eslint-plugin-import>minimatch: ^3.1.2
   '@babel/runtime@<7.26.10': '>=7.28.6'
   '@babel/helpers@<7.26.10': '>=7.28.6'
   brace-expansion@<1.1.12: ^5.0.4


### PR DESCRIPTION
## 関連URL

なし

## 概要

`eslint-plugin-import` と `minimatch@10` の互換性問題により、ESLint の `import/order` ルールが実行時エラーを起こしていた問題を修正しました。

## 変更内容

- `pnpm.overrides` に `"eslint-plugin-import>minimatch": "^3.1.2"` を追加
- `eslint-plugin-import` が使用する `minimatch` のバージョンを 3.x に固定

### 問題の詳細

最近の依存関係更新により `minimatch@10.2.2` がインストールされましたが、`eslint-plugin-import@2.32.0` は `minimatch@^3.1.2` を期待しているため、以下のエラーが発生していました：

```
TypeError: (0 , _minimatch2.default) is not a function
Rule: "import/order"
```

この修正により、他の依存関係は引き続き `minimatch@10` を使用でき、`eslint-plugin-import` のみが互換性のある `minimatch@3.x` を使用します。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- `pnpm ui lint` が正常に完了することを確認
- `eslint-plugin-import` が `minimatch@3.1.5` を使用していることを確認済み