### PR TITLE
refactor(BarChart): tooltipの書き換え禁止を緩和して保護したいものだけ書き換えできないように修正

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -3,6 +3,7 @@ import { chartJsOptionsExamples, multiSmall, singleSmall } from '../__stories__/
 import { BarChart } from './BarChart'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { TooltipItem } from 'chart.js'
 
 const meta: Meta<typeof BarChart> = {
   title: 'Charts/BarChart',
@@ -108,6 +109,48 @@ export const WithAnnotations: Story = {
               yMax: 10,
               borderColor: 'rgb(255, 99, 132)',
               borderWidth: 2,
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const additionalData = {
+  datasets: [
+    {
+      data: ['Aの補足情報', 'Bの補足情報', 'Cの補足情報', 'Dの補足情報', 'Eの補足情報'],
+    },
+  ],
+}
+export const WithTooltipCallbacks: Story = {
+  name: 'with tooltip callbacks options',
+  args: {
+    data: singleSmall,
+    options: {
+      plugins: {
+        tooltip: {
+          titleColor: '#ED1A3D', // 保護しているプロパティの上書きができないことの検証
+          callbacks: {
+            label: function (context: TooltipItem<'bar'>) {
+              // 本来表示するラベル
+              let label = context.dataset.label || ''
+              if (label) {
+                label += ': '
+              }
+              // 単位を付与する
+              if (context.parsed.y !== null) {
+                label += context.parsed.y + '人'
+              }
+              // 補足情報を追加する
+              const additionalDataLabel =
+                additionalData.datasets[context.datasetIndex].data[context.dataIndex]
+              if (additionalDataLabel) {
+                label += `（${additionalDataLabel}）`
+              }
+
+              return label
             },
           },
         },

--- a/packages/charts/src/config/chartConfig.test.ts
+++ b/packages/charts/src/config/chartConfig.test.ts
@@ -86,16 +86,14 @@ describe('createBarChartOptions', () => {
     expect(result.plugins?.tooltip?.cornerRadius).toBe(4)
   })
 
-  it('tooltipの保護対象外のの設定が追加できること', () => {
-    const labelCallback = (context: TooltipItem<'bar'>) => {
-      return 'hello world'
-    }
+  it('tooltipの保護対象外の設定が追加できること', () => {
+    const labelCallback = (_context: TooltipItem<'bar'>) => 'hello world'
     const result = createBarChartOptions({
       plugins: {
         tooltip: {
           callbacks: {
-            label: labelCallback
-          }
+            label: labelCallback,
+          },
         } as ChartOptions<'bar'>['plugins']['tooltip'],
       },
     })

--- a/packages/charts/src/config/chartConfig.test.ts
+++ b/packages/charts/src/config/chartConfig.test.ts
@@ -8,7 +8,7 @@ import {
   createRadarChartOptions,
 } from './chartConfig'
 
-import type { ChartOptions } from 'chart.js'
+import type { ChartOptions, TooltipItem } from 'chart.js'
 
 describe('createBarChartOptions', () => {
   it('外部オプションと内部デフォルトを深くマージすること', () => {
@@ -63,7 +63,7 @@ describe('createBarChartOptions', () => {
     expect(result.scales?.x?.grid?.lineWidth).toBe(2)
   })
 
-  it('tooltipの設定が外部から上書きできないこと（保護されている）', () => {
+  it('tooltipの装飾の設定が外部から上書きできないこと', () => {
     const result = createBarChartOptions({
       plugins: {
         tooltip: {
@@ -84,6 +84,24 @@ describe('createBarChartOptions', () => {
     expect(result.plugins?.tooltip?.borderColor).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
     expect(result.plugins?.tooltip?.borderWidth).toBe(1)
     expect(result.plugins?.tooltip?.cornerRadius).toBe(4)
+  })
+
+  it('tooltipの保護対象外のの設定が追加できること', () => {
+    const labelCallback = (context: TooltipItem<'bar'>) => {
+      return 'hello world'
+    }
+    const result = createBarChartOptions({
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: labelCallback
+          }
+        } as ChartOptions<'bar'>['plugins']['tooltip'],
+      },
+    })
+
+    // 内部のtooltip設定が保持される（外部設定は無視される）
+    expect(result.plugins?.tooltip?.callbacks.label).toBe(labelCallback)
   })
 
   it('その他のplugin設定は外部から追加できること', () => {

--- a/packages/charts/src/config/chartConfig.ts
+++ b/packages/charts/src/config/chartConfig.ts
@@ -108,13 +108,16 @@ const createBaseChartOptions = <T extends ChartType>({
 
   const internalLegendLabels = generateLegendOptions(chartType)
 
-  // 外部pluginsからtooltipを除外（内部設定を保護するため）
-  const { tooltip: _tooltip, ...pluginsRest } = options.plugins || {}
-
-  // 外部オプションからplugins.tooltipを除外したオプションを作成
+  // 外部オプションからinternalTooltipConfigの指定を保護したオプションを作成
   const safeExternalOptions = {
     ...options,
-    plugins: pluginsRest,
+    plugins: {
+      ...options.plugins,
+      tooltip: {
+        ...options.plugins.tooltip,
+        ...internalTooltipConfig,
+      },
+    },
   }
 
   const baseDefaults = {
@@ -123,7 +126,7 @@ const createBaseChartOptions = <T extends ChartType>({
     maintainAspectRatio: false,
     events: ['mousemove', 'mouseout', 'click', 'touchstart', 'touchmove', 'keydown', 'keyup'],
     plugins: {
-      ...pluginsRest,
+      ...options.plugins,
       legend: {
         position: 'bottom' as const,
         labels: internalLegendLabels,

--- a/packages/charts/src/config/chartConfig.ts
+++ b/packages/charts/src/config/chartConfig.ts
@@ -114,7 +114,7 @@ const createBaseChartOptions = <T extends ChartType>({
     plugins: {
       ...options.plugins,
       tooltip: {
-        ...options.plugins.tooltip,
+        ...(options.plugins?.tooltip ?? {}),
         ...internalTooltipConfig,
       },
     },


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

Chartコンポーネントのtooltipオプションは現状利用側から一切の書き換えが出来ないようになっているが、コードベースからその目的は装飾の保護であり、一切のオプションの変更を許したくないものではないように読み取れます。

HRアナリティクスの対応にてtooltip上に単位や補足情報を表示するために`tooltip.callbacks.label`でラベルに追加情報を挿入したく、保護したいもの以外は利用側で宣言できるように制限を緩和したいです。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- `packages/charts/src/config/chartConfig.ts`にて、tooltipのオプションの書き換えを「利用側の指定を完全に無視」から、「利用側の指定に対して、保護したいプロパティを上書き」になるよう変更しました

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

- 特にありません

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

`BarChart`コンポーネントのStoryにて「with tooltip callbacks options」という追加情報の反映と保護ルールの書き換え防止をチェックするシナリオを追加しており、こちらで挙動の検証をしています
