### PR TITLE
refactor(LineClamp): ResizeObserverからwindow.resizeイベントリスナーへ変更

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -68,29 +68,23 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
   const shadowRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    const el = ref.current
-    const shadowEl = shadowRef.current
-
-    if (!el || !shadowEl) return
-
     // -webkit-line-clamp を使った要素ではel.scrollHeightとel.clientHeightの比較だと
     // フォントの高さの計算が期待と異なり適切な高さが取得できないためshadowElと比較している
     // 参考: https://github.com/kufu/smarthr-ui/pull/4710
     const checkOverflow = () => {
-      setTooltipVisible(shadowEl.clientHeight > el.clientHeight)
+      if (ref.current && shadowRef.current) {
+        setTooltipVisible(shadowRef.current.clientHeight > ref.current.clientHeight)
+      }
     }
 
     checkOverflow()
 
-    const resizeObserver = new ResizeObserver(checkOverflow)
-    resizeObserver.observe(el)
-    resizeObserver.observe(shadowEl)
+    window.addEventListener('resize', checkOverflow)
 
     return () => {
-      resizeObserver.unobserve(el)
-      resizeObserver.unobserve(shadowEl)
+      window.removeEventListener('resize', checkOverflow)
     }
-  }, [maxLines])
+  }, [maxLines, children])
 
   const classNames = useMemo(() => {
     const { base, clampedLine, shadowElementWrapper, shadowElement } = classNameGenerator({

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -84,7 +84,9 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
     return () => {
       window.removeEventListener('resize', checkOverflow)
     }
-  }, [maxLines])
+    // TODO: 将来的にMutationObserverに置き換えて、children の変更を監視する実装に変更する
+    // eslint-disable-next-line smarthr/best-practice-for-unstable-dependencies
+  }, [children, maxLines])
 
   const classNames = useMemo(() => {
     const { base, clampedLine, shadowElementWrapper, shadowElement } = classNameGenerator({

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -84,7 +84,7 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
     return () => {
       window.removeEventListener('resize', checkOverflow)
     }
-  }, [maxLines, children])
+  }, [maxLines])
 
   const classNames = useMemo(() => {
     const { base, clampedLine, shadowElementWrapper, shadowElement } = classNameGenerator({


### PR DESCRIPTION
## 関連URL

なし

## 概要

LineClampコンポーネントでResizeObserverを使用していた実装をwindow.resizeイベントリスナーに変更しました。

## 変更内容

- ResizeObserverの削除
  - `new ResizeObserver()`、`observe()`、`unobserve()`の処理を削除
- window.resizeイベントリスナーへ変更
  - `window.addEventListener('resize', checkOverflow)` を使用
  - クリーンアップで `window.removeEventListener('resize', checkOverflow)` を実行
- nullチェックの移動
  - `ref.current`と`shadowRef.current`のnullチェックを`checkOverflow`関数内に移動

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで以下を確認：
1. LineClampコンポーネントのストーリーを開く
2. ブラウザのウィンドウサイズを変更した際、テキストのクランプ状態に応じてTooltipの表示/非表示が正しく切り替わることを確認