### PR TITLE
fix(Table): fixedHeadのテーブルで不要な横スクロールが発生する問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TableScrollContext.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableScrollContext.tsx
@@ -59,7 +59,7 @@ export const TableScrollContext = forwardRef<HTMLDivElement, Props>(
     }, [fixedHead])
 
     return (
-      <Scroller {...rest} ref={setRefs} direction="both" className={classNames.wrapper}>
+      <Scroller {...rest} ref={setRefs} className={classNames.wrapper}>
         {children}
       </Scroller>
     )

--- a/packages/smarthr-ui/src/components/Table/TableScrollContext.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableScrollContext.tsx
@@ -22,6 +22,7 @@ type Props = PropsWithChildren &
 const classNameGenerator = tv({
   slots: {
     // fixedHead のとき、スクロールインスタンスがTableからWrapperに変わるため、Wrapperに対して高さとoverflowを指定する
+    // overflowはScrollerを利用します
     wrapper: 'shr-h-[inherit] shr-max-h-[inherit] shr-scroll-pb-0.5',
   },
 })
@@ -59,6 +60,8 @@ export const TableScrollContext = forwardRef<HTMLDivElement, Props>(
     }, [fixedHead])
 
     return (
+      // fixedHead のとき、スクロールインスタンスがTableからWrapperに変わるため、Wrapperに対して高さ指定とScrollerで対応
+      // 高さはclassNameで指定
       <Scroller {...rest} ref={setRefs} className={classNames.wrapper}>
         {children}
       </Scroller>


### PR DESCRIPTION
## 関連URL

- Slack: https://smarthr.slack.com/archives/C06SWCXS9J3/p1735650171913559
- PR #6275: https://github.com/kufu/smarthr-ui/pull/6275
- PR #6187 (Scroller導入): https://github.com/kufu/smarthr-ui/pull/6187

## 概要

TableScrollContextのスクロール方向が誤って設定されており、本来の縦スクロール動作が失われていました。これにより、kagamiの類似従業員検索画面など、縦スクロールを前提としたレイアウトが破壊される問題が発生していました。

## 変更内容

TableScrollContextから`direction="both"`を削除し、Scrollerのデフォルト値（`vertical`）を使用するように修正しました。

### 経緯

元の実装では`shr-overflow-y-auto`で**縦スクロールのみ**を提供していました。

1. **c47a4c582** (PR #6187): Scroller導入時に`overflow-y-auto`を削除し`direction="horizontal"`を設定（誤り）
   - 縦スクロールが横スクロールに変わってしまった
2. **29718846b** (PR #6275): `direction="both"`に修正
   - 縦スクロールは復活したが、不要な横スクロールも追加された
   - 元の仕様は縦スクロールのみだった
3. **本PR**: `direction`プロパティを削除し、デフォルト（`vertical`）を使用
   - 元の仕様（縦スクロールのみ）に完全に戻す

### Before
```tsx
<Scroller {...rest} ref={setRefs} direction="both" className={classNames.wrapper}>
```

### After
```tsx
<Scroller {...rest} ref={setRefs} className={classNames.wrapper}>
```

Scrollerのデフォルト値は`direction="vertical"`（`overflow-y-auto`相当）なので、プロパティを削除することで元の仕様に戻ります。

## プロダクト側で対応が必要な事項

なし（元の動作に戻す修正のため）

## 確認方法

- `fixedHead`を使用したTableのStorybookで縦スクロールが正しく動作することを確認
- 横スクロールが発生しないことを確認
- https://www.chromatic.com/build?appId=63d0ccabb5d2dd29825524ab&number=latest のTable stories