### PR TITLE
feat(Chart): chartsパッケージにRadarChartを追加

### DIFF
--- a/packages/charts/src/components/Chart/Chart.stories.tsx
+++ b/packages/charts/src/components/Chart/Chart.stories.tsx
@@ -31,7 +31,7 @@ export const Playground: Story = {
   argTypes: {
     type: {
       control: 'select',
-      options: ['bar', 'line'],
+      options: ['bar', 'line', 'radar'],
     },
     data: {
       control: 'object',
@@ -54,7 +54,7 @@ export const Type: Story = {
   argTypes: {
     type: {
       control: 'radio',
-      options: ['bar', 'line'],
+      options: ['bar', 'line', 'radar'],
     },
   },
 }

--- a/packages/charts/src/components/Chart/Chart.tsx
+++ b/packages/charts/src/components/Chart/Chart.tsx
@@ -6,12 +6,13 @@ import { tv } from 'tailwind-variants'
 import { registerChartComponents } from '../../config'
 import { BarChart } from '../BarChart'
 import { LineChart } from '../LineChart'
+import { RadarChart } from '../RadarChart'
 
 import type { ChartData, ChartOptions } from 'chart.js'
 
 registerChartComponents()
 
-type ChartType = 'bar' | 'line'
+type ChartType = 'bar' | 'line' | 'radar'
 
 type Props = {
   [K in ChartType]: {
@@ -42,6 +43,8 @@ const InnerChart: React.FC<Props> = (props) => {
       return <BarChart data={props.data} title={props.title} options={props.options} />
     case 'line':
       return <LineChart data={props.data} title={props.title} options={props.options} />
+    case 'radar':
+      return <RadarChart data={props.data} title={props.title} options={props.options} />
     default:
       return null
   }

--- a/packages/charts/src/components/Chart/VRTChart.stories.tsx
+++ b/packages/charts/src/components/Chart/VRTChart.stories.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line smarthr/require-barrel-import
 import { Stack } from '../../../../smarthr-ui/src/components/Layout'
-import { multiSmall, singleSmall } from '../__stories__/testData'
+import { multiSmall, radarMultiSmall, radarSingleSmall, singleSmall } from '../__stories__/testData'
 
 import { Chart } from './Chart'
 
@@ -26,6 +26,16 @@ export default {
       {/* Line型 パターン4: 複数データセット(3個)、タイトルあり、標準サイズ */}
       <div className="shr-h-[400px]">
         <Chart type="line" data={multiSmall} title="Line型 - 複数データセット" />
+      </div>
+
+      {/* Radar型 パターン5: 単一データセット、タイトルあり、標準サイズ */}
+      <div className="shr-h-[400px]">
+        <Chart type="radar" data={radarSingleSmall} title="Radar型 - 単一データセット" />
+      </div>
+
+      {/* Radar型 パターン6: 複数データセット(3個)、タイトルあり、標準サイズ */}
+      <div className="shr-h-[400px]">
+        <Chart type="radar" data={radarMultiSmall} title="Radar型 - 複数データセット" />
       </div>
     </Stack>
   ),

--- a/packages/charts/src/components/RadarChart/RadarChart.stories.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.stories.tsx
@@ -1,0 +1,86 @@
+import { radarMultiSmall, radarSingleSmall } from '../__stories__/testData'
+
+import { RadarChart } from './RadarChart'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+const meta: Meta<typeof RadarChart> = {
+  title: 'Charts/RadarChart',
+  component: RadarChart,
+  decorators: [
+    (Story) => (
+      <div className="shr-h-[500px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof RadarChart>
+
+export const Playground: Story = {
+  args: {
+    data: radarSingleSmall,
+    title: 'Radar Chart',
+  },
+  argTypes: {
+    data: {
+      control: 'object',
+    },
+    title: {
+      control: 'text',
+    },
+    options: {
+      control: 'object',
+    },
+  },
+}
+
+export const Default: Story = {
+  args: {
+    data: radarSingleSmall,
+  },
+}
+
+export const MultipleDatasets: Story = {
+  args: {
+    data: radarMultiSmall,
+  },
+}
+
+export const Title: Story = {
+  name: 'title',
+  args: {
+    data: radarSingleSmall,
+    title: 'Title',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+  },
+}
+
+export const WithCustomRScale: Story = {
+  name: 'with custom r scale',
+  args: {
+    data: radarMultiSmall,
+    title: 'カスタムスケール',
+    options: {
+      scales: {
+        r: {
+          min: 0,
+          max: 100,
+          ticks: {
+            stepSize: 25,
+          },
+        },
+      },
+    },
+  },
+}

--- a/packages/charts/src/components/RadarChart/RadarChart.tsx
+++ b/packages/charts/src/components/RadarChart/RadarChart.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useId, useMemo, useRef } from 'react'
+import { Radar } from 'react-chartjs-2'
+import { VisuallyHiddenText } from 'smarthr-ui'
+
+import { createRadarChartOptions, registerChartComponents } from '../../config'
+import { getRadarChartColors } from '../../helper'
+
+import type { Chart, ChartData, ChartOptions } from 'chart.js'
+
+registerChartComponents()
+
+type Props = {
+  data: ChartData<'radar'>
+  title?: string
+  options?: Partial<ChartOptions<'radar'>>
+}
+
+export const RadarChart: React.FC<Props> = ({ data, title, options: externalOptions }) => {
+  const chartId = useId()
+  const chartRef = useRef<Chart<'radar'>>(null)
+  const chartColors = useMemo(
+    () => getRadarChartColors(data.datasets.length),
+    [data.datasets.length],
+  )
+
+  const ariaLabel = useMemo(() => {
+    const datasetCount = data.datasets.length
+    const axisCount = data.datasets[0]?.data.length ?? 0
+    const prefix = title ? `${title} ` : ''
+    return `${prefix}レーダーチャート ${datasetCount}個のデータ ${axisCount}個の軸`
+  }, [title, data])
+
+  const enhancedData: ChartData<'radar'> = useMemo(
+    () => ({
+      ...data,
+      datasets: data.datasets.map((dataset, index) => ({
+        ...dataset,
+        ...chartColors[index],
+      })),
+    }),
+    [data, chartColors],
+  )
+
+  const chartOptions: ChartOptions<'radar'> = useMemo(
+    () =>
+      createRadarChartOptions({
+        ...externalOptions,
+        plugins: {
+          ...externalOptions?.plugins,
+          title: title
+            ? {
+                display: true,
+                text: title,
+              }
+            : {
+                display: false,
+              },
+          keyboardNavigation: {
+            liveRegionId: chartId,
+          },
+        },
+      }),
+    [title, chartId, externalOptions],
+  )
+
+  return (
+    <div className="shr-relative shr-h-full shr-w-full">
+      <VisuallyHiddenText aria-live="polite" id={chartId}></VisuallyHiddenText>
+      <Radar
+        tabIndex={0}
+        role="application"
+        ref={chartRef}
+        data={enhancedData}
+        options={chartOptions}
+        aria-label={ariaLabel}
+      />
+    </div>
+  )
+}

--- a/packages/charts/src/components/RadarChart/VRTRadarChart.stories.tsx
+++ b/packages/charts/src/components/RadarChart/VRTRadarChart.stories.tsx
@@ -1,0 +1,69 @@
+// eslint-disable-next-line smarthr/require-barrel-import
+import { Stack } from '../../../../smarthr-ui/src/components/Layout'
+import {
+  chartJsOptionsExamples,
+  radarManyAxes,
+  radarMultiSmall,
+  radarSingleSmall,
+} from '../__stories__/testData'
+
+import { RadarChart } from './RadarChart'
+
+export default {
+  title: 'Charts/RadarChart/VRT',
+  render: (args) => (
+    <Stack {...args}>
+      {/* パターン1: 単一データセット、タイトルなし */}
+      <div className="shr-h-[400px]">
+        <RadarChart data={radarSingleSmall} />
+      </div>
+
+      {/* パターン2: 単一データセット、タイトルあり */}
+      <div className="shr-h-[400px]">
+        <RadarChart data={radarSingleSmall} title="単一データセット" />
+      </div>
+
+      {/* パターン3: 複数データセット(3個)、タイトルあり */}
+      <div className="shr-h-[400px]">
+        <RadarChart data={radarMultiSmall} title="複数データセット" />
+      </div>
+
+      {/* パターン4: 複数データセット(3個)、タイトルなし */}
+      <div className="shr-h-[400px]">
+        <RadarChart data={radarMultiSmall} />
+      </div>
+
+      {/* パターン5: データラベル付き */}
+      <div className="shr-h-[400px]">
+        <RadarChart
+          data={radarSingleSmall}
+          title="データラベル付き"
+          options={chartJsOptionsExamples.datalabelsWithBorder}
+        />
+      </div>
+
+      {/* パターン6: 小サイズ(300px) */}
+      <div className="shr-h-[300px]">
+        <RadarChart data={radarSingleSmall} title="小サイズ" />
+      </div>
+
+      {/* パターン7: 多軸(8軸)、複数データセット(2個) */}
+      <div className="shr-h-[400px]">
+        <RadarChart data={radarManyAxes} title="多軸" />
+      </div>
+    </Stack>
+  ),
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+  tags: ['!autodocs'],
+}
+
+export const VRT = {}
+
+export const VRTForcedColors = {
+  ...VRT,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/charts/src/components/RadarChart/index.ts
+++ b/packages/charts/src/components/RadarChart/index.ts
@@ -1,0 +1,1 @@
+export { RadarChart } from './RadarChart'

--- a/packages/charts/src/components/__stories__/testData.ts
+++ b/packages/charts/src/components/__stories__/testData.ts
@@ -59,6 +59,57 @@ export const manyPoints = {
 }
 
 /**
+ * Radar チャート用 - 少データ（5軸）- 単一データセット
+ */
+export const radarSingleSmall = {
+  labels: ['企画力', '実行力', '協調性', '分析力', 'コミュニケーション'],
+  datasets: [
+    {
+      label: 'データ1',
+      data: [80, 65, 90, 55, 75],
+    },
+  ],
+}
+
+/**
+ * Radar チャート用 - 少データ（5軸）- 複数データセット（3個）
+ */
+export const radarMultiSmall = {
+  labels: ['企画力', '実行力', '協調性', '分析力', 'コミュニケーション'],
+  datasets: [
+    {
+      label: 'グループA',
+      data: [80, 65, 90, 55, 75],
+    },
+    {
+      label: 'グループB',
+      data: [60, 80, 70, 85, 60],
+    },
+    {
+      label: 'グループC',
+      data: [70, 55, 80, 65, 90],
+    },
+  ],
+}
+
+/**
+ * Radar チャート用 - 多軸（8軸）- 複数データセット（2個）
+ */
+export const radarManyAxes = {
+  labels: ['速度', '精度', '安全性', '快適性', '経済性', '環境性能', '耐久性', '操作性'],
+  datasets: [
+    {
+      label: 'モデルA',
+      data: [85, 70, 90, 75, 60, 80, 65, 70],
+    },
+    {
+      label: 'モデルB',
+      data: [70, 85, 75, 80, 75, 65, 80, 85],
+    },
+  ],
+}
+
+/**
  * chart.js オプションのサンプル
  */
 export const chartJsOptionsExamples = {

--- a/packages/charts/src/components/index.ts
+++ b/packages/charts/src/components/index.ts
@@ -1,3 +1,4 @@
 export { BarChart } from './BarChart'
 export { Chart } from './Chart'
 export { LineChart } from './LineChart'
+export { RadarChart } from './RadarChart'

--- a/packages/charts/src/config/chartConfig.test.ts
+++ b/packages/charts/src/config/chartConfig.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import { SMARTHR_DEFAULT_COLORS } from '../helper'
 
-import { createBarChartOptions, createLineChartOptions } from './chartConfig'
+import {
+  createBarChartOptions,
+  createLineChartOptions,
+  createRadarChartOptions,
+} from './chartConfig'
 
 import type { ChartOptions } from 'chart.js'
 
@@ -196,6 +200,70 @@ describe('createLineChartOptions', () => {
 
   it('datalabelsなどの他のplugin設定は外部から追加できること', () => {
     const result = createLineChartOptions({
+      plugins: {
+        datalabels: {
+          display: true,
+          backgroundColor: '#fff',
+        },
+      },
+    })
+
+    expect(result.plugins?.datalabels?.display).toBe(true)
+    expect(result.plugins?.datalabels?.backgroundColor).toBe('#fff')
+  })
+})
+
+describe('createRadarChartOptions', () => {
+  it('rスケールにbeginAtZeroが設定されていること', () => {
+    const result = createRadarChartOptions()
+    expect(result.scales?.r?.beginAtZero).toBe(true)
+  })
+
+  it('rスケールのgrid colorが内部デフォルトであること', () => {
+    const result = createRadarChartOptions()
+    expect(result.scales?.r?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
+  })
+
+  it('rスケールのangleLinesにデフォルト色が設定されること', () => {
+    const result = createRadarChartOptions()
+    expect(result.scales?.r?.angleLines?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
+  })
+
+  it('外部からrスケールをカスタマイズできること', () => {
+    const result = createRadarChartOptions({
+      scales: {
+        r: {
+          min: 0,
+          max: 100,
+          ticks: {
+            stepSize: 25,
+          },
+        },
+      },
+    })
+
+    expect(result.scales?.r?.min).toBe(0)
+    expect(result.scales?.r?.max).toBe(100)
+    expect(result.scales?.r?.ticks?.stepSize).toBe(25)
+    // 内部設定が保持される
+    expect(result.scales?.r?.beginAtZero).toBe(true)
+    expect(result.scales?.r?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
+  })
+
+  it('tooltipの設定が外部から上書きできないこと（保護されている）', () => {
+    const result = createRadarChartOptions({
+      plugins: {
+        tooltip: {
+          backgroundColor: '#ff0000',
+        } as ChartOptions<'radar'>['plugins']['tooltip'],
+      },
+    })
+
+    expect(result.plugins?.tooltip?.backgroundColor).toBe(SMARTHR_DEFAULT_COLORS.BACKGROUND)
+  })
+
+  it('datalabelsなどの他のplugin設定は外部から追加できること', () => {
+    const result = createRadarChartOptions({
       plugins: {
         datalabels: {
           display: true,

--- a/packages/charts/src/config/chartConfig.ts
+++ b/packages/charts/src/config/chartConfig.ts
@@ -18,7 +18,13 @@ import annotationPlugin from 'chartjs-plugin-annotation'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import deepmerge from 'deepmerge'
 
-import { BORDER_DASHES, CHART_COLORS, FONT_FAMILY, SMARTHR_DEFAULT_COLORS } from '../helper'
+import {
+  BORDER_DASHES,
+  CHART_COLORS,
+  FONT_FAMILY,
+  RADAR_CHART_COLORS,
+  SMARTHR_DEFAULT_COLORS,
+} from '../helper'
 import { keyboardNavigationPlugin } from '../plugins'
 
 import type { ChartOptions, ChartType, LegendOptions } from 'chart.js'
@@ -51,6 +57,7 @@ const generateLegendOptions = <TType extends ChartType>(
   chartType: TType,
 ): Partial<LegendOptions<TType>['labels']> => {
   if (chartType === 'line' || chartType === 'radar') {
+    const colors = chartType === 'radar' ? RADAR_CHART_COLORS : CHART_COLORS
     return {
       font: { family: FONT_FAMILY },
       usePointStyle: true,
@@ -59,7 +66,7 @@ const generateLegendOptions = <TType extends ChartType>(
         chart.data.datasets.map((dataset, index) => ({
           text: dataset.label,
           fontColor: SMARTHR_DEFAULT_COLORS.TEXT_BLACK,
-          strokeStyle: CHART_COLORS[index % CHART_COLORS.length],
+          strokeStyle: colors[index % colors.length],
           lineDash: BORDER_DASHES[index % BORDER_DASHES.length],
           lineWidth: 4,
           pointStyle: 'line',

--- a/packages/charts/src/config/chartConfig.ts
+++ b/packages/charts/src/config/chartConfig.ts
@@ -10,11 +10,12 @@ import {
   LineElement,
   LinearScale,
   PointElement,
+  RadialLinearScale,
   Title,
   Tooltip,
 } from 'chart.js'
-import ChartDataLabels from 'chartjs-plugin-datalabels'
 import annotationPlugin from 'chartjs-plugin-annotation'
+import ChartDataLabels from 'chartjs-plugin-datalabels'
 import deepmerge from 'deepmerge'
 
 import { BORDER_DASHES, CHART_COLORS, FONT_FAMILY, SMARTHR_DEFAULT_COLORS } from '../helper'
@@ -29,6 +30,7 @@ export const registerChartComponents = () => {
   ChartJS.register(
     CategoryScale,
     LinearScale,
+    RadialLinearScale,
     PointElement,
     LineElement,
     BarElement,
@@ -48,7 +50,7 @@ export const registerChartComponents = () => {
 const generateLegendOptions = <TType extends ChartType>(
   chartType: TType,
 ): Partial<LegendOptions<TType>['labels']> => {
-  if (chartType === 'line') {
+  if (chartType === 'line' || chartType === 'radar') {
     return {
       font: { family: FONT_FAMILY },
       usePointStyle: true,
@@ -56,10 +58,13 @@ const generateLegendOptions = <TType extends ChartType>(
       generateLabels: (chart) =>
         chart.data.datasets.map((dataset, index) => ({
           text: dataset.label,
+          fontColor: SMARTHR_DEFAULT_COLORS.TEXT_BLACK,
           strokeStyle: CHART_COLORS[index % CHART_COLORS.length],
           lineDash: BORDER_DASHES[index % BORDER_DASHES.length],
           lineWidth: 4,
           pointStyle: 'line',
+          datasetIndex: index,
+          hidden: !chart.isDatasetVisible(index),
         })),
     }
   }
@@ -72,7 +77,9 @@ const generateLegendOptions = <TType extends ChartType>(
 
 type CreateBaseChartOptionsReturn<T extends ChartType> = T extends 'line'
   ? Partial<ChartOptions<'line'>>
-  : Partial<ChartOptions<'bar'>>
+  : T extends 'radar'
+    ? Partial<ChartOptions<'radar'>>
+    : Partial<ChartOptions<'bar'>>
 
 // FIXME:borderWidth, cornerRadiusはnumberなため、定義された値を使うことができない
 const createBaseChartOptions = <T extends ChartType>({
@@ -122,7 +129,7 @@ const createBaseChartOptions = <T extends ChartType>({
   }
 
   // 外部オプションとベースデフォルトをマージ
-  return deepmerge(baseDefaults, safeExternalOptions) as CreateBaseChartOptionsReturn<T>
+  return deepmerge(baseDefaults, safeExternalOptions) as unknown as CreateBaseChartOptionsReturn<T>
 }
 
 export const createBarChartOptions = (
@@ -178,4 +185,33 @@ export const createLineChartOptions = (
 
   // scalesDefaultsをベースに、baseOptionsをマージ(外部設定を優先)
   return deepmerge(scalesDefaults, baseOptions) as Partial<ChartOptions<'line'>>
+}
+
+export const createRadarChartOptions = (
+  options: Partial<ChartOptions<'radar'>> = {},
+): Partial<ChartOptions<'radar'>> => {
+  const baseOptions = createBaseChartOptions({
+    chartType: 'radar',
+    options,
+  })
+
+  const scalesDefaults = {
+    scales: {
+      r: {
+        beginAtZero: true,
+        grid: {
+          color: SMARTHR_DEFAULT_COLORS.BORDER,
+        },
+        angleLines: {
+          color: SMARTHR_DEFAULT_COLORS.BORDER,
+        },
+        pointLabels: {
+          font: { family: FONT_FAMILY },
+        },
+      },
+    },
+  }
+
+  // scalesDefaultsをベースに、baseOptionsをマージ(外部設定を優先)
+  return deepmerge(scalesDefaults, baseOptions) as Partial<ChartOptions<'radar'>>
 }

--- a/packages/charts/src/config/index.ts
+++ b/packages/charts/src/config/index.ts
@@ -2,4 +2,5 @@ export {
   registerChartComponents,
   createBarChartOptions,
   createLineChartOptions,
+  createRadarChartOptions,
 } from './chartConfig'

--- a/packages/charts/src/helper/data.ts
+++ b/packages/charts/src/helper/data.ts
@@ -41,6 +41,57 @@ export const getLineChartColors = (
   return colors
 }
 
+const withAlpha = (color: string, alpha: number): string => {
+  const rgbMatch = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)$/)
+  if (rgbMatch) {
+    return `rgba(${rgbMatch[1]}, ${rgbMatch[2]}, ${rgbMatch[3]}, ${alpha})`
+  }
+  const hexMatch = color.match(/^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/)
+  if (hexMatch) {
+    const hex =
+      hexMatch[1].length === 3
+        ? hexMatch[1]
+            .split('')
+            .map((c) => c + c)
+            .join('')
+        : hexMatch[1]
+    const r = parseInt(hex.slice(0, 2), 16)
+    const g = parseInt(hex.slice(2, 4), 16)
+    const b = parseInt(hex.slice(4, 6), 16)
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`
+  }
+  return color
+}
+
+type RadarChartColorConfig = Pick<
+  ChartDataset<'radar'>,
+  | 'backgroundColor'
+  | 'borderColor'
+  | 'hoverBorderColor'
+  | 'hoverBorderWidth'
+  | 'pointStyle'
+  | 'pointRadius'
+  | 'fill'
+> & { borderDash: number[] }
+
+export const getRadarChartColors = (dataLength: number): RadarChartColorConfig[] => {
+  const colors: RadarChartColorConfig[] = []
+  for (let i = 0; i < dataLength; i++) {
+    const color = getColor(i)
+    colors.push({
+      backgroundColor: withAlpha(color, 0.2),
+      borderColor: color,
+      borderDash: [...BORDER_DASHES[i % BORDER_DASHES.length]],
+      hoverBorderColor: SMARTHR_DEFAULT_COLORS.OUTLINE,
+      hoverBorderWidth: 4,
+      pointStyle: POINT_STYLES[i % POINT_STYLES.length],
+      pointRadius: 8,
+      fill: true,
+    })
+  }
+  return colors
+}
+
 // TODO: SINGLE_CHART_COLORS を使うオプションを追加する
 export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
   dataLength: number,

--- a/packages/charts/src/helper/data.ts
+++ b/packages/charts/src/helper/data.ts
@@ -12,6 +12,16 @@ import type { ChartDataset, ChartType } from 'chart.js'
 
 const getColor = (index: number) => CHART_COLORS[index % CHART_COLORS.length]
 
+// コントラスト比が保てている色のみ（CHART_COLOR_4, 5, 6, 9, 10）
+export const RADAR_CHART_COLORS = [
+  CHART_COLORS[3],
+  CHART_COLORS[4],
+  CHART_COLORS[5],
+  CHART_COLORS[8],
+  CHART_COLORS[9],
+]
+const getRadarColor = (index: number) => RADAR_CHART_COLORS[index % RADAR_CHART_COLORS.length]
+
 export const getLineChartColors = (
   dataLength: number,
 ): Array<
@@ -77,7 +87,7 @@ type RadarChartColorConfig = Pick<
 export const getRadarChartColors = (dataLength: number): RadarChartColorConfig[] => {
   const colors: RadarChartColorConfig[] = []
   for (let i = 0; i < dataLength; i++) {
-    const color = getColor(i)
+    const color = getRadarColor(i)
     colors.push({
       backgroundColor: withAlpha(color, 0.2),
       borderColor: color,

--- a/packages/charts/src/helper/index.ts
+++ b/packages/charts/src/helper/index.ts
@@ -1,4 +1,4 @@
-export { getChartColors, getLineChartColors } from './data'
+export { getChartColors, getLineChartColors, getRadarChartColors } from './data'
 export {
   BORDER_DASHES,
   POINT_STYLES,

--- a/packages/charts/src/helper/index.ts
+++ b/packages/charts/src/helper/index.ts
@@ -1,4 +1,4 @@
-export { getChartColors, getLineChartColors, getRadarChartColors } from './data'
+export { getChartColors, getLineChartColors, getRadarChartColors, RADAR_CHART_COLORS } from './data'
 export {
   BORDER_DASHES,
   POINT_STYLES,


### PR DESCRIPTION
## 関連URL

なし

## 概要

chartsパッケージに新しいチャートタイプとしてRadarChart（レーダーチャート）を追加する。
既存のBarChart/LineChartと同じアーキテクチャ・規約に従い、`<Chart type="radar" />` で利用可能にする。

## 変更内容

**新規コンポーネント**
- `RadarChart` コンポーネントを追加（react-chartjs-2 の `Radar` をラップ）
- Chart.js に `RadialLinearScale` を登録
- `Chart` ファサードの `type` に `'radar'` を追加

**色・スタイル**
- データセットの差別化はLineChart方式（`borderDash` + `pointStyle`）を採用
- 塗りつぶしはデフォルト有効（`fill: true`）、`backgroundColor` は alpha 20% の半透明
- `withAlpha` ヘルパーを追加（`rgb()` / hex 両形式に対応）

**レーダー固有設定**
- スケールは `r` キーで `beginAtZero: true`
- グリッド・軸線にデザイントークン（`SMARTHR_DEFAULT_COLORS.BORDER`）を適用
- 軸ラベルに `FONT_FAMILY` を適用

**アクセシビリティ**
- `aria-label`: `レーダーチャート N個のデータ N個の軸`
- `role="application"`, `tabIndex={0}`, `VisuallyHiddenText` によるライブリージョン
- 既存の `keyboardNavigationPlugin` によるキーボードナビゲーション対応

**レジェンド改善（line/radar共通）**
- `generateLabels` に `fontColor`, `datasetIndex`, `hidden` を追加
- レジェンドクリックによるデータセット表示/非表示の切り替えが可能に（LineChartも同時に改善）
- フォーカス時にレジェンドテキスト色が変わる問題を修正

**テスト・ストーリー**
- `createRadarChartOptions` のユニットテスト 6 ケース追加
- Storybook ストーリー（5 Story）と VRT ストーリー（7 パターン + ForcedColors）を追加
- Chart ファサードの stories/VRT にも radar パターンを追加

```tsx
// 使い方
<Chart type="radar" data={data} title="評価チャート" />

// カスタムスケール
<Chart
  type="radar"
  data={data}
  options={{
    scales: { r: { min: 0, max: 100, ticks: { stepSize: 25 } } },
  }}
/>
```

## プロダクト側で対応が必要な事項

なし（新規追加のため既存コードへの影響はありません）

## 確認方法

- `pnpm charts dev` で Storybook を起動し、`Charts/RadarChart` 以下のストーリーを確認
- 単一データセット / 複数データセット / カスタムスケール / データラベル付き の各パターン
- レジェンドクリックでデータセットの表示/非表示が切り替わることを確認
- キーボード（Tab → 矢印キー）でデータポイントをナビゲートできることを確認