### PR TITLE
feat: useLatestフックを追加してunstableRefパターンを改善

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -211,7 +211,7 @@ const ActualSingleCombobox = <T,>(
   const [isComposing, setIsComposing] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
 
-  const latests = useLatest({
+  const latest = useLatest({
     onChange,
     onChangeInput,
     onAdd,
@@ -247,8 +247,8 @@ const ActualSingleCombobox = <T,>(
     onAdd,
     onSelect: useCallback(
       (selected: ComboboxItem<T>) => {
-        latests.onSelect?.(selected)
-        latests.onChangeSelected?.(selected)
+        latest.onSelect?.(selected)
+        latest.onChangeSelected?.(selected)
 
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
@@ -260,12 +260,12 @@ const ActualSingleCombobox = <T,>(
           //   - 先にclearしてしまうと意図せずこの要素のドロップダウンを閉じる前に他要素の再レンダリングを引き起こす可能性がある
           //   - 例えばFilterDropdownなどで当comboboxを使っている場合、レイアウト上comboboxのdropdown以下の要素がクリックされた扱いになってしまい
           //     FilterDropdownを意図せず閉じてしまうなどの挙動のバグを引き起こす可能性がある
-          latests.onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
+          latest.onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
         })
 
         setIsEditing(false)
       },
-      [latests],
+      [latest],
     ),
     isExpanded,
     isLoading,
@@ -274,42 +274,42 @@ const ActualSingleCombobox = <T,>(
   })
 
   const selectDefaultItem = useCallback(() => {
-    if (latests.onSelect && latests.defaultItem) {
-      latests.onSelect(latests.defaultItem)
+    if (latest.onSelect && latest.defaultItem) {
+      latest.onSelect(latest.defaultItem)
     }
-  }, [latests])
+  }, [latest])
 
   const focus = useCallback(() => {
-    latests.onFocus?.()
+    latest.onFocus?.()
     inputRef.current?.focus()
     setIsFocused(true)
 
-    if (!latests.isFocused) {
+    if (!latest.isFocused) {
       setIsExpanded(true)
     }
-  }, [latests])
+  }, [latest])
   const unfocus = useCallback(() => {
-    if (!latests.isFocused) return
+    if (!latest.isFocused) return
 
-    latests.onBlur?.()
+    latest.onBlur?.()
 
     setIsFocused(false)
     setIsExpanded(false)
     setIsEditing(false)
 
-    if (latests.selectedItem) {
-      setInputValue(innerText(latests.selectedItem.label))
+    if (latest.selectedItem) {
+      setInputValue(innerText(latest.selectedItem.label))
     } else {
       selectDefaultItem()
     }
-  }, [latests, selectDefaultItem])
+  }, [latest, selectDefaultItem])
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
 
       let isExecutedPreventDefault = false
 
-      latests.onClearClick?.({
+      latest.onClearClick?.({
         ...e,
         preventDefault: () => {
           e.preventDefault()
@@ -318,8 +318,8 @@ const ActualSingleCombobox = <T,>(
       })
 
       if (!isExecutedPreventDefault) {
-        latests.onClear?.()
-        latests.onChangeSelected?.(null)
+        latest.onClear?.()
+        latest.onChangeSelected?.(null)
 
         inputRef.current?.focus()
 
@@ -327,7 +327,7 @@ const ActualSingleCombobox = <T,>(
         setIsExpanded(true)
       }
     },
-    [latests],
+    [latest],
   )
   const onClickInput = useCallback(
     (e: MouseEvent) => {
@@ -339,40 +339,40 @@ const ActualSingleCombobox = <T,>(
 
       inputRef.current?.focus()
 
-      if (!latests.isExpanded) {
+      if (!latest.isExpanded) {
         setIsExpanded(true)
       }
     },
-    [disabled, readOnly, latests],
+    [disabled, readOnly, latest],
   )
   const actualOnChangeInput = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      latests.onChange?.(e)
-      latests.onChangeInput?.(e)
+      latest.onChange?.(e)
+      latest.onChangeInput?.(e)
 
-      if (!latests.isEditing) setIsEditing(true)
+      if (!latest.isEditing) setIsEditing(true)
 
       const { value } = e.currentTarget
 
       setInputValue(value)
 
       if (value === '') {
-        latests.onClear?.()
-        latests.onChangeSelected?.(null)
+        latest.onClear?.()
+        latest.onChangeSelected?.(null)
       }
     },
-    [latests],
+    [latest],
   )
   const onCompositionStart = useCallback(() => setIsComposing(true), [])
   const onCompositionEnd = useCallback(() => setIsComposing(false), [])
   const onKeyDownInput = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
-      if (latests.isComposing) {
+      if (latest.isComposing) {
         return
       }
 
       if (ESCAPE_KEY_REGEX.test(e.key)) {
-        if (latests.isExpanded) {
+        if (latest.isExpanded) {
           e.stopPropagation()
           setIsExpanded(false)
         }
@@ -385,13 +385,13 @@ const ActualSingleCombobox = <T,>(
 
         inputRef.current?.focus()
 
-        if (!latests.isExpanded) {
+        if (!latest.isExpanded) {
           setIsExpanded(true)
         }
       }
       onKeyDownListBox(e)
     },
-    [latests, unfocus, onKeyDownListBox],
+    [latest, unfocus, onKeyDownListBox],
   )
 
   // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で
@@ -401,9 +401,9 @@ const ActualSingleCombobox = <T,>(
     (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') e.preventDefault()
 
-      latests.onKeyPress?.(e)
+      latest.onKeyPress?.(e)
     },
-    [latests],
+    [latest],
   )
 
   const caretIconColor = isFocused

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -302,7 +302,7 @@ const ActualSingleCombobox = <T,>(
     } else {
       selectDefaultItem()
     }
-  }, [latest, selectDefaultItem])
+  }, [selectDefaultItem, latest])
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
@@ -391,7 +391,7 @@ const ActualSingleCombobox = <T,>(
       }
       onKeyDownListBox(e)
     },
-    [latest, unfocus, onKeyDownListBox],
+    [unfocus, onKeyDownListBox, latest],
   )
 
   // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -20,6 +20,7 @@ import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { useClick } from '../../../hooks/useClick'
