### PR TITLE
chore: lint/formatルールの適用漏れを修正

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
@@ -130,7 +130,6 @@ const ActualCluster = <T extends ElementType = 'div'>(
     [inline, gaps.row, gaps.column, align, justify, className],
   )
 
-  // eslint-disable-next-line smarthr/best-practice-for-no-unnecessary-variable -- Componentは useSectionWrapper と JSX の2箇所で使用されているため誤検知
   const Component = as || 'div'
   const Wrapper = useSectionWrapper(Component)
   // ポリモーフィックコンポーネント: asプロパティで要素型を動的に変更可能なため、


### PR DESCRIPTION
## 関連URL

なし

## 概要

masterブランチでlint/formatルールの適用漏れがあったファイルを修正する。

## 変更内容

- `Cluster.tsx`: 不要になったESLint disableコメントを削除

`pnpm ui format`実行時に他のファイル（useButtonWrapper.tsx等）も変更されたが、lint-stagedによって自動的に元に戻された。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm ui lint`が警告なく通ることを確認