### PR TITLE
fix: LineClampで短いテキストがw-fullによって意図せず引き伸ばされる問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -19,16 +19,16 @@ type Props = AbstractProps & Omit<ComponentPropsWithRef<'span'>, keyof AbstractP
 const classNameGenerator = tv({
   slots: {
     base: 'smarthr-ui-LineClamp shr-relative',
-    clampedLine: 'shr-w-full',
+    clampedLine: 'shr-max-w-full',
     shadowElementWrapper:
-      'shr-invisible shr-absolute shr-left-0 shr-top-0 shr-h-full shr-w-full shr-overflow-hidden shr-whitespace-normal shr-opacity-0',
-    shadowElement: 'shr-absolute shr-left-0 shr-top-0 shr-w-full',
+      'shr-invisible shr-absolute shr-left-0 shr-top-0 shr-h-full shr-max-w-full shr-overflow-hidden shr-whitespace-normal shr-opacity-0',
+    shadowElement: 'shr-absolute shr-left-0 shr-top-0 shr-max-w-full',
   },
   variants: {
     maxLines: {
       1: {
         clampedLine:
-          'shr-inline-block shr-w-full shr-overflow-x-clip shr-overflow-ellipsis shr-whitespace-nowrap shr-align-middle',
+          'shr-inline-block shr-max-w-full shr-overflow-x-clip shr-overflow-ellipsis shr-whitespace-nowrap shr-align-middle',
       },
       2: {
         clampedLine: 'shr-line-clamp-[2]',


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

LineClampコンポーネントで短いテキストを表示する際、内部で使用していた`w-full`により、テキストの長さに関わらず幅いっぱいに引き伸ばされてしまう問題がありました。
特に、親要素（TextLinkなど）が`inline`または`inline-block`要素の場合、LineClamp内部の`inline-block`要素に`w-full`が適用されることで、短いテキストでも不必要に引き伸ばされる挙動が発生していました。


## 変更内容
- LineClampコンポーネント内の`shr-w-full`を`shr-max-w-full`に変更
  - `clampedLine`（maxLines=1の場合）、`shadowElementWrapper`、`shadowElement`の各スロットで適用
- Storybookに再現ケースを追加
  - Table内でTextLinkに`shr-w-full`を指定し、その中でLineClampを使用するケースを追加
  - 短いテキスト（「短い文章」）と長いテキストの両方を表示

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

以下のコンポーネントを作成します。

```tsx
render(
  <Table>
    <thead>
      <tr>
        <Th style={{ minWidth: '6rem', maxWidth: '10rem', whiteSpace: 'nowrap' }}>列1</Th>
        <Th style={{ minWidth: '20rem', maxWidth: '24rem', whiteSpace: 'nowrap' }}>列2</Th>
        <Th style={{ minWidth: '20rem', maxWidth: '24rem', whiteSpace: 'nowrap' }}>列3</Th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <Td style={{ minWidth: '6rem', maxWidth: '10rem', whiteSpace: 'nowrap' }}>行1</Td>
        <Td
          style={{ minWidth: '20rem', maxWidth: '24rem', whiteSpace: 'nowrap' }}
          fixed="left"
          title="短い文章"
        >
          <TextLink target="_blank" href="#" className="shr-w-full">
            <LineClamp maxLines={1}>短い文章</LineClamp>
          </TextLink>
        </Td>
        <Td style={{ minWidth: '20rem', maxWidth: '24rem', whiteSpace: 'nowrap' }}>hogehoge</Td>
      </tr>
      <tr>
        <Td style={{ minWidth: '6rem', maxWidth: '10rem', whiteSpace: 'nowrap' }}>行2</Td>
        <Td style={{ minWidth: '20rem', maxWidth: '24rem', whiteSpace: 'nowrap' }} fixed="left">
          <TextLink target="_blank" href="#" className="shr-w-full">
            <LineClamp maxLines={1}>{longText}</LineClamp> {/* 任意の長い文字列 */}
          </TextLink>
        </Td>
        <Td style={{ minWidth: '20rem', maxWidth: '24rem', whiteSpace: 'nowrap' }}>hogehoge</Td>
      </tr>
    </tbody>
  </Table>
)
```

キャプチャのようになっていることを確認してください。
|before|afrer|
|---|---|
|<img width="966" height="154" alt="image" src="https://github.com/user-attachments/assets/5b620fd5-1da7-4d6a-9e32-fc0f281135dd" />|<img width="970" height="152" alt="image" src="https://github.com/user-attachments/assets/e64eddeb-07c5-4313-bc0f-3ee46ffa4bfd" />|