+import { useLatest } from '../../../hooks/useLatest'
 import { useTheme } from '../../../hooks/useTheme'
 import { useIntl } from '../../../intl'
 import { genericsForwardRef } from '../../../libs/util'
@@ -210,7 +211,7 @@ const ActualSingleCombobox = <T,>(
   const [isComposing, setIsComposing] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
 
-  const unstableRef = useRef({
+  const latests = useLatest({
     onChange,
     onChangeInput,
     onAdd,
@@ -228,24 +229,6 @@ const ActualSingleCombobox = <T,>(
     isComposing,
     isEditing,
   })
-  unstableRef.current = {
-    onChange,
-    onChangeInput,
-    onAdd,
-    onSelect,
-    onClear,
-    onClearClick,
-    onChangeSelected,
-    onFocus,
-    onBlur,
-    onKeyPress,
-    defaultItem,
-    selectedItem,
-    isFocused,
-    isExpanded,
-    isComposing,
-    isEditing,
-  }
 
   useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(ref, () => inputRef.current)
 
@@ -262,25 +245,28 @@ const ActualSingleCombobox = <T,>(
     dropdownHelpMessage,
     dropdownWidth,
     onAdd,
-    onSelect: useCallback((selected: ComboboxItem<T>) => {
-      unstableRef.current.onSelect?.(selected)
-      unstableRef.current.onChangeSelected?.(selected)
+    onSelect: useCallback(
+      (selected: ComboboxItem<T>) => {
+        latests.onSelect?.(selected)
+        latests.onChangeSelected?.(selected)
 
-      // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-      // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-      requestAnimationFrame(() => {
-        setIsExpanded(false)
-        // HINT:
-        // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
-        // - 対応するdropdownを閉じて以降にonChangeInputを発火する必要がある
-        //   - 先にclearしてしまうと意図せずこの要素のドロップダウンを閉じる前に他要素の再レンダリングを引き起こす可能性がある
-        //   - 例えばFilterDropdownなどで当comboboxを使っている場合、レイアウト上comboboxのdropdown以下の要素がクリックされた扱いになってしまい
-        //     FilterDropdownを意図せず閉じてしまうなどの挙動のバグを引き起こす可能性がある
-        unstableRef.current.onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
-      })
+        // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
+        // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        requestAnimationFrame(() => {
+          setIsExpanded(false)
+          // HINT:
+          // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
+          // - 対応するdropdownを閉じて以降にonChangeInputを発火する必要がある
+          //   - 先にclearしてしまうと意図せずこの要素のドロップダウンを閉じる前に他要素の再レンダリングを引き起こす可能性がある
+          //   - 例えばFilterDropdownなどで当comboboxを使っている場合、レイアウト上comboboxのdropdown以下の要素がクリックされた扱いになってしまい
+          //     FilterDropdownを意図せず閉じてしまうなどの挙動のバグを引き起こす可能性がある
+          latests.onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
+        })
 
-      setIsEditing(false)
-    }, []),
+        setIsEditing(false)
+      },
+      [latests],
+    ),
     isExpanded,
     isLoading,
     triggerRef: outerRef,
@@ -288,58 +274,61 @@ const ActualSingleCombobox = <T,>(
   })
 
   const selectDefaultItem = useCallback(() => {
-    if (unstableRef.current.onSelect && unstableRef.current.defaultItem) {
-      unstableRef.current.onSelect(unstableRef.current.defaultItem)
+    if (latests.onSelect && latests.defaultItem) {
+      latests.onSelect(latests.defaultItem)
     }
-  }, [])
+  }, [latests])
 
   const focus = useCallback(() => {
-    unstableRef.current.onFocus?.()
+    latests.onFocus?.()
     inputRef.current?.focus()
     setIsFocused(true)
 
-    if (!unstableRef.current.isFocused) {
+    if (!latests.isFocused) {
       setIsExpanded(true)
     }
-  }, [])
+  }, [latests])
   const unfocus = useCallback(() => {
-    if (!unstableRef.current.isFocused) return
+    if (!latests.isFocused) return
 
-    unstableRef.current.onBlur?.()
+    latests.onBlur?.()
 
     setIsFocused(false)
     setIsExpanded(false)
     setIsEditing(false)
 
-    if (unstableRef.current.selectedItem) {
-      setInputValue(innerText(unstableRef.current.selectedItem.label))
+    if (latests.selectedItem) {
+      setInputValue(innerText(latests.selectedItem.label))
     } else {
       selectDefaultItem()
     }
-  }, [selectDefaultItem])
-  const onClickClear = useCallback((e: MouseEvent) => {
-    e.stopPropagation()
+  }, [latests, selectDefaultItem])
+  const onClickClear = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation()
 
-    let isExecutedPreventDefault = false
+      let isExecutedPreventDefault = false
 
-    unstableRef.current.onClearClick?.({
-      ...e,
-      preventDefault: () => {
-        e.preventDefault()
-        isExecutedPreventDefault = true
-      },
-    })
+      latests.onClearClick?.({
+        ...e,
+        preventDefault: () => {
+          e.preventDefault()
+          isExecutedPreventDefault = true
+        },
+      })
 
-    if (!isExecutedPreventDefault) {
-      unstableRef.current.onClear?.()
-      unstableRef.current.onChangeSelected?.(null)
+      if (!isExecutedPreventDefault) {
+        latests.onClear?.()
+        latests.onChangeSelected?.(null)
 
-      inputRef.current?.focus()
+        inputRef.current?.focus()
 
-      setIsFocused(true)
-      setIsExpanded(true)
-    }
-  }, [])
+        setIsFocused(true)
+        setIsExpanded(true)
+      }
+    },
+    [latests],
+  )
   const onClickInput = useCallback(
     (e: MouseEvent) => {
       if (disabled || readOnly) {
@@ -350,37 +339,40 @@ const ActualSingleCombobox = <T,>(
 
       inputRef.current?.focus()
 
-      if (!unstableRef.current.isExpanded) {
+      if (!latests.isExpanded) {
         setIsExpanded(true)
       }
     },
-    [disabled, readOnly],
+    [disabled, readOnly, latests],
   )
-  const actualOnChangeInput = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    unstableRef.current.onChange?.(e)
-    unstableRef.current.onChangeInput?.(e)
+  const actualOnChangeInput = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      latests.onChange?.(e)
+      latests.onChangeInput?.(e)
 
-    if (!unstableRef.current.isEditing) setIsEditing(true)
+      if (!latests.isEditing) setIsEditing(true)
 
-    const { value } = e.currentTarget
+      const { value } = e.currentTarget
 
-    setInputValue(value)
+      setInputValue(value)
 
-    if (value === '') {
-      unstableRef.current.onClear?.()
-      unstableRef.current.onChangeSelected?.(null)
-    }
-  }, [])
+      if (value === '') {
+        latests.onClear?.()
+        latests.onChangeSelected?.(null)
+      }
+    },
+    [latests],
+  )
   const onCompositionStart = useCallback(() => setIsComposing(true), [])
   const onCompositionEnd = useCallback(() => setIsComposing(false), [])
   const onKeyDownInput = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
