### PR TITLE
refactor(AnchorButton): actualSuffixのuseMemoを削除してシンプルに

### DIFF
--- a/packages/smarthr-ui/src/components/Button/AnchorButton.tsx
+++ b/packages/smarthr-ui/src/components/Button/AnchorButton.tsx
@@ -58,14 +58,9 @@ const AnchorButton = forwardRef(
   ): ReactElement => {
     const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
-    const actualSuffix = useMemo(() => {
-      // target="_blank" だが OpenInNewTabIcon を表示したくない場合 suffix に null を指定すれば表示しないようにしている
-      if (target === '_blank' && !prefix && suffix === undefined) {
-        return <OpenInNewTabIcon />
-      }
-
-      return suffix
-    }, [prefix, suffix, target])
+    // target="_blank" だが OpenInNewTabIcon を表示したくない場合 suffix に null を指定すれば表示しないようにしている
+    const actualSuffix =
+      target === '_blank' && !prefix && suffix === undefined ? <OpenInNewTabIcon /> : suffix
 
     const button = (
       <ButtonWrapper


### PR DESCRIPTION
## 関連URL

なし

## 概要

ESLint ルール `smarthr/best-practice-for-unstable-dependencies` で `prefix`/`suffix` が依存配列に含まれることによるエラーを解消するため、`actualSuffix` の計算から `useMemo` を削除しました。

## 変更内容

### Before
```tsx
const actualSuffix = useMemo(() => {
  if (target === '_blank' && !prefix && suffix === undefined) {
    return <OpenInNewTabIcon />
  }
  return suffix
}, [prefix, suffix, target])
```

### After
```tsx
const actualSuffix =
  target === '_blank' && !prefix && suffix === undefined ? <OpenInNewTabIcon /> : suffix
```

- 単純な条件分岐のため、useMemo のオーバーヘッドが不要と判断
- 三項演算子で直接計算することでコードもシンプルに
- ESLint エラーも解消

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybook で AnchorButton の動作確認（特に `target="_blank"` の場合に OpenInNewTabIcon が表示されることを確認）