### PR TITLE
fix(DropdownMenuButton): hookの依存配列からReactNodeを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -161,11 +161,11 @@ const MemoizedTriggerButton = memo<
 
   const { active } = useContext(DropdownContext)
 
-  const showTooltip = !!onlyIconTrigger
-  const tooltip = useMemo(() => ({ show: showTooltip, message: children }), [children, showTooltip])
-
   return (
-    <DropdownTrigger className={classNames.triggerWrapper} tooltip={tooltip}>
+    <DropdownTrigger
+      className={classNames.triggerWrapper}
+      tooltip={{ show: !!onlyIconTrigger, message: children }}
+    >
       <Button
         {...rest}
         suffix={

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -90,12 +90,16 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex */}
       <ConditionalWrapper
         shouldWrapContent={tooltip?.show}
-        wrapper={({ children: currentChildren }) => (
-          // eslint-disable-next-line smarthr/a11y-scroller-has-tabindex
-          <Tooltip message={tooltip?.message} triggerType="icon" tabIndex={-1}>
-            {currentChildren}
-          </Tooltip>
-        )}
+        wrapper={({ children: currentChildren }) =>
+          tooltip?.message ? (
+            // eslint-disable-next-line smarthr/a11y-scroller-has-tabindex
+            <Tooltip message={tooltip?.message} triggerType="icon" tabIndex={-1}>
+              {currentChildren}
+            </Tooltip>
+          ) : (
+            currentChildren
+          )
+        }
       >
         {children}
       </ConditionalWrapper>


### PR DESCRIPTION
## 関連URL

なし

## 概要

DropdownMenuButtonコンポーネントでReactNode型の`children`をhookの依存配列に含めている問題を修正しました。ReactNodeを依存配列に含めると、参照が変わるたびに再計算が走り、パフォーマンスの問題や予期しない再レンダリングを引き起こす可能性があります。

## 変更内容

### DropdownMenuButton.tsx

**Before:**
```tsx
const showTooltip = !!onlyIconTrigger
const tooltip = useMemo(() => ({ show: showTooltip, message: children }), [children, showTooltip])

return (
  <DropdownTrigger className={classNames.triggerWrapper} tooltip={tooltip}>
```

**After:**
```tsx
return (
  <DropdownTrigger
    className={classNames.triggerWrapper}
    tooltip={{ show: !!onlyIconTrigger, message: children }}
  >
```

**変更点:**
1. **不要な`useMemo`を削除**
   - `children`を依存配列から削除
   - `DropdownTrigger`は`memo`化されていないため、新しいオブジェクトを毎回生成してもパフォーマンス上の問題なし
   - コードがよりシンプルに

### DropdownTrigger.tsx

**Before:**
```tsx
wrapper={({ children: currentChildren }) => (
  <Tooltip message={tooltip?.message} triggerType="icon" tabIndex={-1}>
    {currentChildren}
  </Tooltip>
)}
```

**After:**
```tsx
wrapper={({ children: currentChildren }) =>
  tooltip?.message ? (
    <Tooltip message={tooltip?.message} triggerType="icon" tabIndex={-1}>
      {currentChildren}
    </Tooltip>
  ) : (
    currentChildren
  )
}
```

**変更点:**
2. **防御的プログラミングの追加**
   - `tooltip.show`が`true`でも`message`が`undefined`の場合にTooltipをレンダリングしないように改善
   - 意図しない空のTooltipが表示されるのを防止

## プロダクト側で対応が必要な事項

なし（内部実装の変更のみで、外部APIに変更はありません）

## 確認方法

Storybookで以下を確認:
- `onlyIconTrigger=true`の場合、Tooltipが正しく表示される
- `onlyIconTrigger=false`の場合、Tooltipが表示されない
- DropdownMenuButtonの動作に影響がない