### PR TITLE
fix: MutationObserverの属性監視を追加しbutton要素の動的な属性変更に対応

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -80,7 +80,9 @@ export const RemoteDialogTrigger: FC<
     observer.observe(currentRef, {
       childList: true,
       subtree: true,
+      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
       attributes: true,
+      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -78,8 +78,9 @@ export const RemoteDialogTrigger: FC<
     })
 
     observer.observe(currentRef, {
-      childList: true, // 直接の子要素の追加・削除を監視
-      subtree: true, // 子孫要素の変更も監視
+      childList: true,
+      subtree: true,
+      attributes: true,
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
@@ -70,6 +70,7 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
     observer.observe(wrapper, {
       childList: true,
       subtree: true,
+      attributes: true,
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
@@ -70,7 +70,9 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
     observer.observe(wrapper, {
       childList: true,
       subtree: true,
+      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
       attributes: true,
+      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -249,6 +249,7 @@ const ButtonListItem: FC<{ children: ReactElement }> = ({ children }) => {
     observer.observe(listItem, {
       childList: true,
       subtree: true,
+      attributes: true,
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -249,7 +249,9 @@ const ButtonListItem: FC<{ children: ReactElement }> = ({ children }) => {
     observer.observe(listItem, {
       childList: true,
       subtree: true,
+      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
       attributes: true,
+      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -101,7 +101,9 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     observer.observe(triggerElement, {
       childList: true,
       subtree: true,
+      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
       attributes: true,
+      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -101,9 +101,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     observer.observe(triggerElement, {
       childList: true,
       subtree: true,
-      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
       attributes: true,
-      attributeFilter: ['disabled', 'aria-disabled'],
     })
 
     return () => {


### PR DESCRIPTION
## 関連URL

なし

## 概要

複数のコンポーネントでMutationObserverに`attributes: true`を追加し、button要素の`disabled`や`aria-disabled`属性が動的に変更された場合も正しく検知できるようにしました。

## 変更内容

以下のコンポーネントでMutationObserverの設定に`attributes: true`を追加：

- `RemoteDialogTrigger`
- `DisclosureTrigger`
- `DropdownMenuButton`
- `DropdownTrigger`

これにより、ボタン要素の属性が動的に変更された場合（例: disabledの追加/削除）も、MutationObserverが検知してイベントリスナーを適切に更新できるようになります。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認