### PR TITLE
fix(BottomFixedArea): hookの依存配列からReactNodeを削除

### DIFF
--- a/packages/smarthr-ui/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/packages/smarthr-ui/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -10,7 +10,6 @@ import {
   type PropsWithChildren,
   type ReactNode,
   memo,
-  useEffect,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
@@ -86,9 +85,7 @@ export const BottomFixedArea: FC<Props> = ({
   }, [className])
   const style = useMemo(() => ({ zIndex }), [zIndex])
 
-  useEffect(() => {
-    validateElement(primaryButton, secondaryButton)
-  }, [primaryButton, secondaryButton])
+  validateElement(primaryButton, secondaryButton)
 
   return (
     <Base {...rest} className={classNames.wrapper} style={style}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

BottomFixedAreaコンポーネントで`ButtonType`(FunctionComponentElement = ReactElement)を`useEffect`の依存配列に含めている問題を修正しました。ReactElementを依存配列に含めると、参照が変わるたびに再実行され、パフォーマンスの問題を引き起こす可能性があります。

## 変更内容

### BottomFixedArea.tsx

**Before:**
```tsx
useEffect(() => {
  validateElement(primaryButton, secondaryButton)
}, [primaryButton, secondaryButton])
```

**After:**
```tsx
validateElement(primaryButton, secondaryButton)
```

### 主な変更点

1. **`useEffect`を削除**
   - `primaryButton`, `secondaryButton`(ButtonType = FunctionComponentElement)を依存配列から削除
   - `validateElement`は開発時のバリデーション(console.error)のみを行うため、`useEffect`で実行する必要がない

2. **レンダリング時に直接呼び出し**
   - `useEffect`の代わりに、コンポーネントのレンダリング時に直接呼び出すように変更
   - より単純で理解しやすいコード

### ButtonTypeとは

```tsx
export type ButtonType =
  | FunctionComponentElement<ComponentProps<typeof Button>>
  | FunctionComponentElement<ComponentProps<typeof AnchorButton>>
```

これはReactElementであり、親から渡されるたびに新しい参照が作られます。

### validateElementの役割

```tsx
export const validateElement = (primary?: ButtonType, secondary?: ButtonType) => {
  if (primary) {
    // primaryButtonが正しいvariant('primary')を持っているかチェック
    // 違反があればconsole.errorを出力
  }
  if (secondary) {
    // secondaryButtonが正しいvariant('secondary')を持っているかチェック
    // 違反があればconsole.errorを出力
  }
}
```

開発時のバリデーションのみを行い、副作用はありません。レンダリング時に毎回実行しても問題ありません。

## プロダクト側で対応が必要な事項

なし（内部実装の変更のみで、外部APIに変更はありません）

## 確認方法

Storybookで以下を確認:
- 不正なvariantのButtonを渡すとconsole.errorが表示される
- BottomFixedAreaの動作に影響がない