### PR TITLE
fix: DropdownとComboboxにforced-colors時のoutlineを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -56,7 +56,7 @@ const classNameGenerator = tv({
     wrapper: 'shr-absolute',
     dropdownList: [
       'smarthr-ui-Combobox-dropdownList',
-      'shr-absolute shr-z-overlap shr-box-border shr-min-w-full shr-rounded-m shr-bg-white shr-py-0.5 shr-shadow-layer-3',
+      'shr-absolute shr-z-overlap shr-box-border shr-min-w-full shr-rounded-m shr-bg-white shr-py-0.5 shr-shadow-layer-3 forced-colors:shr-outline forced-colors:shr-outline-1',
       /* 縦スクロールに気づきやすくするために8個目のアイテムが半分見切れるように max-height を算出
       = (アイテムのフォントサイズ + アイテムの上下padding) * 7.5 + コンテナの上padding */
       'shr-max-h-[calc((theme(fontSize.base)_+_theme(spacing[0.5])_*_2)_*_7.5_+_theme(spacing[0.5]))]',

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -19,7 +19,7 @@ import { type ContentBoxStyle, type Rect, getContentBoxStyle } from './dropdownH
 import { useKeyboardNavigation } from './useKeyboardNavigation'
 
 const classNameGenerator = tv({
-  base: 'smarthr-ui-Dropdown-content shr-absolute shr-z-overlap-base shr-overflow-y-auto shr-break-words shr-rounded-m shr-bg-white shr-shadow-layer-3',
+  base: 'smarthr-ui-Dropdown-content shr-absolute shr-z-overlap-base shr-overflow-y-auto shr-break-words shr-rounded-m shr-bg-white shr-shadow-layer-3 forced-colors:shr-outline forced-colors:shr-outline-1',
   variants: {
     isActive: {
       true: 'shr-visible',


### PR DESCRIPTION
強制カラーモードでは、Dropdown系とCombobox系のコンポーネントのオーバーレイのボーダーが正しく表示されない

## 関連URL

[JIRA: forced-colorsモードでComboboxとDropdownのドロップダウンオーバーレイのボーダーが見えないない](https://smarthr.atlassian.net/browse/SHRUI-1407?atlOrigin=eyJpIjoiYjIzMzJiZmI2NjU2NDI4YjljNWNlZGVmNmM1MWE4ZjkiLCJwIjoiaiJ9)

## 概要

## 変更内容

Dropdownのオーバーレイの `DropdownContentInner` と Comboboxのオーバーレイの `listbox` のクラスリストに `forced-colors:shr-outline` と、（1pxの幅を指定しないと2pxになるため） `forced-colors:shr-outline-1` を追加した。 

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

<img width="889" height="836" alt="listbox-combobox" src="https://github.com/user-attachments/assets/7a253039-86eb-4627-b1ed-1e4272d73584" />


## プロダクト側で対応が必要な事項

特になし

## 確認方法

Storybook上、以下のことを確認
- 強制カラーモードを有効にしたとき、ボーダーが表示されるか
- 強制カラーモードを無効にしたとき、影響がないか

対象コンポーネント

- [Storybook: FilterDropdown](https://2696856--63d0ccabb5d2dd29825524ab.chromatic.com/?path=/docs/components-dropdown-filterdropdown--docs)
- [Storybook: SortDropdown](https://2696856--63d0ccabb5d2dd29825524ab.chromatic.com/?path=/docs/components-dropdown-sortdropdown--docs)
- [Storybook: MultiCombobox](http://localhost:6006/?path=/docs/components-combobox-multicombobox--docs)
- [Storybook: SingleCombobox](http://localhost:6006/?path=/docs/components-combobox-singlecombobox--docs)