### PR TITLE
fix: twMergeConfigの副作用がランタイムで実行されない問題を修正

### DIFF
--- a/packages/smarthr-ui/package.json
+++ b/packages/smarthr-ui/package.json
@@ -170,7 +170,8 @@
     "scaffold:storybook": "plop"
   },
   "sideEffects": [
-    "*.css"
+    "*.css",
+    "**/configureTwMerge.*"
   ],
   "typings": "lib/index.d.ts"
 }

--- a/packages/smarthr-ui/src/configureTwMerge.ts
+++ b/packages/smarthr-ui/src/configureTwMerge.ts
@@ -1,0 +1,60 @@
+import { validators } from 'tailwind-merge'
+import { defaultConfig } from 'tailwind-variants'
+
+import { defaultWidth } from './themes'
+
+const DEFAULT_WIDTH_KEYS = Object.keys(defaultWidth) as Array<keyof typeof defaultWidth>
+
+defaultConfig.twMergeConfig = {
+  prefix: 'shr-',
+  classGroups: {
+    w: [{ w: [...DEFAULT_WIDTH_KEYS, validators.isArbitraryValue] }],
+    basis: [{ basis: [...DEFAULT_WIDTH_KEYS, validators.isArbitraryValue] }],
+    boxShadow: [
+      {
+        shadow: [
+          'layer-0',
+          'layer-1',
+          'layer-2',
+          'layer-3',
+          'layer-4',
+          'outline',
+          'underline',
+          'input-hover',
+          'none',
+        ],
+      },
+    ],
+    'border-shorthand': [
+      'border-shorthand',
+      'border-t-shorthand',
+      'border-r-shorthand',
+      'border-b-shorthand',
+      'border-l-shorthand',
+    ],
+    fontSize: [
+      {
+        text: ['2xs', 'xs', 'sm', 'base', 'lg', 'xl', '2xl', 'inherit'],
+      },
+    ],
+    lineHeight: [
+      {
+        leading: ['none', 'tight', 'normal', 'loose', '[0]'],
+      },
+    ],
+    zIndex: [
+      {
+        z: [
+          'auto',
+          '0',
+          '1',
+          'fixed-menu',
+          'overlap-base',
+          'overlap',
+          (classPart: string) => /^\[\d+\]$/.test(classPart),
+        ],
+      },
+    ],
+    focus: ['focus-indicator', 'focus-indicator--outer', 'focus-indicator-none'],
+  },
+}

--- a/packages/smarthr-ui/src/index.ts
+++ b/packages/smarthr-ui/src/index.ts
@@ -1,3 +1,5 @@
+import './configureTwMerge'
+
 // components
 export { DisclosureTrigger, DisclosureContent } from './components/Disclosure'
 export { Balloon } from './components/Balloon'

--- a/packages/smarthr-ui/src/smarthr-ui-preset.test.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.test.ts
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants'
 
