### PR TITLE
fix(charts): chartConfig.testの型エラーを修正

### DIFF
--- a/packages/charts/src/config/chartConfig.test.ts
+++ b/packages/charts/src/config/chartConfig.test.ts
@@ -8,7 +8,7 @@ import {
   createRadarChartOptions,
 } from './chartConfig'
 
-import type { ChartOptions, TooltipItem } from 'chart.js'
+import type { ChartOptions, LinearScaleOptions, TooltipItem } from 'chart.js'
 
 describe('createBarChartOptions', () => {
   it('外部オプションと内部デフォルトを深くマージすること', () => {
@@ -22,11 +22,11 @@ describe('createBarChartOptions', () => {
     })
 
     // 内部設定が保持される
-    expect(result.scales?.y?.beginAtZero).toBe(true)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.beginAtZero).toBe(true)
     expect(result.scales?.y?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
 
     // 外部設定が反映される
-    expect(result.scales?.y?.ticks?.stepSize).toBe(50)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.ticks?.stepSize).toBe(50)
     expect(result.scales?.y?.grid?.display).toBe(false)
   })
 
@@ -40,7 +40,7 @@ describe('createBarChartOptions', () => {
     })
 
     expect(result.scales?.y?.suggestedMax).toBe(150)
-    expect(result.scales?.y?.beginAtZero).toBe(true)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.beginAtZero).toBe(true)
   })
 
   it('x軸のgrid設定も深くマージされること', () => {
@@ -128,7 +128,7 @@ describe('createBarChartOptions', () => {
         y: {
           ticks: { stepSize: 50 },
           suggestedMax: 150,
-          grid: { drawBorder: false },
+          grid: { drawTicks: false },
         },
       },
     })
@@ -139,11 +139,32 @@ describe('createBarChartOptions', () => {
     expect(result.scales?.x?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
 
     // y軸の設定
-    expect(result.scales?.y?.beginAtZero).toBe(true)
-    expect(result.scales?.y?.ticks?.stepSize).toBe(50)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.beginAtZero).toBe(true)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.ticks?.stepSize).toBe(50)
     expect(result.scales?.y?.suggestedMax).toBe(150)
-    expect(result.scales?.y?.grid?.drawBorder).toBe(false)
+    expect(result.scales?.y?.grid?.drawTicks).toBe(false)
     expect(result.scales?.y?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
+  })
+
+  it('scaleのborder設定（Chart.js v4でgrid.drawBorderの後継）が深くマージされること', () => {
+    const result = createBarChartOptions({
+      scales: {
+        y: {
+          border: {
+            display: false,
+            width: 2,
+          },
+        },
+      },
+    })
+
+    // 外部設定が反映される
+    expect(result.scales?.y?.border?.display).toBe(false)
+    expect(result.scales?.y?.border?.width).toBe(2)
+
+    // 内部設定が保持される
+    expect(result.scales?.y?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.beginAtZero).toBe(true)
   })
 })
 
@@ -162,7 +183,7 @@ describe('createLineChartOptions', () => {
     expect(result.scales?.y?.grid?.color).toBe(SMARTHR_DEFAULT_COLORS.BORDER)
 
     // 外部設定が反映される
-    expect(result.scales?.y?.ticks?.stepSize).toBe(50)
+    expect((result.scales?.y as LinearScaleOptions | undefined)?.ticks?.stepSize).toBe(50)
     expect(result.scales?.y?.grid?.display).toBe(false)
   })
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`packages/charts/src/config/chartConfig.test.ts` に型エラーが存在していた。

これらのエラーはビルド用の `tsconfig.build.json` がテストファイルを除外しているため `lint:tsc` では検出されず、IDE（ベースの `tsconfig.json`）でのみ検出される状態だった。実害として、エディタ上で型エラーが表示され続けていた。

## 変更内容

型エラー8件を解消し、あわせて誤ったテストを修正した。

- **linearスケール固有プロパティへのアクセス**: `result.scales?.y?.beginAtZero` / `ticks?.stepSize` は、`scales.y` がChart.jsの全スケール型のユニオンになっているため参照できなかった。linearスケール特有のプロパティなので `LinearScaleOptions` にキャストして参照するように修正。
- **Chart.js v4で削除された `grid.drawBorder`**: v4 で `GridLineOptions` から削除され `scale.border` に移行済みの架空プロパティをテストしていた。`deepmerge` が型を無視してマージするためテストは通っていたが実質無意味だったため、実在する `grid.drawTicks` に置換。
- **borderのテストを追加**: `drawBorder` の後継である `scale.border`（`border.display` / `border.width`）の deep merge を検証するテストを1件追加。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`packages/charts` で以下を実行し、いずれも通ることを確認済み。

- `npx tsc --noEmit -p tsconfig.json`（テストファイルを含むベース設定）で型エラーなし
- `npx vitest --run src/config/chartConfig.test.ts` で 19 tests passed
- eslint / prettier クリーン