### PR TITLE
fix(Chip)!: size表記を "s" から "S"に修正

### DIFF
--- a/packages/smarthr-ui/src/components/Chip/Chip.tsx
+++ b/packages/smarthr-ui/src/components/Chip/Chip.tsx
@@ -20,14 +20,14 @@ const classNameGenerator = tv({
       red: 'shr-border-danger',
     },
     size: {
-      s: 'shr-px-0.5 shr-py-0.25 shr-text-sm',
+      S: 'shr-px-0.5 shr-py-0.25 shr-text-sm',
     },
     disabled: {
       true: 'shr-bg-white/50 shr-text-disabled',
     },
   },
   defaultVariants: {
-    size: 's',
+    size: 'S',
     color: 'grey',
   },
 })

--- a/packages/smarthr-ui/src/components/Chip/stories/Chip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Chip/stories/Chip.stories.tsx
@@ -30,7 +30,7 @@ export const Size: StoryObj<typeof Chip> = {
   name: 'size',
   render: (args) => (
     <Stack align="flex-start">
-      {[undefined, 's'].map((size) => (
+      {[undefined, 'S'].map((size) => (
         <Chip {...args} size={size as any} key={String(size)} />
       ))}
     </Stack>


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL
https://kufuinc.slack.com/archives/CGC58MW01/p1779700192745469
<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

他のコンポーネントでは、size propsに大文字で`"S"`などと指定するが、Chipコンポーネントのみ、小文字の`"s"`を指定する必要がある。

これはおそらく変更漏れなので、大文字を指定するように修正した。

## 変更内容

Chipコンポーネントのsize propsは、大文字のサイズ指定（`"S"`）を受け取るようにした
<!--
。packages/smarthr-ui/src/components/Chip/Chip.tsx
-->

## プロダクト側で対応が必要な事項

**Chip componentのsize propsの値変更**

サイズ指定値を大文字に変更する必要があります。
```jsx
// Before
<Chip size="s">Hanshin Tigers</Chip>
// After
<Chip size="S">Hanshin Tigers</Chip>
```

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

Storybookで Components/Chip を開き、size propsが正しく動作することを確認してください。

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
