### PR TITLE
fix(SingleCombobox): onChangeInputの発火タイミングを修正

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -182,13 +182,17 @@ const ActualSingleCombobox = <T,>(
         onSelect?.(selected)
         onChangeSelected?.(selected)
 
-        // 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
-        onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
-
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
         requestAnimationFrame(() => {
           setIsExpanded(false)
+          // HINT:
+          // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
+          // - 対応するdropdownを閉じて以降にonChangeInputを発火する必要がある
+          //   - 先にclearしてしまうと意図せずこの要素のドロップダウンを閉じる前に他要素の再レンダリングを引き起こす可能性がある
+          //   - 例えばFilterDropdownなどで当comboboxを使っている場合、レイアウト上comboboxのdropdown以下の要素がクリックされた扱いになってしまい
+          //     FilterDropdownを意図せず閉じてしまうなどの挙動のバグを引き起こす可能性がある
+          onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
         })
 
         setIsEditing(false)


### PR DESCRIPTION
## 関連URL

なし

## 概要

FilterDropdown内でSingleComboboxを使った際に、選択時に親の再レンダリングが発生してFilterDropdownが意図せず閉じてしまう問題を修正。

## 変更内容

`onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)` の発火タイミングを `requestAnimationFrame` 内、かつ `setIsExpanded(false)` の後に移動しました。

### 修正前の挙動

1. 選択肢をクリック
2. すぐに `onChangeInput` が発火
3. 親コンポーネントが再レンダリング
4. レイアウト上の位置が変わり、ドロップダウン以下の要素がクリックされた扱いになる
5. FilterDropdownが意図せず閉じてしまう

### 修正後の挙動

1. 選択肢をクリック
2. `setIsExpanded(false)` でドロップダウンを閉じる
3. その後 `onChangeInput` が発火
4. 親コンポーネントが再レンダリングされても、既にドロップダウンは閉じているため影響しない

## プロダクト側で対応が必要な事項

なし

## 確認方法

FilterDropdown内でSingleComboboxを使用しているストーリーで、選択時にFilterDropdownが意図せず閉じないことを確認してください。