### PR TITLE
refactor(FilterDropdown)!: iconAltの型をstringに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -9,7 +9,6 @@ import {
   isValidElement,
   useMemo,
 } from 'react'
-import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
@@ -40,7 +39,7 @@ type AbstractProps = {
   filtered?:
     | boolean
     | {
-        iconAlt?: ReactNode
+        iconAlt?: string
       }
   responseStatus?: ResponseStatus
   onApply: MouseEventHandler<HTMLButtonElement>
@@ -143,10 +142,6 @@ export const FilterDropdown: FC<Props> = ({
     [filtered, trigger.text, applyText, cancelText, resetText, localize],
   )
 
-  const filteredIconAlt = useMemo(
-    () => innerText(decorated.filteredIconAlt),
-    [decorated.filteredIconAlt],
-  )
   const calcedResponseStatus = useResponseStatus(responseStatus)
 
   const classNamesMapper = useMemo(() => {
@@ -190,7 +185,10 @@ export const FilterDropdown: FC<Props> = ({
 
         {filtered && (
           // HINT: altに揃えたいが、styleが複雑になってしまうためaria-labelを利用している
-          <FaCircleCheckIcon aria-label={filteredIconAlt} className={classNames.filteredIcon} />
+          <FaCircleCheckIcon
+            aria-label={decorated.filteredIconAlt}
+            className={classNames.filteredIcon}
+          />
         )}
       </span>
     )
@@ -206,7 +204,7 @@ export const FilterDropdown: FC<Props> = ({
       buttonSuffix: FilterIcon,
       buttonContent: decorated.trigger,
     }
-  }, [filtered, decorated.trigger, trigger.onlyIcon, filteredIconAlt, classNames])
+  }, [filtered, decorated.trigger, decorated.filteredIconAlt, trigger.onlyIcon, classNames])
 
   return (
     <Dropdown onOpen={onOpen} onClose={onClose}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

aria-labelはstring型のみを受け付けるため、FilterDropdownの`filtered.iconAlt`の型をReactNodeからstringに統一し、不要なinnerText変換処理を削除する。

## 変更内容

- **破壊的変更**: `filtered.iconAlt`の型を`ReactNode`から`string`に変更
- `react-innertext`のimportを削除
- `filteredIconAlt`のuseMemoを削除して`decorated.filteredIconAlt`を直接使用
- useMemoの依存配列に`decorated.filteredIconAlt`を追加

### 変更例

```tsx
// Before
<FilterDropdown filtered={{ iconAlt: <span>適用中</span> }} />

// After
<FilterDropdown filtered={{ iconAlt: '適用中' }} />
```

## プロダクト側で対応が必要な事項

`filtered.iconAlt`にReactNodeを渡している場合は、stringに変更する必要があります。

## 確認方法

- Storybookでの動作確認
- テストの通過を確認