### PR TITLE
chore(i18n): Crowdin同期用のワークフローを追加したい（リベンジ）

### DIFF
--- a/.github/workflows/crowdinPullTranslations.yml
+++ b/.github/workflows/crowdinPullTranslations.yml
@@ -1,0 +1,57 @@
+# 各言語の翻訳辞書を翻訳ツール(Crowdin)からダウンロード
+name: "i18n: Download translations from Crowdin"
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  crowdin:
+    name: Download translations from Crowdin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      
+      - name: Generate localization branch name
+        id: generate-branch-name
+        run: |
+          echo "name=l10n_${{ github.ref_name }}_$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Read PR template
+        id: read-pr-template
+        run: |
+          {
+            echo 'PR_BODY<<EOF'
+            cat .github/PULL_REQUEST_TEMPLATE.md
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+          
+      - name: Download translations from Crowdin
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
+        with:
+          config: crowdin.yml
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: ${{ steps.generate-branch-name.outputs.name }}
+          crowdin_branch_name: ${{ github.ref_name }}
+          create_pull_request: true
+          pull_request_title: 'chore(i18n): 定期辞書更新'
+          pull_request_body: ${{ steps.read-pr-template.outputs.PR_BODY }}
+          pull_request_labels: 'i18n, crowdin'
+          pull_request_base_branch_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PUSH_PULL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_BASE_URL: ${{ secrets.CROWDIN_BASE_URL }}

--- a/.github/workflows/crowdinPushSources.yml
+++ b/.github/workflows/crowdinPushSources.yml
@@ -1,0 +1,46 @@
+# 日本語辞書を翻訳ツール(Crowdin)にアップロード
+name: "i18n: Upload Japanese dictionary to Crowdin"
+
+on:
+  schedule:
+    - cron: "0 8 * * MON"
+      timezone: Asia/Tokyo
+  workflow_dispatch:
+    inputs:
+      github_branch:
+        description: アップするブランチ名（Crowdinブランチ名としても使用される）
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.github_branch || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  crowdin:
+    name: "Upload Japanese dictionary to Crowdin"
+    runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: ${{ inputs.github_branch || github.ref_name }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          persist-credentials: false
+      - name: Push ja-JP source to Crowdin
+        uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
+        with:
+          config: crowdin.yml
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          crowdin_branch_name: ${{ env.TARGET_BRANCH }}
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PUSH_PULL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_BASE_URL: ${{ secrets.CROWDIN_BASE_URL }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,49 @@
+# Crowdinの設定ファイル
+# 参照：https://support.crowdin.com/developer/configuration-file/
+
+# CrowdinプロジェクトID
+project_id_env: "CROWDIN_PROJECT_ID"
+
+# このディレクトリを基準にパスを解決
+base_path: .
+
+# Crowdin API URL
+base_url_env: "CROWDIN_BASE_URL"
+
+# Crowdin上でフォルダ構成を保持
+preserve_hierarchy: 1
+
+# Crowdinの認証トークン
+api_token_env: "CROWDIN_PERSONAL_TOKEN"
+
+files:
+  # 原文の辞書ファイルへのパス
+  - source: packages/smarthr-ui/src/intl/locales/ja.json
+
+    # 翻訳の辞書ファイルへのパス
+    translation: packages/smarthr-ui/src/intl/locales/%locale%.json
+
+    # Crowdin上のファイル表示階層
+    dest: ja.json
+
+    # 除外するファイル
+    # ignore:
+    #  - "packages/smarthr-ui/src/intl/locales/index.ts"
+
+    # 翻訳をエクスポートする時に未翻訳の文字列を除外（""として書き込む）
+    skip_untranslated_strings: 1
+
+    # 確定済みの翻訳のみエクスポート
+    export_only_approved: 1
+
+    # Crowdinの言語コードをカスタムなロケール名に変換
+    languages_mapping:
+      locale:
+        en-US: en_us
+        id: id_id
+        ja-easy: ja_easy
+        ko: ko_kr
+        pt-BR: pt_br
+        vi: vi_vn
+        zh-CN: zh_hans_cn
+        zh-TW: zh_hant_tw


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- SmartHR UIの翻訳を翻訳管理ツールと同期できるため、GitHub Workflowと設定ファイルを追加したい

## 変更内容

- Workflowを2つ追加した
- 関連するシークレットを登録した
- Crowdinの設定ファイルも置いた

## プロダクト側で対応が必要な事項

なし

## 確認方法

i18n部が手元で確認します。コードのfmfmでOKです


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Crowdinとの翻訳連携を追加しました。
  * 日本語の原文辞書を定期的または手動でアップロードできます。
  * 翻訳辞書を取得し、更新内容を自動的にプルリクエストとして作成できます。
  * 未翻訳・未承認の文字列を除外する同期設定に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->