### PR TITLE
refactor(Dropdown): コールバック依存配列を安定化

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -83,29 +83,30 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     }
   }, [isChildPortal, portalRoot])
 
+  const activeRef = useRef(active)
+  activeRef.current = active
+
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(() => {
     const result: FC<{ children: ReactNode }> = (props) =>
-      active ? createPortal(props.children) : null
+      activeRef.current ? createPortal(props.children) : null
 
     // set the displayName explicit for DevTools
     result.displayName = 'DropdownContentRoot'
 
     return result
-  }, [active, createPortal])
+  }, [createPortal])
 
   const togglerRef = useRef({
     isPortalRootMounted,
     onOpen,
     onClose,
   })
-  useEffect(() => {
-    togglerRef.current = {
-      isPortalRootMounted,
-      onOpen,
-      onClose,
-    }
-  }, [isPortalRootMounted, onOpen, onClose])
+  togglerRef.current = {
+    isPortalRootMounted,
+    onOpen,
+    onClose,
+  }
 
   useEffect(() => {
     if (togglerRef.current.isPortalRootMounted()) {

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -83,13 +83,23 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     }
   }, [isChildPortal, portalRoot])
 
-  const activeRef = useRef(active)
-  activeRef.current = active
+  const propsRef = useRef({
+    active,
+    isPortalRootMounted,
+    onOpen,
+    onClose,
+  })
+  propsRef.current = {
+    active,
+    isPortalRootMounted,
+    onOpen,
+    onClose,
+  }
 
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(() => {
     const result: FC<{ children: ReactNode }> = (props) =>
-      activeRef.current ? createPortal(props.children) : null
+      propsRef.current.active ? createPortal(props.children) : null
 
     // set the displayName explicit for DevTools
     result.displayName = 'DropdownContentRoot'
@@ -97,20 +107,9 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     return result
   }, [createPortal])
 
