### PR TITLE
refactor(InputFile): InputFileMultiplyAppendableのonChangeとfilesを安定化

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -3,6 +3,7 @@
 import {
   type ChangeEvent,
   type MouseEvent,
+  type PropsWithChildren,
   type ReactNode,
   forwardRef,
   memo,
@@ -127,18 +128,15 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
         {!disabled && hasFileList && files.length > 0 && (
           <BaseColumn as="ul" padding={BASE_COLUMN_PADDING} className={classNames.fileList}>
             {files.map((file, index) => (
-              <li key={index} className={classNames.fileItem}>
-                <span className="smarthr-ui-InputFile-fileName">{file.name}</span>
-                <Button
-                  variant="text"
-                  prefix={<FaTrashCanIcon />}
-                  value={index}
-                  onClick={handleDelete}
-                  className="smarthr-ui-InputFile-deleteButton"
-                >
-                  {destroyLabel}
-                </Button>
-              </li>
+              <FileListItem
+                key={index}
+                value={index}
+                onDeleteClick={handleDelete}
+                destroyLabel={destroyLabel}
+                className={classNames.fileItem}
+              >
+                {file.name}
+              </FileListItem>
             ))}
           </BaseColumn>
         )}
@@ -161,6 +159,30 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
       </Stack>
     )
   },
+)
+
+type FileListItemProps = PropsWithChildren<{
+  value: number
+  onDeleteClick: (e: MouseEvent<HTMLButtonElement>) => void
+  destroyLabel: string
+  className: string
+}>
+
+const FileListItem = memo<FileListItemProps>(
+  ({ value, onDeleteClick, destroyLabel, className, children }) => (
+    <li className={className}>
+      <span className="smarthr-ui-InputFile-fileName">{children}</span>
+      <Button
+        variant="text"
+        prefix={<FaTrashCanIcon />}
+        value={value}
+        onClick={onDeleteClick}
+        className="smarthr-ui-InputFile-deleteButton"
+      >
+        {destroyLabel}
+      </Button>
+    </li>
+  ),
 )
 
 const StyledFaFolderOpenIcon = memo<{ className: string }>(({ className }) => (

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -66,36 +66,33 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
       () => inputRef.current,
     )
 
-    const updateInputFiles = useCallback(
+    const onChangeRef = useRef(onChange)
+    onChangeRef.current = onChange
+
+    const filesRef = useRef(files)
+    filesRef.current = files
+
+    const updateInputFiles = useCallback((newFiles: File[]) => {
+      if (!inputRef.current) {
+        return
+      }
+      const buff = new DataTransfer()
+      newFiles.forEach((file) => {
+        buff.items.add(file)
+      })
+
+      isUpdatingFilesDirectly.current = true
+      inputRef.current.files = buff.files
+      isUpdatingFilesDirectly.current = false
+    }, [])
+
+    const updateFiles = useCallback(
       (newFiles: File[]) => {
-        if (!inputRef.current) {
-          return
-        }
-        const buff = new DataTransfer()
-        newFiles.forEach((file) => {
-          buff.items.add(file)
-        })
-
-        isUpdatingFilesDirectly.current = true
-        inputRef.current.files = buff.files
-        isUpdatingFilesDirectly.current = false
+        onChangeRef.current?.(newFiles)
+        updateInputFiles(newFiles)
+        setFiles(newFiles)
       },
-      [inputRef],
-    )
-
-    const updateFiles = useMemo(
-      () =>
-        onChange
-          ? (newFiles: File[]) => {
-              onChange(newFiles)
-              updateInputFiles(newFiles)
-              setFiles(newFiles)
-            }
-          : (newFiles: File[]) => {
-              setFiles(newFiles)
-              updateInputFiles(newFiles)
-            },
-      [onChange, updateInputFiles],
+      [updateInputFiles],
     )
 
     const handleChange = useCallback(
@@ -107,9 +104,9 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
 
         const newFiles = Array.from(e.target.files ?? [])
 
-        updateFiles([...files, ...newFiles])
+        updateFiles([...filesRef.current, ...newFiles])
       },
-      [files, isUpdatingFilesDirectly, updateFiles],
+      [updateFiles],
     )
 
     const handleDelete = useCallback(
@@ -119,14 +116,14 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
         }
 
         const index = parseInt(e.currentTarget.value, 10)
-        const newFiles = files.filter((_, i) => index !== i)
+        const newFiles = filesRef.current.filter((_, i) => index !== i)
 
         // 削除後、同一ファイルを再選択可能にするためinput.valueをリセット
         inputRef.current.value = ''
 
         updateFiles(newFiles)
       },
