### PR TITLE
refactor(SideNav)!: cloneElementを削除しContext APIに移行、interfaceを整理

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -12,7 +12,7 @@ import { SearchInput } from '../../../Input'
 import { Cluster } from '../../../Layout'
 import { Scroller } from '../../../Scroller'
 import { Section } from '../../../SectioningContent'
-import { SideNav } from '../../../SideNav'
+import { SideNav, SideNavItemButton } from '../../../SideNav'
 import { HelpLink } from '../../../TextLink'
 import { useAppLauncher } from '../../hooks/useAppLauncher'
 import { AppLauncherFeatures } from '../common/AppLauncherFeatures'
@@ -269,9 +269,15 @@ const SideNavs = memo<
       <SideNav
         className={classNames.unselectedSideNav}
         size="S"
-        items={unselectedItems}
         onClick={onClick}
-      />
+        aria-label={typeof translated.favorite === 'string' ? translated.favorite : undefined}
+      >
+        {unselectedItems.map((item) => (
+          <SideNavItemButton key={item.id} id={item.id} prefix={item.prefix} current={item.current}>
+            {item.title}
+          </SideNavItemButton>
+        ))}
+      </SideNav>
 
       <hr />
 
@@ -282,9 +288,15 @@ const SideNavs = memo<
         <SideNav
           className={classNames.selectedSideNav}
           size="S"
-          items={selectedItems}
           onClick={onClick}
-        />
+          aria-label={typeof translated.listText === 'string' ? translated.listText : undefined}
+        >
+          {selectedItems.map((item) => (
+            <SideNavItemButton key={item.id} id={item.id} current={item.current}>
+              {item.title}
+            </SideNavItemButton>
+          ))}
+        </SideNav>
       </Section>
 
       <HelpLinkArea className={classNames.help}>{translated.helpText}</HelpLinkArea>

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -258,8 +258,8 @@ const SideNavs = memo<
   )
 
   const onClick = useCallback(
-    (_: any, id: string) => {
-      changePage(id as Launcher['page'])
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      changePage(e.currentTarget.value as Launcher['page'])
     },
     [changePage],
   )
@@ -269,11 +269,16 @@ const SideNavs = memo<
       <SideNav
         className={classNames.unselectedSideNav}
         size="S"
-        onClick={onClick}
         aria-label={typeof translated.favorite === 'string' ? translated.favorite : undefined}
       >
         {unselectedItems.map((item) => (
-          <SideNavItemButton key={item.id} id={item.id} prefix={item.prefix} current={item.current}>
+          <SideNavItemButton
+            key={item.id}
+            id={item.id}
+            prefix={item.prefix}
+            current={item.current}
+            onClick={onClick}
+          >
             {item.title}
           </SideNavItemButton>
         ))}
@@ -288,11 +293,10 @@ const SideNavs = memo<
         <SideNav
           className={classNames.selectedSideNav}
           size="S"
-          onClick={onClick}
           aria-label={typeof translated.listText === 'string' ? translated.listText : undefined}
         >
           {selectedItems.map((item) => (
-            <SideNavItemButton key={item.id} id={item.id} current={item.current}>
+            <SideNavItemButton key={item.id} id={item.id} current={item.current} onClick={onClick}>
               {item.title}
             </SideNavItemButton>
           ))}

--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -5,9 +5,9 @@ import {
   type PropsWithChildren,
   useMemo,
 } from 'react'
-import { Children, cloneElement } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
+import { SideNavProvider } from './SideNavContext'
 import { SideNavItemButton, type SideNavSizeType } from './SideNavItemButton'
 
 export type SideNavItemButtonProps = Omit<