-  const togglerRef = useRef({
-    isPortalRootMounted,
-    onOpen,
-    onClose,
-  })
-  togglerRef.current = {
-    isPortalRootMounted,
-    onOpen,
-    onClose,
-  }
-
   useEffect(() => {
-    if (togglerRef.current.isPortalRootMounted()) {
-      togglerRef.current[active ? 'onOpen' : 'onClose']?.()
+    if (propsRef.current.isPortalRootMounted()) {
+      propsRef.current[active ? 'onOpen' : 'onClose']?.()
     }
   }, [active])
 

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -64,14 +64,14 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   const triggerElementRef = useRef<HTMLDivElement>(null)
   const contentId = useId()
 
-  const propsRef = useRef({
+  const unstableRef = useRef({
     active,
     isPortalRootMounted,
     onOpen,
     onClose,
     createPortal,
   })
-  propsRef.current = {
+  unstableRef.current = {
     active,
     isPortalRootMounted,
     onOpen,
@@ -82,7 +82,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(() => {
     const result: FC<{ children: ReactNode }> = (props) =>
-      propsRef.current.active ? propsRef.current.createPortal(props.children) : null
+      unstableRef.current.active ? unstableRef.current.createPortal(props.children) : null
 
     // set the displayName explicit for DevTools
     result.displayName = 'DropdownContentRoot'
@@ -129,8 +129,8 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   }, [isChildPortal, portalRoot, contentId])
 
   useEffect(() => {
-    if (propsRef.current.isPortalRootMounted()) {
-      propsRef.current[active ? 'onOpen' : 'onClose']?.()
+    if (unstableRef.current.isPortalRootMounted()) {
+      unstableRef.current[active ? 'onOpen' : 'onClose']?.()
     }
   }, [active])
 

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -64,54 +64,31 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   const triggerElementRef = useRef<HTMLDivElement>(null)
   const contentId = useId()
 
-  if (portalRoot) {
-    portalRoot.setAttribute('id', contentId)
-  }
-
-  useEffect(() => {
-    const onClickBody = (e: any) => {
-      // ignore events from events within DropdownTrigger and DropdownContent
-      if (!isEventFromChild(e, triggerElementRef.current) && !isChildPortal(e.target)) {
-        setActive(false)
-      }
-    }
-
-    document.body.addEventListener('click', onClickBody, false)
-
-    return () => {
-      document.body.removeEventListener('click', onClickBody, false)
-    }
-  }, [isChildPortal, portalRoot])
-
   const propsRef = useRef({
     active,
     isPortalRootMounted,
     onOpen,
     onClose,
+    createPortal,
   })
   propsRef.current = {
     active,
     isPortalRootMounted,
     onOpen,
     onClose,
+    createPortal,
   }
 
   // This is the root container of a dropdown content located in outside the DOM tree
   const DropdownContentRoot = useMemo<FC<{ children: ReactNode }>>(() => {
     const result: FC<{ children: ReactNode }> = (props) =>
-      propsRef.current.active ? createPortal(props.children) : null
+      propsRef.current.active ? propsRef.current.createPortal(props.children) : null
 
     // set the displayName explicit for DevTools
     result.displayName = 'DropdownContentRoot'
 
     return result
-  }, [createPortal])
-
-  useEffect(() => {
-    if (propsRef.current.isPortalRootMounted()) {
-      propsRef.current[active ? 'onOpen' : 'onClose']?.()
-    }
-  }, [active])
+  }, [])
 
   const memoizedOnClickTrigger = useCallback((rect: Rect) => {
     setActive((current) => {
@@ -131,6 +108,31 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     // return focus to the Trigger
     getFirstTabbable(triggerElementRef)?.focus()
   }, [])
+
+  useEffect(() => {
+    if (portalRoot) {
+      portalRoot.setAttribute('id', contentId)
+    }
+
+    const onClickBody = (e: any) => {
+      // ignore events from events within DropdownTrigger and DropdownContent
+      if (!isEventFromChild(e, triggerElementRef.current) && !isChildPortal(e.target)) {
+        setActive(false)
+      }
+    }
+
+    document.body.addEventListener('click', onClickBody, false)
+
+    return () => {
+      document.body.removeEventListener('click', onClickBody, false)
+    }
+  }, [isChildPortal, portalRoot, contentId])
+
+  useEffect(() => {
+    if (propsRef.current.isPortalRootMounted()) {
+      propsRef.current[active ? 'onOpen' : 'onClose']?.()
+    }
+  }, [active])
 
   return (
     <PortalParentProvider>

--- a/packages/smarthr-ui/src/hooks/usePortal.tsx
+++ b/packages/smarthr-ui/src/hooks/usePortal.tsx
@@ -36,8 +36,8 @@ export function usePortal() {
     }
   }, [currentSeq, parent.seqs])
 
-  const propsRef = useRef({ calculatedSeqs, portalRoot })
-  propsRef.current = { calculatedSeqs, portalRoot }
+  const portalRootRef = useRef(portalRoot)
+  portalRootRef.current = portalRoot
 
   useEnhancedEffect(() => {
     // Next.jsのhydration error回避のため、初回レンダリング時にdivを作成する
@@ -62,23 +62,26 @@ export function usePortal() {
     [currentSeq],
   )
 
-  const PortalParentProvider: FC<{ children: ReactNode }> = useCallback(({ children }) => {
-    const value: ParentContextValue = {
-      seqs: propsRef.current.calculatedSeqs.parentSeqs,
-    }
+  const PortalParentProvider: FC<{ children: ReactNode }> = useCallback(
+    ({ children }) => {
+      const value: ParentContextValue = {
+        seqs: calculatedSeqs.parentSeqs,
+      }
 
-    return <ParentContext.Provider value={value}>{children}</ParentContext.Provider>
-  }, [])
+      return <ParentContext.Provider value={value}>{children}</ParentContext.Provider>
+    },
+    [calculatedSeqs.parentSeqs],
+  )
 
   const wrappedCreatePortal = useCallback((children: ReactNode) => {
-    if (propsRef.current.portalRoot === null) {
+    if (portalRootRef.current === null) {
       return null
     }
 
-    return createPortal(children, propsRef.current.portalRoot)
+    return createPortal(children, portalRootRef.current)
   }, [])
 
-  const isPortalRootMounted = useCallback(() => propsRef.current.portalRoot !== null, [])
+  const isPortalRootMounted = useCallback(() => portalRootRef.current !== null, [])
 
   return {
     portalRoot,

--- a/packages/smarthr-ui/src/hooks/usePortal.tsx
+++ b/packages/smarthr-ui/src/hooks/usePortal.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useContext,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'
@@ -35,9 +34,6 @@ export function usePortal() {
       portalChildOf: parentSeqs.join(','),
     }
   }, [currentSeq, parent.seqs])
-
-  const portalRootRef = useRef(portalRoot)
-  portalRootRef.current = portalRoot
 
   useEnhancedEffect(() => {
     // Next.jsのhydration error回避のため、初回レンダリング時にdivを作成する
@@ -73,15 +69,18 @@ export function usePortal() {
     [calculatedSeqs.parentSeqs],
   )
 
-  const wrappedCreatePortal = useCallback((children: ReactNode) => {
-    if (portalRootRef.current === null) {
-      return null
-    }
+  const wrappedCreatePortal = useCallback(
+    (children: ReactNode) => {
+      if (portalRoot === null) {
+        return null
+      }
 
-    return createPortal(children, portalRootRef.current)
-  }, [])
+      return createPortal(children, portalRoot)
+    },
+    [portalRoot],
+  )
 
-  const isPortalRootMounted = useCallback(() => portalRootRef.current !== null, [])
+  const isPortalRootMounted = useCallback(() => portalRoot !== null, [portalRoot])
 
   return {
     portalRoot,

--- a/packages/smarthr-ui/src/hooks/usePortal.tsx
+++ b/packages/smarthr-ui/src/hooks/usePortal.tsx
@@ -35,6 +35,9 @@ export function usePortal() {
     }
   }, [currentSeq, parent.seqs])
 
+  const propsRef = useRef({ calculatedSeqs, portalRoot })
+  propsRef.current = { calculatedSeqs, portalRoot }
+
   useEnhancedEffect(() => {
     // Next.jsのhydration error回避のため、初回レンダリング時にdivを作成する
     setPortalRoot(document.createElement('div'))
@@ -58,29 +61,23 @@ export function usePortal() {
     [currentSeq],
   )
 
-  const PortalParentProvider: FC<{ children: ReactNode }> = useCallback(
-    ({ children }) => {
-      const value: ParentContextValue = {
-        seqs: calculatedSeqs.parentSeqs,
-      }
+  const PortalParentProvider: FC<{ children: ReactNode }> = useCallback(({ children }) => {
+    const value: ParentContextValue = {
+      seqs: propsRef.current.calculatedSeqs.parentSeqs,
+    }
 
-      return <ParentContext.Provider value={value}>{children}</ParentContext.Provider>
-    },
-    [calculatedSeqs.parentSeqs],
-  )
+    return <ParentContext.Provider value={value}>{children}</ParentContext.Provider>
+  }, [])
 
-  const wrappedCreatePortal = useCallback(
-    (children: ReactNode) => {
-      if (portalRoot === null) {
-        return null
-      }
+  const wrappedCreatePortal = useCallback((children: ReactNode) => {
+    if (propsRef.current.portalRoot === null) {
+      return null
+    }
 
-      return createPortal(children, portalRoot)
-    },
-    [portalRoot],
-  )
+    return createPortal(children, propsRef.current.portalRoot)
+  }, [])
 
-  const isPortalRootMounted = useCallback(() => portalRoot !== null, [portalRoot])
+  const isPortalRootMounted = useCallback(() => propsRef.current.portalRoot !== null, [])
 
   return {
     portalRoot,

--- a/packages/smarthr-ui/src/hooks/usePortal.tsx
+++ b/packages/smarthr-ui/src/hooks/usePortal.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0の`best-practice-for-unstable-dependencies`ルールに対応するため、Dropdownコンポーネントのコールバック依存配列を安定化する。

## 変更内容

- **Dropdown.tsx**: unstableRefパターンを導入し、`onOpen`、`onClose`、`createPortal`などの不安定な依存関係を安定化
  - `DropdownContentRoot`の依存配列を空に変更
  - `portalRoot.setAttribute`をuseEffect内に移動して副作用を一箇所に集約
  - 複数のrefを`unstableRef`に統合してコードを整理

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- テストの通過を確認