### PR TITLE
refactor(DropdownTrigger): childrenを依存配列から削除しMutationObserverを使用

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -30,7 +30,7 @@ type DropdownContextType = {
   triggerRect: Rect
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
-  onClickTrigger: (rect: Rect) => void
+  memoizedOnClickTrigger: (rect: Rect) => void
   onClickCloser: () => void
   DropdownContentRoot: FC<{ children: ReactNode }>
   contentId: string
@@ -43,7 +43,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   triggerRect: initialRect,
   triggerElementRef: createRef(),
   rootTriggerRef: null,
-  onClickTrigger: () => {
+  memoizedOnClickTrigger: () => {
     /* noop */
   },
   onClickCloser: () => {
@@ -113,7 +113,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     }
   }, [active])
 
-  const onClickTrigger = useCallback((rect: Rect) => {
+  const memoizedOnClickTrigger = useCallback((rect: Rect) => {
     setActive((current) => {
       const newActive = !current
 
@@ -140,7 +140,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerRect,
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
-          onClickTrigger,
+          memoizedOnClickTrigger,
           onClickCloser,
           DropdownContentRoot,
           contentId,

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -43,7 +43,8 @@ const classNameGenerator = tv({
 })
 
 export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => {
-  const { active, onClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)
+  const { active, memoizedOnClickTrigger, contentId, triggerElementRef } =
+    useContext(DropdownContext)
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
   useEffect(() => {
@@ -61,29 +62,52 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
   }, [active, triggerElementRef, contentId])
 
   useEffect(() => {
-    if (!triggerElementRef.current) {
+    const triggerElement = triggerElementRef.current
+    if (!triggerElement) {
       return
     }
 
-    const button = triggerElementRef.current.querySelector<HTMLButtonElement>('button')
+    let currentCleanup: (() => void) | undefined
 
-    // 引き金となる要素が disabled な場合、処理を差し込む必要がないため、そのまま出力する
-    if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
-      return
+    const setupButton = () => {
+      // 既存のクリーンアップを実行
+      currentCleanup?.()
+      currentCleanup = undefined
+
+      const button = triggerElement.querySelector<HTMLButtonElement>('button')
+
+      // 引き金となる要素が disabled な場合、処理を差し込む必要がないため、そのまま出力する
+      if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
+        return
+      }
+
+      // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
+      // そのためcaptureで開く処理を実行する
+      const callback = (e: MouseEvent) => {
+        memoizedOnClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
+      }
+
+      button.addEventListener('click', callback, CAPTURE_OPTION)
+
+      currentCleanup = () => {
+        button.removeEventListener('click', callback, CAPTURE_OPTION)
+      }
     }
 
-    // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
-    // そのためcaptureで開く処理を実行する
-    const callback = (e: MouseEvent) => {
-      onClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
-    }
+    setupButton()
 
-    button.addEventListener('click', callback, CAPTURE_OPTION)
+    const observer = new MutationObserver(setupButton)
+
+    observer.observe(triggerElement, {
+      childList: true,
+      subtree: true,
+    })
 
     return () => {
-      button.removeEventListener('click', callback, CAPTURE_OPTION)
+      currentCleanup?.()
+      observer.disconnect()
     }
-  }, [children, onClickTrigger, triggerElementRef])
+  }, [memoizedOnClickTrigger, triggerElementRef])
 
   return (
     <div ref={triggerElementRef} className={actualClassName}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0で追加された`smarthr/best-practice-for-unstable-dependencies`ルールにより、useEffectの依存配列に不安定な参照である`children`が含まれていることが警告されるようになりました。

`children`は参照が頻繁に変わるため、依存配列に含めると不要な再実行や無限ループの原因となる可能性があります。

## 変更内容

### 1. childrenを依存配列から削除しMutationObserverを使用

- useEffectの依存配列から`children`を削除
- MutationObserverを追加してtrigger要素のDOM構造の変更を監視
- 内容が変わった際も、MutationObserverが検知して適切に再設定

### 2. onClickTriggerをmemoizedOnClickTriggerにリネーム

- `Dropdown.tsx`の`onClickTrigger`を`memoizedOnClickTrigger`にリネーム
- この関数がuseCallbackでメモ化されており、安定していることを明示
- 将来のメンテナンス時に、この関数がメモ化されていることが期待されている設計意図を明確化

### Before

```typescript
// Dropdown.tsx
const onClickTrigger = useCallback((rect: Rect) => {
  // ...
}, [])

// DropdownTrigger.tsx
const { active, onClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)

useEffect(() => {
  // ...
  const callback = (e: MouseEvent) => {
    onClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
  }
  
  button.addEventListener('click', callback, CAPTURE_OPTION)
  
  return () => {
    button.removeEventListener('click', callback, CAPTURE_OPTION)
  }
}, [children, onClickTrigger, triggerElementRef]) // childrenが不安定な参照
```

### After

```typescript
// Dropdown.tsx
const memoizedOnClickTrigger = useCallback((rect: Rect) => {
  // ...
}, [])

// DropdownTrigger.tsx
const { active, memoizedOnClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)

useEffect(() => {
  let currentCleanup: (() => void) | undefined

  const setupButton = () => {
    currentCleanup?.()
    const button = triggerElement.querySelector<HTMLButtonElement>('button')
    // ...
    button.addEventListener('click', callback, CAPTURE_OPTION)
    currentCleanup = () => {
      button.removeEventListener('click', callback, CAPTURE_OPTION)
    }
  }

  setupButton()

  const observer = new MutationObserver(setupButton)
  observer.observe(triggerElement, {
    childList: true,
    subtree: true,
  })

  return () => {
    currentCleanup?.()
    observer.disconnect()
  }
}, [memoizedOnClickTrigger, triggerElementRef]) // childrenを削除、メモ化が明示的
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybookでドロップダウンの動作を確認
- 内容が動的に変わる場合の動作を確認