### PR TITLE
refactor(Localizer): コンポーネントをmemo化して不要な再レンダリングを防止

### DIFF
--- a/packages/smarthr-ui/src/intl/Localizer.tsx
+++ b/packages/smarthr-ui/src/intl/Localizer.tsx
@@ -1,9 +1,9 @@
 'use client'
 
+import { type ComponentProps, memo } from 'react'
 import { FormattedMessage as ReactIntlFormattedMessage } from 'react-intl'
 
 import type { typedJa } from './locales'
-import type { ComponentProps } from 'react'
 
 type Messages = Record<keyof typeof typedJa, string>
 
@@ -13,7 +13,7 @@ type Props<Id extends keyof Messages> = {
   values?: ComponentProps<typeof ReactIntlFormattedMessage>['values']
 }
 
-export const Localizer = <ID extends keyof Messages>({
+const LocalizerInner = <ID extends keyof Messages>({
   values,
   id,
   defaultText,
@@ -26,3 +26,7 @@ export const Localizer = <ID extends keyof Messages>({
     values={{ ...values, break: values?.break ?? <br /> }}
   />
 )
+
+// eslint-disable-next-line smarthr/best-practice-for-no-unnecessary-variable
+const typedMemo: <T>(c: T) => T = memo
+export const Localizer = typedMemo(LocalizerInner)


### PR DESCRIPTION
## 関連URL

なし

## 概要

Localizerコンポーネントをmemo化することで、パフォーマンスを改善します。

## 変更内容

- `Localizer`コンポーネントを`memo`でラップ
- ジェネリクス型を保持するために`typedMemo`パターンを使用
- propsが変わらない限り再レンダリングを防ぐことで、パフォーマンスを改善

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが全て通ることを確認
- Storybookで動作確認