### PR TITLE
refactor(SingleCombobox): useRefで生成されたrefを依存配列から除外

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -342,7 +342,7 @@ const ActualSingleCombobox = <T,>(
   }, [disabled, readOnly, isFocused, theme.textColor])
 
   useClick(
-    useMemo(() => [outerRef, listBoxRef, clearButtonRef], [outerRef, listBoxRef, clearButtonRef]),
+    useMemo(() => [outerRef, listBoxRef, clearButtonRef], [listBoxRef]),
     isFocused || selectedItem ? NOOP : selectDefaultItem,
     unfocus,
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

React Hooksの依存配列において、`useRef`で生成されたrefオブジェクトは常に同じ参照を保持するため、依存配列に含める必要がありません。コードをクリーンアップするため、不要な依存を削除します。

## 変更内容

- `useClick`の`useMemo`で生成される配列から、コンポーネント内で`useRef`により生成された`outerRef`と`clearButtonRef`を依存配列から除外
- 外部hookから返される`listBoxRef`は依存配列に残す（外部から返されるrefは変更される可能性があるため）

### 変更箇所

```tsx
// Before
useMemo(() => [outerRef, listBoxRef, clearButtonRef], [outerRef, listBoxRef, clearButtonRef])

// After
useMemo(() => [outerRef, listBoxRef, clearButtonRef], [listBoxRef])
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストが全て通過することを確認しました。