### PR TITLE
refactor(Textarea)!: decorators属性を削除

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -22,8 +22,6 @@ import { debounce } from '../../libs/debounce'
 import { defaultHtmlFontSize } from '../../themes'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import type { DecoratorsType } from '../../hooks/useDecorators'
-
 type AbstractProps = {
   /** 入力値にエラーがあるかどうか */
   error?: boolean
@@ -39,8 +37,6 @@ type AbstractProps = {
   rows?: number
   /** 入力可能な最大文字数。あと何文字入力できるかの表示が追加される。html的なvalidateは発生しない */
   maxLetters?: number
-  /** コンポーネント内の文言を変更するための関数を設定 */
-  decorators?: DecoratorsType<DecoratorKeyTypes>
   /**
    * placeholder属性は非推奨です。別途ヒント用要素の設置を検討してください。
    */
@@ -61,15 +57,6 @@ const getStringLength = (value: TextareaValue) => {
   const surrogatePairs = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g
   return formattedValue.length - (formattedValue.match(surrogatePairs) || []).length
 }
-
-const DECORATOR_DEFAULT_TEXTS = {
-  beforeMaxLettersCount: 'あと',
-  afterMaxLettersCount: '文字',
-  afterMaxLettersCountExceeded: 'オーバー',
-  beforeScreenReaderMaxLettersDescription: '最大',
-  afterScreenReaderMaxLettersDescription: '文字入力できます',
-} as const
-type DecoratorKeyTypes = keyof typeof DECORATOR_DEFAULT_TEXTS
 
 const classNameGenerator = tv({
   slots: {
@@ -123,7 +110,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       autoResize = false,
       maxRows = Infinity,
       rows = 2,
-      decorators,
       error,
       onChange,
       value,
@@ -144,78 +130,36 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
     const [srCounterMessage, setSrCounterMessage] = useState<ReactNode>('')
 
     const buildAvailableLetters = useCallback(
-      (availableLetters: number): ReactNode => {
-        if (decorators?.beforeMaxLettersCount || decorators?.afterMaxLettersCount) {
-          return (
-            <>
-              {decorators.beforeMaxLettersCount?.(DECORATOR_DEFAULT_TEXTS.beforeMaxLettersCount)}
-              {availableLetters}
-              {decorators.afterMaxLettersCount?.(DECORATOR_DEFAULT_TEXTS.afterMaxLettersCount)}
-            </>
-          )
-        }
-        return (
-          <Localizer
-            id="smarthr-ui/Textarea/availableLetters"
-            defaultText="あと{availableLetters}文字"
-            values={{ availableLetters }}
-          />
-        )
-      },
-      [decorators],
+      (availableLetters: number): ReactNode => (
+        <Localizer
+          id="smarthr-ui/Textarea/availableLetters"
+          defaultText="あと{availableLetters}文字"
+          values={{ availableLetters }}
+        />
+      ),
+      [],
     )
 
     const buildmaxLettersExceeded = useCallback(
-      (exceededLetters: number): ReactNode => {
-        if (decorators?.afterMaxLettersCount || decorators?.afterMaxLettersCountExceeded) {
-          return (
-            <>
-              {exceededLetters}
-              {decorators.afterMaxLettersCount?.(DECORATOR_DEFAULT_TEXTS.afterMaxLettersCount)}
-              {decorators.afterMaxLettersCountExceeded?.(
-                DECORATOR_DEFAULT_TEXTS.afterMaxLettersCountExceeded,
-              )}
-            </>
-          )
-        }
-        return (
-          <Localizer
-            id="smarthr-ui/Textarea/maxLettersExceeded"
-            defaultText="{exceededLetters}文字オーバー"
-            values={{ exceededLetters }}
-          />
-        )
-      },
-      [decorators],
+      (exceededLetters: number): ReactNode => (
+        <Localizer
+          id="smarthr-ui/Textarea/maxLettersExceeded"
+          defaultText="{exceededLetters}文字オーバー"
+          values={{ exceededLetters }}
+        />
+      ),
+      [],
     )
 
     const buildScreenReaderMaxLettersDescription = useCallback(
-      (internalMaxLetters: number): ReactNode => {
-        if (
-          decorators?.beforeScreenReaderMaxLettersDescription ||
-          decorators?.afterScreenReaderMaxLettersDescription
-        ) {
-          return (
-            <>
-              {decorators.beforeScreenReaderMaxLettersDescription?.(
-                DECORATOR_DEFAULT_TEXTS.beforeScreenReaderMaxLettersDescription,
-              )}
-              {internalMaxLetters}
-              {decorators.afterScreenReaderMaxLettersDescription?.(
-                DECORATOR_DEFAULT_TEXTS.afterScreenReaderMaxLettersDescription,
-              )}
-            </>
-          )
-        }
-        return (
-          <Localizer
-            id="smarthr-ui/Textarea/screenReaderMaxLettersDescription"
-            defaultText="最大{maxLetters}文字入力できます"
-            values={{ maxLetters: internalMaxLetters }}
-          />
-        )
-      },
-      [decorators],
+      (internalMaxLetters: number): ReactNode => (
+        <Localizer
+          id="smarthr-ui/Textarea/screenReaderMaxLettersDescription"
+          defaultText="最大{maxLetters}文字入力できます"
+          values={{ maxLetters: internalMaxLetters }}
+        />
+      ),
+      [],
     )
 
     const getCounterMessage = useCallback(

--- a/packages/smarthr-ui/src/components/Textarea/stories/Textarea.stories.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/stories/Textarea.stories.tsx
@@ -81,29 +81,6 @@ export const MaxLetters: StoryObj<typeof Textarea> = {
   },
 }
 
-export const Decorators: StoryObj<typeof Textarea> = {
-  name: 'decorators',
-  args: {
-    decorators: {
-      beforeMaxLettersCount: (org) => <>beforeMaxLettersCount({org})</>,
-      afterMaxLettersCount: (org) => <>afterMaxLettersCount({org})</>,
-      afterMaxLettersCountExceeded: (org) => <>afterMaxLettersCountExceeded({org})</>,
-      beforeScreenReaderMaxLettersDescription: (org) => (
-        <>beforeScreenReaderMaxLettersDescription({org})</>
-      ),
-      afterScreenReaderMaxLettersDescription: (org) => (
-        <>afterScreenReaderMaxLettersDescription({org})</>
-      ),
-    },
-  },
-  render: (args) => (
-    <>
-      <Textarea {...args} maxLetters={5} value="テキストエ" />
-      <Textarea {...args} maxLetters={5} value="テキストエリア" />
-    </>
-  ),
-}
-
 export const Placeholder: StoryObj<typeof Textarea> = {
   name: 'placeholder（非推奨）',
   args: {


### PR DESCRIPTION
## 関連URL

なし

## 概要

Textareaの`decorators`属性を削除し、smarthr-uiの国際化方針に沿ってIntlProviderのみを使用するように変更します。

## 変更内容

- `decorators`属性を削除
- decoratorsの分岐処理を削除し、常に`Localizer`を使用するように統一
- 文字数カウンター表示（「あと10文字」「5文字オーバー」など）はIntlProviderから取得（既に全9言語で翻訳済み）
- Decoratorsストーリーを削除

### 変更前
```tsx
<Textarea
  maxLetters={100}
  decorators={{
    beforeMaxLettersCount: (defaultText) => 'カスタムあと',
    afterMaxLettersCount: (defaultText) => 'カスタム文字',
    afterMaxLettersCountExceeded: (defaultText) => 'カスタムオーバー',
    beforeScreenReaderMaxLettersDescription: (defaultText) => 'カスタム最大',
    afterScreenReaderMaxLettersDescription: (defaultText) => 'カスタム文字入力できます',
  }}
/>
```

### 変更後
```tsx
<Textarea maxLetters={100} />
```

## プロダクト側で対応が必要な事項

`decorators` propsが削除されました。

- `decorators`属性を使用している箇所を削除してください
- 文字数カウンター表示はsmarthr-uiの翻訳が自動的に適用されます（全9言語対応済み）

## 確認方法

Storybook: TextareaのStorybookで`maxLetters`指定時の文字数カウンター表示が正常に動作することを確認