### PR TITLE
refactor(useOuterClick): useEffectの依存配列からcallbackを削除

### DIFF
--- a/packages/smarthr-ui/src/hooks/useOuterClick.ts
+++ b/packages/smarthr-ui/src/hooks/useOuterClick.ts
@@ -1,13 +1,17 @@
-import { type RefObject, useEffect } from 'react'
+import { type RefObject, useEffect, useRef } from 'react'
 
 export function useOuterClick(
   targets: Array<RefObject<HTMLElement>>,
   callback: (e: MouseEvent) => void,
 ) {
+  // callbackをrefに保存（毎レンダリング時に最新の値を設定）
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
+
   useEffect(() => {
     const handleOuterClick = (e: MouseEvent) => {
       if (targets.every((target) => isEventExcludedParent(e, target.current))) {
-        callback(e)
+        callbackRef.current(e)
       }
     }
 
@@ -16,7 +20,7 @@ export function useOuterClick(
     return () => {
       window.removeEventListener('click', handleOuterClick)
     }
-  }, [callback, targets])
+  }, [targets])
 }
 
 function isEventExcludedParent(e: MouseEvent, parent: Element | null): boolean {


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0で追加された`smarthr/best-practice-for-unstable-dependencies`ルールへの対応として、useOuterClickカスタムフックのuseEffectの依存配列からcallbackを削除します。

## 変更内容

- `callback`をrefで保存し、毎レンダリング時に最新の値を更新
- useEffect内でref経由でcallbackを参照
- 依存配列から不安定な参照である`callback`を削除

### 実装の詳細

```typescript
// callbackをrefに保存（毎レンダリング時に最新の値を設定）
const callbackRef = useRef(callback)
callbackRef.current = callback

useEffect(() => {
  const handleOuterClick = (e: MouseEvent) => {
    if (targets.every((target) => isEventExcludedParent(e, target.current))) {
      callbackRef.current(e)  // ref経由で呼び出し
    }
  }

  window.addEventListener('click', handleOuterClick)

  return () => {
    window.removeEventListener('click', handleOuterClick)
  }
}, [targets])  // callbackを除外
```

### メリット

- イベントリスナーの不要な再登録を防止
- callbackが変わってもuseEffectが再実行されない
- 常に最新のcallbackが実行される

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- useOuterClickを使用しているDatePicker、MultiComboboxで動作確認