### PR TITLE
fix(SegmentedControl/SideNav): フォーカス中でフォーカスリングと選択中の要素を見分けれない

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -51,9 +51,13 @@ const classNameGenerator = tv({
 
       '[&:not([aria-checked="true"]):focus-visible]:shr-relative [&:not([aria-checked="true"]):focus-visible]:shr-border-x',
 
+      // ::before: フォーカスリングと前のボタンの右端の間の隙間を埋めるために、左端から2px外側に1pxの縦線を描画する。
+      // 非選択かつ先頭以外のボタンにフォーカスが当たったときのみ表示する
       'before:-shr-left-[2px] before:shr-hidden before:shr-h-[calc(100%+2px)] before:shr-w-px before:shr-bg-border before:shr-content-[""]',
       '[&:first-child]:before:shr-hidden [&:not([aria-checked="true"]):not(:first-child):focus-visible]:before:shr-absolute [&:not([aria-checked="true"]):not(:first-child):focus-visible]:before:shr-block',
 
+      // ::after: フォーカスリングと次のボタンの左端の間の隙間を埋めるために、右端から2px外側に1pxの縦線を描画する。
+      // 非選択かつ末尾以外のボタンにフォーカスが当たったときのみ表示する
       'after:-shr-right-[2px] after:shr-hidden after:shr-h-[calc(100%+2px)] after:shr-w-px after:shr-bg-border after:shr-content-[""]',
       '[&:last-child]:after:shr-hidden [&:not([aria-checked="true"]):not(:last-child):focus-visible]:after:shr-absolute [&:not([aria-checked="true"]):not(:last-child):focus-visible]:after:shr-block',
     ],

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -46,7 +46,7 @@ const classNameGenerator = tv({
       'smarthr-ui-SegmentedControl-button',
       'shr-m-0 shr--ml-px shr-rounded-none',
       'focus-visible:shr-focus-indicator',
-      'first:shr-rounded-bl-m first:shr-rounded-tl-m',
+      'first:shr-ml-0 first:shr-rounded-bl-m first:shr-rounded-tl-m',
       'last:shr-rounded-br-m last:shr-rounded-tr-m',
 
       '[&:not([aria-checked="true"]):focus-visible]:shr-relative [&:not([aria-checked="true"]):focus-visible]:shr-border-x',

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -41,13 +41,21 @@ type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
 const classNameGenerator = tv({
   slots: {
     container: 'smarthr-ui-SegmentedControl shr-inline-flex',
-    buttonGroup: '-shr-space-x-px',
+    buttonGroup: 'shr-flex',
     button: [
       'smarthr-ui-SegmentedControl-button',
-      'shr-m-0 shr-rounded-none',
+      'shr-m-0 shr--ml-px shr-rounded-none',
       'focus-visible:shr-focus-indicator',
       'first:shr-rounded-bl-m first:shr-rounded-tl-m',
       'last:shr-rounded-br-m last:shr-rounded-tr-m',
+
+      '[&:not([aria-checked="true"]):focus-visible]:shr-relative [&:not([aria-checked="true"]):focus-visible]:shr-border-x',
+
+      'before:-shr-left-[2px] before:shr-hidden before:shr-h-[calc(100%+2px)] before:shr-w-px before:shr-bg-border before:shr-content-[""]',
+      '[&:first-child]:before:shr-hidden [&:not([aria-checked="true"]):not(:first-child):focus-visible]:before:shr-absolute [&:not([aria-checked="true"]):not(:first-child):focus-visible]:before:shr-block',
+
+      'after:-shr-right-[2px] after:shr-hidden after:shr-h-[calc(100%+2px)] after:shr-w-px after:shr-bg-border after:shr-content-[""]',
+      '[&:last-child]:after:shr-hidden [&:not([aria-checked="true"]):not(:last-child):focus-visible]:after:shr-absolute [&:not([aria-checked="true"]):not(:last-child):focus-visible]:after:shr-block',
     ],
   },
   variants: {

--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -42,7 +42,7 @@ const ROUNDED = {
 const ROUNDED_ALL = ['shr-rounded-l', ROUNDED.t_l, ROUNDED.t_r, ROUNDED.b_l, ROUNDED.b_r]
 
 const classNameGenerator = tv({
-  base: ['smarthr-ui-SideNav', 'shr-list-none shr-bg-column'],
+  base: ['smarthr-ui-SideNav', 'shr-relative shr-list-none shr-bg-column'],
   variants: {
     rounded: {
       true: ROUNDED_ALL,

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -36,10 +36,11 @@ type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'li'>, keyof Abstract
 const classNameGenerator = tv({
   slots: {
     wrapper: [
-      'smarthr-ui-SideNav-item',
-      'data-[current=true]:shr-relative data-[current=true]:shr-bg-main data-[current=true]:shr-text-white',
+      'smarthr-ui-SideNav-item shr-relative',
+      'data-[current=true]:shr-bg-main data-[current=true]:shr-text-white',
       'data-[current=true]:after:shr-absolute data-[current=true]:after:-shr-right-0.25 data-[current=true]:after:shr-top-1/2 data-[current=true]:after:-shr-translate-y-1/2 data-[current=true]:after:shr-translate-x-0 data-[current=true]:after:shr-border-b-4 data-[current=true]:after:shr-border-l-4 data-[current=true]:after:shr-border-r-0 data-[current=true]:after:shr-border-t-4 data-[current=true]:after:shr-border-solid data-[current=true]:after:shr-border-b-transparent data-[current=true]:after:shr-border-l-main data-[current=true]:after:shr-border-r-transparent data-[current=true]:after:shr-border-t-transparent data-[current=true]:after:shr-content-[""]',
       'data-[current=false]:hover:shr-bg-column-darken',
+      '[&:has(:focus-visible)]:shr-z-1', // pseudoエレメントがliの::afterと衝突しないために子要素に適用しますが、次のエレメントに被られるからz-indexを一時的に変更します
     ],
     button: [
       'shr-w-full shr-leading-none [&]:shr-box-border',
@@ -47,6 +48,12 @@ const classNameGenerator = tv({
       '[[data-current=true]_&:focus-visible]:shr-focus-indicator',
       'shr-inline-flex shr-items-center',
       'shr-no-underline',
+
+      'before:shr-absolute before:-shr-top-[1px] before:shr-left-0 before:shr-hidden before:shr-h-px before:shr-w-full before:shr-bg-border before:shr-content-[""]',
+      '[:first-child_&]:before:shr-hidden [[data-current=false]:not(:first-child)_&:focus-visible]:before:shr-block [[data-current=false]_&:focus-visible]:before:shr-absolute',
+
+      'after:shr-absolute after:-shr-bottom-[1px] after:shr-left-0 after:shr-hidden after:shr-h-px after:shr-w-full after:shr-bg-border after:shr-content-[""]',
+      '[:last-child_&]:after:shr-hidden [[data-current=false]:not(:last-child)_&:focus-visible]:after:shr-block [[data-current=false]_&:focus-visible]:after:shr-absolute',
     ],
     body: 'shr-w-full',
     bodyText: 'smarthr-ui-SideNav-itemBodyText shr-grow',

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -49,9 +49,13 @@ const classNameGenerator = tv({
       'shr-inline-flex shr-items-center',
       'shr-no-underline',
 
+      // ::before: フォーカスリングと上のアイテムの下端の間の隙間を埋めるために、上端から1px外側に1pxの横線を描画する。
+      // 非選択かつ先頭以外のボタンにフォーカスが当たったときのみ表示する
       'before:shr-absolute before:-shr-top-[1px] before:shr-left-0 before:shr-hidden before:shr-h-px before:shr-w-full before:shr-bg-border before:shr-content-[""]',
       '[:first-child_&]:before:shr-hidden [[data-current=false]:not(:first-child)_&:focus-visible]:before:shr-block [[data-current=false]_&:focus-visible]:before:shr-absolute',
 
+      // ::after: フォーカスリングと下のアイテムの上端の間の隙間を埋めるために、下端から1px外側に1pxの横線を描画する。
+      // 非選択かつ末尾以外のボタンにフォーカスが当たったときのみ表示する
       'after:shr-absolute after:-shr-bottom-[1px] after:shr-left-0 after:shr-hidden after:shr-h-px after:shr-w-full after:shr-bg-border after:shr-content-[""]',
       '[:last-child_&]:after:shr-hidden [[data-current=false]:not(:last-child)_&:focus-visible]:after:shr-block [[data-current=false]_&:focus-visible]:after:shr-absolute',
     ],


### PR DESCRIPTION


<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

- https://www.notion.so/SegmentedControl-SideNav-SideMenu-34937b6398eb802aa3addbc07961a48a?v=31737b6398eb807b8dc3000c583344f5&source=copy_link

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- `SegmentedControl`や`SideNav`の選択肢がすでに選択中の場合、隣にある選択肢をキーボードフォーカスするとフォーカスされている箇所がどこまでのを見分けられない。そのためにWCAGのフォーカスリング周りのルール違反となるため対応。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- `SegmentedControl`に選択されている/されていないによって`before/after`のpseudo-エレメントを活かしてフォーカスリングと選択中の選択肢の間に空白を開ける
- `SegmentedControl`の細かいCSSの不具合を直しました
- `SideNav`に選択されている/されていないによって`before/after`のpseudo-エレメントを活かしてフォーカスリングと選択中の選択肢の間に空白を開ける

#### SegmentedControl

| Before | After |
| ------- | ------ |
| <img width="324" height="126" alt="スクリーンショット 2026-04-30 18 14 56" src="https://github.com/user-attachments/assets/fd601ddd-8759-41a2-8cca-033bc94f392e" /> | <img width="324" height="126" alt="スクリーンショット 2026-04-30 18 15 07" src="https://github.com/user-attachments/assets/109b77a2-a735-4f27-94f1-54b09305aa68" /> |

#### SideNav

| Before | After |
| ------- | ------ |
| <img width="494" height="196" alt="スクリーンショット 2026-04-30 18 19 22" src="https://github.com/user-attachments/assets/3f37499b-b7c3-476c-8554-8dc97064252f" /> | <img width="494" height="196" alt="スクリーンショット 2026-04-30 18 19 30" src="https://github.com/user-attachments/assets/a559a5c0-d8b8-4e98-9d9f-f4d4dfd2c418" /> |

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

特にありません

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- https://63d0ccabb5d2dd29825524ab-tenxpqbapk.chromatic.com/?path=/docs/components-segmentedcontrol--docs
- https://63d0ccabb5d2dd29825524ab-tenxpqbapk.chromatic.com/?path=/docs/components-sidenav--docs