-      if (unstableRef.current.isComposing) {
+      if (latests.isComposing) {
         return
       }
 
       if (ESCAPE_KEY_REGEX.test(e.key)) {
-        if (unstableRef.current.isExpanded) {
+        if (latests.isExpanded) {
           e.stopPropagation()
           setIsExpanded(false)
         }
@@ -393,23 +385,26 @@ const ActualSingleCombobox = <T,>(
 
         inputRef.current?.focus()
 
-        if (!unstableRef.current.isExpanded) {
+        if (!latests.isExpanded) {
           setIsExpanded(true)
         }
       }
       onKeyDownListBox(e)
     },
-    [unfocus, onKeyDownListBox],
+    [latests, unfocus, onKeyDownListBox],
   )
 
   // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で
   // アイテムをキーボードで選択し、Enterを押すとinput上でEnterを押したことになるため、
   // submitイベントが発生し、formが送信される場合がある
-  const handleKeyPress = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') e.preventDefault()
+  const handleKeyPress = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') e.preventDefault()
 
-    unstableRef.current.onKeyPress?.(e)
-  }, [])
+      latests.onKeyPress?.(e)
+    },
+    [latests],
+  )
 
   const caretIconColor = isFocused
     ? theme.textColor.black

--- a/packages/smarthr-ui/src/hooks/useLatest.ts
+++ b/packages/smarthr-ui/src/hooks/useLatest.ts
@@ -8,15 +8,15 @@ import { useMemo, useRef } from 'react'
  * 常に最新の値を参照する。
  *
  * @example
