### PR TITLE
fix: SideNavにforced-colors時のsystem-colorを適用

### DIFF
--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -52,6 +52,7 @@ const classNameGenerator = tv({
       'smarthr-ui-SideNav-item shr-relative',
       'data-[current=true]:shr-bg-main data-[current=true]:shr-text-white',
       'data-[current=true]:after:shr-absolute data-[current=true]:after:-shr-right-0.25 data-[current=true]:after:shr-top-1/2 data-[current=true]:after:-shr-translate-y-1/2 data-[current=true]:after:shr-translate-x-0 data-[current=true]:after:shr-border-b-4 data-[current=true]:after:shr-border-l-4 data-[current=true]:after:shr-border-r-0 data-[current=true]:after:shr-border-t-4 data-[current=true]:after:shr-border-solid data-[current=true]:after:shr-border-b-transparent data-[current=true]:after:shr-border-l-main data-[current=true]:after:shr-border-r-transparent data-[current=true]:after:shr-border-t-transparent data-[current=true]:after:shr-content-[""]',
+      'forced-colors:data-[current=true]:shr-bg-[SelectedItem] forced-colors:data-[current=true]:shr-text-[SelectedItemText] forced-colors:data-[current=true]:after:shr-border-l-[color:SelectedItem] forced-colors:data-[current=true]:after:shr-forced-color-adjust-none',
       'data-[current=false]:hover:shr-bg-column-darken',
       '[&:has(:focus-visible)]:shr-z-1', // pseudoエレメントがliの::afterと衝突しないために子要素に適用しますが、次のエレメントに被られるからz-indexを一時的に変更します
     ],
@@ -73,7 +74,8 @@ const classNameGenerator = tv({
       '[:last-child_&]:after:shr-hidden [[data-current=false]:not(:last-child)_&:focus-visible]:after:shr-block [[data-current=false]_&:focus-visible]:after:shr-absolute',
     ],
     body: 'shr-w-full',
-    bodyText: 'smarthr-ui-SideNav-itemBodyText shr-grow',
+    bodyText:
+      'smarthr-ui-SideNav-itemBodyText shr-grow [[data-current=true]_&]:forced-colors:shr-bg-[SelectedItem] [[data-current=true]_&]:forced-colors:shr-text-[SelectedItemText]',
   },
   variants: {
     size: {


### PR DESCRIPTION
# WIP  - Windows上の確認が必要

Storybookの生成のためdraft状態を一時的に解除したので、レビューをしなくてもOKです。

## 関連URL

[JIRA: forced-colorsモード時にSideNavでアクティブアイテムが区別できず、キャレットがブロック表示される](https://smarthr.atlassian.net/browse/SHRUI-1409)

## 概要

`forced-colors: active`時に選択集のアイテムが見えるように[system-color](https://developer.mozilla.org/ja/docs/Web/CSS/Reference/Values/system-color)を適用した。

## 変更内容

WIP

## プロダクト側で対応が必要な事項

ない

## 確認方法

開発ツールで `forced-colors: active` を有効にし、Storybook上 `prefers-color-scheme: light` と `prefers-color-scheme: dark` で問題なく表示されるかを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ改善**
  * 強制カラーモード環境で、現在選択中のサイドナビゲーション項目が背景色・文字色・選択状態を適切に表示できるよう改善しました。
  * サイドナビゲーションの表示切り替え時に、強制カラーモードの配色が正しく反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->