### PR TITLE
refactor(LineClamp): childrenを依存配列から削除しResizeObserverを使用

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -77,8 +77,7 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
     // フォントの高さの計算が期待と異なり適切な高さが取得できないためshadowElと比較している
     // 参考: https://github.com/kufu/smarthr-ui/pull/4710
     const checkOverflow = () => {
-      const isMultiLineOverflow = shadowEl.clientHeight > el.clientHeight
-      setTooltipVisible(isMultiLineOverflow)
+      setTooltipVisible(shadowEl.clientHeight > el.clientHeight)
     }
 
     checkOverflow()

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -71,13 +71,27 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
     const el = ref.current
     const shadowEl = shadowRef.current
 
+    if (!el || !shadowEl) return
+
     // -webkit-line-clamp を使った要素ではel.scrollHeightとel.clientHeightの比較だと
     // フォントの高さの計算が期待と異なり適切な高さが取得できないためshadowElと比較している
     // 参考: https://github.com/kufu/smarthr-ui/pull/4710
-    const isMultiLineOverflow = el && shadowEl ? shadowEl.clientHeight > el.clientHeight : false
+    const checkOverflow = () => {
+      const isMultiLineOverflow = shadowEl.clientHeight > el.clientHeight
+      setTooltipVisible(isMultiLineOverflow)
+    }
 
-    setTooltipVisible(isMultiLineOverflow)
-  }, [maxLines, children])
+    checkOverflow()
+
+    const resizeObserver = new ResizeObserver(checkOverflow)
+    resizeObserver.observe(el)
+    resizeObserver.observe(shadowEl)
+
+    return () => {
+      resizeObserver.unobserve(el)
+      resizeObserver.unobserve(shadowEl)
+    }
+  }, [maxLines])
 
   const classNames = useMemo(() => {
     const { base, clampedLine, shadowElementWrapper, shadowElement } = classNameGenerator({


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0で追加された`smarthr/best-practice-for-unstable-dependencies`ルールにより、useEffectの依存配列に不安定な参照である`children`が含まれていることが警告されるようになりました。

`children`は参照が頻繁に変わるため、依存配列に含めると不要な再実行や無限ループの原因となる可能性があります。

## 変更内容

- useEffectの依存配列から`children`を削除
- ResizeObserverを追加して表示要素（ref）と高さ計測用要素（shadowRef）のサイズ変更を監視
- 内容が変わってサイズが変わった際も、ResizeObserverが検知して適切に再計算

### Before

```typescript
useEffect(() => {
  const el = ref.current
  const shadowEl = shadowRef.current

  const isMultiLineOverflow = el && shadowEl ? shadowEl.clientHeight > el.clientHeight : false

  setTooltipVisible(isMultiLineOverflow)
}, [maxLines, children]) // childrenが不安定な参照
```

### After

```typescript
useEffect(() => {
  const el = ref.current
  const shadowEl = shadowRef.current

  if (!el || !shadowEl) return

  const checkOverflow = () => {
    const isMultiLineOverflow = shadowEl.clientHeight > el.clientHeight
    setTooltipVisible(isMultiLineOverflow)
  }

  checkOverflow()

  const resizeObserver = new ResizeObserver(checkOverflow)
  resizeObserver.observe(el)
  resizeObserver.observe(shadowEl)

  return () => {
    resizeObserver.unobserve(el)
    resizeObserver.unobserve(shadowEl)
  }
}, [maxLines]) // childrenを削除
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybookで行数制限されたテキストの動作を確認
- 内容が動的に変わる場合のツールチップ表示を確認