### PR TITLE
refactor(DropdownMenuButton): childrenを依存配列から削除しMutationObserverを使用

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -227,20 +227,35 @@ const ButtonListItem: FC<{ children: ReactElement }> = ({ children }) => {
   const ref = useRef<HTMLLIElement>(null)
 
   useEffect(() => {
-    if (!ref.current) {
+    const listItem = ref.current
+    if (!listItem) {
       return
     }
 
-    const button = ref.current.querySelector('button,a')
+    const setupButton = () => {
+      const button = listItem.querySelector('button,a')
 
-    if (button) {
-      button.setAttribute('role', 'menuitem')
-      button.setAttribute(
-        'class',
-        actionListItemButton({ className: button.getAttribute('class') }),
-      )
+      if (button) {
+        button.setAttribute('role', 'menuitem')
+        button.setAttribute(
+          'class',
+          actionListItemButton({ className: button.getAttribute('class') }),
+        )
+      }
     }
-  }, [children])
+
+    setupButton()
+
+    const observer = new MutationObserver(setupButton)
+    observer.observe(listItem, {
+      childList: true,
+      subtree: true,
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
 
   return (
     <li role="presentation" ref={ref}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0で追加された`smarthr/best-practice-for-unstable-dependencies`ルールにより、useEffectの依存配列に不安定な参照である`children`が含まれていることが警告されるようになりました。

`children`は参照が頻繁に変わるため、依存配列に含めると不要な再実行や無限ループの原因となる可能性があります。

## 変更内容

- useEffectの依存配列から`children`を削除
- MutationObserverを追加してlist item要素のDOM構造の変更を監視
- 内容が変わった際も、MutationObserverが検知して適切に再設定

### Before

```typescript
useEffect(() => {
  if (!ref.current) {
    return
  }

  const button = ref.current.querySelector('button,a')

  if (button) {
    button.setAttribute('role', 'menuitem')
    button.setAttribute(
      'class',
      actionListItemButton({ className: button.getAttribute('class') }),
    )
  }
}, [children]) // childrenが不安定な参照
```

### After

```typescript
useEffect(() => {
  const listItem = ref.current
  if (!listItem) {
    return
  }

  const setupButton = () => {
    const button = listItem.querySelector('button,a')

    if (button) {
      button.setAttribute('role', 'menuitem')
      button.setAttribute(
        'class',
        actionListItemButton({ className: button.getAttribute('class') }),
      )
    }
  }

  setupButton()

  const observer = new MutationObserver(setupButton)
  observer.observe(listItem, {
    childList: true,
    subtree: true,
  })

  return () => {
    observer.disconnect()
  }
}, []) // childrenを削除、依存配列は空
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybookでドロップダウンメニューの動作を確認
- 内容が動的に変わる場合の動作を確認