### PR TITLE
fix: SegmentedControlにforced-colors時のsystem-colorを適用

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -48,7 +48,7 @@ const classNameGenerator = tv({
       'focus-visible:shr-focus-indicator',
       'first:shr-ml-0 first:shr-rounded-bl-m first:shr-rounded-tl-m',
       'last:shr-rounded-br-m last:shr-rounded-tr-m',
-
+      '[&[aria-checked="true"]]:forced-colors:shr-bg-[SelectedItem] [&[aria-checked="true"]]:forced-colors:shr-text-[SelectedItemText]',
       '[&:not([aria-checked="true"]):focus-visible]:shr-relative [&:not([aria-checked="true"]):focus-visible]:shr-border-x',
 
       // ::before: フォーカスリングと前のボタンの右端の間の隙間を埋めるために、左端から2px外側に1pxの縦線を描画する。


### PR DESCRIPTION
# WIP  - Windows上の確認が必要

## 関連URL

[JIRA: forced-colorsモード時にSegmentedControlで選択状態が視認できない](https://smarthr.atlassian.net/browse/SHRUI-1408)

## 概要

SegmentedControlに、強制カラーモードのための [system-color](https://developer.mozilla.org/ja/docs/Web/CSS/Reference/Values/system-color) を適用した。

## 変更内容

選択されたボタンの背景を `SelectedItem`、テキストを `SelectedItemText`にした


## プロダクト側で対応が必要な事項

なし

## 確認方法

開発ツールで `forced-colors: active` を有効にし、Storybook上 `prefers-color-scheme: light` と `prefers-color-scheme: dark` で問題なく表示されるかを確認する