### PR TITLE
refactor(CommonButton): prefixの依存配列問題を解決

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/common/CommonButton.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/common/CommonButton.tsx
@@ -46,15 +46,17 @@ type Props = (({ elementAs: 'a' } & AnchorProps) | ({ elementAs: 'button' } & Bu
 
 export const CommonButton = memo<Props>(
   ({ elementAs, prefix, current, boldWhenCurrent, className, children, ...rest }) => {
+    const hasPrefix = !!prefix
+
     const actualClassName = useMemo(
       () =>
         commonButtonClassNameGenerator({
-          prefix: !!prefix,
+          prefix: hasPrefix,
           current,
           boldWhenCurrent,
           className,
         }),
-      [current, prefix, boldWhenCurrent, className],
+      [current, hasPrefix, boldWhenCurrent, className],
     )
 
     switch (elementAs) {


### PR DESCRIPTION
## 関連URL

なし

## 概要

ESLint ルール `smarthr/best-practice-for-unstable-dependencies` で `prefix`（ReactNode）が依存配列に含まれることによるエラーを解消するため、`prefix` を boolean 値に変換して依存配列を安定化しました。

## 変更内容

### Before
```tsx
const actualClassName = useMemo(
  () =>
    commonButtonClassNameGenerator({
      prefix: !!prefix,
      current,
      boldWhenCurrent,
      className,
    }),
  [current, prefix, boldWhenCurrent, className],
)
```

### After
```tsx
const hasPrefix = !!prefix

const actualClassName = useMemo(
  () =>
    commonButtonClassNameGenerator({
      prefix: hasPrefix,
      current,
      boldWhenCurrent,
      className,
    }),
  [current, hasPrefix, boldWhenCurrent, className],
)
```

- `prefix`（ReactNode、unstable）を `hasPrefix`（boolean、stable）に変換
- 依存配列から unstable な参照を除去
- useMemo による className 生成の最適化を維持

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybook で AppHeader の CommonButton の表示確認