### PR TITLE
refactor(SearchInput)!: decorators属性を削除しIntlProviderのみを使用

### DIFF
--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -1,10 +1,4 @@
-import {
-  type ComponentProps,
-  type ComponentPropsWithoutRef,
-  type ReactNode,
-  forwardRef,
-  useMemo,
-} from 'react'
+import { type ComponentProps, type ReactNode, forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { InputWithTooltip } from '../InputWithTooltip'
@@ -14,7 +8,6 @@ import { SearchInputIcon } from './SearchInputIcon'
 type Props = Omit<ComponentProps<typeof InputWithTooltip>, 'tooltipMessage' | 'prefix'> & {
   /** 入力欄の説明を紐付けるツールチップに表示するメッセージ */
   tooltipMessage: ReactNode
-  decorators?: ComponentPropsWithoutRef<typeof SearchInputIcon>['decorators']
 }
 
 const classNameGenerator = tv({
@@ -33,7 +26,7 @@ const classNameGenerator = tv({
 })
 
 export const SearchInput = forwardRef<HTMLInputElement, Props>(
-  ({ decorators, width, className, ...rest }, ref) => {
+  ({ width, className, ...rest }, ref) => {
     const labelStyle = useMemo(
       () => ({
         width: typeof width === 'number' ? `${width}px` : width,
@@ -54,7 +47,7 @@ export const SearchInput = forwardRef<HTMLInputElement, Props>(
         <InputWithTooltip
           {...rest}
           ref={ref}
-          prefix={<SearchInputIcon decorators={decorators} />}
+          prefix={<SearchInputIcon />}
           className={classNames.input}
         />
       </label>

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInputIcon.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInputIcon.tsx
@@ -2,30 +2,20 @@
 
 import { useMemo } from 'react'
 
-import { type DecoratorsType, useDecorators } from '../../../hooks/useDecorators'
 import { useIntl } from '../../../intl'
 import { FaMagnifyingGlassIcon } from '../../Icon'
 
-type Props = {
-  decorators?: DecoratorsType<DecoratorKeyTypes>
-}
-
-type DecoratorKeyTypes = 'iconAlt'
-
-export const SearchInputIcon = ({ decorators }: Props) => {
+export const SearchInputIcon = () => {
   const { localize } = useIntl()
 
-  const decoratorDefaultTexts = useMemo(
-    () => ({
-      iconAlt: localize({
+  const iconAlt = useMemo(
+    () =>
+      localize({
         id: 'smarthr-ui/SearchInput/iconAlt',
         defaultText: '検索',
       }),
-    }),
     [localize],
   )
 
-  const decorated = useDecorators<DecoratorKeyTypes>(decoratorDefaultTexts, decorators)
-
-  return <FaMagnifyingGlassIcon alt={decorated.iconAlt} color="TEXT_GREY" />
+  return <FaMagnifyingGlassIcon alt={iconAlt} color="TEXT_GREY" />
 }


### PR DESCRIPTION
## 関連URL

- decorators削除作業の一環

## 概要

SearchInputコンポーネント（SearchInputIconを含む）から`decorators`属性を削除し、IntlProviderのみを使用するように変更しました。

## 変更内容

### 削除した属性
- `decorators?: DecoratorsType<'iconAlt'>`
  - 検索アイコンのalt属性（デフォルト: 「検索」）

### 変更内容
- SearchInput: `decorators`属性をPropsから削除
- SearchInputIcon: `decorators`パラメータを削除し、`localize`関数を直接使用
- `useDecorators`フックの使用を削除
- 既に全9言語で翻訳済み（`smarthr-ui/SearchInput/iconAlt`）

### 影響範囲
- SearchInput.tsx
- SearchInputIcon.tsx

## プロダクト側で対応が必要な事項

`decorators`属性を使用している場合は削除してください。検索アイコンのalt属性はsmarthr-uiが提供する翻訳が自動的に適用されます（IntlProvider経由）。

```typescript
// Before
<SearchInput decorators={{ iconAlt: () => 'Search' }} />

// After
<SearchInput />
// smarthr-uiの翻訳が自動適用されます
```

## 確認方法

- `npm run lint` が成功することを確認
- Storybookで動作確認（検索アイコンのaltが「検索」と設定されていること）