### PR TITLE
fix(DropZone): onDrop時にinputのfilesが更新されないのを修正

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.test.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.test.tsx
@@ -5,7 +5,6 @@ import { IntlProvider } from '../../intl'
 
 import { DropZone } from './DropZone'
 
-// FileList のモックヘルパー
 const createFileList = (files: File[]): FileList => {
   const fileList = {
     length: files.length,
@@ -23,9 +22,25 @@ const createFileList = (files: File[]): FileList => {
   return fileList as FileList
 }
 
+// jsdom は input.files への FileList 代入をサポートしないため、セッターをスタブする
+const stubInputFilesSetter = () => {
+  const original = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'files')!
+  beforeEach(() => {
+    Object.defineProperty(HTMLInputElement.prototype, 'files', {
+      ...original,
+      set: vi.fn(),
+    })
+  })
+  afterEach(() => {
+    Object.defineProperty(HTMLInputElement.prototype, 'files', original)
+  })
+}
+
 describe('DropZone', () => {
   describe('onSelectFiles', () => {
     describe('ファイルをドロップした場合', () => {
+      stubInputFilesSetter()
+
       it('onSelectFiles が発火する', () => {
         const onSelectFiles = vi.fn()
         const { container } = render(

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -106,6 +106,9 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         setFilesDraggedOver(false)
 
         if (e.dataTransfer.types.includes('Files')) {
+          if (fileRef.current) {
+            fileRef.current.files = e.dataTransfer.files
+          }
           onSelectFiles(e, e.dataTransfer.files)
         }
       },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

- https://kufuinc.slack.com/archives/CJEUZ4MS6/p1782355173597619

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- #6347 で修正した際にinputのfilesに書き戻す処理を入れ忘れたので修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->