- * const latests = useLatest({
+ * const latest = useLatest({
  *   onChange,
  *   onSelect,
  *   selectedItem,
  * })
  *
  * // 最新の値に常にアクセス可能
- * latests.onChange?.(e)
- * if (latests.selectedItem) { ... }
+ * latest.onChange?.(e)
+ * if (latest.selectedItem) { ... }
  */
 export function useLatest<T extends Record<string, any>>(values: T): Readonly<T> {
   const ref = useRef<T>(values)

--- a/packages/smarthr-ui/src/hooks/useLatest.ts
+++ b/packages/smarthr-ui/src/hooks/useLatest.ts
@@ -18,7 +18,7 @@ import { useMemo, useRef } from 'react'
  * latest.onChange?.(e)
  * if (latest.selectedItem) { ... }
  */
-export function useLatest<T extends Record<string, any>>(values: T): Readonly<T> {
+export function useLatest<T extends object>(values: T): Readonly<T> {
   const ref = useRef<T>(values)
   ref.current = values
 

--- a/packages/smarthr-ui/src/hooks/useLatest.ts
+++ b/packages/smarthr-ui/src/hooks/useLatest.ts
@@ -1,0 +1,34 @@
+import { useMemo, useRef } from 'react'
+
+/**
+ * 常に最新の値を参照するためのフック。
+ * useCallbackやuseMemoの依存配列を減らし、不要な再実行を防ぐために使用する。
+ *
+ * 返されるオブジェクトのプロパティは読み取り専用で、
+ * 常に最新の値を参照する。
+ *
+ * @example
+ * const latests = useLatest({
+ *   onChange,
+ *   onSelect,
+ *   selectedItem,
+ * })
+ *
+ * // 最新の値に常にアクセス可能
+ * latests.onChange?.(e)
+ * if (latests.selectedItem) { ... }
+ */
+export function useLatest<T extends Record<string, any>>(values: T): Readonly<T> {
+  const ref = useRef<T>(values)
+  ref.current = values
+
+  const proxy = useMemo(
+    () =>
+      new Proxy({} as T, {
+        get: (_target, prop) => ref.current[prop as keyof T],
+      }) as Readonly<T>,
+    [],
+  )
+
+  return proxy
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

unstableRefパターンの煩雑さを解消するため、`useLatest` フックを新規作成しました。

従来のunstableRefパターンでは以下の問題がありました：
- 初期化と更新の2箇所で同じ構造を記述する必要があり、重複が多い
- プロパティの追加/削除時に両方を修正する必要がある
- 手動での `ref.current = {...}` 代入がバグの温床

これらを解決するため、Proxyベースの `useLatest` フックを実装しました。

## 変更内容

### useLatestフックの追加

- `src/hooks/useLatest.ts` を新規作成
- Proxyを使用して、常に最新の値を参照しつつ安定した参照を提供
- 返されるオブジェクトは読み取り専用（`Readonly<T>`）

### 使用例

```tsx
// Before（unstableRefパターン）
const unstableRef = useRef({
  onChange,
  onSelect,
  selectedItem,
})
unstableRef.current = {
  onChange,
  onSelect,
  selectedItem,
}

const callback = useCallback(() => {
  unstableRef.current.onChange?.()
}, [])

// After（useLatest）
const latests = useLatest({
  onChange,
  onSelect,
  selectedItem,
})

const callback = useCallback(() => {
  latests.onChange?.()
}, [latests])  // latestsは常に同じ参照なので再実行されない
```

### SingleComboboxでの適用

- SingleComboboxでunstableRefからuseLatestに移行
- `.current` なしで直接アクセス可能に
- 依存配列に `latests` を含めることで `react-hooks/exhaustive-deps` に対応

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookで SingleCombobox の動作確認
- テスト実行: `pnpm ui test`
- Lint実行: `pnpm ui lint`