### PR TITLE
refactor(MultiSelectedItem): onClickとonKeyDownの依存配列を空に

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -155,21 +155,25 @@ const BaseDestroyButton = <T,>({
   iconStyle: string
 }) => {
   const { localize } = useIntl()
-  const onClick = useCallback(() => {
-    onDelete(item)
-  }, [item, onDelete])
-  const onKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>) => {
-      if (EXEC_DESTROY_KEY.test(e.key)) {
-        e.stopPropagation()
 
-        // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
-        // このタイミングで明示的に削除処理を実行する
-        onClick()
-      }
-    },
-    [onClick],
-  )
+  const onDeleteRef = useRef(onDelete)
+  onDeleteRef.current = onDelete
+  const itemRef = useRef(item)
+  itemRef.current = item
+
+  const onClick = useCallback(() => {
+    onDeleteRef.current(itemRef.current)
+  }, [])
+
+  const onKeyDown = useCallback((e: KeyboardEvent<HTMLButtonElement>) => {
+    if (EXEC_DESTROY_KEY.test(e.key)) {
+      e.stopPropagation()
+
+      // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
+      // このタイミングで明示的に削除処理を実行する
+      onDeleteRef.current(itemRef.current)
+    }
+  }, [])
 
   const destroyButtonIconAltSuffix = useMemo(
     () =>


### PR DESCRIPTION
## 関連URL

なし

## 概要

ESLint ルール `smarthr/best-practice-for-unstable-dependencies` で `onClick` が依存配列に含まれることによるエラーを解消するため、`onDelete` と `item` を ref に保存して両方のコールバックの依存配列を安定化しました。

## 変更内容

### Before
```tsx
const onClick = useCallback(() => {
  onDelete(item)
}, [item, onDelete])

const onKeyDown = useCallback(
  (e: KeyboardEvent<HTMLButtonElement>) => {
    if (EXEC_DESTROY_KEY.test(e.key)) {
      e.stopPropagation()
      onClick()
    }
  },
  [onClick],
)
```

### After
```tsx
const onDeleteRef = useRef(onDelete)
onDeleteRef.current = onDelete
const itemRef = useRef(item)
itemRef.current = item

const onClick = useCallback(() => {
  onDeleteRef.current(itemRef.current)
}, [])

const onKeyDown = useCallback(
  (e: KeyboardEvent<HTMLButtonElement>) => {
    if (EXEC_DESTROY_KEY.test(e.key)) {
      e.stopPropagation()
      onDeleteRef.current(itemRef.current)
    }
  },
  [],
)
```

- `onDelete`（関数、unstable）と `item`（オブジェクト、unstable）を ref に保存
- `onClick` と `onKeyDown` の両方の依存配列を空に
- 完全に安定したコールバックを実現

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが通ることを確認
- Storybook で MultiCombobox のアイテム削除が正常に動作することを確認