### PR TITLE
refactor(FileViewer): unstableRefパターンでコールバックを安定化しパフォーマンス最適化

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -57,20 +57,10 @@ type Props = {
 }
 
 export const FileViewer: FC<Props> = ({ file, ...rest }) => {
-  const isPDF = file.contentType === 'application/pdf'
   const [rotation, setRotation] = useState<number | undefined>(undefined)
+  const Component = file.contentType === 'application/pdf' ? PDFFileViewer : ActualFileViewer
 
-  const commonProps = {
-    file,
-    rotation,
-    setRotation,
-  }
-
-  return isPDF ? (
-    <PDFFileViewer {...rest} {...commonProps} />
-  ) : (
-    <ActualFileViewer {...rest} {...commonProps} />
-  )
+  return <Component {...rest} file={file} rotation={rotation} setRotation={setRotation} />
 }
 
 const PDFFileViewer: FC<

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -55,29 +55,70 @@ type Props = {
 
 export const FileViewer: FC<Props> = ({ file, ...rest }) => {
   const isPDF = file.contentType === 'application/pdf'
+  const [rotation, setRotation] = useState<number | undefined>(undefined)
+
+  const commonProps = {
+    file,
+    rotation,
+    setRotation,
+  }
 
   return isPDF ? (
-    <PDFFileViewer {...rest} file={file} />
+    <PDFFileViewer {...rest} {...commonProps} />
   ) : (
-    <ActualFileViewer {...rest} file={file} />
+    <ActualFileViewer {...rest} {...commonProps} />
   )
 }
 
-const PDFFileViewer: FC<Props> = ({ file, ...rest }) => {
+const PDFFileViewer: FC<
+  Props & {
+    rotation: number | undefined
+    setRotation: (rotation: number) => void
+  }
+> = ({ file, rotation, setRotation, ...rest }) => {
   const pdfSearch = usePDFSearch(file.url)
 
-  return <ActualFileViewer {...rest} file={file} pdfSearch={pdfSearch} />
+  const handlePDFLoaded = useCallback(
+    (defaultRotation: number) => {
+      setRotation(defaultRotation)
+    },
+    [setRotation],
+  )
+
+  return (
+    <ActualFileViewer
+      {...rest}
+      file={file}
+      rotation={rotation}
+      setRotation={setRotation}
+      pdfSearch={pdfSearch}
+      handlePDFLoaded={handlePDFLoaded}
+    />
+  )
 }
 
 const ActualFileViewer: FC<
   Props & {
+    rotation: number | undefined
+    setRotation: (rotation: number) => void
     pdfSearch?: ReturnType<typeof usePDFSearch>
+    handlePDFLoaded?: (defaultRotation: number) => void
   }
-> = ({ file, scaleStep, scaleSteps, width: fixedWidth, onPassword, onLoadError, pdfSearch }) => {
+> = ({
+  file,
+  scaleStep,
+  scaleSteps,
+  width: fixedWidth,
+  onPassword,
+  onLoadError,
+  rotation,
+  setRotation,
+  pdfSearch,
+  handlePDFLoaded,
+}) => {
   const ref = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)
   const [loaded, setLoaded] = useState(false)
-  const [rotation, setRotation] = useState<number | undefined>(undefined)
   const [width, setWidth] = useState(fixedWidth ?? 0)
 
   const internalScaleStep = useMemo(
@@ -98,14 +139,10 @@ const ActualFileViewer: FC<
     const currentRotation = rotation ?? 0
     const newRotation = currentRotation === 0 ? 270 : currentRotation - 90
     setRotation(newRotation)
-  }, [rotation])
+  }, [rotation, setRotation])
 
   const handleLoaded = useCallback(() => {
     setLoaded(true)
-  }, [])
-
-  const handlePDFLoaded = useCallback((defaultRotation: number) => {
-    setRotation(defaultRotation)
   }, [])
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -53,22 +53,32 @@ type Props = {
   onLoadError?: () => void
 }
 
