### PR TITLE
chore(Dialog): DialogWrapper.test.tsx の使用されていない import を削除

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogWrapper.test.tsx
@@ -6,7 +6,6 @@ import { Button } from '../Button'
 import { Heading } from '../Heading'
 import { Section } from '../SectioningContent'
 
-import { MessageDialogContent } from './ControlledMessageDialog'
 import { DialogCloser } from './DialogCloser'
 import { DialogContent } from './DialogContent'
 import { DialogTrigger } from './DialogTrigger'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DialogWrapper.test.tsx` 内で `MessageDialogContent` が import されていたが、テスト本文では一度も参照されていなかった。デッドコードのため削除する。

## 変更内容

- `packages/smarthr-ui/src/components/Dialog/DialogWrapper.test.tsx` から未使用の `MessageDialogContent` import を1行削除

なお、この未使用 import は ESLint・knip いずれでも検出されていなかった。原因は以下の通り（本PRでは設定変更は行わない、要相談）:

- `eslint-config-smarthr` 側で `no-unused-vars` が `vars: 'local'` 指定のため、モジュールスコープである import は検出対象外
- 同設定で `@typescript-eslint/no-unused-vars` は `'off'`
- knip は「ファイル内の未使用 import」自体を主目的とせず、加えて `knip.json` の `"vitest": false` によりテストファイルがエントリ扱いされないため解析対象外

## プロダクト側で対応が必要な事項

なし

## 確認方法

- `pnpm ui test -- --run src/components/Dialog/DialogWrapper.test.tsx` でテストが従来通りパスすること