### PR TITLE
fix(DropZone): ファイル以外のドロップ時にonSelectFilesを呼ばないように修正

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.test.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { IntlProvider } from '../../intl'
+
+import { DropZone } from './DropZone'
+
+// FileList のモックヘルパー
+const createFileList = (files: File[]): FileList => {
+  const fileList = {
+    length: files.length,
+    item: (index: number) => files[index] ?? null,
+    [Symbol.iterator]: function* () {
+      yield* files
+    },
+  }
+  files.forEach((file, index) => {
+    Object.defineProperty(fileList, index, {
+      value: file,
+      enumerable: true,
+    })
+  })
+  return fileList as FileList
+}
+
+describe('DropZone', () => {
+  describe('onSelectFiles', () => {
+    describe('ファイルをドロップした場合', () => {
+      it('onSelectFiles が発火する', () => {
+        const onSelectFiles = vi.fn()
+        const { container } = render(
+          <IntlProvider locale="ja">
+            <DropZone name="test_file" onSelectFiles={onSelectFiles}>
+              ファイルをドロップ
+            </DropZone>
+          </IntlProvider>,
+        )
+
+        const dropZone = container.querySelector('.smarthr-ui-DropZone')
+        if (!dropZone) throw new Error('DropZone not found')
+
+        const file = new File(['content'], 'test.txt', { type: 'text/plain' })
+        const fileList = createFileList([file])
+        const dataTransfer = {
+          files: fileList,
+          types: ['Files'],
+        }
+
+        fireEvent.drop(dropZone, { dataTransfer })
+
+        expect(onSelectFiles).toHaveBeenCalledTimes(1)
+        expect(onSelectFiles).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            length: 1,
+          }),
+        )
+      })
+    })
+
+    describe('テキストをドロップした場合', () => {
+      it('onSelectFiles が発火しない', () => {
+        const onSelectFiles = vi.fn()
+        const { container } = render(
+          <IntlProvider locale="ja">
+            <DropZone name="test_file" onSelectFiles={onSelectFiles}>
+              ファイルをドロップ
+            </DropZone>
+          </IntlProvider>,
+        )
+
+        const dropZone = container.querySelector('.smarthr-ui-DropZone')
+        if (!dropZone) throw new Error('DropZone not found')
+
+        const fileList = createFileList([])
+        const dataTransfer = {
+          files: fileList,
+          types: ['text/plain'],
+        }
+
+        fireEvent.drop(dropZone, { dataTransfer })
+
+        expect(onSelectFiles).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('URLをドロップした場合', () => {
+      it('onSelectFiles が発火しない', () => {
+        const onSelectFiles = vi.fn()
+        const { container } = render(
+          <IntlProvider locale="ja">
+            <DropZone name="test_file" onSelectFiles={onSelectFiles}>
+              ファイルをドロップ
+            </DropZone>
+          </IntlProvider>,
+        )
+
+        const dropZone = container.querySelector('.smarthr-ui-DropZone')
+        if (!dropZone) throw new Error('DropZone not found')
+
+        const fileList = createFileList([])
+        const dataTransfer = {
+          files: fileList,
+          types: ['text/uri-list'],
+        }
+
+        fireEvent.drop(dropZone, { dataTransfer })
+
+        expect(onSelectFiles).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('ボタンクリックでファイルを選択した場合', () => {
+      it('onSelectFiles が発火する', async () => {
+        const onSelectFiles = vi.fn()
+        render(
+          <IntlProvider locale="ja">
+            <DropZone name="test_file" onSelectFiles={onSelectFiles}>
+              ファイルをドロップ
+            </DropZone>
+          </IntlProvider>,
+        )
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement
+        if (!input) throw new Error('Input not found')
+
+        const file = new File(['content'], 'test.txt', { type: 'text/plain' })
+        await userEvent.upload(input, file)
+
+        expect(onSelectFiles).toHaveBeenCalledTimes(1)
+        expect(onSelectFiles).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            length: 1,
+          }),
+        )
+      })
+    })
+  })
+})

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -104,10 +104,9 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
       (e: DragEvent<HTMLElement>) => {
         overrideEventDefault(e)
         setFilesDraggedOver(false)
-        onSelectFiles(e, e.dataTransfer.files)
 
-        if (fileRef.current) {
-          fileRef.current.files = e.dataTransfer.files
+        if (e.dataTransfer.types.includes('Files')) {
+          onSelectFiles(e, e.dataTransfer.files)
         }
       },
       [setFilesDraggedOver, onSelectFiles],


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/C06KVP5PL23/p1778747004294979

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

DropZoneにファイル以外をドロップした時に、onSelectFilesを呼ばないように修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- ドロップした時にファイルかどうかをチェックしてonSelectFilesを呼ぶようにした

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
