### PR TITLE
fix: AccordionPanelのrounded cornersが表示されない問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -45,13 +45,11 @@ export const AccordionPanelContext = createContext<{
   parentRef: null,
 })
 
-const ITEM_SELECTOR = '&>.smarthr-ui-AccordionPanel-item'
-const TRIGGER_SELECTOR = '.smarthr-ui-AccordionPanel-trigger'
 const ROUNDED = {
-  t_l: `[${ITEM_SELECTOR}:first-child_${TRIGGER_SELECTOR}]:shr-rounded-tl-l`,
-  t_r: `[${ITEM_SELECTOR}:first-child_${TRIGGER_SELECTOR}]:shr-rounded-tr-l`,
-  b_l: `[${ITEM_SELECTOR}:last-child_${TRIGGER_SELECTOR}:not([aria-expanded="true"])]:shr-rounded-bl-l`,
-  b_r: `[${ITEM_SELECTOR}:last-child_${TRIGGER_SELECTOR}:not([aria-expanded="true"])]:shr-rounded-br-l`,
+  t_l: '[&>.smarthr-ui-AccordionPanel-item:first-child_.smarthr-ui-AccordionPanel-trigger]:shr-rounded-tl-l',
+  t_r: '[&>.smarthr-ui-AccordionPanel-item:first-child_.smarthr-ui-AccordionPanel-trigger]:shr-rounded-tr-l',
+  b_l: '[&>.smarthr-ui-AccordionPanel-item:last-child_.smarthr-ui-AccordionPanel-trigger:not([aria-expanded="true"])]:shr-rounded-bl-l',
+  b_r: '[&>.smarthr-ui-AccordionPanel-item:last-child_.smarthr-ui-AccordionPanel-trigger:not([aria-expanded="true"])]:shr-rounded-br-l',
 }
 
 const ROUNDED_ALL = [ROUNDED.t_l, ROUNDED.t_r, ROUNDED.b_l, ROUNDED.b_r]


### PR DESCRIPTION
## 関連URL

ユーザーからの報告：AccordionPanelのroundedが正しく表示されない

## 概要

AccordionPanelの `rounded` propを指定してもrounded cornersが正しく表示されない問題を修正しました。

## 変更内容

### 原因

`ROUNDED` クラス定義でテンプレートリテラルの変数補間を使用してセレクタ文字列を構築していました。TailwindのJITコンパイラは、CSSを適切に検出・生成するために、コンパイル時に完全なクラス名が見える必要があります。テンプレートリテラルの変数補間により、Tailwindがビルドプロセス中にこれらを有効なクラス名として認識できませんでした。

### 修正内容

テンプレートリテラル変数（`ITEM_SELECTOR` と `TRIGGER_SELECTOR`）を、`ROUNDED` オブジェクト内で直接ハードコードされた値に置き換えました。

#### 変更前
```typescript
const ITEM_SELECTOR = '&>.smarthr-ui-AccordionPanel-item'
const TRIGGER_SELECTOR = '.smarthr-ui-AccordionPanel-trigger'
const ROUNDED = {
  t_l: `[${ITEM_SELECTOR}:first-child_${TRIGGER_SELECTOR}]:shr-rounded-tl-l`,
  // ...
}
```

#### 変更後
```typescript
const ROUNDED = {
  t_l: '[&>.smarthr-ui-AccordionPanel-item:first-child_.smarthr-ui-AccordionPanel-trigger]:shr-rounded-tl-l',
  // ...
}
```

## プロダクト側で対応が必要な事項

なし（バグ修正のみ）

## 確認方法

AccordionPanel.stories.tsxの `Rounded` storyで、`rounded` propのすべてのバリエーション（true, 'all', 'top', 'right', 'bottom', 'left'）が正しく表示されることを確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)