### PR TITLE
refactor(FormControl): label.textの依存配列問題をMutationObserverで解決

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -422,17 +422,11 @@ const LabelCluster = memo<
     statusLabels,
     labelTextRef,
   }) => {
-    const labelTextElement = (
-      <span ref={labelTextRef}>
-        <Text styleType={labelType} icon={labelIcon}>
-          {label}
-        </Text>
-      </span>
-    )
-
     const body = (
       <>
-        {labelTextElement}
+        <Text styleType={labelType} icon={labelIcon} ref={labelTextRef}>
+          {label}
+        </Text>
         <StatusLabelCluster statusLabels={statusLabels} />
       </>
     )

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -424,8 +424,8 @@ const LabelCluster = memo<
   }) => {
     const body = (
       <>
-        <Text styleType={labelType} icon={labelIcon} ref={labelTextRef}>
-          {label}
+        <Text styleType={labelType} icon={labelIcon}>
+          <span ref={labelTextRef}>{label}</span>
         </Text>
         <StatusLabelCluster statusLabels={statusLabels} />
       </>

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -422,11 +422,17 @@ const LabelCluster = memo<
     statusLabels,
     labelTextRef,
   }) => {
-    const body = (
-      <>
+    const labelTextElement = (
+      <span ref={labelTextRef}>
         <Text styleType={labelType} icon={labelIcon}>
           {label}
         </Text>
+      </span>
+    )
+
+    const body = (
+      <>
+        {labelTextElement}
         <StatusLabelCluster statusLabels={statusLabels} />
       </>
     )
@@ -467,9 +473,7 @@ const LabelCluster = memo<
     return (
       <>
         {attrs.visuallyHidden && (
-          <VisuallyHiddenText {...attrs.visuallyHidden} ref={labelTextRef}>
-            {body}
-          </VisuallyHiddenText>
+          <VisuallyHiddenText {...attrs.visuallyHidden}>{body}</VisuallyHiddenText>
         )}
         {attrs.label && (
           <Cluster
@@ -478,7 +482,7 @@ const LabelCluster = memo<
             // 常にmargin-topを0にする
             className="[&&&]:shr--mt-0"
           >
-            <Cluster {...attrs.label} align="center" className={labelClassName} ref={labelTextRef}>
+            <Cluster {...attrs.label} align="center" className={labelClassName}>
               {body}
             </Cluster>
             {subActionArea && <div className="shr-grow">{subActionArea}</div>}

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -15,7 +15,6 @@ import {
   useState,
 } from 'react'
 import { useId } from 'react'
-import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
@@ -169,6 +168,7 @@ export const ActualFormControl: FC<Props> = ({
   const managedHtmlFor = label.htmlFor || childInputId || defaultHtmlFor
   const managedLabelId = label.id || defaultLabelId
   const inputWrapperRef = useRef<HTMLDivElement>(null)
+  const labelTextRef = useRef<HTMLElement>(null)
   const isFieldset = as === 'fieldset'
 
   const describedbyIds = useMemo(() => {
@@ -298,33 +298,46 @@ export const ActualFormControl: FC<Props> = ({
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
   useEffect(() => {
-    if (!isFieldset || !inputWrapperRef.current) return
+    if (!isFieldset || !inputWrapperRef.current || !labelTextRef.current) return
 
-    const inputs =
-      inputWrapperRef.current.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
+    const updateAriaLabels = () => {
+      const labelText = labelTextRef.current?.textContent || ''
+      if (!labelText) return
 
-    if (!inputs.length) return
+      const inputs =
+        inputWrapperRef.current!.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
+      if (!inputs.length) return
 
-    const legendText = innerText(label.text)
+      inputs.forEach((input: HTMLInputElement) => {
+        const accessibleName =
+          input.getAttribute('aria-label') ||
+          (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
+            ? input.labels[0].textContent
+            : '')
 
-    if (!legendText) return
+        if (
+          accessibleName &&
+          !accessibleName.includes(labelText) &&
+          !labelText.includes(accessibleName)
+        ) {
+          input.setAttribute('aria-label', `${accessibleName} ${labelText}`)
+        }
+      })
+    }
 
-    inputs.forEach((input: HTMLInputElement) => {
-      const accessibleName =
-        input.getAttribute('aria-label') ||
-        (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
-          ? input.labels![0].textContent
-          : '')
+    // 初回実行
+    updateAriaLabels()
 
-      if (
-        accessibleName &&
-        !accessibleName.includes(legendText) &&
-        !legendText.includes(accessibleName)
-      ) {
-        input.setAttribute('aria-label', `${accessibleName} ${legendText}`)
-      }
+    // label要素の変更を監視
+    const observer = new MutationObserver(updateAriaLabels)
+    observer.observe(labelTextRef.current, {
+      childList: true,
+      subtree: true,
+      characterData: true,
     })
-  }, [isFieldset, label.text])
+
+    return () => observer.disconnect()
+  }, [isFieldset])
 
   let body = (
     <>
@@ -375,6 +388,7 @@ export const ActualFormControl: FC<Props> = ({
         statusLabels={actualStatusLabels}
         subActionArea={subActionArea}
         labelClassName={classNames.label}
+        labelTextRef={labelTextRef}
       />
       {body}
     </Stack>
@@ -392,6 +406,7 @@ const LabelCluster = memo<
     managedLabelId: string
     labelClassName: string
     statusLabels: StatusLabelType[]
+    labelTextRef: React.RefObject<HTMLElement>
   }
 >(
   ({
@@ -405,6 +420,7 @@ const LabelCluster = memo<
     subActionArea,
     labelClassName,
     statusLabels,
+    labelTextRef,
   }) => {
     const body = (
       <>
@@ -451,12 +467,8 @@ const LabelCluster = memo<
     return (
       <>
         {attrs.visuallyHidden && (
-          <VisuallyHiddenText {...attrs.visuallyHidden}>
-            {
-              // HINT: innerTextでは正しく文字が取得できない場合がある
-              // 安全策としてinnerTextが空を取得してきたらbody自体を埋めこみます
-              innerText(body) || body
-            }
+          <VisuallyHiddenText {...attrs.visuallyHidden} ref={labelTextRef}>
+            {body}
           </VisuallyHiddenText>
         )}
         {attrs.label && (
@@ -466,7 +478,7 @@ const LabelCluster = memo<
             // 常にmargin-topを0にする
             className="[&&&]:shr--mt-0"
           >
-            <Cluster {...attrs.label} align="center" className={labelClassName}>
+            <Cluster {...attrs.label} align="center" className={labelClassName} ref={labelTextRef}>
               {body}
             </Cluster>
             {subActionArea && <div className="shr-grow">{subActionArea}</div>}

--- a/packages/smarthr-ui/src/components/FormControl/stories/FormControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/stories/FormControl.stories.tsx
@@ -5,6 +5,7 @@ import { FaAddressBookIcon } from '../../Icon'
 import { CurrencyInput, Input } from '../../Input'
 import { InputFile } from '../../InputFile'
 import { Cluster, Stack } from '../../Layout'
+import { RadioButton } from '../../RadioButton'
 import { Select } from '../../Select'
 import { StatusLabel } from '../../StatusLabel'
 import { STYLE_TYPE_MAP } from '../../Text'
@@ -201,5 +202,27 @@ export const SupplementaryMessage: StoryObj<typeof FormControl> = {
   name: 'supplementaryMessage',
   args: {
     supplementaryMessage: '入力要素に紐づく補足メッセージ',
+  },
+}
+
+export const AsFieldset: StoryObj<typeof FormControl> = {
+  name: 'as="fieldset"（legend文言のaria-label追加を確認）',
+  args: {
+    as: 'fieldset',
+    label: '性別',
+    statusLabels: <StatusLabel type="grey">任意</StatusLabel>,
+    children: (
+      <Stack gap={0.5}>
+        <RadioButton name="gender" value="male" aria-label="hoge">
+          男性
+        </RadioButton>
+        <RadioButton name="gender" value="female">
+          女性
+        </RadioButton>
+        <RadioButton name="gender" value="other">
+          その他
+        </RadioButton>
+      </Stack>
+    ),
   },
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

eslint-config-smarthr@14.7.0の`best-practice-for-unstable-dependencies`ルールに対応するため、FormControlコンポーネントのlabel.text依存配列問題を解決する。

label.textはReactNode型で不安定な参照のため、従来の`innerText(label.text)`による文字列化では以下の問題があった：
- label.textの参照変更のたびに不要な再実行が発生
- 複雑なReactNode（カスタムコンポーネントのpropsなど）から正確なテキストを抽出できない

これをMutationObserverで実際のDOM textContentを監視することで解決する。

## 変更内容

- **labelTextRefの追加**: label/legend要素への参照を保持
- **MutationObserverの導入**: DOM内容の変更を監視してaria-labelを更新
- **正確なテキスト取得**: `innerText(label.text)`から`labelTextRef.current.textContent`に変更
- **不要な処理の削除**: `innerText(body) || body`を単純に`{body}`に変更（VisuallyHiddenTextはReactNodeをそのまま受け取れる）
- **react-innertextのimport削除**: 不要になったため削除

これにより以下を実現：
- label.textの参照変更による不要な再実行を完全に防止
- 実際にレンダリングされたテキストから正確な文字列を取得
- アクセシビリティ要件（WCAG 2.1 Label in Name）を正確に満たす

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認（特にFieldsetとして使用される場合）
- テストの通過を確認