### PR TITLE
refactor(Textarea): onChangeの依存配列を安定化

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -129,6 +129,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
     const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
     const [srCounterMessage, setSrCounterMessage] = useState<ReactNode>('')
 
+    const onChangeRef = useRef(onChange)
+    onChangeRef.current = onChange
+
     const buildAvailableLetters = useCallback(
       (availableLetters: number): ReactNode => (
         <Localizer
@@ -229,10 +232,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
           setInterimRows(currentRows)
         }
 
-        onChange?.(e)
+        onChangeRef.current?.(e)
       },
       [
-        onChange,
         debouncedUpdateCount,
         debouncedUpdateSrCounterMessage,
         autoResize,


### PR DESCRIPTION
## 関連URL

なし

## 概要

ESLint設定の`smarthr/best-practice-for-unstable-dependencies`ルールに対応するため、TextareaコンポーネントのonChange依存配列を安定化します。

## 変更内容

- `onChange`をrefで管理し、`handleChange`の依存配列から`onChange`を除外

### 変更前後

```tsx
// Before
const handleChange = useCallback(
  (e: ChangeEvent<HTMLTextAreaElement>) => {
    // ...
    onChange?.(e)
  },
  [
    onChange,  // 不安定な依存
    debouncedUpdateCount,
    // ...
  ],
)

// After
const onChangeRef = useRef(onChange)
onChangeRef.current = onChange

const handleChange = useCallback(
  (e: ChangeEvent<HTMLTextAreaElement>) => {
    // ...
    onChangeRef.current?.(e)
  },
  [
    // onChange を削除
    debouncedUpdateCount,
    // ...
  ],
)
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストが通ることを確認