### PR TITLE
refactor(Text): iconの依存配列問題を解決

### DIFF
--- a/packages/smarthr-ui/src/components/Text/Text.tsx
+++ b/packages/smarthr-ui/src/components/Text/Text.tsx
@@ -213,9 +213,12 @@ const ActualText = <T extends ElementType = 'span'>({
       className,
     })
   }, [size, weight, italic, color, leading, whiteSpace, maxLines, className, styleType])
+  const hasIcon = !!icon
+  const iconGap = icon?.gap
+
   const wrapperClassName = useMemo(
-    () => (icon ? wrapperClassNameGenerator({ gap: icon.gap || 0.25 }) : ''),
-    [icon],
+    () => (hasIcon ? wrapperClassNameGenerator({ gap: iconGap || 0.25 }) : ''),
+    [hasIcon, iconGap],
   )
 
   return (


### PR DESCRIPTION
## 関連URL

なし

## 概要

ESLint ルール `smarthr/best-practice-for-unstable-dependencies` で `icon`（ReactNode | object）が依存配列に含まれることによるエラーを解消するため、`icon` を stable なプリミティブ値に分解して依存配列を安定化しました。

## 変更内容

### Before
```tsx
const wrapperClassName = useMemo(
  () => (icon ? wrapperClassNameGenerator({ gap: icon.gap || 0.25 }) : ''),
  [icon],
)
```

### After
```tsx
const hasIcon = !!icon
const iconGap = icon?.gap

const wrapperClassName = useMemo(
  () => (hasIcon ? wrapperClassNameGenerator({ gap: iconGap || 0.25 }) : ''),
  [hasIcon, iconGap],
)
```

- `icon`（ReactNode | object、unstable）を `hasIcon`（boolean）と `iconGap`（number | string | undefined）に分解
- 依存配列から unstable な参照を除去
- useMemo による className 生成の最適化を維持

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybook で Text コンポーネントの icon 表示確認