-export const FileViewer: FC<Props> = ({
-  file,
-  scaleStep,
-  scaleSteps,
-  width: fixedWidth,
-  onPassword,
-  onLoadError,
-}) => {
+export const FileViewer: FC<Props> = ({ file, ...rest }) => {
+  const isPDF = file.contentType === 'application/pdf'
+
+  return isPDF ? (
+    <PDFFileViewer {...rest} file={file} />
+  ) : (
+    <ActualFileViewer {...rest} file={file} />
+  )
+}
+
+const PDFFileViewer: FC<Props> = ({ file, ...rest }) => {
+  const pdfSearch = usePDFSearch(file.url)
+
+  return <ActualFileViewer {...rest} file={file} pdfSearch={pdfSearch} />
+}
+
+const ActualFileViewer: FC<
+  Props & {
+    pdfSearch?: ReturnType<typeof usePDFSearch>
+  }
+> = ({ file, scaleStep, scaleSteps, width: fixedWidth, onPassword, onLoadError, pdfSearch }) => {
   const ref = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)
   const [loaded, setLoaded] = useState(false)
   const [rotation, setRotation] = useState<number | undefined>(undefined)
   const [width, setWidth] = useState(fixedWidth ?? 0)
-  const isPDF = file.contentType === 'application/pdf'
-
-  const search = usePDFSearch(file.url)
 
   const internalScaleStep = useMemo(
     () => (scaleStep ? new Decimal(scaleStep) : defaultScaleStep),
@@ -128,7 +138,7 @@ export const FileViewer: FC<Props> = ({
           onClickScaleUpButton={scaleUp}
           onClickScaleDownButton={scaleDown}
           onClickRotateButton={rotate}
-          searchController={isPDF ? <SearchController search={search} /> : undefined}
+          searchController={pdfSearch ? <SearchController search={pdfSearch} /> : undefined}
         />
       </div>
       <div className="shr-z-[0] shr-mx-auto shr-my-0 shr-box-border shr-flex shr-w-fit shr-flex-shrink-0 shr-grow shr-items-center shr-justify-center shr-px-2 shr-pb-2">
@@ -138,7 +148,7 @@ export const FileViewer: FC<Props> = ({
           </div>
         )}
         <div className={!loaded ? 'shr-invisible' : ''}>
-          {isPDF ? (
+          {pdfSearch ? (
             <PDFViewer
               scale={scale}
               rotation={rotation}
@@ -148,7 +158,7 @@ export const FileViewer: FC<Props> = ({
               onPDFLoaded={handlePDFLoaded}
               onPassword={onPassword}
               onLoadError={onLoadError}
-              search={search}
+              search={pdfSearch}
             />
           ) : file.contentType.startsWith('image/') ? (
             <ImageViewer

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -142,14 +142,13 @@ const ActualFileViewer: FC<
 
   const latest = useLatest({ internalScaleStep, onLoadError, rotation, setRotation })
 
-  const handleLoaded = useCallback(() => {
-    setLoaded(true)
-  }, [])
-
   const hasOnLoadError = !!onLoadError
 
   const functions = useMemo(
     () => ({
+      handleLoaded: () => {
+        setLoaded(true)
+      },
       scaleUp: () => {
         setScale((currentScale) =>
           new Decimal(currentScale).add(latest.internalScaleStep).toNumber(),
@@ -216,7 +215,7 @@ const ActualFileViewer: FC<
               rotation={rotation}
               file={file}
               width={width}
-              onLoad={handleLoaded}
+              onLoad={functions.handleLoaded}
               onPDFLoaded={handlePDFLoaded}
               onPassword={onPassword}
               onLoadError={functions.actualHandleLoadError}
@@ -228,7 +227,7 @@ const ActualFileViewer: FC<
               rotation={rotation}
               file={file}
               width={width}
-              onLoad={handleLoaded}
+              onLoad={functions.handleLoaded}
               onLoadError={functions.actualHandleLoadError}
             />
           ) : (

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -83,15 +83,19 @@ const PDFFileViewer: FC<
 
   const latest = useLatest({ onPassword, setRotation })
 
+  const hasOnPassword = !!onPassword
+
   const functions = useMemo(
     () => ({
       handlePDFLoaded: (defaultRotation: number) => {
         latest.setRotation(defaultRotation)
       },
-      actualOnPassword: ((...passRest: Parameters<OnPasswordType>) =>
-        latest.onPassword?.(...passRest)) as OnPasswordType,
+      actualOnPassword: hasOnPassword
+        ? (((...passRest: Parameters<OnPasswordType>) =>
+            latest.onPassword?.(...passRest)) as OnPasswordType)
+        : undefined,
     }),
-    [latest],
+    [hasOnPassword, latest],
   )
 
   return (
@@ -102,7 +106,7 @@ const PDFFileViewer: FC<
       setRotation={setRotation}
       pdfSearch={pdfSearch}
       handlePDFLoaded={functions.handlePDFLoaded}
-      onPassword={onPassword ? functions.actualOnPassword : undefined}
+      onPassword={functions.actualOnPassword}
     />
   )
 }

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -167,7 +167,7 @@ const ActualFileViewer: FC<
       },
       actualHandleLoadError: hasOnLoadError ? () => latest.onLoadError?.() : undefined,
     }),
-    [latest, hasOnLoadError],
+    [hasOnLoadError, latest],
   )
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -16,6 +16,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
+import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { DropdownMenuButton } from '../Dropdown'
@@ -80,15 +81,17 @@ const PDFFileViewer: FC<
 > = ({ file, rotation, setRotation, onPassword, ...rest }) => {
   const pdfSearch = usePDFSearch(file.url)
 
-  const unstableRef = useRef({ onPassword, setRotation })
-  unstableRef.current = { onPassword, setRotation }
+  const latest = useLatest({ onPassword, setRotation })
 
-  const handlePDFLoaded = useCallback((defaultRotation: number) => {
-    unstableRef.current.setRotation(defaultRotation)
-  }, [])
-  const actualOnPassword: OnPasswordType = useCallback(
-    (...passRest) => unstableRef.current.onPassword?.(...passRest),
-    [],
+  const functions = useMemo(
+    () => ({
+      handlePDFLoaded: (defaultRotation: number) => {
+        latest.setRotation(defaultRotation)
+      },
+      actualOnPassword: ((...passRest: Parameters<OnPasswordType>) =>
+        latest.onPassword?.(...passRest)) as OnPasswordType,
+    }),
+    [latest],
   )
 
   return (
@@ -98,8 +101,8 @@ const PDFFileViewer: FC<
       rotation={rotation}
       setRotation={setRotation}
       pdfSearch={pdfSearch}
-      handlePDFLoaded={handlePDFLoaded}
-      onPassword={onPassword ? actualOnPassword : undefined}
+      handlePDFLoaded={functions.handlePDFLoaded}
+      onPassword={onPassword ? functions.actualOnPassword : undefined}
     />
   )
 }
@@ -133,35 +136,35 @@ const ActualFileViewer: FC<
     [scaleStep],
   )
 
-  const unstableRef = useRef({ internalScaleStep, onLoadError, rotation, setRotation })
-  unstableRef.current = { internalScaleStep, onLoadError, rotation, setRotation }
-
-  const scaleUp = useCallback(() => {
-    setScale((currentScale) =>
-      new Decimal(currentScale).add(unstableRef.current.internalScaleStep).toNumber(),
-    )
-  }, [])
-
-  const scaleDown = useCallback(() => {
-    setScale((currentScale) =>
-      new Decimal(currentScale).sub(unstableRef.current.internalScaleStep).toNumber(),
-    )
-  }, [])
-
-  const rotate = useCallback(() => {
-    // HINT: react-pdf側のAnnotationLayer.cssではマイナスの回転に対応しておらず、また0, 90, 180, 270度のみ対応しているため、-90度の場合は+270度として扱う
-    const currentRotation = unstableRef.current.rotation ?? 0
-    unstableRef.current.setRotation(currentRotation === 0 ? 270 : currentRotation - 90)
-  }, [])
+  const latest = useLatest({ internalScaleStep, onLoadError, rotation, setRotation })
 
   const handleLoaded = useCallback(() => {
     setLoaded(true)
   }, [])
 
-  const handleLoadError = useCallback(() => {
-    unstableRef.current.onLoadError?.()
-  }, [])
-  const actualHandleLoadError = onLoadError ? handleLoadError : undefined
+  const hasOnLoadError = !!onLoadError
+
+  const functions = useMemo(
+    () => ({
+      scaleUp: () => {
+        setScale((currentScale) =>
+          new Decimal(currentScale).add(latest.internalScaleStep).toNumber(),
+        )
+      },
+      scaleDown: () => {
+        setScale((currentScale) =>
+          new Decimal(currentScale).sub(latest.internalScaleStep).toNumber(),
+        )
+      },
+      rotate: () => {
+        // HINT: react-pdf側のAnnotationLayer.cssではマイナスの回転に対応しておらず、また0, 90, 180, 270度のみ対応しているため、-90度の場合は+270度として扱う
+        const currentRotation = latest.rotation ?? 0
+        latest.setRotation(currentRotation === 0 ? 270 : currentRotation - 90)
+      },
+      actualHandleLoadError: hasOnLoadError ? () => latest.onLoadError?.() : undefined,
+    }),
+    [latest, hasOnLoadError],
+  )
 
   useEffect(() => {
     if (!ref.current || fixedWidth !== undefined) {
@@ -190,9 +193,9 @@ const ActualFileViewer: FC<
           scale={scale}
           setScale={setScale}
           scaleSteps={scaleSteps || defaultScaleSteps}
-          onClickScaleUpButton={scaleUp}
-          onClickScaleDownButton={scaleDown}
-          onClickRotateButton={rotate}
+          onClickScaleUpButton={functions.scaleUp}
+          onClickScaleDownButton={functions.scaleDown}
+          onClickRotateButton={functions.rotate}
           searchController={pdfSearch ? <SearchController search={pdfSearch} /> : undefined}
         />
       </div>
@@ -212,7 +215,7 @@ const ActualFileViewer: FC<
               onLoad={handleLoaded}
               onPDFLoaded={handlePDFLoaded}
               onPassword={onPassword}
-              onLoadError={actualHandleLoadError}
+              onLoadError={functions.actualHandleLoadError}
               search={pdfSearch}
             />
           ) : file.contentType.startsWith('image/') ? (
@@ -222,7 +225,7 @@ const ActualFileViewer: FC<
               file={file}
               width={width}
               onLoad={handleLoaded}
-              onLoadError={actualHandleLoadError}
+              onLoadError={functions.actualHandleLoadError}
             />
           ) : (
             <Localizer

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -39,6 +39,8 @@ import type { FileForViewer } from './types'
 const defaultScaleStep = new Decimal(0.2)
 const defaultScaleSteps = [0.2, 0.6, 1, 1.6, 2, 3]
 
+type OnPasswordType = Exclude<ComponentProps<typeof PDFViewer>['onPassword'], undefined>
+
 type Props = {
   file: FileForViewer
   width?: number
@@ -49,7 +51,7 @@ type Props = {
   scaleSteps?: number[]
 
   scaleStep?: number
-  onPassword?: ComponentProps<typeof PDFViewer>['onPassword']
+  onPassword?: OnPasswordType
   onLoadError?: () => void
 }
 
@@ -75,14 +77,18 @@ const PDFFileViewer: FC<
     rotation: number | undefined
     setRotation: (rotation: number) => void
   }
-> = ({ file, rotation, setRotation, ...rest }) => {
+> = ({ file, rotation, setRotation, onPassword, ...rest }) => {
   const pdfSearch = usePDFSearch(file.url)
 
-  const handlePDFLoaded = useCallback(
-    (defaultRotation: number) => {
-      setRotation(defaultRotation)
-    },
-    [setRotation],
+  const unstableRef = useRef({ onPassword, setRotation })
+  unstableRef.current = { onPassword, setRotation }
+
+  const handlePDFLoaded = useCallback((defaultRotation: number) => {
+    unstableRef.current.setRotation(defaultRotation)
+  }, [])
+  const actualOnPassword: OnPasswordType = useCallback(
+    (...passRest) => unstableRef.current.onPassword?.(...passRest),
+    [],
   )
 
   return (
@@ -93,6 +99,7 @@ const PDFFileViewer: FC<
       setRotation={setRotation}
       pdfSearch={pdfSearch}
       handlePDFLoaded={handlePDFLoaded}
+      onPassword={onPassword ? actualOnPassword : undefined}
     />
   )
 }
@@ -126,24 +133,35 @@ const ActualFileViewer: FC<
     [scaleStep],
   )
 
+  const unstableRef = useRef({ internalScaleStep, onLoadError, rotation, setRotation })
+  unstableRef.current = { internalScaleStep, onLoadError, rotation, setRotation }
+
   const scaleUp = useCallback(() => {
-    setScale((currentScale) => new Decimal(currentScale).add(internalScaleStep).toNumber())
-  }, [internalScaleStep])
+    setScale((currentScale) =>
+      new Decimal(currentScale).add(unstableRef.current.internalScaleStep).toNumber(),
+    )
+  }, [])
 
   const scaleDown = useCallback(() => {
-    setScale((currentScale) => new Decimal(currentScale).sub(internalScaleStep).toNumber())
-  }, [internalScaleStep])
+    setScale((currentScale) =>
+      new Decimal(currentScale).sub(unstableRef.current.internalScaleStep).toNumber(),
+    )
+  }, [])
 
   const rotate = useCallback(() => {
     // HINT: react-pdf側のAnnotationLayer.cssではマイナスの回転に対応しておらず、また0, 90, 180, 270度のみ対応しているため、-90度の場合は+270度として扱う
-    const currentRotation = rotation ?? 0
-    const newRotation = currentRotation === 0 ? 270 : currentRotation - 90
-    setRotation(newRotation)
-  }, [rotation, setRotation])
+    const currentRotation = unstableRef.current.rotation ?? 0
+    unstableRef.current.setRotation(currentRotation === 0 ? 270 : currentRotation - 90)
+  }, [])
 
   const handleLoaded = useCallback(() => {
     setLoaded(true)
   }, [])
+
+  const handleLoadError = useCallback(() => {
+    unstableRef.current.onLoadError?.()
+  }, [])
+  const actualHandleLoadError = onLoadError ? handleLoadError : undefined
 
   useEffect(() => {
     if (!ref.current || fixedWidth !== undefined) {
@@ -194,7 +212,7 @@ const ActualFileViewer: FC<
               onLoad={handleLoaded}
               onPDFLoaded={handlePDFLoaded}
               onPassword={onPassword}
-              onLoadError={onLoadError}
+              onLoadError={actualHandleLoadError}
               search={pdfSearch}
             />
           ) : file.contentType.startsWith('image/') ? (
@@ -204,7 +222,7 @@ const ActualFileViewer: FC<
               file={file}
               width={width}
               onLoad={handleLoaded}
-              onLoadError={onLoadError}
+              onLoadError={actualHandleLoadError}
             />
           ) : (
             <Localizer

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -127,7 +127,7 @@ export const PDFViewer: FC<Props> = memo(
           latest.onPageTextLoaded(pageIndex, texts)
         }),
       }),
-      [latest, pdfPageArray],
+      [pdfPageArray, latest],
     )
 
     useEffect(() => {

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -85,27 +85,24 @@ export const PDFViewer: FC<Props> = memo(
     const [pdfNumPages, setPdfNumPages] = useState(1)
     const rootRef = useRef<HTMLDivElement>(null)
 
+    const unstableRef = useRef({ onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation })
+    unstableRef.current = { onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation }
+
     const onDocumentLoadSuccess = useCallback<
       NonNullable<ComponentProps<typeof Document>['onLoadSuccess']>
     >(({ numPages }) => {
       setPdfNumPages(numPages)
     }, [])
 
-    const onPageLoad: ComponentProps<typeof Page>['onLoadSuccess'] = useMemo(() => {
-      if (!onLoad && !onPDFLoaded) {
-        return undefined
+    const onPageLoad = useCallback<ComponentProps<typeof Page>['onLoadSuccess']>((page) => {
+      if (unstableRef.current.onPDFLoaded && unstableRef.current.rotation === undefined) {
+        unstableRef.current.onPDFLoaded(page.rotate)
       }
-
-      return (page) => {
-        if (onPDFLoaded && rotation === undefined) {
-          onPDFLoaded(page.rotate)
-        }
-        // DocumentのLoadだとページごとの読み込みが考慮されないため
-        if (onLoad && page.pageNumber === pdfNumPages) {
-          onLoad()
-        }
+      // DocumentのLoadだとページごとの読み込みが考慮されないため
+      if (unstableRef.current.onLoad && page.pageNumber === unstableRef.current.pdfNumPages) {
+        unstableRef.current.onLoad()
       }
-    }, [onLoad, onPDFLoaded, pdfNumPages, rotation])
+    }, [])
 
     const customTextRenderer = useMemo<CustomTextRenderer | undefined>(() => {
       if (!matches || matches.length === 0) {
@@ -116,16 +113,16 @@ export const PDFViewer: FC<Props> = memo(
 
     const handleGetTextSuccess = useCallback(
       (pageIndex: number) => (textContent: TextContent) => {
-        if (!onPageTextLoaded) return
+        if (!unstableRef.current.onPageTextLoaded) return
         const texts = textContent.items.reduce<string[]>((acc, item) => {
           if ('str' in item) {
             acc.push(item.str)
           }
           return acc
         }, [])
-        onPageTextLoaded(pageIndex, texts)
+        unstableRef.current.onPageTextLoaded(pageIndex, texts)
       },
-      [onPageTextLoaded],
+      [],
     )
 
     useEffect(() => {

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 
+import { useLatest } from '../../hooks/useLatest'
 import { Scroller } from '../Scroller'
 
 import {
@@ -86,24 +87,13 @@ export const PDFViewer: FC<Props> = memo(
     const [pdfPageArray, setPdfPageArray] = useState<unknown[]>([])
     const rootRef = useRef<HTMLDivElement>(null)
 
-    const unstableRef = useRef({ onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation })
-    unstableRef.current = { onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation }
+    const latest = useLatest({ onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation })
 
     const onDocumentLoadSuccess = useCallback<
       NonNullable<ComponentProps<typeof Document>['onLoadSuccess']>
     >(({ numPages }) => {
       setPdfNumPages(numPages)
       setPdfPageArray(Array.from({ length: numPages }))
-    }, [])
-
-    const onPageLoad = useCallback<ComponentProps<typeof Page>['onLoadSuccess']>((page) => {
-      if (unstableRef.current.onPDFLoaded && unstableRef.current.rotation === undefined) {
-        unstableRef.current.onPDFLoaded(page.rotate)
-      }
-      // DocumentのLoadだとページごとの読み込みが考慮されないため
-      if (unstableRef.current.onLoad && page.pageNumber === unstableRef.current.pdfNumPages) {
-        unstableRef.current.onLoad()
-      }
     }, [])
 
     const customTextRenderer = useMemo<CustomTextRenderer | undefined>(() => {
@@ -113,22 +103,32 @@ export const PDFViewer: FC<Props> = memo(
       return buildCustomTextRenderer(matches)
     }, [matches])
 
-    const handleGetTextSuccess = useMemo(() => {
-      const commonAction = (pageIndex: number, textContent: TextContent) => {
-        if (!unstableRef.current.onPageTextLoaded) return
-        const texts = textContent.items.reduce<string[]>((acc, item) => {
-          if ('str' in item) {
-            acc.push(item.str)
+    const functions = useMemo(
+      () => ({
+        onPageLoad: (
+          page: Parameters<NonNullable<ComponentProps<typeof Page>['onLoadSuccess']>>[0],
+        ) => {
+          if (latest.onPDFLoaded && latest.rotation === undefined) {
+            latest.onPDFLoaded(page.rotate)
           }
-          return acc
-        }, [])
-        unstableRef.current.onPageTextLoaded(pageIndex, texts)
-      }
-
-      return pdfPageArray.map(
-        (_, pageIndex) => (textContent: TextContent) => commonAction(pageIndex, textContent),
-      )
-    }, [pdfPageArray])
+          // DocumentのLoadだとページごとの読み込みが考慮されないため
+          if (latest.onLoad && page.pageNumber === latest.pdfNumPages) {
+            latest.onLoad()
+          }
+        },
+        handleGetTextSuccess: pdfPageArray.map((_, pageIndex) => (textContent: TextContent) => {
+          if (!latest.onPageTextLoaded) return
+          const texts = textContent.items.reduce<string[]>((acc, item) => {
+            if ('str' in item) {
+              acc.push(item.str)
+            }
+            return acc
+          }, [])
+          latest.onPageTextLoaded(pageIndex, texts)
+        }),
+      }),
+      [latest, pdfPageArray],
+    )
 
     useEffect(() => {
       const root = rootRef.current
@@ -180,8 +180,8 @@ export const PDFViewer: FC<Props> = memo(
                 width={width}
                 scale={scale}
                 className="shr-w-full"
-                onLoadSuccess={onPageLoad}
-                onGetTextSuccess={handleGetTextSuccess[i]}
+                onLoadSuccess={functions.onPageLoad}
+                onGetTextSuccess={functions.handleGetTextSuccess[i]}
                 customTextRenderer={customTextRenderer}
                 loading={null}
               />

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -1,15 +1,6 @@
 'use client'
 
-import {
-  type ComponentProps,
-  type FC,
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { type ComponentProps, type FC, memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 
 import { useLatest } from '../../hooks/useLatest'
@@ -89,13 +80,6 @@ export const PDFViewer: FC<Props> = memo(
 
     const latest = useLatest({ onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation })
 
-    const onDocumentLoadSuccess = useCallback<
-      NonNullable<ComponentProps<typeof Document>['onLoadSuccess']>
-    >(({ numPages }) => {
-      setPdfNumPages(numPages)
-      setPdfPageArray(Array.from({ length: numPages }))
-    }, [])
-
     const customTextRenderer = useMemo<CustomTextRenderer | undefined>(() => {
       if (!matches || matches.length === 0) {
         return undefined
@@ -105,6 +89,10 @@ export const PDFViewer: FC<Props> = memo(
 
     const functions = useMemo(
       () => ({
+        onDocumentLoadSuccess: ({ numPages }: { numPages: number }) => {
+          setPdfNumPages(numPages)
+          setPdfPageArray(Array.from({ length: numPages }))
+        },
         onPageLoad: (
           page: Parameters<NonNullable<ComponentProps<typeof Page>['onLoadSuccess']>>[0],
         ) => {
@@ -165,7 +153,7 @@ export const PDFViewer: FC<Props> = memo(
           <Document
             options={options}
             file={file.url}
-            onLoadSuccess={onDocumentLoadSuccess}
+            onLoadSuccess={functions.onDocumentLoadSuccess}
             onLoadError={onLoadError}
             rotate={rotation}
             className="shr-flex shr-w-fit shr-flex-col shr-items-center shr-gap-1"

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -83,6 +83,7 @@ export const PDFViewer: FC<Props> = memo(
     const currentMatchIndex = search?.currentMatchIndex
     const onPageTextLoaded = search?.registerPageText
     const [pdfNumPages, setPdfNumPages] = useState(1)
+    const [pdfPageArray, setPdfPageArray] = useState<unknown[]>([])
     const rootRef = useRef<HTMLDivElement>(null)
 
     const unstableRef = useRef({ onLoad, onPDFLoaded, onPageTextLoaded, pdfNumPages, rotation })
@@ -92,6 +93,7 @@ export const PDFViewer: FC<Props> = memo(
       NonNullable<ComponentProps<typeof Document>['onLoadSuccess']>
     >(({ numPages }) => {
       setPdfNumPages(numPages)
+      setPdfPageArray(Array.from({ length: numPages }))
     }, [])
 
     const onPageLoad = useCallback<ComponentProps<typeof Page>['onLoadSuccess']>((page) => {
@@ -111,8 +113,8 @@ export const PDFViewer: FC<Props> = memo(
       return buildCustomTextRenderer(matches)
     }, [matches])
 
-    const handleGetTextSuccess = useCallback(
-      (pageIndex: number) => (textContent: TextContent) => {
+    const handleGetTextSuccess = useMemo(() => {
+      const commonAction = (pageIndex: number, textContent: TextContent) => {
         if (!unstableRef.current.onPageTextLoaded) return
         const texts = textContent.items.reduce<string[]>((acc, item) => {
           if ('str' in item) {
@@ -121,9 +123,12 @@ export const PDFViewer: FC<Props> = memo(
           return acc
         }, [])
         unstableRef.current.onPageTextLoaded(pageIndex, texts)
-      },
-      [],
-    )
+      }
+
+      return pdfPageArray.map(
+        (_, pageIndex) => (textContent: TextContent) => commonAction(pageIndex, textContent),
+      )
+    }, [pdfPageArray])
 
     useEffect(() => {
       const root = rootRef.current
@@ -168,7 +173,7 @@ export const PDFViewer: FC<Props> = memo(
             loading={null}
             onPassword={onPassword}
           >
-            {Array.from({ length: pdfNumPages }).map((_, i) => (
+            {pdfPageArray.map((_, i) => (
               <Page
                 key={`page_${i}`}
                 pageNumber={i + 1}
@@ -176,7 +181,7 @@ export const PDFViewer: FC<Props> = memo(
                 scale={scale}
                 className="shr-w-full"
                 onLoadSuccess={onPageLoad}
-                onGetTextSuccess={handleGetTextSuccess(i)}
+                onGetTextSuccess={handleGetTextSuccess[i]}
                 customTextRenderer={customTextRenderer}
                 loading={null}
               />

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -1,17 +1,10 @@
 'use client'
 
-import {
-  type ChangeEvent,
-  type FC,
-  type KeyboardEvent,
-  memo,
-  useCallback,
-  useMemo,
-  useRef,
-} from 'react'
+import { type ChangeEvent, type FC, type KeyboardEvent, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
+import { useLatest } from '../../hooks/useLatest'
 import { useIntl } from '../../intl'
 import { Button } from '../Button'
 import { FaAngleDownIcon, FaAngleUpIcon } from '../Icon'
@@ -68,33 +61,36 @@ export const SearchController: FC<Props> = memo(({ search }) => {
 
   const notMatches = matchCount === 0
 
-  const unstableRef = useRef({ setQuery, goNext, goPrev, clear, query })
-  unstableRef.current = { setQuery, goNext, goPrev, clear, query }
+  const latest = useLatest({ setQuery, goNext, goPrev, clear, query })
 
-  const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    unstableRef.current.setQuery(e.target.value)
-  }, [])
-
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.nativeEvent.isComposing) {
-      return
-    }
-
-    switch (e.key) {
-      case 'Enter': {
-        e.preventDefault()
-        unstableRef.current[e.shiftKey ? 'goPrev' : 'goNext']()
-        break
-      }
-      case 'Escape': {
-        if (unstableRef.current.query !== '') {
-          e.preventDefault()
-          unstableRef.current.clear()
+  const functions = useMemo(
+    () => ({
+      handleChange: (e: ChangeEvent<HTMLInputElement>) => {
+        latest.setQuery(e.target.value)
+      },
+      handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.nativeEvent.isComposing) {
+          return
         }
-        break
-      }
-    }
-  }, [])
+
+        switch (e.key) {
+          case 'Enter': {
+            e.preventDefault()
+            latest[e.shiftKey ? 'goPrev' : 'goNext']()
+            break
+          }
+          case 'Escape': {
+            if (latest.query !== '') {
+              e.preventDefault()
+              latest.clear()
+            }
+            break
+          }
+        }
+      },
+    }),
+    [latest],
+  )
 
   return (
     <div className={classNames.wrapper}>
@@ -103,8 +99,8 @@ export const SearchController: FC<Props> = memo(({ search }) => {
           name="file_viewer_search"
           tooltipMessage={translated.searchInputTooltipMessage}
           value={query}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
+          onChange={functions.handleChange}
+          onKeyDown={functions.handleKeyDown}
           width="100%"
           suffix={
             query !== '' ? (

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { type ChangeEvent, type FC, type KeyboardEvent, memo, useCallback, useMemo } from 'react'
+import {
+  type ChangeEvent,
+  type FC,
+  type KeyboardEvent,
+  memo,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
@@ -33,15 +41,7 @@ const classNameGenerator = tv({
 })
 
 export const SearchController: FC<Props> = memo(({ search }) => {
-  const {
-    query,
-    setQuery,
-    matchCount,
-    currentMatchIndex,
-    goNext: onClickNext,
-    goPrev: onClickPrev,
-    clear: onClickClear,
-  } = search
+  const { query, setQuery, matchCount, currentMatchIndex, goNext, goPrev, clear } = search
   const { localize } = useIntl()
   const { mobile } = useEnvironment()
   const classNames = useMemo(() => {
@@ -66,42 +66,35 @@ export const SearchController: FC<Props> = memo(({ search }) => {
     [localize],
   )
 
-  const hasMatches = matchCount > 0
-  const displayedCurrent = hasMatches ? currentMatchIndex + 1 : 0
+  const notMatches = matchCount === 0
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      setQuery(e.target.value)
-    },
-    [setQuery],
-  )
+  const unstableRef = useRef({ setQuery, goNext, goPrev, clear, query })
+  unstableRef.current = { setQuery, goNext, goPrev, clear, query }
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.nativeEvent.isComposing) {
-        return
+  const handleChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    unstableRef.current.setQuery(e.target.value)
+  }, [])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing) {
+      return
+    }
+
+    switch (e.key) {
+      case 'Enter': {
+        e.preventDefault()
+        unstableRef.current[e.shiftKey ? 'goPrev' : 'goNext']()
+        break
       }
-      switch (e.key) {
-        case 'Enter': {
+      case 'Escape': {
+        if (unstableRef.current.query !== '') {
           e.preventDefault()
-          if (e.shiftKey) {
-            onClickPrev()
-          } else {
-            onClickNext()
-          }
-          break
+          unstableRef.current.clear()
         }
-        case 'Escape': {
-          if (query !== '') {
-            e.preventDefault()
-            onClickClear()
-          }
-          break
-        }
+        break
       }
-    },
-    [onClickNext, onClickPrev, onClickClear, query],
-  )
+    }
+  }, [])
 
   return (
     <div className={classNames.wrapper}>
@@ -116,7 +109,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
           suffix={
             query !== '' ? (
               <Text size="S" aria-live="polite" className="shr-tabular-nums">
-                {`${displayedCurrent}/${matchCount}`}
+                {`${notMatches ? 0 : currentMatchIndex + 1}/${matchCount}`}
               </Text>
             ) : undefined
           }
@@ -124,15 +117,15 @@ export const SearchController: FC<Props> = memo(({ search }) => {
         />
       </div>
       <Button
-        onClick={onClickPrev}
-        disabled={!hasMatches}
+        onClick={goPrev}
+        disabled={notMatches}
         className="shr-rounded-none shr-border-s-0 shr-p-0.75 aria-disabled:!shr-border-default"
       >
         <FaAngleUpIcon alt={translated.previousMatchAlt} />
       </Button>
       <Button
-        onClick={onClickNext}
-        disabled={!hasMatches}
+        onClick={goNext}
+        disabled={notMatches}
         className="shr-rounded-s-none shr-border-s-0 shr-p-0.75 aria-disabled:!shr-border-default"
       >
         <FaAngleDownIcon alt={translated.nextMatchAlt} />

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -52,9 +52,11 @@ export const usePDFSearch = (fileUrl: string) => {
   const [matches, setMatches] = useState<PDFSearchMatch[]>([])
   const [currentMatchIndex, setCurrentMatchIndex] = useState(-1)
   const pageTextsRef = useRef<Map<number, string[]>>(new Map())
-  const queryRef = useRef('')
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
+
+  const unstableRef = useRef({ matchCount, query })
+  unstableRef.current = { matchCount, query }
 
   const resetMatchState = useCallback(() => {
     setMatches([])
@@ -99,7 +101,6 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const setQuery = useCallback(
     (nextQuery: string) => {
-      queryRef.current = nextQuery
       setQueryState(nextQuery)
       recalculate(nextQuery, { resetSelection: true })
     },
@@ -110,38 +111,40 @@ export const usePDFSearch = (fileUrl: string) => {
     (pageIndex: number, texts: string[]) => {
       pageTextsRef.current.set(pageIndex, texts.map(normalize))
       // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
-      if (queryRef.current !== '') {
-        recalculate(queryRef.current)
+      if (unstableRef.current.query !== '') {
+        recalculate(unstableRef.current.query)
       }
     },
     [recalculate],
   )
 
   const clear = useCallback(() => {
-    queryRef.current = ''
     setQueryState('')
     resetMatchState()
   }, [resetMatchState])
 
   const goNext = useCallback(() => {
     setCurrentMatchIndex((prev) => {
-      if (matchCount === 0) return -1
+      const { matchCount: count } = unstableRef.current
+
+      if (count === 0) return -1
       if (prev < 0) return 0
-      return (prev + 1) % matchCount
+      return (prev + 1) % count
     })
-  }, [matchCount])
+  }, [])
 
   const goPrev = useCallback(() => {
     setCurrentMatchIndex((prev) => {
-      if (matchCount === 0) return -1
-      if (prev < 0) return matchCount - 1
-      return (prev - 1 + matchCount) % matchCount
+      const { matchCount: count } = unstableRef.current
+
+      if (count === 0) return -1
+      if (prev < 0) return count - 1
+      return (prev - 1 + count) % count
     })
-  }, [matchCount])
+  }, [])
 
   useEffect(() => {
     pageTextsRef.current.clear()
-    queryRef.current = ''
     setQueryState('')
     resetMatchState()
   }, [fileUrl, resetMatchState])

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -99,7 +99,6 @@ export const usePDFSearch = (fileUrl: string) => {
     }
 
     return {
-      recalculate,
       setQuery: (nextQuery: string) => {
         setQueryState(nextQuery)
         recalculate(nextQuery, { resetSelection: true })

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { useLatest } from '../../hooks/useLatest'
+
 import type { PDFSearchMatch } from './types'
 
 export const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -55,8 +57,7 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const unstableRef = useRef({ matchCount, query })
-  unstableRef.current = { matchCount, query }
+  const latest = useLatest({ matchCount, query })
 
   const resetMatchState = useCallback(() => {
     setMatches([])
@@ -107,41 +108,41 @@ export const usePDFSearch = (fileUrl: string) => {
     [recalculate],
   )
 
-  const registerPageText = useCallback(
-    (pageIndex: number, texts: string[]) => {
-      pageTextsRef.current.set(pageIndex, texts.map(normalize))
-      // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
-      if (unstableRef.current.query !== '') {
-        recalculate(unstableRef.current.query)
-      }
-    },
-    [recalculate],
-  )
-
   const clear = useCallback(() => {
     setQueryState('')
     resetMatchState()
   }, [resetMatchState])
 
-  const goNext = useCallback(() => {
-    setCurrentMatchIndex((prev) => {
-      const { matchCount: count } = unstableRef.current
+  const functions = useMemo(
+    () => ({
+      registerPageText: (pageIndex: number, texts: string[]) => {
+        pageTextsRef.current.set(pageIndex, texts.map(normalize))
+        // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
+        if (latest.query !== '') {
+          recalculate(latest.query)
+        }
+      },
+      goNext: () => {
+        setCurrentMatchIndex((prev) => {
+          const { matchCount: count } = latest
 
-      if (count === 0) return -1
-      if (prev < 0) return 0
-      return (prev + 1) % count
-    })
-  }, [])
+          if (count === 0) return -1
+          if (prev < 0) return 0
+          return (prev + 1) % count
+        })
+      },
+      goPrev: () => {
+        setCurrentMatchIndex((prev) => {
+          const { matchCount: count } = latest
 
-  const goPrev = useCallback(() => {
-    setCurrentMatchIndex((prev) => {
-      const { matchCount: count } = unstableRef.current
-
-      if (count === 0) return -1
-      if (prev < 0) return count - 1
-      return (prev - 1 + count) % count
-    })
-  }, [])
+          if (count === 0) return -1
+          if (prev < 0) return count - 1
+          return (prev - 1 + count) % count
+        })
+      },
+    }),
+    [latest, recalculate],
+  )
 
   useEffect(() => {
     pageTextsRef.current.clear()
@@ -156,22 +157,12 @@ export const usePDFSearch = (fileUrl: string) => {
       matches,
       matchCount,
       currentMatchIndex,
-      goNext,
-      goPrev,
+      goNext: functions.goNext,
+      goPrev: functions.goPrev,
       clear,
-      registerPageText,
+      registerPageText: functions.registerPageText,
     }),
-    [
-      query,
-      setQuery,
-      matches,
-      matchCount,
-      currentMatchIndex,
-      goNext,
-      goPrev,
-      clear,
-      registerPageText,
-    ],
+    [query, setQuery, matches, matchCount, currentMatchIndex, clear, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -64,8 +64,8 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const latest = useLatest({ matchCount, query, resetMatchState })
 
-  const recalculate = useCallback(
-    (nextQuery: string, options?: { resetSelection?: boolean }) => {
+  const functions = useMemo(() => {
+    const recalculate = (nextQuery: string, options?: { resetSelection?: boolean }) => {
       if (nextQuery === '') {
         latest.resetMatchState()
         return
@@ -96,20 +96,14 @@ export const usePDFSearch = (fileUrl: string) => {
         if (prev >= globalIndex) return globalIndex - 1
         return prev
       })
-    },
-    [latest],
-  )
+    }
 
-  const setQuery = useCallback(
-    (nextQuery: string) => {
-      setQueryState(nextQuery)
-      recalculate(nextQuery, { resetSelection: true })
-    },
-    [recalculate],
-  )
-
-  const functions = useMemo(
-    () => ({
+    return {
+      recalculate,
+      setQuery: (nextQuery: string) => {
+        setQueryState(nextQuery)
+        recalculate(nextQuery, { resetSelection: true })
+      },
       registerPageText: (pageIndex: number, texts: string[]) => {
         pageTextsRef.current.set(pageIndex, texts.map(normalize))
         // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
@@ -139,9 +133,8 @@ export const usePDFSearch = (fileUrl: string) => {
         setQueryState('')
         latest.resetMatchState()
       },
-    }),
-    [recalculate, latest],
-  )
+    }
+  }, [latest])
 
   useEffect(() => {
     pageTextsRef.current.clear()
@@ -152,7 +145,7 @@ export const usePDFSearch = (fileUrl: string) => {
   return useMemo(
     () => ({
       query,
-      setQuery,
+      setQuery: functions.setQuery,
       matches,
       matchCount,
       currentMatchIndex,
@@ -161,7 +154,7 @@ export const usePDFSearch = (fileUrl: string) => {
       clear: functions.clear,
       registerPageText: functions.registerPageText,
     }),
-    [query, setQuery, matches, matchCount, currentMatchIndex, functions],
+    [query, matches, matchCount, currentMatchIndex, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -57,17 +57,17 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const latest = useLatest({ matchCount, query })
-
   const resetMatchState = useCallback(() => {
     setMatches([])
     setCurrentMatchIndex(-1)
   }, [])
 
+  const latest = useLatest({ matchCount, query, resetMatchState })
+
   const recalculate = useCallback(
     (nextQuery: string, options?: { resetSelection?: boolean }) => {
       if (nextQuery === '') {
-        resetMatchState()
+        latest.resetMatchState()
         return
       }
       const escapedQuery = escapeRegExp(normalize(nextQuery))
@@ -97,7 +97,7 @@ export const usePDFSearch = (fileUrl: string) => {
         return prev
       })
     },
-    [resetMatchState],
+    [latest],
   )
 
   const setQuery = useCallback(
@@ -110,8 +110,8 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const clear = useCallback(() => {
     setQueryState('')
-    resetMatchState()
-  }, [resetMatchState])
+    latest.resetMatchState()
+  }, [latest])
 
   const functions = useMemo(
     () => ({
@@ -147,8 +147,8 @@ export const usePDFSearch = (fileUrl: string) => {
   useEffect(() => {
     pageTextsRef.current.clear()
     setQueryState('')
-    resetMatchState()
-  }, [fileUrl, resetMatchState])
+    latest.resetMatchState()
+  }, [fileUrl, latest])
 
   return useMemo(
     () => ({

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -108,11 +108,6 @@ export const usePDFSearch = (fileUrl: string) => {
     [recalculate],
   )
 
-  const clear = useCallback(() => {
-    setQueryState('')
-    latest.resetMatchState()
-  }, [latest])
-
   const functions = useMemo(
     () => ({
       registerPageText: (pageIndex: number, texts: string[]) => {
@@ -140,8 +135,12 @@ export const usePDFSearch = (fileUrl: string) => {
           return (prev - 1 + count) % count
         })
       },
+      clear: () => {
+        setQueryState('')
+        latest.resetMatchState()
+      },
     }),
-    [latest, recalculate],
+    [recalculate, latest],
   )
 
   useEffect(() => {
@@ -159,10 +158,10 @@ export const usePDFSearch = (fileUrl: string) => {
       currentMatchIndex,
       goNext: functions.goNext,
       goPrev: functions.goPrev,
-      clear,
+      clear: functions.clear,
       registerPageText: functions.registerPageText,
     }),
-    [query, setQuery, matches, matchCount, currentMatchIndex, clear, functions],
+    [query, setQuery, matches, matchCount, currentMatchIndex, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -57,17 +57,17 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const resetMatchState = useCallback(() => {
-    setMatches([])
-    setCurrentMatchIndex(-1)
-  }, [])
-
-  const latest = useLatest({ matchCount, query, resetMatchState })
+  const latest = useLatest({ matchCount, query })
 
   const functions = useMemo(() => {
+    const resetMatchState = () => {
+      setMatches([])
+      setCurrentMatchIndex(-1)
+    }
+
     const recalculate = (nextQuery: string, options?: { resetSelection?: boolean }) => {
       if (nextQuery === '') {
-        latest.resetMatchState()
+        resetMatchState()
         return
       }
       const escapedQuery = escapeRegExp(normalize(nextQuery))
@@ -130,16 +130,17 @@ export const usePDFSearch = (fileUrl: string) => {
       },
       clear: () => {
         setQueryState('')
-        latest.resetMatchState()
+        resetMatchState()
       },
+      resetMatchState,
     }
   }, [latest])
 
   useEffect(() => {
     pageTextsRef.current.clear()
     setQueryState('')
-    latest.resetMatchState()
-  }, [fileUrl, latest])
+    functions.resetMatchState()
+  }, [fileUrl, functions])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## 関連URL

なし

## 概要

FileViewer関連コンポーネント（FileViewer、PDFViewer、SearchController、usePDFSearch）のコールバック依存配列を最適化し、不要な再レンダリングを削減するためのリファクタリング。

## 変更内容

### unstableRefパターンの適用

外部から渡される不安定なコールバック（`onLoad`、`onPDFLoaded`、`setQuery`など）を`unstableRef`で管理し、全てのコールバックの依存配列を空または最小限にすることで、コンポーネントの再レンダリングを抑制。

- `usePDFSearch`: `goNext`、`goPrev`の依存配列を空に
- `FileViewer`: 
  - コンポーネントを3つに分割（`FileViewer`、`PDFFileViewer`、`ActualFileViewer`）
  - `usePDFSearch`フックをPDF専用コンポーネント内で条件付き呼び出しに変更
  - `rotation`状態を`FileViewer`に移動
  - 全コールバックで`unstableRef`パターンを適用
- `SearchController`: `handleChange`、`handleKeyDown`の依存配列を空に
- `PDFViewer`: `onPageLoad`、`handleGetTextSuccess`の依存配列を最適化

### PDFViewerのパフォーマンス最適化

`handleGetTextSuccess`を`useCallback`から`useMemo`に変更し、ページごとに動的に関数を生成する代わりに、全ページ分のコールバック関数を事前に配列として生成。レンダリング時のパフォーマンスを改善。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookで`FileViewer`の動作確認
- 既存のテストが通ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * PDFと画像の表示処理を整理し、ファイル表示の安定性を向上しました。
  * PDFの検索、ページ移動、検索結果件数の表示を改善しました。
  * PDFの拡大・縮小・回転操作や読み込み時の動作を安定化しました。
  * パスワード付きPDFや読み込みエラー時の通知処理を改善しました。
  * PDF検索状態を適切にリセットできるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->