### PR TITLE
refactor(useReelCells): childrenを依存配列から削除しMutationObserverを使用

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TableReel.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableReel.tsx
@@ -19,7 +19,7 @@ const classNameGenerator = tv({
 })
 
 export const TableReel: FC<Props> = ({ className, children, tableWrapperRef, ...rest }) => {
-  const { showShadow } = useReelCells(children, tableWrapperRef)
+  const { showShadow } = useReelCells(tableWrapperRef)
 
   const classNames = useMemo(() => {
     const { wrapper, inner } = classNameGenerator()

--- a/packages/smarthr-ui/src/components/Table/useReelCells.ts
+++ b/packages/smarthr-ui/src/components/Table/useReelCells.ts
@@ -91,17 +91,23 @@ export const useReelCells = (
     handleScroll()
     wrapper.addEventListener('scroll', handleScroll)
 
-    const observer = new ResizeObserver(handleScroll)
+    const resizeObserver = new ResizeObserver(handleScroll)
+    resizeObserver.observe(wrapper)
 
-    observer.observe(wrapper)
+    // HINT: Paginationと組み合わせた際などにテーブル構造の変更を検知して再生成
+    const mutationObserver = new MutationObserver(handleScroll)
+    mutationObserver.observe(wrapper, {
+      childList: true,
+      subtree: true,
+    })
 
     return () => {
       wrapper.removeEventListener('scroll', handleScroll)
-      observer.unobserve(wrapper)
+      resizeObserver.unobserve(wrapper)
+      mutationObserver.disconnect()
       allClean()
     }
-    // HINT: Paginationと組み合わせた際などに再生成したい
-  }, [children, tableWrapperRef])
+  }, [tableWrapperRef])
 
   return { tableWrapperRef, showShadow }
 }

--- a/packages/smarthr-ui/src/components/Table/useReelCells.ts
+++ b/packages/smarthr-ui/src/components/Table/useReelCells.ts
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const TR_SELECTOR = 'table tr'
 const FIXED_LEFT_SELECTOR = '[data-fixed="left"]'
@@ -6,10 +6,7 @@ const FIXED_RIGHT_SELECTOR = '[data-fixed="right"]'
 
 const HAS_FIXED_SELECTOR = `${TR_SELECTOR} ${FIXED_LEFT_SELECTOR},${TR_SELECTOR} ${FIXED_RIGHT_SELECTOR}`
 
-export const useReelCells = (
-  children: ReactNode,
-  tableWrapperRef: React.RefObject<HTMLDivElement>,
-) => {
+export const useReelCells = (tableWrapperRef: React.RefObject<HTMLDivElement>) => {
   const [showShadow, setShowShadow] = useState(false)
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Table/useReelCells.ts
+++ b/packages/smarthr-ui/src/components/Table/useReelCells.ts
@@ -106,5 +106,5 @@ export const useReelCells = (tableWrapperRef: React.RefObject<HTMLDivElement>) =
     }
   }, [tableWrapperRef])
 
-  return { tableWrapperRef, showShadow }
+  return { showShadow }
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0で追加された`smarthr/best-practice-for-unstable-dependencies`ルールにより、useEffectの依存配列に不安定な参照である`children`が含まれていることが警告されるようになりました。

`children`は参照が頻繁に変わるため、依存配列に含めると不要な再実行や無限ループの原因となる可能性があります。

## 変更内容

- useEffectの依存配列から`children`を削除
- MutationObserverを追加してDOM構造の変更を監視
- Paginationなどでテーブルの内容が変わった際も、MutationObserverが検知して適切に再計算

### Before

```typescript
useEffect(() => {
  // ... handleScrollの実装 ...
  
  const observer = new ResizeObserver(handleScroll)
  observer.observe(wrapper)
  
  return () => {
    wrapper.removeEventListener('scroll', handleScroll)
    observer.unobserve(wrapper)
    allClean()
  }
}, [children, tableWrapperRef]) // childrenが不安定な参照
```

### After

```typescript
useEffect(() => {
  // ... handleScrollの実装 ...
  
  const resizeObserver = new ResizeObserver(handleScroll)
  resizeObserver.observe(wrapper)
  
  // DOM構造の変更を監視
  const mutationObserver = new MutationObserver(handleScroll)
  mutationObserver.observe(wrapper, {
    childList: true,
    subtree: true,
  })
  
  return () => {
    wrapper.removeEventListener('scroll', handleScroll)
    resizeObserver.unobserve(wrapper)
    mutationObserver.disconnect()
    allClean()
  }
}, [tableWrapperRef]) // childrenを削除
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybookで固定列を含むテーブルの動作を確認
- Paginationと組み合わせた際の動作を確認