### PR TITLE
refactor(Tooltip): TooltipPortalのuseEffectをref callbackパターンに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FC, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, type ReactNode, useCallback, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useTheme } from '../../hooks/useTheme'
@@ -32,42 +32,42 @@ type VerticalType = 'top' | 'middle' | 'bottom'
 
 export const TooltipPortal: FC<Props> = ({ messageId, message, isVisible, parentRect, isIcon }) => {
   const theme = useTheme()
-  const portalRef = useRef<HTMLDivElement>(null)
   const [style, setStyle] = useState<{ [key: string]: undefined | string }>({})
   const [actualHorizontal, setActualHorizontal] = useState<HorizontalType>('center')
   const [actualVertical, setActualVertical] = useState<VerticalType>('bottom')
 
-  useEffect(() => {
-    if (!portalRef.current || !parentRect) {
-      return
-    }
+  const portalRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element || !parentRect) {
+        return
+      }
 
-    const portal = portalRef.current
+      const action = () => {
+        const vertical = calculateVertical(element.offsetHeight, parentRect)
+        const horizontal = calculateHorizontal(element.offsetWidth, parentRect, theme)
 
-    const action = () => {
-      const vertical = calculateVertical(portal.offsetHeight, parentRect)
-      const horizontal = calculateHorizontal(portal.offsetWidth, parentRect, theme)
+        setStyle({
+          insetBlockStart: vertical.insetBlockStart,
+          insetInlineStart: horizontal.insetInlineStart,
+          insetInlineEnd: horizontal.insetInlineEnd,
+          maxWidth: horizontal.maxWidth,
+          maxHeight: vertical.maxHeight,
+        })
+        setActualVertical(vertical.alignment)
+        setActualHorizontal(horizontal.alignment)
+      }
+      const debouncedAction = debounce(action, 100)
 
-      setStyle({
-        insetBlockStart: vertical.insetBlockStart,
-        insetInlineStart: horizontal.insetInlineStart,
-        insetInlineEnd: horizontal.insetInlineEnd,
-        maxWidth: horizontal.maxWidth,
-        maxHeight: vertical.maxHeight,
-      })
-      setActualVertical(vertical.alignment)
-      setActualHorizontal(horizontal.alignment)
-    }
-    const debouncedAction = debounce(action, 100)
+      action()
 
-    action()
+      window.addEventListener('resize', debouncedAction)
 
-    window.addEventListener('resize', debouncedAction)
-
-    return () => {
-      window.removeEventListener('resize', debouncedAction)
-    }
-  }, [parentRect, theme])
+      return () => {
+        window.removeEventListener('resize', debouncedAction)
+      }
+    },
+    [parentRect, theme],
+  )
 
   const classNames = useMemo(() => {
     const { container, balloon, balloonText } = classNameGenerator()


### PR DESCRIPTION
## 関連URL

なし

## 概要

コードの可読性とメンテナンス性向上のため、TooltipPortalコンポーネントのDOM要素との同期処理をuseRefとuseEffectの組み合わせからref callbackパターンに変更します。

## 変更内容

- `useRef<HTMLDivElement>(null)`と`useEffect`の組み合わせを`useCallback`のref callbackパターンに変更
- DOM要素のマウント・アンマウント、およびparentRect/themeの変更時の処理が、ref callbackの依存配列で明示的に表現されるように
- `portalRef.current`のnullチェックが不要になり、引数の`element`を直接使用

### コード変更

```tsx
// Before
const portalRef = useRef<HTMLDivElement>(null)

useEffect(() => {
  if (!portalRef.current || !parentRect) {
    return
  }
  
  const portal = portalRef.current
  const action = () => { ... }
  // ...
}, [parentRect, theme])

// After
const portalRef = useCallback(
  (element: HTMLDivElement | null) => {
    if (!element || !parentRect) {
      return
    }
    
    const action = () => { ... }
    // ...
  },
  [parentRect, theme],
)
```

### メリット

1. **意図が明確**: DOM要素との同期が`useEffect`より明示的
2. **nullチェックが自然**: `portalRef.current`ではなく引数`element`を直接使用
3. **コードが簡潔**: useRefの宣言が不要

## プロダクト側で対応が必要な事項

なし（内部実装の変更のみで、コンポーネントのインターフェースは変更なし）

## 確認方法

- 既存のStorybookで動作確認
- 既存のテストが通ることを確認
- tooltip位置計算のロジックは変更なし（リグレッションなし）