### PR TITLE
fix: MutationObserverの属性監視を追加しbutton要素の動的な属性変更に対応

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -78,8 +78,9 @@ export const RemoteDialogTrigger: FC<
     })
 
     observer.observe(currentRef, {
-      childList: true, // 直接の子要素の追加・削除を監視
-      subtree: true, // 子孫要素の変更も監視
+      childList: true,
+      subtree: true,
+      attributes: true,
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
@@ -70,6 +70,7 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
     observer.observe(wrapper, {
       childList: true,
       subtree: true,
+      attributes: true,
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -249,6 +249,7 @@ const ButtonListItem: FC<{ children: ReactElement }> = ({ children }) => {
     observer.observe(listItem, {
       childList: true,
       subtree: true,
+      attributes: true,
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -101,9 +101,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     observer.observe(triggerElement, {
       childList: true,
       subtree: true,
-      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
       attributes: true,
-      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {


### PR DESCRIPTION
## 関連URL

なし

## 概要

RemoteDialogTrigger、DisclosureTrigger、DropdownMenuButton、DropdownTriggerの各コンポーネントで、MutationObserverが属性変更を監視していなかったため、button要素のdisabled属性などが動的に変更された場合に適切に対応できていなかった問題を修正する。

## 変更内容

4つのコンポーネントのMutationObserver設定に`attributes: true`を追加：

- **RemoteDialogTrigger**: `attributes: true`を追加
- **DisclosureTrigger**: `attributes: true`を追加
- **DropdownMenuButton**: `attributes: true`を追加
- **DropdownTrigger**: `attributeFilter`を削除し`attributes: true`を追加（より広範な属性変更を監視）

これにより、button要素のdisabled、aria-disabled、その他の属性が動的に変更された場合も、MutationObserverが検知して適切に再セットアップが実行されるようになる。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストでカバーされている。Storybookで各コンポーネントのbutton要素の属性を動的に変更した場合の動作を確認可能。