### PR TITLE
chore(Dialog): RemoteTrigger版StepFormDialogのstoryを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/StepFormDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/StepFormDialog.stories.tsx
@@ -1,0 +1,50 @@
+import { action } from 'storybook/actions'
+
+import { Button } from '../../../Button'
+import { StepFormDialogItem } from '../../ControlledStepFormDialog'
+import { RemoteDialogTrigger } from '../RemoteDialogTrigger'
+import { StepFormDialog } from '../StepFormDialog'
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+
+/** props は [StepFormDialog](./?path=/docs/dialog（ダイアログ）-dialog-stepformdialog--docs) を参照してください。 */
+export default {
+  title: 'Components/Dialog/RemoteDialogTrigger/StepFormDialog',
+  component: StepFormDialog,
+  render: (args) => (
+    <>
+      <RemoteDialogTrigger targetId="remote-dialog">
+        <Button>ダイアログを開く</Button>
+      </RemoteDialogTrigger>
+      <StepFormDialog
+        {...args}
+        id="remote-dialog"
+        heading="ステップフォームダイアログ"
+        stepLength={2}
+        submitButton="保存"
+        firstStep={{ id: 'step-1', stepNumber: 1 }}
+        onSubmit={(e, { currentStep, goto, close }) => {
+          action('onSubmit')(e, currentStep)
+
+          if (currentStep.id === 'step-2') {
+            close()
+          } else {
+            goto({ id: 'step-2', stepNumber: 2 })
+          }
+        }}
+      >
+        <StepFormDialogItem id="step-1" stepNumber={1}>
+          <p>ステップ1のコンテンツです。</p>
+        </StepFormDialogItem>
+        <StepFormDialogItem id="step-2" stepNumber={2}>
+          <p>ステップ2のコンテンツです。</p>
+        </StepFormDialogItem>
+      </StepFormDialog>
+    </>
+  ),
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+} as Meta<typeof StepFormDialog>
+
+export const Playground: StoryObj<typeof StepFormDialog> = {}


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/pull/6326#discussion_r3231020773

## 概要

RemoteDialogTrigger経由でStepFormDialogを使用する際のストーリーがなかったため追加しました。
元々は #6326 に含まれていましたが、レビュー指摘により別PRに切り出しました。

## 変更内容

- `RemoteDialogTrigger/stories/StepFormDialog.stories.tsx` を新規作成
- RemoteDialogTriggerとStepFormDialogを組み合わせた動作確認用のストーリーを追加

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで `Components/Dialog/RemoteDialogTrigger/StepFormDialog` を開き、以下を確認:
- ボタンをクリックしてダイアログが開くこと
- ステップ間の遷移が正しく動作すること
- RemoteDialogTriggerとStepFormDialogの連携が正しく機能すること