### PR TITLE
fix: sideEffectsにエントリポイントを追加しconfigureTwMergeが確実に実行されるようにする

### DIFF
--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -11,6 +11,12 @@ import ReactGA from 'react-ga4'
 import { INITIAL_VIEWPORTS } from 'storybook/viewport'
 import resolveConfig from 'tailwindcss/resolveConfig'
 
+// tv() が shr- プレフィックスを認識するために必要。
+// パッケージ利用側では package.json の sideEffects 宣言により index.js 経由で自動実行されるが、
+// プロジェクト内の Storybook はソース（../src）を直接参照するため sideEffects が適用されず、
+// build-storybook（Rollup）の tree-shaking で除去されてしまう。
+// eslint-disable-next-line smarthr/require-barrel-import
+import '../src/configureTwMerge'
 // eslint-disable-next-line smarthr/require-barrel-import
 import '../src/styles/index.css'
 import { EnvironmentProvider, IntlProvider, locales } from '../src'

--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -11,9 +11,6 @@ import ReactGA from 'react-ga4'
 import { INITIAL_VIEWPORTS } from 'storybook/viewport'
 import resolveConfig from 'tailwindcss/resolveConfig'
 
-// twMergeConfig を最初に設定する（他のモジュールの tv() より先に実行する必要がある）
-// eslint-disable-next-line smarthr/require-barrel-import
-import '../src/configureTwMerge'
 // eslint-disable-next-line smarthr/require-barrel-import
 import '../src/styles/index.css'
 import { EnvironmentProvider, IntlProvider, locales } from '../src'

--- a/packages/smarthr-ui/package.json
+++ b/packages/smarthr-ui/package.json
@@ -170,7 +170,9 @@
   },
   "sideEffects": [
     "*.css",
-    "**/configureTwMerge.*"
+    "**/configureTwMerge.*",
+    "./lib/index.js",
+    "./lib/index.cjs"
   ],
   "typings": "lib/index.d.ts"
 }


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/pull/6254

## 概要

利用側プロジェクトで `configureTwMerge` のサイドエフェクトが実行されず、`tv()` の tailwind-merge が `shr-` プレフィックスを認識しない問題を修正します。

`package.json` の `sideEffects` に `lib/index.js` が含まれていないため、利用側のバンドラー（webpack / Turbopack）が `index.js` を副作用なしと判断し、先頭の `import './configureTwMerge.js'` ごとスキップしていました。

## 変更内容

### `package.json`

`sideEffects` にエントリポイントを追加し、バンドラーが `index.js` をスキップしないようにします。

```diff
  "sideEffects": [
    "*.css",
-   "**/configureTwMerge.*"
+   "**/configureTwMerge.*",
+   "./lib/index.js",
+   "./lib/index.cjs"
  ]
```

未使用コンポーネントの tree-shaking は引き続き機能するため、バンドルサイズへの影響はありません。

### `.storybook/preview.tsx`

明示的な `import '../src/configureTwMerge'` が必要な理由をコメントに追記しました。プロジェクト内の Storybook はソースを直接参照するため `sideEffects` が適用されず、`build-storybook` の tree-shaking で除去されるためです。

## プロダクト側で対応が必要な事項

この修正により、利用側で追加していたワークアラウンド（`import 'smarthr-ui/lib/configureTwMerge'`）が不要になります。該当のインポートがある場合は削除してください。

## 確認方法

- Chromatic で意図しないスタイル差分が発生しないこと
- 利用側プロジェクトにて、ワークアラウンドなしで動作することを確認済み