@@ -86,39 +86,22 @@ export const SideNav: FC<Props> = ({
   )
 
   return (
-    <ul {...rest} className={actualClassName}>
-      {items
-        ? items.map((item) => (
-            <SideNavItemButton
-              key={item.id}
-              id={item.id}
-              title={item.title}
-              prefix={item.prefix}
-              current={item.current}
-              size={size}
-              onClick={actualOnClick}
-            />
-          ))
-        : children &&
-          Children.map(children, (child) => {
-            if (
-              child &&
-              typeof child === 'object' &&
-              'type' in child &&
-              child.type === SideNavItemButton
-            ) {
-              return cloneElement(
-                child as React.ReactElement<ComponentProps<typeof SideNavItemButton>>,
-                {
-                  // 子コンポーネントに対して親コンポーネントから onClick size を一括で適用
-                  size,
-                  onClick: actualOnClick,
-                },
-              )
-            }
-
-            return child
-          })}
-    </ul>
+    <SideNavProvider value={{ size, onClick: actualOnClick }}>
+      <ul {...rest} className={actualClassName}>
+        {items
+          ? items.map((item) => (
+              <SideNavItemButton
+                key={item.id}
+                id={item.id}
+                title={item.title}
+                prefix={item.prefix}
+                current={item.current}
+                size={size}
+                onClick={actualOnClick}
+              />
+            ))
+          : children}
+      </ul>
+    </SideNavProvider>
   )
 }

--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -46,10 +46,8 @@ export const SideNav: FC<Props> = ({ size = 'M', className, rounded, children, .
   )
 
   return (
-    <SideNavProvider value={{ size }}>
-      <ul {...rest} className={actualClassName}>
-        {children}
-      </ul>
-    </SideNavProvider>
+    <ul {...rest} className={actualClassName}>
+      <SideNavProvider value={{ size }}>{children}</SideNavProvider>
+    </ul>
   )
 }

--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -1,25 +1,11 @@
-import {
-  type ComponentProps,
-  type ComponentPropsWithoutRef,
-  type FC,
-  type PropsWithChildren,
-  useMemo,
-} from 'react'
+import { type ComponentPropsWithoutRef, type FC, type PropsWithChildren, useMemo } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
 import { SideNavProvider } from './SideNavContext'
-import { SideNavItemButton, type SideNavSizeType } from './SideNavItemButton'
 
