### PR TITLE
fix(ModelessDialog): ダイアログヘッダのフォーカスリング修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -101,11 +101,11 @@ const classNameGenerator = tv({
       'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5',
       'hover:shr-bg-white-darken',
       /* DialogHandlerにフォーカスが当たっているときは、headerもフォーカス状態のスタイルにする。 */
-      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-bg-white-darken has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-transition-colors has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-duration-100 has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-ease-in-out',
+      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-focus-indicator has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-bg-white-darken has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-transition-colors has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-duration-100 has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-ease-in-out',
     ],
     dialogHandler: [
       'smarthr-ui-ModelessDialog-handle shr-absolute shr-inset-x-0 shr-bottom-0 shr-top-[2px] shr-m-auto shr-flex shr-justify-center shr-rounded-tl-s shr-rounded-tr-s shr-border-none shr-text-grey shr-transition-colors shr-duration-100 shr-ease-in-out',
-      'shr-cursor-[inherit] shr-bg-[unset] focus-visible:shr-shadow-outline focus-visible:shr-outline-none',
+      'focus-visible:shr-focus-indicator--none shr-cursor-[inherit] shr-bg-[unset]',
     ],
     headingEl: ['shr-my-1 shr-me-1'],
     closeButtonLayout: [


### PR DESCRIPTION
## 関連URL

なし

## 概要

ModelessDialogのヘッダ部分（ドラッグハンドル）にフォーカスが当たった際のフォーカスリング表示を修正します。

## 変更内容

- ダイアログハンドルに `focus-visible` が当たった際、ヘッダに `shr-focus-indicator` クラスを適用してフォーカスリングを表示するようにしました
- ダイアログハンドル自体のフォーカススタイル（`focus-visible:shr-shadow-outline` / `focus-visible:shr-outline-none`）を `focus-visible:shr-focus-indicator--none` に置き換え、ハンドル側ではフォーカスリングを非表示にしました
- これにより、フォーカスリングがヘッダ全体に統一的に表示されるようになります

|before|after|
|---|---|
|<img width="402" height="235" alt="image" src="https://github.com/user-attachments/assets/17db068d-7db6-4d1d-99a2-da948c5740f2" />|<img width="426" height="273" alt="image" src="https://github.com/user-attachments/assets/4b370fe6-1c0b-4ca4-a2a0-894518cbda36" />|

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookで `ModelessDialog` を開き、Tabキーでヘッダ部分にフォーカスを当てた際にフォーカスリングが正しく表示されることを確認してください