### PR TITLE
refactor(Select): onChangeハンドラーをインライン化してコードを簡潔に

### DIFF
--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -10,6 +10,7 @@ import {
   memo,
   useCallback,
   useMemo,
+  useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -101,24 +102,26 @@ const ActualSelect = <T extends string>(
   }: Props<T>,
   ref: ForwardedRef<HTMLSelectElement>,
 ) => {
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLSelectElement>) => {
-      onChange?.(e)
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+  const onChangeValueRef = useRef(onChangeValue)
+  onChangeValueRef.current = onChangeValue
+  const optionsRef = useRef<Array<Option<T> | Optgroup<T>>>(options)
+  optionsRef.current = options
 
-      if (onChangeValue) {
-        const flattenOptions = options.reduce(
-          (pre, cur) => pre.concat('value' in cur ? cur : cur.options),
-          [] as Array<Option<T>>,
-        )
-        const selectedOption = flattenOptions.find((option) => option.value === e.target.value)
+  const handleChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
+    onChangeRef.current?.(e)
 
-        if (selectedOption) {
-          onChangeValue(selectedOption.value)
-        }
+    if (onChangeValueRef.current) {
+      const selectedOption = optionsRef.current
+        .flatMap((option) => ('value' in option ? [option] : option.options))
+        .find((option) => option.value === e.target.value)
+
+      if (selectedOption) {
+        onChangeValueRef.current(selectedOption.value)
       }
-    },
-    [onChange, onChangeValue, options],
-  )
+    }
+  }, [])
 
   const classNames = useMemo(() => {
     const { wrapper, select, iconWrap, blankOptgroup } = classNameGenerator()

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -8,9 +8,7 @@ import {
   type OptionHTMLAttributes,
   type PropsWithChildren,
   memo,
-  useCallback,
   useMemo,
-  useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -102,27 +100,6 @@ const ActualSelect = <T extends string>(
   }: Props<T>,
   ref: ForwardedRef<HTMLSelectElement>,
 ) => {
-  const onChangeRef = useRef(onChange)
-  onChangeRef.current = onChange
-  const onChangeValueRef = useRef(onChangeValue)
-  onChangeValueRef.current = onChangeValue
-  const optionsRef = useRef<Array<Option<T> | Optgroup<T>>>(options)
-  optionsRef.current = options
-
-  const handleChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
-    onChangeRef.current?.(e)
-
-    if (onChangeValueRef.current) {
-      const selectedOption = optionsRef.current
-        .flatMap((option) => ('value' in option ? [option] : option.options))
-        .find((option) => option.value === e.target.value)
-
-      if (selectedOption) {
-        onChangeValueRef.current(selectedOption.value)
-      }
-    }
-  }, [])
-
   const classNames = useMemo(() => {
     const { wrapper, select, iconWrap, blankOptgroup } = classNameGenerator()
     const sizeProps = {
@@ -150,7 +127,19 @@ const ActualSelect = <T extends string>(
       <select
         {...rest}
         data-smarthr-ui-input="true"
-        onChange={handleChange}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+          onChange?.(e)
+
+          if (onChangeValue) {
+            const selectedOption = options
+              .flatMap((option) => ('value' in option ? [option] : option.options))
+              .find((option) => option.value === e.target.value)
+
+            if (selectedOption) {
+              onChangeValue(selectedOption.value)
+            }
+          }
+        }}
         aria-invalid={error || undefined}
         disabled={disabled}
         // HINT: required属性を設定すると、iOS端末で以下の問題が発生します


### PR DESCRIPTION
## 関連URL

なし

## 概要

SelectコンポーネントのonChangeハンドラーをインライン化することで、refパターンやuseCallbackを削除し、コードをより簡潔で読みやすくします。

## 変更内容

- `onChange`, `onChangeValue`, `options`のrefパターンを削除
- `useCallback`によるハンドラーメモ化を削除
- onChangeハンドラーをインライン実装に変更
- Tooltipで採用したアプローチと同じパターン

### 変更前後

```tsx
// Before
const onChangeRef = useRef(onChange)
onChangeRef.current = onChange
const onChangeValueRef = useRef(onChangeValue)
onChangeValueRef.current = onChangeValue
const optionsRef = useRef<Array<Option<T> | Optgroup<T>>>(options)
optionsRef.current = options

const handleChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
  onChangeRef.current?.(e)

  if (onChangeValueRef.current) {
    const selectedOption = optionsRef.current
      .flatMap((option) => ('value' in option ? [option] : option.options))
      .find((option) => option.value === e.target.value)

    if (selectedOption) {
      onChangeValueRef.current(selectedOption.value)
    }
  }
}, [])

<select onChange={handleChange} />

// After
<select
  onChange={(e: ChangeEvent<HTMLSelectElement>) => {
    onChange?.(e)

    if (onChangeValue) {
      const selectedOption = options
        .flatMap((option) => ('value' in option ? [option] : option.options))
        .find((option) => option.value === e.target.value)

      if (selectedOption) {
        onChangeValue(selectedOption.value)
      }
    }
  }}
/>
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストが通ることを確認