### PR TITLE
refactor(DialogOverlap): useEffectの依存配列からchildrenを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -44,11 +44,15 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
 
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
+  // childrenをrefに保存（毎レンダリング時に最新の値を設定）
+  const childrenRef = useRef(children)
+  childrenRef.current = children
+
   useEffect(() => {
     if (isOpen) {
-      setChildrenBuffer(children)
+      setChildrenBuffer(childrenRef.current)
     }
-  }, [isOpen, children])
+  }, [isOpen])
 
   return (
     <CSSTransition


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0で追加された`smarthr/best-practice-for-unstable-dependencies`ルールへの対応として、DialogOverlapコンポーネントのuseEffectの依存配列からchildrenを削除します。

## 変更内容

- `children`をrefで保存し、毎レンダリング時に最新の値を更新
- useEffectの依存配列から`children`を削除し、`isOpen`のみにする
- 不要な再実行を防止しつつ、動作は変わらず

### 実装の詳細

```typescript
// childrenをrefに保存（毎レンダリング時に最新の値を設定）
const childrenRef = useRef(children)
childrenRef.current = children

useEffect(() => {
  if (isOpen) {
    setChildrenBuffer(childrenRef.current)
  }
}, [isOpen])
```

DialogOverlapは、ダイアログが閉じる際のアニメーション中に表示するために`children`をバッファリングするコンポーネントです。`isOpen`がtrueの時に最新のchildrenをバッファに保存し、閉じる際にそのバッファを使用します。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybookで動作確認