### PR TITLE
fix: disabled なトリガーで Dialog・Disclosure が発火しないようにする

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.test.tsx
@@ -1,0 +1,67 @@
+import { act, render, screen } from '@testing-library/react'
+
+import { IntlProvider } from '../../../intl'
+import { Button } from '../../Button'
+
+import { MessageDialog } from './MessageDialog'
+import { RemoteDialogTrigger } from './RemoteDialogTrigger'
+
+describe('RemoteDialogTrigger', () => {
+  it('Button が disabled のとき、クリックしてもダイアログが開かないこと', () => {
+    render(
+      <IntlProvider locale="ja">
+        <RemoteDialogTrigger targetId="remote-dialog">
+          <Button disabled>ダイアログを開く</Button>
+        </RemoteDialogTrigger>
+        <MessageDialog id="remote-dialog" heading="リモートダイアログ">
+          ダイアログの内容
+        </MessageDialog>
+      </IntlProvider>,
+    )
+
+    act(() => {
+      screen.getByRole('button', { name: 'ダイアログを開く' }).click()
+    })
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('Button が loading のとき、クリックしてもダイアログが開かないこと', () => {
+    render(
+      <IntlProvider locale="ja">
+        <RemoteDialogTrigger targetId="remote-dialog">
+          <Button loading>ダイアログを開く</Button>
+        </RemoteDialogTrigger>
+        <MessageDialog id="remote-dialog" heading="リモートダイアログ">
+          ダイアログの内容
+        </MessageDialog>
+      </IntlProvider>,
+    )
+
+    act(() => {
+      // loading 中は accessible name に「処理中」が付与されるため部分一致で取得する
+      screen.getByRole('button', { name: /ダイアログを開く/ }).click()
+    })
+
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('Button が enabled のとき、クリックするとダイアログが開くこと', () => {
+    render(
+      <IntlProvider locale="ja">
+        <RemoteDialogTrigger targetId="remote-dialog">
+          <Button>ダイアログを開く</Button>
+        </RemoteDialogTrigger>
+        <MessageDialog id="remote-dialog" heading="リモートダイアログ">
+          ダイアログの内容
+        </MessageDialog>
+      </IntlProvider>,
+    )
+
+    act(() => {
+      screen.getByRole('button', { name: 'ダイアログを開く' }).click()
+    })
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -52,9 +52,19 @@ export const RemoteDialogTrigger: FC<
     // 現在の子要素に対して処理を実行
     const setupElement = () => {
       const element = getClickableElement()
-      if (element) {
-        element.setAttribute('aria-haspopup', 'dialog')
-        element.setAttribute('aria-controls', targetId)
+      if (!element) {
+        return
+      }
+
+      element.setAttribute('aria-haspopup', 'dialog')
+      element.setAttribute('aria-controls', targetId)
+
+      // Button は native disabled ではなく aria-disabled を使うため、
+      // 無効時はリスナーを貼らず Dialog が開かないようにする（DropdownTrigger と同じ）
+      if (
+        !('disabled' in element && element.disabled) &&
+        element.getAttribute('aria-disabled') !== 'true'
+      ) {
         // HINT: DropdownCloser のonClickより先に実行するため、キャプチャフェーズで処理する
         element.addEventListener('click', actualOnClick, CAPTURE_OPTION)
       }

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/RemoteDialogTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/RemoteDialogTrigger.stories.tsx
@@ -26,3 +26,16 @@ export default {
 } as Meta<typeof RemoteDialogTrigger>
 
 export const Playground: StoryObj<typeof RemoteDialogTrigger> = {}
+
+export const Disabled: StoryObj<typeof RemoteDialogTrigger> = {
+  render: (args) => (
+    <>
+      <RemoteDialogTrigger {...args}>
+        <Button disabled>ダイアログを開く（disabled）</Button>
+      </RemoteDialogTrigger>
+      <MessageDialog id="remote-dialog" heading="リモートトリガーメッセージダイアログ">
+        RemoteDialogTrigger
+      </MessageDialog>
+    </>
+  ),
+}

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.test.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
+import { IntlProvider } from '../../intl'
 import { Button } from '../Button'
 
 import { DisclosureContent } from './DisclosureContent'
@@ -34,6 +35,68 @@ describe('Disclosure', () => {
       await waitFor(async () => {
         expect(screen.queryByText('これは詳細です')).toBeNull()
       })
+    })
+  })
+
+  describe('トリガーボタンが disabled の場合', () => {
+    it('クリックしても開かないこと', async () => {
+      render(
+        <div className="App">
+          <DisclosureTrigger targetId="dc">
+            <Button disabled>押してね</Button>
+          </DisclosureTrigger>
+
+          <DisclosureContent id="dc">
+            <p>これは詳細です</p>
+          </DisclosureContent>
+        </div>,
+      )
+
+      act(() => {
+        screen.getByRole('button', { name: '押してね' }).click()
+      })
+
+      // useDisclosure は requestAnimationFrame 経由で状態更新する
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve())
+        })
+      })
+
+      expect(screen.queryByText('これは詳細です')).toBeNull()
+    })
+  })
+
+  describe('トリガーボタンが loading の場合', () => {
+    it('クリックしても開かないこと', async () => {
+      render(
+        // loading 中の Button は「処理中」テキストを描画するため IntlProvider が必要
+        <IntlProvider locale="ja">
+          <div className="App">
+            <DisclosureTrigger targetId="dc">
+              <Button loading>押してね</Button>
+            </DisclosureTrigger>
+
+            <DisclosureContent id="dc">
+              <p>これは詳細です</p>
+            </DisclosureContent>
+          </div>
+        </IntlProvider>,
+      )
+
+      act(() => {
+        // loading 中は accessible name に「処理中」が付与されるため部分一致で取得する
+        screen.getByRole('button', { name: /押してね/ }).click()
+      })
+
+      // useDisclosure は requestAnimationFrame 経由で状態更新する
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve())
+        })
+      })
+
+      expect(screen.queryByText('これは詳細です')).toBeNull()
     })
   })
 

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
@@ -57,10 +57,15 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
 
       button.setAttribute('aria-expanded', expanded.toString())
       button.setAttribute('aria-controls', targetId)