-// smarthr-ui-presetをimportして設定を適用
-import './smarthr-ui-preset'
+// configureTwMergeをimportして設定を適用
+import './configureTwMerge'
 
 describe('twMergeConfig', () => {
   describe('classGroups', () => {

--- a/packages/smarthr-ui/src/smarthr-ui-preset.ts
+++ b/packages/smarthr-ui/src/smarthr-ui-preset.ts
@@ -1,6 +1,4 @@
 import { darken } from 'polished'
-import { validators } from 'tailwind-merge'
-import { defaultConfig } from 'tailwind-variants'
 import plugin from 'tailwindcss/plugin'
 
 import {
@@ -15,62 +13,6 @@ import {
 } from './themes'
 
 import type { Config } from 'tailwindcss'
-
-const DEFAULT_WIDTH_KEYS = Object.keys(defaultWidth) as Array<keyof typeof defaultWidth>
-
-defaultConfig.twMergeConfig = {
-  prefix: 'shr-',
-  classGroups: {
-    w: [{ w: [...DEFAULT_WIDTH_KEYS, validators.isArbitraryValue] }],
-    basis: [{ basis: [...DEFAULT_WIDTH_KEYS, validators.isArbitraryValue] }],
-    boxShadow: [
-      {
-        shadow: [
-          'layer-0',
-          'layer-1',
-          'layer-2',
-          'layer-3',
-          'layer-4',
-          'outline',
-          'underline',
-          'input-hover',
-          'none',
-        ],
-      },
-    ],
-    'border-shorthand': [
-      'border-shorthand',
-      'border-t-shorthand',
-      'border-r-shorthand',
-      'border-b-shorthand',
-      'border-l-shorthand',
-    ],
-    fontSize: [
-      {
-        text: ['2xs', 'xs', 'sm', 'base', 'lg', 'xl', '2xl', 'inherit'],
-      },
-    ],
-    lineHeight: [
-      {
-        leading: ['none', 'tight', 'normal', 'loose', '[0]'],
-      },
-    ],
-    zIndex: [
-      {
-        z: [
-          'auto',
-          '0',
-          '1',
-          'fixed-menu',
-          'overlap-base',
-          'overlap',
-          (classPart: string) => /^\[\d+\]$/.test(classPart),
-        ],
-      },
-    ],
-    focus: ['focus-indicator', 'focus-indicator--outer', 'focus-indicator-none'],
-  },
-}
 
 const spacingByChar = createSpacingByChar(defaultHtmlFontSize / 2)
 type Spacing = {


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/pull/6217 (v91 で TailwindConfig.tsx を削除した PR)

## 概要

v91 (PR #6217) で `TailwindConfig.tsx` を削除した際、`smarthr-ui-preset.ts` のモジュールレベル副作用（`defaultConfig.twMergeConfig = { prefix: 'shr-', ... }`）がランタイムで実行されなくなりました。

これにより `tv()` 内の tailwind-merge が `shr-` プレフィックスを認識せず、`className` による上書きが効かなくなっています。例として LanguageSwitcher の Button が白い四角になるなど、`className` で `tv()` のスタイルを上書きしている箇所すべてに影響しうる問題です。

### 原因の連鎖

- v89: `index.ts` → `themes/index.ts`（`export * from './tailwind'`）→ `TailwindConfig.tsx`（`import presetConfig from '../../smarthr-ui-preset'`）→ 副作用が実行されていた
- v91: PR #6217 で `TailwindConfig.tsx` 削除 + `themes/index.ts` を個別 export に変更 → `smarthr-ui-preset.ts` をランタイムでインポートするモジュールがなくなり副作用が消失

## 変更内容

`smarthr-ui-preset.ts` から `twMergeConfig` の副作用コードを `configureTwMerge.ts` に分離し、`index.ts` の先頭でインポートすることで、ライブラリ利用時に副作用が確実に実行されるようにしました。

### ファイル分離の理由

`smarthr-ui-preset.ts` は以下の2つの責務を持っていました：

1. **ランタイム副作用**: `defaultConfig.twMergeConfig = {...}`（`tv()` が正しく動くために必要）
2. **ビルドタイム設定**: Tailwind CSS の preset config（`tailwindcss/plugin` に依存）

`smarthr-ui-preset.ts` をそのまま `index.ts` からインポートすると、ビルドタイムでのみ必要な `tailwindcss/plugin`（約25KB）がランタイムバンドルに含まれてしまいます。副作用部分だけを `configureTwMerge.ts`（約2.3KB）に分離することで、ランタイムバンドルへの影響を最小限にしています。

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/configureTwMerge.ts` | 新規作成。`twMergeConfig` 設定の副作用モジュール |
| `src/index.ts` | 先頭に `import './configureTwMerge'` を追加 |
| `src/smarthr-ui-preset.ts` | 副作用コードを除去（`configureTwMerge.ts` に移動） |
| `src/smarthr-ui-preset.test.ts` | インポートパスを `./configureTwMerge` に変更 |
| `package.json` | `sideEffects` に `**/configureTwMerge.*` を追加（tree-shaking で副作用が除去されるのを防止） |

## プロダクト側で対応が必要な事項

なし

## 確認方法

- `pnpm ui test` でテストがパスすること
- `pnpm ui build` でビルドが成功すること
- ビルド出力の `lib/index.js`（ESM）と `lib/index.cjs`（CJS）の両方に `configureTwMerge` へのインポートが含まれていること
- Storybook で LanguageSwitcher 等、`className` で `tv()` のスタイルを上書きしているコンポーネントが正しく表示されること