### PR TITLE
fix(DropdownMenuButton): IconのaltにReactNodeを直接渡すように修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -16,7 +16,6 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
@@ -204,7 +203,7 @@ const TriggerLabelText = memo<{
 
   const Icon = (typeof onlyIconTrigger === 'object' && onlyIconTrigger.component) || FaEllipsisIcon
 
-  return <Icon alt={typeof children === 'string' ? children : innerText(children)} />
+  return <Icon alt={children} />
 })
 
 export const renderButtonList = (children: Actions) =>


### PR DESCRIPTION
## 関連URL

なし

## 概要

DropdownMenuButtonの`onlyIcon`モードで、`FormattedMessage`などのReactNodeをトリガーのchildrenとして渡した場合、Iconの`alt`属性が空文字になってしまう問題を修正します。

## 変更内容

- `react-innertext`のimportを削除
- `TriggerLabelText`コンポーネント内で、`innerText(children)`による文字列変換を削除
- IconコンポーネントのaltにchildrenをReactNodeとして直接渡すように変更

### 変更前後

```tsx
// Before
import innerText from 'react-innertext'

const TriggerLabelText = memo(({ children, onlyIconTrigger }) => {
  if (!onlyIconTrigger) {
    return children
  }

  const Icon = (typeof onlyIconTrigger === 'object' && onlyIconTrigger.component) || FaEllipsisIcon

  return <Icon alt={typeof children === 'string' ? children : innerText(children)} />
})

// After
const TriggerLabelText = memo(({ children, onlyIconTrigger }) => {
  if (!onlyIconTrigger) {
    return children
  }

  const Icon = (typeof onlyIconTrigger === 'object' && onlyIconTrigger.component) || FaEllipsisIcon

  return <Icon alt={children} />
})
```

### 問題の詳細

`innerText(children)`は、`<Hoge>文言</Hoge>`のようにchildrenとして渡されたテキストを抽出する関数です。そのため、`<FormattedMessage defaultMessage="hoge" />`のようにpropsで文言を指定するコンポーネントでは、childrenが存在せず文言を取得できません。

IconコンポーネントのaltプロパティはReactNodeを受け取れる設計になっているため（`alt?: ReactNode`）、条件分岐や文字列変換は不要です。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 特に`onlyIconTrigger`を使用し、childrenに`FormattedMessage`などのReactNodeを渡している場合の動作確認