### PR TITLE
refactor(AppNaviDropdownMenuButton): cloneElementを削除してTailwindの子孫セレクターを使用

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
@@ -1,16 +1,8 @@
-import {
-  Children,
-  type FC,
-  Fragment,
-  type PropsWithChildren,
-  type ReactElement,
-  type ReactNode,
-  cloneElement,
-  isValidElement,
-} from 'react'
 import { tv } from 'tailwind-variants'
 
-import { DropdownMenuButton, DropdownMenuGroup } from '../Dropdown'
+import { DropdownMenuButton } from '../Dropdown'
+
+import type { FC, PropsWithChildren, ReactNode } from 'react'
 
 type Props = PropsWithChildren<{
   /** 引き金となるボタンラベル */
@@ -41,36 +33,18 @@ const classNameGenerator = tv({
         '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-h-0.25',
         '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-bg-main',
       ],
-    ],
-    actionItem: [
       // HINT: DropdownMenuButton内で設定されるclassNameより優先度を上げる必要がある
-      '[&&]:aria-current-page:shr-bg-grey-9 [&&]:aria-current-page:shr-font-bold',
-      '[&&]:hover:shr-bg-head-darken',
+      [
+        '[&&_button[aria-current="page"]]:shr-bg-grey-9',
+        '[&&_button[aria-current="page"]]:shr-font-bold',
+        '[&&_a[aria-current="page"]]:shr-bg-grey-9',
+        '[&&_a[aria-current="page"]]:shr-font-bold',
+      ],
+      ['[&&_button:hover]:shr-bg-head-darken', '[&&_a:hover]:shr-bg-head-darken'],
     ],
   },
 })
-const { trigger, actionItem } = classNameGenerator()
-
-const renderItemList = (children: ReactNode) =>
-  Children.map(children, (item): ReactNode => {
-    if (!isValidElement(item)) {
-      return null
-    }
-
-    if (item.type === Fragment) {
-      return renderItemList(item.props.children)
-    }
-
-    if (item.type === DropdownMenuGroup) {
-      return (
-        <DropdownMenuGroup {...item.props}>{renderItemList(item.props.children)}</DropdownMenuGroup>
-      )
-    }
-
-    return cloneElement(item as ReactElement, {
-      className: actionItem({ className: item.props.className }),
-    })
-  })
+const { trigger } = classNameGenerator()
 
 export const AppNaviDropdownMenuButton: FC<Props> = ({ label, onOpen, onClose, children }) => (
   <DropdownMenuButton
@@ -85,6 +59,6 @@ export const AppNaviDropdownMenuButton: FC<Props> = ({ label, onOpen, onClose, c
     onClose={onClose}
     className={trigger()}
   >
-    {renderItemList(children)}
+    {children}
   </DropdownMenuButton>
 )


### PR DESCRIPTION
## 関連URL

なし

## 概要

AppNaviDropdownMenuButtonコンポーネント内でReact 19で非推奨となる`cloneElement`を使用していたため、Tailwindの子孫セレクターを使ったアプローチに置き換えました。

## 変更内容

- `cloneElement`による子要素へのclassName追加を削除
- `renderItemList`関数を削除し、childrenを直接DropdownMenuButtonに渡す
- 親要素からTailwindの子孫セレクター（`[&&_button[aria-current="page"]]`、`[&&_a[aria-current="page"]]`など）で直接スタイルを適用
- `actionItem`スロットを`trigger`スロットに統合
- 優先度を上げるために`[&&_...]`記法を使用

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが全て通過することを確認
- Storybookで`aria-current="page"`が設定されたボタンのスタイルが正しく適用されることを確認
- hover時のスタイルが正しく適用されることを確認