### PR TITLE
feat(BulkActionRow): BulkActionRow内にButton[variant="tertiary"]がある場合コントラスト比を上げるスタイル追加

### DIFF
--- a/packages/smarthr-ui/src/components/Table/BulkActionRow.tsx
+++ b/packages/smarthr-ui/src/components/Table/BulkActionRow.tsx
@@ -11,6 +11,7 @@ const classNameGenerator = tv({
     cell: [
       'shr-bg-action-background shr-p-1 shr-text-base',
       'forced-colors:shr-border-t-shorthand',
+      '[&_.smarthr-ui-Button.shr-text-link]:shr-text-link-darken',
     ],
   },
 })

--- a/packages/smarthr-ui/src/components/Table/WakuWakuButton.tsx
+++ b/packages/smarthr-ui/src/components/Table/WakuWakuButton.tsx
@@ -7,6 +7,9 @@ type Props = Omit<
   'variant' | 'size' | 'prefix' | 'suffix' | 'disabledReason' | 'wide' | 'loading'
 >
 
+/**
+ * @deprecated WakuWakuButton は非推奨です。Button[variant="tertiary"] を使ってください。
+ */
 export const WakuWakuButton: FC<Props> = (props) => (
   <Button {...props} variant="tertiary" size="S" className="shr-text-link-darken" />
 )

--- a/packages/smarthr-ui/src/components/Table/stories/WakuWakuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/WakuWakuButton.stories.tsx
@@ -5,7 +5,7 @@ import { WakuWakuButton } from '../WakuWakuButton'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
-// TODO: WakuWakuButtionは非推奨のため、完全に削除するまではストーリーを残す必要があるが、削除後はこのファイルも削除すること
+// TODO: WakuWakuButtonは非推奨のため、完全に削除するまではストーリーを残す必要があるが、削除後はこのファイルも削除すること
 export default {
   title: 'Components/Table/WakuWakuButton（非推奨）',
   component: WakuWakuButton,

--- a/packages/smarthr-ui/src/components/Table/stories/WakuWakuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/WakuWakuButton.stories.tsx
@@ -5,8 +5,9 @@ import { WakuWakuButton } from '../WakuWakuButton'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
+// TODO: WakuWakuButtionは非推奨のため、完全に削除するまではストーリーを残す必要があるが、削除後はこのファイルも削除すること
 export default {
-  title: 'Components/Table/WakuWakuButton',
+  title: 'Components/Table/WakuWakuButton（非推奨）',
   component: WakuWakuButton,
   render: (args) => (
     <Table>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
n/a

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

BulkActionRow内で「すべてのオブジェクトを選択」ボタンを実装する際、WakuWakuButtonがあまり認知されておらず使われないケースがあり(以前スレッド上で議論されている件)、その結果コントラスト比（4.5:1）を満たせない問題がありますので、
その対策として、BulkActionRow内に Button[variant="tertiary"] がある場合でも、4.5:1のコントラスト比を満たせるようスタイルを調整しました。
これにより、Button[variant="tertiary"] の利用を推奨したいため、WakuWakuButtonは不要となり、deprecatedにしたいと考えています。
現状プロダクト側でWakuWakuButtonを利用していても、特に影響はありません

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

BulkActionRow内に Button[variant="tertiary"] がある場合、shr-text-link-darken を適用し、コントラスト比を上げるようにスタイルを追加しています

BEFORE | AFTER
--- | ---
<img width="877" height="281" alt="修正前「すべてのオブジェクトを選択」ボタンのコントラスト比が4.5:1以上を満たされていないことを確認されている画面" src="https://github.com/user-attachments/assets/9fb7eda5-1cbc-47f6-8121-f41be102334c" /> | <img width="946" height="258" alt="修正後「すべてのオブジェクトを選択」ボタンのコントラスト比が4.5:1以上を満たしていることを確認されている画面" src="https://github.com/user-attachments/assets/97acc94c-e9fb-46aa-858e-4653e2a22f89" />



<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

- BulkActionRow内の「すべてのオブジェクトを選択」ボタンは、Button[variant="tertiary"] の利用を推奨しています
それに伴い、WakuWakuButtonはdeprecatedとしています
タイミングの良いときに、Button[variant="tertiary"] への置き換えをお願いします 🙏

※ 現状WakuWakuButtonを使っていても特に影響はないので、無理のないタイミングで大丈夫です
<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法
BulkActionRow内に Button[variant="tertiary"] を実装してコントラスト比を確認する

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
