### PR TITLE
fix(charts): chartjs-plugin-datalabels の型拡張を利用者側に伝播させる

### DIFF
--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -1,1 +1,3 @@
+/// <reference types="chartjs-plugin-datalabels" preserve="true" />
+
 export { Chart } from './components/Chart'


### PR DESCRIPTION
## 関連URL

- https://github.com/chartjs/chartjs-plugin-datalabels/blob/61e38903333a3da882f1b64dac14af16e8c52d17/types/index.d.ts#L13

## 概要

`@smarthr/smarthr-ui-charts` の `BarChart` コンポーネントで `options.plugins.datalabels` を指定すると、TypeScript の型エラーが発生する問題を修正します。

## 変更内容

`packages/charts/src/index.ts` に `/// <reference types="chartjs-plugin-datalabels" preserve="true" />` を追加しました。

### 背景

`chartjs-plugin-datalabels` は [module augmentation](https://github.com/chartjs/chartjs-plugin-datalabels/blob/61e38903333a3da882f1b64dac14af16e8c52d17/types/index.d.ts#L13) により Chart.js の `PluginOptionsByType` に `datalabels` プロパティを追加しています。

ライブラリ内部の `chartConfig.ts` では `import ChartDataLabels from 'chartjs-plugin-datalabels'` をしていますが、これは値としてのみ使用されているため、TypeScript のビルド時に `.d.ts` 出力から除去されます。その結果、利用者の型空間に `datalabels` の型拡張が伝播せず、以下のようなコードで型エラーが発生していました。

```tsx
<BarChart
  options={{
    plugins: {
      datalabels: { display: true }, // TS2353: 'datalabels' does not exist in type ...
    },
  }}
/>
```

TypeScript 5.5 以降で導入された `preserve="true"` 属性を使用することで、`.d.ts` 出力に triple-slash directive を保持させ、利用者側で追加の import なしに型拡張が有効になるようにしました。

## プロダクト側で対応が必要な事項

なし。利用者側での変更は不要です。

## 確認方法

ビルド後の `lib/index.d.ts` に `/// <reference types="chartjs-plugin-datalabels" preserve="true" />` が残っていることを確認してください。

```bash
cd packages/charts
pnpm run build:lib
cat lib/index.d.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)