### PR TITLE
refactor(InformationPanel)!: decorators属性を削除

### DIFF
--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
-import { type DecoratorsType, useDecorators } from '../../hooks/useDecorators'
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { useIntl } from '../../intl'
 import { Base, type BaseElementProps } from '../Base'
@@ -37,7 +36,6 @@ type ObjectHeadingType = {
   unrecommendedTag?: HeadingTagTypes
 }
 type HeadingType = ReactNode | ObjectHeadingType
-type DecoratorKeyTypes = 'openButtonLabel' | 'closeButtonLabel'
 type AbstractProps = PropsWithChildren<{
   /** パネルのタイトル */
   heading: HeadingType
@@ -45,8 +43,6 @@ type AbstractProps = PropsWithChildren<{
   toggleable?: boolean
   /** 開閉ボタン押下時に発火するコールバック関数 */
   onClickTrigger?: (active: boolean) => void
-  /** コンポーネント内の文言を変更するための関数を設定 */
-  decorators?: DecoratorsType<DecoratorKeyTypes>
 }> &
   VariantProps<typeof classNameGenerator>
 
@@ -133,7 +129,6 @@ export const InformationPanel: FC<Props> = ({
   className,
   children,
   onClickTrigger,
-  decorators,
   ...rest
 }) => {
   const [active, setActive] = useState(activeProps)
@@ -194,7 +189,6 @@ export const InformationPanel: FC<Props> = ({
             setActive={setActive}
             contentId={contentId}
             className={classNames.toggleableButton}
-            decorators={decorators}
           />
         )}
       </Sidebar>
@@ -249,30 +243,28 @@ const MemoizedHeading = memo<
 })
 
 const ToggleableButton: FC<
-  Pick<Props, 'onClickTrigger' | 'decorators'> & {
+  Pick<Props, 'onClickTrigger'> & {
     active: boolean
     setActive: (flg: boolean) => void
     contentId: string
     className: string
   }
-> = ({ active, onClickTrigger, setActive, contentId, className, decorators }) => {
+> = ({ active, onClickTrigger, setActive, contentId, className }) => {
   const { localize } = useIntl()
 
-  const decoratorDefaultTexts = useMemo(
+  const buttonLabels = useMemo(
     () => ({
-      openButtonLabel: localize({
+      open: localize({
         id: 'smarthr-ui/InformationPanel/openButtonLabel',
         defaultText: '開く',
       }),
-      closeButtonLabel: localize({
+      close: localize({
         id: 'smarthr-ui/InformationPanel/closeButtonLabel',
         defaultText: '閉じる',
       }),
     }),
     [localize],
   )
-
-  const decorated = useDecorators<DecoratorKeyTypes>(decoratorDefaultTexts, decorators)
 
   const onClick = useMemo(
     () => (onClickTrigger ? () => onClickTrigger(active) : () => setActive(!active)),
@@ -288,7 +280,7 @@ const ToggleableButton: FC<
       size="s"
       className={className}
     >
-      {decorated[active ? 'closeButtonLabel' : 'openButtonLabel']}
+      {active ? buttonLabels.close : buttonLabels.open}
     </Button>
   )
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

InformationPanelの`decorators`属性を削除し、smarthr-uiの国際化方針に沿ってIntlProviderのみを使用するように変更します。

## 変更内容

- `decorators`属性を削除
- `useDecorators`フックの代わりに`localize`を直接使用
- 開閉ボタンのラベル（「開く」「閉じる」）はIntlProviderから取得（既に全9言語で翻訳済み）

### 変更前
```tsx
<InformationPanel
  heading="タイトル"
  toggleable
  decorators={{
    openButtonLabel: (defaultText) => 'カスタム開く',
    closeButtonLabel: (defaultText) => 'カスタム閉じる',
  }}
>
  内容
</InformationPanel>
```

### 変更後
```tsx
<InformationPanel
  heading="タイトル"
  toggleable
>
  内容
</InformationPanel>
```

## プロダクト側で対応が必要な事項

`decorators` propsが削除されました。

- `decorators`属性を使用している箇所を削除してください
- 開閉ボタンのラベルはsmarthr-uiの翻訳が自動的に適用されます（全9言語対応済み）

## 確認方法

Storybook: InformationPanelのStorybookで開閉ボタンが正常に動作することを確認