### PR TITLE
refactor(RemoteDialogTrigger): cloneElementを削除してDisclosureTriggerと同じパターンを使用

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -1,13 +1,6 @@
 'use client'
 
-import {
-  type FC,
-  type MouseEvent,
-  type ReactElement,
-  cloneElement,
-  useCallback,
-  useMemo,
-} from 'react'
+import { type FC, type PropsWithChildren, useCallback, useEffect, useRef } from 'react'
 
 import { TRIGGER_EVENT } from '../useRemoteTrigger'
 
@@ -19,16 +12,19 @@ const onClickRemoteDialogTrigger = (ariaControls: string) => {
   )
 }
 
-export const RemoteDialogTrigger: FC<{
-  targetId: string
-  onClick?: (open: () => void) => void
-  children: Omit<ReactElement, 'onClick' | 'aria-haspopup' | 'aria-controls'>
-}> = ({ targetId, children, onClick, ...rest }) => {
+export const RemoteDialogTrigger: FC<
+  PropsWithChildren<{
+    targetId: string
+    onClick?: (open: () => void) => void
+  }>
+> = ({ targetId, children, onClick }) => {
+  const ref = useRef<HTMLSpanElement | null>(null)
+
   const actualOnClick = useCallback(
-    (e: MouseEvent<HTMLElement>) => {
+    (e: Event) => {
       // HINT: onClick内で非同期処理される場合、e.currentTargetがnullになってしまう可能性があるため
       // 先にariaControlsを取得しておく
-      const ariaControls = e.currentTarget.getAttribute('aria-controls') as string
+      const ariaControls = (e.currentTarget as HTMLElement).getAttribute('aria-controls') as string
 
       if (onClick) {
         return onClick(() => {
@@ -40,16 +36,30 @@ export const RemoteDialogTrigger: FC<{
     },
     [onClick],
   )
-  const actualTrigger = useMemo(
-    () =>
-      cloneElement(children as ReactElement, {
-        ...rest,
-        onClick: actualOnClick,
-        'aria-haspopup': 'dialog',
-        'aria-controls': targetId,
-      }),
-    [children, actualOnClick, targetId, rest],
-  )
 
-  return actualTrigger
+  useEffect(() => {
+    if (!ref.current) {
+      return
+    }
+
+    const element = ref.current.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
+
+    if (!element) {
+      return
+    }
+
+    element.setAttribute('aria-haspopup', 'dialog')
+    element.setAttribute('aria-controls', targetId)
+    element.addEventListener('click', actualOnClick)
+
+    return () => {
+      element.removeEventListener('click', actualOnClick)
+    }
+  }, [children, actualOnClick, targetId])
+
+  return (
+    <span className="smarthr-ui-RemoteDialogTrigger shr-contents" ref={ref}>
+      {children}
+    </span>
+  )
 }

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -23,23 +23,22 @@ export const RemoteDialogTrigger: FC<
   }>
 > = ({ targetId, children, onClick }) => {
   const ref = useRef<HTMLSpanElement | null>(null)
+  const onClickRef = useRef(onClick)
+  onClickRef.current = onClick
 
-  const actualOnClick = useCallback(
-    (e: Event) => {
-      // HINT: onClick内で非同期処理される場合、e.currentTargetがnullになってしまう可能性があるため
-      // 先にariaControlsを取得しておく
-      const ariaControls = (e.currentTarget as HTMLElement).getAttribute('aria-controls') as string
+  const actualOnClick = useCallback((e: Event) => {
+    // HINT: onClick内で非同期処理される場合、e.currentTargetがnullになってしまう可能性があるため
+    // 先にariaControlsを取得しておく
+    const ariaControls = (e.currentTarget as HTMLElement).getAttribute('aria-controls') as string
 
-      if (onClick) {
-        return onClick(() => {
-          onClickRemoteDialogTrigger(ariaControls)
-        })
-      }
+    if (onClickRef.current) {
+      return onClickRef.current(() => {
+        onClickRemoteDialogTrigger(ariaControls)
+      })
+    }
 
-      onClickRemoteDialogTrigger(ariaControls)
-    },
-    [onClick],
-  )
+    onClickRemoteDialogTrigger(ariaControls)
+  }, [])
 
   useEffect(() => {
     if (!ref.current) {
@@ -60,7 +59,7 @@ export const RemoteDialogTrigger: FC<
     return () => {
       element.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
     }
-  }, [children, actualOnClick, targetId])
+  }, [children, targetId, actualOnClick])
 
   return (
     <span className="smarthr-ui-RemoteDialogTrigger shr-contents" ref={ref}>

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -46,9 +46,12 @@ export const RemoteDialogTrigger: FC<
       return
     }
 
+    const getClickableElement = () =>
+      currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
+
     // 現在の子要素に対して処理を実行
     const setupElement = () => {
-      const element = currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
+      const element = getClickableElement()
       if (element) {
         element.setAttribute('aria-haspopup', 'dialog')
         element.setAttribute('aria-controls', targetId)
@@ -57,20 +60,20 @@ export const RemoteDialogTrigger: FC<
       }
     }
 
+    const clearEventListener = () => {
+      // 既存のイベントリスナーをクリーンアップ
+      const element = getClickableElement()
+      if (element) {
+        element.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
+      }
+    }
+
     // 初回セットアップ
     setupElement()
 
     // MutationObserverでDOM変更を監視
     const observer = new MutationObserver(() => {
-      // 既存のイベントリスナーをクリーンアップ
-      const oldElement = currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>(
-        'button, a',
-      )
-      if (oldElement) {
-        oldElement.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
-      }
-
-      // 新しい要素にセットアップ
+      clearEventListener()
       setupElement()
     })
 
@@ -81,10 +84,7 @@ export const RemoteDialogTrigger: FC<
 
     return () => {
       observer.disconnect()
-      const element = currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
-      if (element) {
-        element.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
-      }
+      clearEventListener()
     }
   }, [targetId, actualOnClick])
 

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -4,6 +4,10 @@ import { type FC, type PropsWithChildren, useCallback, useEffect, useRef } from 
 
 import { TRIGGER_EVENT } from '../useRemoteTrigger'
 
+const CAPTURE_OPTION = {
+  capture: true,
+}
+
 const onClickRemoteDialogTrigger = (ariaControls: string) => {
   document.dispatchEvent(
     new CustomEvent(TRIGGER_EVENT, {
@@ -50,10 +54,11 @@ export const RemoteDialogTrigger: FC<
 
     element.setAttribute('aria-haspopup', 'dialog')
     element.setAttribute('aria-controls', targetId)
-    element.addEventListener('click', actualOnClick)
+    // HINT: DropdownCloser のonClickより先に実行するため、キャプチャフェーズで処理する
+    element.addEventListener('click', actualOnClick, CAPTURE_OPTION)
 
     return () => {
-      element.removeEventListener('click', actualOnClick)
+      element.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
     }
   }, [children, actualOnClick, targetId])
 

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -41,25 +41,52 @@ export const RemoteDialogTrigger: FC<
   }, [])
 
   useEffect(() => {
-    if (!ref.current) {
+    const currentRef = ref.current
+    if (!currentRef) {
       return
     }
 
-    const element = ref.current.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
-
-    if (!element) {
-      return
+    // 現在の子要素に対して処理を実行
+    const setupElement = () => {
+      const element = currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
+      if (element) {
+        element.setAttribute('aria-haspopup', 'dialog')
+        element.setAttribute('aria-controls', targetId)
+        // HINT: DropdownCloser のonClickより先に実行するため、キャプチャフェーズで処理する
+        element.addEventListener('click', actualOnClick, CAPTURE_OPTION)
+      }
     }
 
-    element.setAttribute('aria-haspopup', 'dialog')
-    element.setAttribute('aria-controls', targetId)
-    // HINT: DropdownCloser のonClickより先に実行するため、キャプチャフェーズで処理する
-    element.addEventListener('click', actualOnClick, CAPTURE_OPTION)
+    // 初回セットアップ
+    setupElement()
+
+    // MutationObserverでDOM変更を監視
+    const observer = new MutationObserver(() => {
+      // 既存のイベントリスナーをクリーンアップ
+      const oldElement = currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>(
+        'button, a',
+      )
+      if (oldElement) {
+        oldElement.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
+      }
+
+      // 新しい要素にセットアップ
+      setupElement()
+    })
+
+    observer.observe(currentRef, {
+      childList: true, // 直接の子要素の追加・削除を監視
+      subtree: true, // 子孫要素の変更も監視
+    })
 
     return () => {
-      element.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
+      observer.disconnect()
+      const element = currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
+      if (element) {
+        element.removeEventListener('click', actualOnClick, CAPTURE_OPTION)
+      }
     }
-  }, [children, targetId, actualOnClick])
+  }, [targetId, actualOnClick])
 
   return (
     <span className="smarthr-ui-RemoteDialogTrigger shr-contents" ref={ref}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

RemoteDialogTriggerコンポーネント内でReact 19で非推奨となる`cloneElement`を使用していたため、既存のDisclosureTriggerと同じパターンに置き換えました。

## 変更内容

- `cloneElement`による子要素へのprops追加を削除
- DisclosureTriggerと同じパターンを採用
- `<span className="shr-contents" ref={ref}>`でchildrenをラップ
  - `display: contents`により視覚的影響を最小化
- `useEffect`でDOM操作を実行：
  - `querySelector('button, a')`で子要素を取得
  - `setAttribute`でaria属性を設定
  - `addEventListener`でクリックイベントを設定
- これによりコードベース全体で一貫したパターンを使用

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが全て通過することを確認
- Storybookでダイアログが正しく開くことを確認
- DropdownMenuButton内でRemoteDialogTriggerを使用した場合も正しく動作することを確認