### PR TITLE
fix(DropdownTrigger): トリガーのdisabled動的切り替え時にメニューが開閉しなくなる問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { act } from 'react'
+import { act, useState } from 'react'
 
 import { Button } from '../Button'
 import { Stack } from '../Layout'
@@ -86,5 +86,48 @@ describe('Dropdown', () => {
     expect(screen.getByRole('button', { name: 'Button3' })).toHaveFocus()
     await userEvent.tab()
     expect(screen.queryByRole('button', { name: 'Button1' })).toBeNull()
+  })
+
+  describe('トリガーボタンの disabled が動的に切り替わる場合', () => {
+    const ToggleTemplate = ({ initialDisabled }: { initialDisabled: boolean }) => {
+      const [disabled, setDisabled] = useState(initialDisabled)
+
+      return (
+        <>
+          <Button onClick={() => setDisabled((d) => !d)}>Toggle</Button>
+          <Dropdown>
+            <DropdownTrigger>
+              <Button disabled={disabled}>Trigger</Button>
+            </DropdownTrigger>
+            <DropdownContent controllable>
+              <Stack>
+                <Button>Button1</Button>
+                <Button>Button2</Button>
+              </Stack>
+            </DropdownContent>
+          </Dropdown>
+        </>
+      )
+    }
+
+    it('disabled から enabled に変わった後、トリガーをクリックするとドロップダウンが開くこと', async () => {
+      const user = userEvent.setup()
+      render(<ToggleTemplate initialDisabled={true} />)
+
+      await user.click(screen.getByRole('button', { name: 'Toggle' }))
+
+      await user.click(screen.getByRole('button', { name: 'Trigger' }))
+      expect(screen.getByRole('button', { name: 'Button1' })).toBeVisible()
+    })
+
+    it('enabled から disabled に変わった後、トリガーをクリックしてもドロップダウンが開かないこと', async () => {
+      const user = userEvent.setup()
+      render(<ToggleTemplate initialDisabled={false} />)
+
+      await user.click(screen.getByRole('button', { name: 'Toggle' }))
+
+      await user.click(screen.getByRole('button', { name: 'Trigger' }))
+      expect(screen.queryByRole('button', { name: 'Button1' })).toBeNull()
+    })
   })
 })

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -101,6 +101,9 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     observer.observe(triggerElement, {
       childList: true,
       subtree: true,
+      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
+      attributes: true,
+      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {


### PR DESCRIPTION
## 関連URL

- 原因PR: #6408

## 概要

v96.1.2 から、`DropdownMenuButton` などでトリガーの `disabled` が動的に切り替わるとメニューの開閉が壊れる不具合が報告されました。

- `disabled` → `enabled` に変えてもメニューが開かない
- `enabled` → `disabled` に変えてもメニューが開いてしまう

`DropdownMenuButton` をはじめ、`DropdownTrigger` を内部で利用するすべてのコンポーネント（FilterDropdown, SortDropdown, AppHeader 配下など）が影響を受けていました。

## 変更内容

原因は #6408 で `DropdownTrigger` の useEffect を `children` 依存から MutationObserver ベースに移行した際、監視対象が `childList` / `subtree` のみで `attributes` を監視していなかったことです。

トリガーボタンの `disabled` / `aria-disabled` が動的に変化しても `setupButton`（開く処理のクリックリスナー貼り直し）が再実行されず、リスナーの付け外しが追従していませんでした。

MutationObserver の監視に `attributes` を追加し、`attributeFilter` で `disabled` / `aria-disabled` のみを対象に絞って追従させるよう修正しました。

``` observer.observe(triggerElement, {
   childList: true,
   subtree: true,
+  // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
+  attributes: true,
+  attributeFilter: ['disabled', 'aria-disabled'],
 })
```

あわせて `Dropdown.test.tsx` に、トリガーの disabled 動的切り替えに対するリグレッションテストを追加しました。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`Dropdown.test.tsx` に追加したテストで確認できます。

- 修正前: 追加したテスト2件が失敗（不具合を再現）
- 修正後: Dropdown 配下のテストおよび smarthr-ui 全体テスト（301 passed）が通過

```
pnpm ui test -- --run src/components/Dropdown/Dropdown.test.tsx
```