### PR TITLE
refactor(TabItem)!: onClickの型をイベントハンドラに変更

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -7,6 +7,7 @@ import {
   memo,
   useCallback,
   useMemo,
+  useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -58,16 +59,28 @@ type AbstractProps = PropsWithChildren<{
     message: ReactNode
   }
   /** タブをクリックした時に発火するコールバック関数 */
-  onClick: (tabId: string) => void
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void
 }>
 type Props = AbstractProps &
   Omit<ComponentProps<typeof UnstyledButton>, keyof AbstractProps | 'aria-selected' | 'type'>
 
-export const TabItem: FC<Props> = ({ selected = false, disabled, disabledReason, ...rest }) => {
+export const TabItem: FC<Props> = ({
+  selected = false,
+  disabled,
+  disabledReason,
+  onClick,
+  ...rest
+}) => {
   const tabAttrs = {
     role: 'tab',
     'aria-selected': selected,
   }
+  const onClickRef = useRef(onClick)
+  onClickRef.current = onClick
+
+  const actualOnClick = useCallback((e: MouseEvent<HTMLButtonElement>) => {
+    onClickRef.current(e)
+  }, [])
 
   if (disabled && disabledReason) {
     const Icon = disabledReason.icon || <FaCircleInfoIcon color="TEXT_GREY" />
@@ -79,15 +92,15 @@ export const TabItem: FC<Props> = ({ selected = false, disabled, disabledReason,
         aria-disabled={disabled}
         className="focus-visible:shr-focus-indicator"
       >
-        <TabButton {...rest} disabled={disabled} suffix={Icon} />
+        <TabButton {...rest} onClick={actualOnClick} disabled={disabled} suffix={Icon} />
       </Tooltip>
     )
   }
 
-  return <TabButton {...rest} {...tabAttrs} disabled={disabled} />
+  return <TabButton {...rest} {...tabAttrs} onClick={actualOnClick} disabled={disabled} />
 }
 
-const TabButton: FC<Props> = ({ id, children, suffix, onClick, className, ...rest }) => {
+const TabButton = memo<PropsWithChildren<Props>>(({ id, children, suffix, className, ...rest }) => {
   const classNames = useMemo(() => {
     const { wrapper, label, suffixWrapper } = classNameGenerator()
 
@@ -98,29 +111,10 @@ const TabButton: FC<Props> = ({ id, children, suffix, onClick, className, ...res
     }
   }, [className])
 
-  const actualOnClick = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => onClick(e.currentTarget.value),
-    [onClick],
-  )
-
   return (
-    <UnstyledButton
-      {...rest}
-      type="button"
-      value={id}
-      id={id}
-      className={classNames.wrapper}
-      onClick={actualOnClick}
-    >
-      <TabLabel className={classNames.label}>{children}</TabLabel>
-      <TabButtonSuffix className={classNames.suffixWrapper}>{suffix}</TabButtonSuffix>
+    <UnstyledButton {...rest} type="button" value={id} id={id} className={classNames.wrapper}>
+      <span className={classNames.label}>{children}</span>
+      {suffix && <span className={classNames.suffixWrapper}>{suffix}</span>}
     </UnstyledButton>
   )
-}
-
-const TabLabel = memo<PropsWithChildren<{ className: string }>>(({ children, className }) => (
-  <span className={className}>{children}</span>
-))
-const TabButtonSuffix = memo<PropsWithChildren<{ className: string }>>(
-  ({ children, className }) => children && <span className={className}>{children}</span>,
-)
+})


### PR DESCRIPTION
## 関連URL

なし

## 概要

ESLint ルール `smarthr/best-practice-for-unstable-dependencies` で `onClick` が依存配列に含まれることによるエラーを解消するため、`onClick` を ref に保存して依存配列を安定化しました。

同時に、onClick の型を breaking change として変更しています。

## 変更内容

### Breaking Change

**onClick の型変更:**
```typescript
// Before
onClick: (tabId: string) => void

// After  
onClick: (e: MouseEvent<HTMLButtonElement>) => void
```

利用側では `e.currentTarget.value` から tabId を取得できます。

**理由:**
- 実用上、TabItem には個別に onClick を設定するパターンが一般的
- 個別の TabItem ごとに tabId を渡すために、TabButton 内で `e.currentTarget.value` から id を取得する実装が不要に
- より標準的なイベントハンドラの型に統一

### 依存配列の安定化

```typescript
const onClickRef = useRef(onClick)
onClickRef.current = onClick

const actualOnClick = useCallback((e: MouseEvent<HTMLButtonElement>) => {
  onClickRef.current(e)
}, [])
```

- `onClick` を ref に保存
- 依存配列を空配列 `[]` に - 完全に安定したコールバック

## プロダクト側で対応が必要な事項

**Breaking Change があります。**

TabItem の onClick を使用している箇所で、引数を変更する必要があります。

```tsx
// Before
<TabItem onClick={(tabId) => console.log(tabId)} />

// After
<TabItem onClick={(e) => console.log(e.currentTarget.value)} />
```

## 確認方法

- 既存のテストが通ることを確認
- Storybook で TabBar のタブクリックが正常に動作することを確認