-export type SideNavItemButtonProps = Omit<
-  ComponentProps<typeof SideNavItemButton>,
-  'size' | 'onClick'
->
+import type { SideNavSizeType } from './SideNavItemButton'
 
 type AbstractProps = PropsWithChildren<{
-  /** 各アイテムのデータの配列
-   * @deprecated SideNavItemButton を使ってください
-   */
-  items?: SideNavItemButtonProps[]
   /** 各アイテムの大きさ */
   size?: SideNavSizeType
   /** アイテムを押下したときに発火するコールバック関数 */
@@ -59,7 +45,6 @@ const classNameGenerator = tv({
 })
 
 export const SideNav: FC<Props> = ({
-  items,
   size = 'M',
   onClick,
   className,
@@ -88,19 +73,7 @@ export const SideNav: FC<Props> = ({
   return (
     <SideNavProvider value={{ size, onClick: actualOnClick }}>
       <ul {...rest} className={actualClassName}>
-        {items
-          ? items.map((item) => (
-              <SideNavItemButton
-                key={item.id}
-                id={item.id}
-                title={item.title}
-                prefix={item.prefix}
-                current={item.current}
-                size={size}
-                onClick={actualOnClick}
-              />
-            ))
-          : children}
+        {children}
       </ul>
     </SideNavProvider>
   )

--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -8,11 +8,6 @@ import type { SideNavSizeType } from './SideNavItemButton'
 type AbstractProps = PropsWithChildren<{
   /** 各アイテムの大きさ */
   size?: SideNavSizeType
-  /** アイテムを押下したときに発火するコールバック関数 */
-  onClick?: (
-    e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>,
-    id: string,
-  ) => void
   /** コンポーネントに適用するクラス名 */
   className?: string
 }> &
@@ -44,34 +39,14 @@ const classNameGenerator = tv({
   },
 })
 
-export const SideNav: FC<Props> = ({
-  size = 'M',
-  onClick,
-  className,
-  rounded,
-  children,
-  ...rest
-}) => {
-  const actualOnClick = useMemo(
-    () =>
-      onClick
-        ? (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>) =>
-            onClick(
-              e,
-              ((e as React.MouseEvent<HTMLButtonElement, MouseEvent>).currentTarget.value ||
-                e.currentTarget.getAttribute('data-value')) as string,
-            )
-        : undefined,
-    [onClick],
-  )
-
+export const SideNav: FC<Props> = ({ size = 'M', className, rounded, children, ...rest }) => {
   const actualClassName = useMemo(
     () => classNameGenerator({ rounded, className }),
     [rounded, className],
   )
 
   return (
-    <SideNavProvider value={{ size, onClick: actualOnClick }}>
+    <SideNavProvider value={{ size }}>
       <ul {...rest} className={actualClassName}>
         {children}
       </ul>

--- a/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
@@ -4,7 +4,6 @@ import type { SideNavSizeType } from './SideNavItemButton'
 
 type SideNavContextValue = {
   size: SideNavSizeType
-  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>) => void
 }
 
 const SideNavContext = createContext<SideNavContextValue | undefined>(undefined)

--- a/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react'
+
+import type { SideNavSizeType } from './SideNavItemButton'
+
+type SideNavContextValue = {
+  size: SideNavSizeType
+  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>) => void
+}
+
+const SideNavContext = createContext<SideNavContextValue | undefined>(undefined)
+
+export const useSideNavContext = () => useContext(SideNavContext)
+
+export const SideNavProvider = SideNavContext.Provider

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -11,6 +11,8 @@ import { tv } from 'tailwind-variants'
 import { UnstyledButton } from '../Button'
 import { Cluster } from '../Layout'
 
+import { useSideNavContext } from './SideNavContext'
+
 export type SideNavSizeType = 'M' | 'S'
 
 type AbstractProps = {
@@ -97,18 +99,22 @@ export const SideNavItemButton: FC<ButtonProps> = ({
   prefix,
   suffix,
   current,
-  size,
-  onClick,
+  size: sizeProp,
+  onClick: onClickProp,
   children,
   className,
   ...rest
 }) => {
+  const context = useSideNavContext()
+  const size = sizeProp ?? context?.size ?? 'M'
+  const onClick = onClickProp ?? context?.onClick
+
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
 
     return {
       wrapper: wrapper({ className }),
-      button: button({ size: size ?? 'M' }),
+      button: button({ size }),
       body: body(),
       bodyText: bodyText(),
     }
@@ -134,20 +140,24 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   prefix,
   suffix,
   current,
-  size,
-  onClick,
+  size: sizeProp,
+  onClick: onClickProp,
   children,
   className,
   href,
   elementAs,
   ...rest
 }: AnchorProps<T>) => {
+  const context = useSideNavContext()
+  const size = sizeProp ?? context?.size ?? 'M'
+  const onClick = onClickProp ?? context?.onClick
+
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
 
     return {
       wrapper: wrapper({ className }),
-      button: button({ size: size ?? 'M' }),
+      button: button({ size }),
       body: body(),
       bodyText: bodyText(),
     }

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -16,10 +16,6 @@ import { useSideNavContext } from './SideNavContext'
 export type SideNavSizeType = 'M' | 'S'
 
 type AbstractProps = {
-  /** アイテムのタイトル
-   * @deprecated SideNav で items を使う時の props です。children を使ってください。
-   */
-  title?: ReactNode
   /** タイトルのプレフィックスの内容。通常、StatusLabelやIconの配置に用います。 */
   prefix?: ReactNode
   /** タイトルのサフィックスの内容。通常、Prefixを使用済みの場合にStatusLabelやChipの配置に用います。 */
@@ -95,7 +91,6 @@ const classNameGenerator = tv({
 
 export const SideNavItemButton: FC<ButtonProps> = ({
   id,
-  title,
   prefix,
   suffix,
   current,
@@ -123,12 +118,9 @@ export const SideNavItemButton: FC<ButtonProps> = ({
   return (
     <li {...rest} data-current={!!current} className={classNames.wrapper}>
       <UnstyledButton className={classNames.button} onClick={onClick} value={id}>
-        <BodyCluster
-          prefix={prefix}
-          suffix={suffix}
-          title={children ?? title}
-          classNames={classNames}
-        />
+        <BodyCluster prefix={prefix} suffix={suffix} classNames={classNames}>
+          {children}
+        </BodyCluster>
       </UnstyledButton>
     </li>
   )
@@ -136,7 +128,6 @@ export const SideNavItemButton: FC<ButtonProps> = ({
 
 export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   id,
-  title,
   prefix,
   suffix,
   current,
@@ -168,25 +159,23 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   return (
     <li {...rest} data-current={!!current} className={classNames.wrapper}>
       <Anchor className={classNames.button} href={href} onClick={onClick} data-value={id}>
-        <BodyCluster
-          prefix={prefix}
-          suffix={suffix}
-          title={children ?? title}
-          classNames={classNames}
-        />
+        <BodyCluster prefix={prefix} suffix={suffix} classNames={classNames}>
+          {children}
+        </BodyCluster>
       </Anchor>
     </li>
   )
 }
 
 const BodyCluster = memo<
-  Pick<AbstractProps, 'prefix' | 'suffix' | 'title'> & {
+  Pick<AbstractProps, 'prefix' | 'suffix'> & {
+    children: ReactNode
     classNames: { body: string; bodyText: string }
   }
->(({ prefix, suffix, title, classNames }) => (
+>(({ prefix, suffix, children, classNames }) => (
   <Cluster inline align="center" className={classNames.body} as="span">
     {prefix}
-    <span className={classNames.bodyText}>{title}</span>
+    <span className={classNames.bodyText}>{children}</span>
     {suffix}
   </Cluster>
 ))

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -25,14 +25,16 @@ type AbstractProps = {
 }
 
 type AbstractButtonProps = AbstractProps & {
-  /** アイテムの識別子。onClickのイベントオブジェクトのcurrentTarget.valueで取得できます。 */
-  id: string
+  /** アイテムを押下したときに発火するコールバック関数 */
+  onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
 type AbstractAnchorProps<T extends ElementType = 'a'> = AbstractProps & {
   href: string
   /** next/link などのカスタムコンポーネントを指定します。指定がない場合はデフォルトで `a` タグが使用されます。 */
   elementAs?: T
+  /** アイテムを押下したときに発火するコールバック関数 */
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void
 }
 
 type ButtonProps = Omit<ComponentPropsWithoutRef<'li'>, keyof AbstractButtonProps> &
@@ -92,11 +94,11 @@ export const SideNavItemButton: FC<ButtonProps> = ({
   current,
   children,
   className,
+  onClick,
   ...rest
 }) => {
   const context = useSideNavContext()
   const size = context?.size ?? 'M'
-  const onClick = context?.onClick
 
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
@@ -110,7 +112,7 @@ export const SideNavItemButton: FC<ButtonProps> = ({
   }, [className, size])
 
   return (
-    <li {...rest} data-current={!!current} className={classNames.wrapper}>
+    <li {...rest} id={id} data-current={!!current} className={classNames.wrapper}>
       <UnstyledButton className={classNames.button} onClick={onClick} value={id}>
         <BodyCluster prefix={prefix} suffix={suffix} classNames={classNames}>
           {children}
@@ -121,7 +123,6 @@ export const SideNavItemButton: FC<ButtonProps> = ({
 }
 
 export const SideNavItemAnchor = <T extends ElementType = 'a'>({
-  id,
   prefix,
   suffix,
   current,
@@ -129,11 +130,11 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   className,
   href,
   elementAs,
+  onClick,
   ...rest
 }: AnchorProps<T>) => {
   const context = useSideNavContext()
   const size = context?.size ?? 'M'
-  const onClick = context?.onClick
 
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
@@ -150,7 +151,7 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
 
   return (
     <li {...rest} data-current={!!current} className={classNames.wrapper}>
-      <Anchor className={classNames.button} href={href} onClick={onClick} data-value={id}>
+      <Anchor className={classNames.button} href={href} onClick={onClick}>
         <BodyCluster prefix={prefix} suffix={suffix} classNames={classNames}>
           {children}
         </BodyCluster>

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -22,10 +22,6 @@ type AbstractProps = {
   suffix?: ReactNode
   /** 選択されているアイテムかどうか */
   current?: boolean
-  /** アイテムの大きさ */
-  size?: SideNavSizeType
-  /** アイテムを押下したときに発火するコールバック関数 */
-  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>) => void
 }
 
 type AbstractButtonProps = AbstractProps & {
@@ -94,15 +90,13 @@ export const SideNavItemButton: FC<ButtonProps> = ({
   prefix,
   suffix,
   current,
-  size: sizeProp,
-  onClick: onClickProp,
   children,
   className,
   ...rest
 }) => {
   const context = useSideNavContext()
-  const size = sizeProp ?? context?.size ?? 'M'
-  const onClick = onClickProp ?? context?.onClick
+  const size = context?.size ?? 'M'
+  const onClick = context?.onClick
 
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
@@ -131,8 +125,6 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   prefix,
   suffix,
   current,
-  size: sizeProp,
-  onClick: onClickProp,
   children,
   className,
   href,
@@ -140,8 +132,8 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   ...rest
 }: AnchorProps<T>) => {
   const context = useSideNavContext()
-  const size = sizeProp ?? context?.size ?? 'M'
-  const onClick = onClickProp ?? context?.onClick
+  const size = context?.size ?? 'M'
+  const onClick = context?.onClick
 
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
@@ -3,12 +3,12 @@ import { action } from 'storybook/actions'
 import { FaGearIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { StatusLabel } from '../../StatusLabel'
-import { SideNav, type SideNavItemButtonProps } from '../SideNav'
+import { SideNav } from '../SideNav'
 import { SideNavItemAnchor, SideNavItemButton, type SideNavSizeType } from '../SideNavItemButton'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
-export const _sideNavItems: SideNavItemButtonProps[] = [
+export const _sideNavItems = [
   {
     id: 'id-1',
     children: 'サイドナビ1',
@@ -37,35 +37,25 @@ export const _sideNavItems: SideNavItemButtonProps[] = [
 export default {
   title: 'Components/SideNav',
   component: SideNav,
-  argTypes: {
-    items: {
-      control: false,
-    },
-  },
-  render: (args) => {
-    const { items, ...rest } = args
-    return items ? (
-      <SideNav {...rest} items={items} />
-    ) : (
-      <SideNav {...rest}>
-        {_sideNavItems.map((item, index) => {
-          const commonAttrs = {
-            key: item.id,
-            id: item.id,
-            current: item.current,
-            prefix: item.prefix,
-            children: item.children,
-          }
+  render: (args) => (
+    <SideNav {...args}>
+      {_sideNavItems.map((item, index) => {
+        const commonAttrs = {
+          key: item.id,
+          id: item.id,
+          current: item.current,
+          prefix: item.prefix,
+          children: item.children,
+        }
 
-          return index % 2 === 0 ? (
-            <SideNavItemButton {...commonAttrs} />
-          ) : (
-            <SideNavItemAnchor {...commonAttrs} href={`#${index}`} />
-          )
-        })}
-      </SideNav>
-    )
-  },
+        return index % 2 === 0 ? (
+          <SideNavItemButton {...commonAttrs} />
+        ) : (
+          <SideNavItemAnchor {...commonAttrs} href={`#${index}`} />
+        )
+      })}
+    </SideNav>
+  ),
   excludeStories: ['_sideNavItems'],
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -74,37 +64,6 @@ export default {
 
 export const Playground: StoryObj<typeof SideNav> = {
   args: {},
-}
-
-export const Items: StoryObj<typeof SideNav> = {
-  name: 'items（非推奨）',
-  argTypes: {
-    items: {
-      control: { disable: false, type: 'object' },
-    },
-  },
-  args: {
-    items: [
-      {
-        id: 'id-1',
-        title: 'サイドナビ1',
-        current: false,
-      },
-
-      {
-        id: 'id-2',
-        title: 'サイドナビ2',
-        current: true,
-      },
-
-      {
-        id: 'id-3',
-        title: 'サイドナビ3',
-        current: false,
-        prefix: <StatusLabel>ラベル</StatusLabel>,
-      },
-    ],
-  },
 }
 
 export const Size: StoryObj<typeof SideNav> = {

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
@@ -112,9 +112,24 @@ export const Rounded: StoryObj<typeof SideNav> = {
 
 export const OnClick: StoryObj<typeof SideNav> = {
   name: 'onClick',
-  args: {
-    onClick: (_, id) => {
-      action('clicked')(id)
-    },
-  },
+  render: (args) => (
+    <SideNav {...args}>
+      {_sideNavItems.map((item, index) => {
+        const commonAttrs = {
+          key: item.id,
+          id: item.id,
+          current: item.current,
+          prefix: item.prefix,
+          children: item.children,
+          onClick: () => action('clicked')(item.id),
+        }
+
+        return index % 2 === 0 ? (
+          <SideNavItemButton {...commonAttrs} />
+        ) : (
+          <SideNavItemAnchor {...commonAttrs} href={`#${index}`} />
+        )
+      })}
+    </SideNav>
+  ),
 }

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemAnchor.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemAnchor.stories.tsx
@@ -18,7 +18,6 @@ export default {
     size: {
       description: 'SideNavItemAnchor に指定せず、SideNav に指定してください。',
     },
-    onClick: { description: 'SideNavItemAnchor に指定せず、SideNav に指定してください。' },
   },
   args: {
     id: 'id-1',

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemAnchor.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemAnchor.stories.tsx
@@ -1,8 +1,5 @@
-import { action } from 'storybook/actions'
-
-import { Stack } from '../../Layout'
 import { StatusLabel } from '../../StatusLabel'
-import { SideNavItemAnchor, type SideNavSizeType } from '../SideNavItemButton'
+import { SideNavItemAnchor } from '../SideNavItemButton'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
@@ -37,14 +34,6 @@ export const Playground: StoryObj<typeof SideNavItemAnchor> = {
   args: {},
 }
 
-export const Title: StoryObj<typeof SideNavItemAnchor> = {
-  name: 'title（非推奨）',
-  args: {
-    title: 'サイドナビ',
-    children: undefined,
-  },
-}
-
 export const Prefix: StoryObj<typeof SideNavItemAnchor> = {
   name: 'prefix',
   args: {
@@ -56,27 +45,5 @@ export const Selected: StoryObj<typeof SideNavItemAnchor> = {
   name: 'selected',
   args: {
     current: true,
-  },
-}
-
-export const Size: StoryObj<typeof SideNavItemAnchor> = {
-  name: 'size',
-  render: (args) => (
-    <Stack as="ul" className="shr-list-none">
-      {[undefined, 'default', 's'].map((size, i) => (
-        <SideNavItemAnchor {...args} id={i.toString()} key={i} size={size as SideNavSizeType}>
-          サイドナビ{i + 1}
-        </SideNavItemAnchor>
-      ))}
-    </Stack>
-  ),
-}
-
-export const OnClick: StoryObj<typeof SideNavItemAnchor> = {
-  name: 'onClick',
-  args: {
-    onClick: (e) => {
-      action('clicked')(e.currentTarget.value)
-    },
   },
 }

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemButton.stories.tsx
@@ -1,8 +1,5 @@
-import { action } from 'storybook/actions'
-
-import { Stack } from '../../Layout'
 import { StatusLabel } from '../../StatusLabel'
-import { SideNavItemButton, type SideNavSizeType } from '../SideNavItemButton'
+import { SideNavItemButton } from '../SideNavItemButton'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
@@ -36,14 +33,6 @@ export const Playground: StoryObj<typeof SideNavItemButton> = {
   args: {},
 }
 
-export const Title: StoryObj<typeof SideNavItemButton> = {
-  name: 'title（非推奨）',
-  args: {
-    title: 'サイドナビ',
-    children: undefined,
-  },
-}
-
 export const Prefix: StoryObj<typeof SideNavItemButton> = {
   name: 'prefix',
   args: {
@@ -55,27 +44,5 @@ export const Selected: StoryObj<typeof SideNavItemButton> = {
   name: 'selected',
   args: {
     current: true,
-  },
-}
-
-export const Size: StoryObj<typeof SideNavItemButton> = {
-  name: 'size',
-  render: (args) => (
-    <Stack as="ul" className="shr-list-none">
-      {[undefined, 'default', 's'].map((size, i) => (
-        <SideNavItemButton {...args} id={i.toString()} key={i} size={size as SideNavSizeType}>
-          サイドナビ{i + 1}
-        </SideNavItemButton>
-      ))}
-    </Stack>
-  ),
-}
-
-export const OnClick: StoryObj<typeof SideNavItemButton> = {
-  name: 'onClick',
-  args: {
-    onClick: (e) => {
-      action('clicked')(e.currentTarget.value)
-    },
   },
 }

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemButton.stories.tsx
@@ -18,7 +18,6 @@ export default {
     size: {
       description: 'SideNavItemButton に指定せず、SideNav に指定してください。',
     },
-    onClick: { description: 'SideNavItemButton に指定せず、SideNav に指定してください。' },
   },
   args: {
     id: 'id-1',


### PR DESCRIPTION
## 関連URL

なし

## 概要

SideNavコンポーネントで使用していた非推奨のcloneElementをContext APIに置き換え、同時にinterfaceを整理しました。

cloneElementはReactで非推奨とされており、Context APIの使用が推奨されています。また、非推奨だったitemsプロパティを削除し、childrenパターンのみをサポートすることでAPIをシンプル化しました。さらに、onClickをContextから削除し、個別のアイテムで直接受け取るように変更することで、より柔軟な設計になりました。

## 変更内容

### 1. cloneElementをContext APIに置き換え
- `SideNavContext.tsx` を新規作成
- `SideNav` から `cloneElement` と `Children.map` を削除
- `SideNavItemButton` と `SideNavItemAnchor` でContextから値を取得

### 2. items プロパティを削除
- `SideNav` から非推奨の `items` プロパティを削除
- `SideNavItemButtonProps` 型を削除
- `SideNavItemButton` から `title` プロパティを削除（children のみサポート）
- `AppHeader` 内の実装を children パターンに移行

### 3. 個別アイテムから size プロパティを削除
- `SideNavItemButton` と `SideNavItemAnchor` から `size` を削除
- Contextから取得するように変更

### 4. onClickをContextから削除し個別のitemに移動
- `SideNav` から `onClick` プロパティを削除
- `SideNavItemButton` と `SideNavItemAnchor` で直接 `onClick` を受け取るように変更
- 共通のonClickハンドラを使用する場合は `e.currentTarget.value` で識別可能
- `id` は `ComponentPropsWithoutRef<'li'>` で提供されるため、型定義から削除

### Before/After

```tsx
// Before
<SideNav 
  items={[
    { id: '1', title: 'Item 1', current: true },
    { id: '2', title: 'Item 2' }
  ]}
  size="M"
  onClick={(e, id) => console.log(id)}
/>

// After
<SideNav size="M">
  <SideNavItemButton id="1" current onClick={(e) => console.log(e.currentTarget.value)}>
    Item 1
  </SideNavItemButton>
  <SideNavItemAnchor id="2" href="/" onClick={(e) => console.log('clicked')}>
    Item 2
  </SideNavItemAnchor>
</SideNav>
```

## プロダクト側で対応が必要な事項

### 破壊的変更

1. **items プロパティが削除されました**
   - children を使用してください
   ```tsx
   // 修正が必要
   <SideNav items={[{ id: '1', title: 'Item' }]} />
   
   // 修正後
   <SideNav>
     <SideNavItemButton id="1">Item</SideNavItemButton>
   </SideNav>
   ```

2. **SideNav の onClick プロパティが削除されました**
   - 各アイテムに直接 onClick を指定してください
   - 共通のハンドラを使う場合は `e.currentTarget.value` で id を取得できます
   ```tsx
   // 修正が必要
   <SideNav onClick={(e, id) => handleClick(id)}>
     <SideNavItemButton id="1">Item</SideNavItemButton>
   </SideNav>
   
   // 修正後（個別のハンドラ）
   <SideNav>
     <SideNavItemButton id="1" onClick={() => handleClick('1')}>Item</SideNavItemButton>
   </SideNav>
   
   // 修正後（共通のハンドラ）
   <SideNav>
     <SideNavItemButton id="1" onClick={(e) => handleClick(e.currentTarget.value)}>
       Item
     </SideNavItemButton>
   </SideNav>
   ```

3. **SideNavItemButton/Anchor に直接 size を渡せなくなりました**
   - 親の SideNav に指定してください
   ```tsx
   // 修正が必要
   <SideNavItemButton size="S">Item</SideNavItemButton>
   
   // 修正後
   <SideNav size="S">
     <SideNavItemButton>Item</SideNavItemButton>
   </SideNav>
   ```

4. **title プロパティが削除されました**
   - children を使用してください
   ```tsx
   // 修正が必要
   <SideNavItemButton title="Item" />
   
   // 修正後
   <SideNavItemButton>Item</SideNavItemButton>
   ```

## 確認方法

- Storybookで動作確認
- テスト: `pnpm ui test -- --run src/components/SideNav` （全テスト通過）
- lint: `pnpm ui lint` （通過）