### PR TITLE
fix(Dialog): IME 変換中の Tab がフォーカストラップに奪われないようにする

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { type FC, useRef, useState } from 'react'
 
@@ -119,6 +119,32 @@ describe('Dialog', () => {
     expect(screen.getByRole('button', { name: 'close' })).toHaveFocus()
     await userEvent.tab()
     expect(screen.getByRole('textbox', { name: 'dialog_datepicker' })).toHaveFocus()
+  })
+
+  it('IME 変換中の Tab はフォーカストラップの対象外になること', async () => {
+    renderWithIntl(<DialogTemplate />)
+
+    await userEvent.tab()
+    await userEvent.keyboard('{enter}')
+    expect(screen.getByRole('dialog', { name: 'Dialog' })).toBeVisible()
+
+    // ダイアログ内の最後の tabbable 要素 (close ボタン) にフォーカスを移し、
+    // 通常であれば Tab で最初の要素に戻る（preventDefault される）状態を再現する。
+    const closeButton = screen.getByRole('button', { name: 'close' })
+    closeButton.focus()
+    expect(closeButton).toHaveFocus()
+
+    // IME 変換中 (isComposing: true) の Tab では preventDefault されないことを確認する。
+    // このとき、フォーカスは Tab の本来の挙動 (IME の変換候補選択) に委ねられ、
+    // FocusTrap は介入しない。
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      isComposing: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    fireEvent(closeButton, event)
+    expect(event.defaultPrevented).toBe(false)
   })
 
   const DialogTemplateWithFocusTrap: FC = () => {

--- a/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
@@ -33,7 +33,10 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || innerRef.current === null) {
+      // IME 変換中の Tab は変換候補の選択に使われるため、フォーカストラップの対象外にする。
+      // ここで preventDefault してしまうと、Dialog 内で日本語入力中に Tab を押しても
+      // 変換候補が確定されず、未確定文字列がそのまま入力されてしまう。
+      if (e.key !== 'Tab' || e.isComposing || innerRef.current === null) {
         return
       }
 


### PR DESCRIPTION
## 関連URL

- 発見元 (社内): https://github.com/kufu/utsuwa/pull/13906 （utsuwa 側で workaround を先行して入れた PR）

## 概要

Dialog 内の Textarea や Input で日本語入力中に、IME の変換候補を Tab キーで選択しようとすると、`FocusTrap` が `window` レベルの `keydown` リスナーで Tab を `preventDefault` してしまい、変換候補が確定されず未確定文字列がそのまま入力されてしまう不具合を修正します。

### 再現手順

1. Dialog（例: 内部に tabbable な要素が1つだけある小さな Dialog）を開く
2. Textarea や Input に日本語で入力する（例: `てんp`）
3. 変換候補が表示された状態で Tab キーを押して候補を選択しようとする

**期待動作**: 変換候補（例:「テンプレート」）が確定される。
**現状**: `てんp` のような未確定文字列がそのまま確定され、変換候補は捨てられる。

Dialog 内の tabbable 要素が1つだけ（`firstTabbable === lastTabbable`）になるケースでは、Tab 押下時に必ず `preventDefault` ルートを通るため、この問題が顕在化しやすくなります。

## 変更内容

`FocusTrap` の keydown ハンドラで `e.isComposing` を判定し、IME 変換中の Tab はフォーカストラップの対象外にします。

```diff
 const handleKeyDown = (e: KeyboardEvent) => {
-  if (e.key !== 'Tab' || innerRef.current === null) {
+  // IME 変換中の Tab は変換候補の選択に使われるため、フォーカストラップの対象外にする。
+  if (e.key !== 'Tab' || e.isComposing || innerRef.current === null) {
     return
   }
```

あわせて、`Dialog.test.tsx` に IME 変換中の Tab (`isComposing: true`) に対して `preventDefault` されないことを検証するテストを追加しています。

## プロダクト側で対応が必要な事項

なし（後方互換の修正）。

Dialog 内で IME 変換中に Tab を扱うために各プロダクトが個別に workaround を入れている場合、本 PR がリリースされた後は不要になります。

## 確認方法

- `pnpm ui test --run src/components/Dialog/Dialog.test.tsx` で新規テストを含む 5 テストが通ることを確認できます
- 修正前の `FocusTrap.tsx` に戻すと、新規テストは `expected false to be true`（`defaultPrevented` が `true` になる）で失敗します
- ローカルで `pnpm ui lint` が通ることを確認しています
