### PR TITLE
fix: maxLinesに収まる場合でもTooltipが表示される問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -21,8 +21,8 @@ const classNameGenerator = tv({
     base: 'smarthr-ui-LineClamp shr-relative',
     clampedLine: 'shr-max-w-full',
     shadowElementWrapper:
-      'shr-invisible shr-absolute shr-left-0 shr-top-0 shr-h-full shr-max-w-full shr-overflow-hidden shr-whitespace-normal shr-opacity-0',
-    shadowElement: 'shr-absolute shr-left-0 shr-top-0 shr-max-w-full',
+      'shr-invisible shr-absolute shr-left-0 shr-top-0 shr-h-full shr-w-full shr-overflow-hidden shr-whitespace-normal shr-opacity-0',
+    shadowElement: 'shr-absolute shr-left-0 shr-top-0 shr-w-full',
   },
   variants: {
     maxLines: {
@@ -74,10 +74,7 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
     // -webkit-line-clamp を使った要素ではel.scrollHeightとel.clientHeightの比較だと
     // フォントの高さの計算が期待と異なり適切な高さが取得できないためshadowElと比較している
     // 参考: https://github.com/kufu/smarthr-ui/pull/4710
-    const isMultiLineOverflow =
-      el && shadowEl
-        ? shadowEl.clientWidth > el.clientWidth || shadowEl.clientHeight > el.clientHeight
-        : false
+    const isMultiLineOverflow = el && shadowEl ? shadowEl.clientHeight > el.clientHeight : false
 
     setTooltipVisible(isMultiLineOverflow)
   }, [maxLines, children])


### PR DESCRIPTION
## 概要

`LineClamp` コンポーネントで、テキストが `maxLines` に収まっている場合でも Tooltip が表示されてしまう問題を修正します。

## 変更内容

- 高さ計測用の要素に使われる `shadowElementWrapper` / `shadowElement` のクラスの幅指定を `shr-max-w-full` から `shr-w-full` に設定を変更しました。

- オーバーフロー判定から幅の比較を削除し、高さの比較のみにしました。
  - ベースが内容より広い場合 (プロダク側で `w-full` を指定した場合など) では、幅に収まっていても `shadowEl.clientWidth > el.clientWidth` が誤発火してしまうケースがあるためです。

## プロダクト側で対応が必要な事項

なし（破壊的変更はありません）。`maxLines` に収まるテキストで意図せず表示されていた Tooltip が表示されなくなります。

## 確認方法

Storybook の `Components/LineClamp` を確認してください。

- `maxLines`（既存 Story）: 1〜6 の各 `maxLines` で、収まる短文では Tooltip が出ず、溢れる長文では Tooltip が出ること。