-      button.addEventListener('click', actualOnClick)
 
-      currentCleanup = () => {
-        button.removeEventListener('click', actualOnClick)
+      // Button は native disabled ではなく aria-disabled を使うため、
+      // 無効時はリスナーを貼らず開閉しないようにする（DropdownTrigger と同じ）
+      if (!button.disabled && button.getAttribute('aria-disabled') !== 'true') {
+        button.addEventListener('click', actualOnClick)
+
+        currentCleanup = () => {
+          button.removeEventListener('click', actualOnClick)
+        }
       }
     }
 

--- a/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureTrigger.stories.tsx
@@ -51,3 +51,15 @@ export const Children: StoryObj<typeof DisclosureTrigger> = {
     </>
   ),
 }
+
+export const Disabled: StoryObj<typeof DisclosureTrigger> = {
+  name: 'disabled',
+  render: () => (
+    <>
+      <DisclosureTrigger targetId="disclosure_disabled">
+        <Button disabled>ディスクロージャートリガー（disabled）</Button>
+      </DisclosureTrigger>
+      <DisclosureContent id="disclosure_disabled">ディスクロージャーコンテンツ</DisclosureContent>
+    </>
+  ),
+}


### PR DESCRIPTION
## 関連URL

- 原因PR: https://github.com/kufu/smarthr-ui/pull/6403

## 概要

`RemoteDialogTrigger` および `DisclosureTrigger` で、子の `Button` に `disabled` を付けていてもクリックするとダイアログが開く／開閉が発火してしまう不具合を修正します。#6403（v96.1.2 で混入）以降、`cloneElement` をやめて `useEffect` でクリックリスナーを直接貼るパターンに変わった際に、`disabled` を考慮せずリスナーを貼っていたことが原因です。

smarthr-ui の `Button` は `disabled` 指定時に native の `disabled` 属性ではなく `aria-disabled` を付与するため、無効なボタンにもリスナーが貼られ発火していました。

## 変更内容

`DropdownTrigger` と同じく、リスナーを貼る前に `disabled` / `aria-disabled` を確認し、無効な場合はリスナーを貼らないようにしました。

- `RemoteDialogTrigger` / `DisclosureTrigger` の `useEffect` 内で、対象要素が `disabled` または `aria-disabled="true"` のときはクリックリスナーを登録しない
- `MutationObserver` の `attributeFilter` に `disabled` / `aria-disabled` を追加し、これらが動的に変化した場合もリスナーを貼り直す
- `loading` 中の `Button` も `aria-disabled` が付くため、同様に発火しないことをテストで担保

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybook の `Dialog/RemoteDialogTrigger` > `Disabled`、`Disclosure/DisclosureTrigger` > `disabled` ストーリーで、disabled な Button をクリックしても発火しないことを確認
- 追加した以下のテストが通ること
  - `RemoteDialogTrigger.test.tsx`: disabled / loading でダイアログが開かない、enabled で開く
  - `DisclosureContent.test.tsx`: disabled / loading で開閉しない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 無効状態または読み込み中のボタンをクリックしても、ダイアログや開閉コンテンツが誤って表示されないよう改善しました。
  - 有効なボタンでは、従来どおりダイアログやコンテンツを開けます。
  - 無効状態のダイアログ・開閉コンポーネントを確認できるサンプルを追加しました。

- **テスト**
  - ボタンの有効・無効・読み込み中の各状態における表示動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->