### PR TITLE
fix(RadioButtonPanel): onClick属性を正しく処理し二重実行を防止

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -47,6 +47,36 @@ const classNameGenerator = tv({
   },
 })
 
+/** RadioButtonのクリック可能な要素（labelまたはinput）を判定するための正規表現 */
+const REGEX_RADIO_CLICKABLE_ELEMENT = /^(label|input)$/
+
+/**
+ * イベントパス内にRadioButtonの要素（LABELまたはINPUT）が含まれているか判定
+ *
+ * NOTE: ReactのSyntheticEventは非同期処理内でnullになる可能性があるため、
+ * イベントオブジェクトではなく、事前に取得したpathとcurrentTargetを受け取る
+ *
+ * @param path イベントのcomposedPath（事前に取得したもの）
+ * @param currentTarget イベントのcurrentTarget（事前に取得したもの）
+ * @returns RadioButtonの要素がクリックされた場合true
+ */
+const isRadioButtonElementClicked = (path: EventTarget[], currentTarget: EventTarget): boolean => {
+  for (const node of path) {
+    // 先にLABELまたはINPUTをチェック（高頻度ケース）
+    if (
+      node instanceof HTMLElement &&
+      REGEX_RADIO_CLICKABLE_ELEMENT.test(node.tagName.toLowerCase())
+    ) {
+      return true
+    } else if (node === currentTarget) {
+      // Base要素に到達したらfalse（低頻度ケース）
+      return false
+    }
+  }
+
+  return false
+}
+
 export const RadioButtonPanel: FC<Props> = ({
   onClick,
   as,
@@ -68,8 +98,16 @@ export const RadioButtonPanel: FC<Props> = ({
 
   // 外側の装飾を押しても内側のラジオボタンが押せるようにする
   const innerRef = useRef<HTMLInputElement>(null)
-  const onDelegateClick = useCallback(() => {
-    innerRef.current?.click()
+  const onDelegateClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // RadioButtonの要素（labelまたはinput）以外がクリックされた場合（description や Base の余白）
+    if (!isRadioButtonElementClicked(e.nativeEvent.composedPath(), e.currentTarget)) {
+      // Base要素のclickイベントは止める（実装の詳細を隠蔽し、input要素のclickのみを親に伝える）
+      e.stopPropagation()
+      // 手動でinputをクリック
+      innerRef.current?.click()
+    }
+    // RadioButtonの要素（labelまたはinput）がクリックされた場合は何もしない
+    // （ブラウザの標準動作でinputがクリックされ、そのイベントが親に伝わる）
   }, [])
 
   const descriptionId = useId()
@@ -78,6 +116,7 @@ export const RadioButtonPanel: FC<Props> = ({
     <Base padding={1} onClick={onDelegateClick} as={as} className={classNames.base}>
       <RadioButton
         {...rest}
+        onClick={onClick}
         ref={innerRef}
         aria-describedby={`${descriptionId}${ariaDescribedby ? ` ${ariaDescribedby}` : ''}`}
         className={classNames.radio}


### PR DESCRIPTION
## 関連URL

なし

## 概要

RadioButtonPanelコンポーネントのonClick属性が内部のRadioButtonに渡されておらず機能していなかった問題と、description領域やBase余白をクリックした際に親コンポーネントでonClickイベントが二重実行される問題を修正しました。

## 変更内容

- onClick属性をRadioButtonに正しく渡すよう修正
- composedPath()を使用してクリックされた要素を判定するヘルパー関数を実装
- label/input要素がクリックされた場合: ブラウザの標準動作に任せる（そのままイベントがバブルアップ）
- description領域やBase余白がクリックされた場合: Base要素のclickイベントを停止（stopPropagation）し、手動でinput要素をクリック

これにより、親コンポーネントにはinput要素のclickイベントのみが伝播し、どこをクリックしても正確に1回だけイベントが発火するようになりました。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで RadioButtonPanel のストーリーを確認し、以下の動作を確認:
- onClick属性が正しく動作すること
- description領域や余白をクリックしてもonClickが1回だけ実行されること