### PR TITLE
chore(Chart): chartsのsmarthr-uiの依存先をworkspaceに変更

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -46,7 +46,7 @@
     "react": "^19.0.3",
     "react-dom": "^19.0.3",
     "react-intl": "^7.0.4 || ^8.0.0 || ^10.0.0",
-    "smarthr-ui": "^74.0.0",
+    "smarthr-ui": "workspace:^",
     "styled-components": "^5.0.1"
   },
   "dependencies": {
@@ -57,6 +57,7 @@
     "react-chartjs-2": "^5.3.1"
   },
   "devDependencies": {
+    "smarthr-ui": "workspace:*",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,6 @@ importers:
       react-chartjs-2:
         specifier: ^5.3.1
         version: 5.3.1(chart.js@4.5.1)(react@19.2.4)
-      smarthr-ui:
-        specifier: ^74.0.0
-        version: 74.2.0(@types/react@18.3.28)(eslint@9.39.3(jiti@2.6.1))(react-dom@19.2.4(react@19.2.4))(react-intl@10.1.0(@types/react@18.3.28)(react@19.2.4)(typescript@5.9.3))(react@19.2.4)(styled-components@5.3.11(react-dom@19.2.4(react@19.2.4))(react-is@19.2.0)(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^29.0.0
@@ -202,6 +199,9 @@ importers:
       rollup:
         specifier: ^4.59.0
         version: 4.59.0
+      smarthr-ui:
+        specifier: workspace:*
+        version: link:../smarthr-ui
       storybook:
         specifier: 9.1.19
         version: 9.1.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.2.4(@types/node@20.19.35)(jiti@2.6.1)(less@4.2.0)(terser@5.46.0)(tsx@4.20.6)(yaml@2.8.3))
@@ -1593,32 +1593,17 @@ packages:
   '@formatjs/bigdecimal@0.2.0':
     resolution: {integrity: sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==}
 
-  '@formatjs/ecma402-abstract@2.3.6':
-    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
-
   '@formatjs/ecma402-abstract@3.2.0':
     resolution: {integrity: sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==}
-
-  '@formatjs/fast-memoize@2.2.7':
-    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
 
   '@formatjs/fast-memoize@3.1.1':
     resolution: {integrity: sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg==}
 
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
-
   '@formatjs/icu-messageformat-parser@3.5.3':
     resolution: {integrity: sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==}
 
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
-
   '@formatjs/icu-skeleton-parser@2.1.3':
     resolution: {integrity: sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
   '@formatjs/intl-localematcher@0.8.2':
     resolution: {integrity: sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==}
@@ -4178,9 +4163,6 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  intl-messageformat@10.7.18:
-    resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
-
   intl-messageformat@11.2.0:
     resolution: {integrity: sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==}
 
@@ -5639,14 +5621,6 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
-
-  smarthr-ui@74.2.0:
-    resolution: {integrity: sha512-7qLYS3SPozb0/xNP7GI8VLax302XLhSv79iM5nP8M+n3BqyjoMpNjGhbphc6yQASGa0wMo9+r7rcJhgOLkqjvQ==}
-    peerDependencies:
-      react: ^19.2.4
-      react-dom: ^19.2.4
-      react-intl: ^7.0.4
-      styled-components: ^5.0.1
 
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
@@ -7577,48 +7551,22 @@ snapshots:
 
   '@formatjs/bigdecimal@0.2.0': {}
 
-  '@formatjs/ecma402-abstract@2.3.6':
-    dependencies:
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/intl-localematcher': 0.6.2
-      decimal.js: 10.6.0
-      tslib: 2.8.1
-
   '@formatjs/ecma402-abstract@3.2.0':
     dependencies:
       '@formatjs/bigdecimal': 0.2.0
       '@formatjs/fast-memoize': 3.1.1
       '@formatjs/intl-localematcher': 0.8.2
 
-  '@formatjs/fast-memoize@2.2.7':
-    dependencies:
-      tslib: 2.8.1
-
   '@formatjs/fast-memoize@3.1.1': {}
-
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/icu-skeleton-parser': 1.8.16
-      tslib: 2.8.1
 
   '@formatjs/icu-messageformat-parser@3.5.3':
     dependencies:
       '@formatjs/ecma402-abstract': 3.2.0
       '@formatjs/icu-skeleton-parser': 2.1.3
 
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      tslib: 2.8.1
-
   '@formatjs/icu-skeleton-parser@2.1.3':
     dependencies:
       '@formatjs/ecma402-abstract': 3.2.0
-
-  '@formatjs/intl-localematcher@0.6.2':
-    dependencies:
-      tslib: 2.8.1
 
   '@formatjs/intl-localematcher@0.8.2':
     dependencies:
@@ -10236,13 +10184,6 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  intl-messageformat@10.7.18:
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/icu-messageformat-parser': 2.11.4
-      tslib: 2.8.1
-
   intl-messageformat@11.2.0:
     dependencies:
       '@formatjs/ecma402-abstract': 3.2.0
@@ -11797,34 +11738,6 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
-
-  smarthr-ui@74.2.0(@types/react@18.3.28)(eslint@9.39.3(jiti@2.6.1))(react-dom@19.2.4(react@19.2.4))(react-intl@10.1.0(@types/react@18.3.28)(react@19.2.4)(typescript@5.9.3))(react@19.2.4)(styled-components@5.3.11(react-dom@19.2.4(react@19.2.4))(react-is@19.2.0)(react@19.2.4))(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))(typescript@5.9.3):
-    dependencies:
-      '@smarthr/wareki': 1.3.0
-      dayjs: 1.11.18
-      decimal.js: 10.6.0
-      intl-messageformat: 10.7.18
-      lodash.merge: 4.6.2
-      lodash.range: 3.2.0
-      polished: 4.3.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-draggable: 4.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-icons: 5.5.0(react@19.2.4)
-      react-innertext: 1.1.5(@types/react@18.3.28)(react@19.2.4)
-      react-intl: 10.1.0(@types/react@18.3.28)(react@19.2.4)(typescript@5.9.3)
-      react-pdf: 9.2.1(@types/react@18.3.28)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      styled-components: 5.3.11(react-dom@19.2.4(react@19.2.4))(react-is@19.2.0)(react@19.2.4)
-      tailwind-variants: 0.3.1(tailwindcss@3.4.19(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3)))
-      tailwindcss: 3.4.19(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))
-      typescript-eslint: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - eslint
-      - supports-color
-      - ts-node
-      - typescript
 
   smol-toml@1.6.1: {}
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`packages/charts` が依存する `smarthr-ui` を、npm registry からではなく pnpm workspace 内の `packages/smarthr-ui` を参照するように変更します。