-      [files, updateFiles],
+      [updateFiles],
     )
 
     return (

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -72,10 +72,13 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
     const filesRef = useRef(files)
     filesRef.current = files
 
-    const updateInputFiles = useCallback((newFiles: File[]) => {
+    const updateFiles = useCallback((newFiles: File[]) => {
       if (!inputRef.current) {
         return
       }
+
+      onChangeRef.current?.(newFiles)
+
       const buff = new DataTransfer()
       newFiles.forEach((file) => {
         buff.items.add(file)
@@ -84,16 +87,9 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
       isUpdatingFilesDirectly.current = true
       inputRef.current.files = buff.files
       isUpdatingFilesDirectly.current = false
-    }, [])
 
-    const updateFiles = useCallback(
-      (newFiles: File[]) => {
-        onChangeRef.current?.(newFiles)
-        updateInputFiles(newFiles)
-        setFiles(newFiles)
-      },
-      [updateInputFiles],
-    )
+      setFiles(newFiles)
+    }, [])
 
     const handleChange = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -67,18 +67,15 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
       () => inputRef.current,
     )
 
-    const onChangeRef = useRef(onChange)
-    onChangeRef.current = onChange
-
-    const filesRef = useRef(files)
-    filesRef.current = files
+    const unstableRef = useRef({ onChange, files })
+    unstableRef.current = { onChange, files }
 
     const updateFiles = useCallback((newFiles: File[]) => {
       if (!inputRef.current) {
         return
       }
 
-      onChangeRef.current?.(newFiles)
+      unstableRef.current.onChange?.(newFiles)
 
       const buff = new DataTransfer()
       newFiles.forEach((file) => {
@@ -101,7 +98,7 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
 
         const newFiles = Array.from(e.target.files ?? [])
 
-        updateFiles([...filesRef.current, ...newFiles])
+        updateFiles([...unstableRef.current.files, ...newFiles])
       },
       [updateFiles],
     )
@@ -113,7 +110,7 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
         }
 
         const index = parseInt(e.currentTarget.value, 10)
-        const newFiles = filesRef.current.filter((_, i) => index !== i)
+        const newFiles = unstableRef.current.files.filter((_, i) => index !== i)
 
         // 削除後、同一ファイルを再選択可能にするためinput.valueをリセット
         inputRef.current.value = ''


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr v14.7.0以降で有効化された`best-practice-for-unstable-dependencies`ルールに対応するため、InputFileMultiplyAppendableコンポーネントの`onChange`と`files`依存を安定化します。

## 変更内容

- `onChange`と`files`をuseRefで保持し、毎レンダリング時に最新値を更新
- `updateInputFiles`の依存配列を空に（`inputRef`を削除）
- `updateFiles`をuseMemoからuseCallbackに変更し、依存配列を`[updateInputFiles]`のみに
- `handleChange`と`handleDelete`で`filesRef.current`を使用し、依存配列から`files`と不要なuseRefを削除

### コード変更

```tsx
// Before
const updateInputFiles = useCallback(
  (newFiles: File[]) => {
    // ...
  },
  [inputRef],  // ← useRefは不要
)

const updateFiles = useMemo(
  () =>
    onChange
      ? (newFiles: File[]) => {
          onChange(newFiles)
          updateInputFiles(newFiles)
          setFiles(newFiles)
        }
      : (newFiles: File[]) => {
          setFiles(newFiles)
          updateInputFiles(newFiles)
        },
  [onChange, updateInputFiles],  // ← onChangeが不安定
)

const handleChange = useCallback(
  (e: ChangeEvent<HTMLInputElement>) => {
    const newFiles = Array.from(e.target.files ?? [])
    updateFiles([...files, ...newFiles])
  },
  [files, isUpdatingFilesDirectly, updateFiles],  // ← filesが不安定
)

// After
const onChangeRef = useRef(onChange)
onChangeRef.current = onChange

const filesRef = useRef(files)
filesRef.current = files

const updateInputFiles = useCallback((newFiles: File[]) => {
  // ...
}, [])  // ← 依存配列が空

const updateFiles = useCallback(
  (newFiles: File[]) => {
    onChangeRef.current?.(newFiles)
    updateInputFiles(newFiles)
    setFiles(newFiles)
  },
  [updateInputFiles],
)

const handleChange = useCallback(
  (e: ChangeEvent<HTMLInputElement>) => {
    const newFiles = Array.from(e.target.files ?? [])
    updateFiles([...filesRef.current, ...newFiles])
  },
  [updateFiles],  // ← 安定化
)
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Lintチェックでエラーが解消されることを確認
- 既存のテストが通ることを確認