これにより、charts の開発時に常に最新の smarthr-ui を使用でき、バージョンの乖離（従来は npm registry の v74.2.0 を参照していた）を解消します。

## 変更内容

`packages/charts/package.json` を以下のように変更しました：

- `peerDependencies` の `smarthr-ui` を `"^74.0.0"` → `"workspace:^"` に変更
  - publish 時に自動的にその時点の smarthr-ui バージョン（現在は `^91.0.0`）に変換されます
- `devDependencies` に `"smarthr-ui": "workspace:*"` を追加
  - workspace リンクで確実にローカルの smarthr-ui が使用されるようになります

`sandbox/next` パッケージで既に `workspace:*` による参照が使われており、同じ方式に統一しています。

## プロダクト側で対応が必要な事項

publish 時に `peerDependencies` の `smarthr-ui` が `^91.0.0` に変換されるため、charts の次回リリース以降は `smarthr-ui` v91 以上が必要になります。

## 確認方法

- `pnpm install` → `pnpm ui build` → `pnpm charts build` でビルドが成功することを確認
- `pnpm charts lint` で lint が通ることを確認
- `pnpm charts test -- --run` でテストが通ることを確認
- `cd packages/charts && pnpm pack` で publish 時の package.json を確認し、`peerDependencies.smarthr-ui` が `^91.0.0` に変換されていることを確認済み