### PR TITLE
refactor(Textarea): debounce関数を統合して依存配列を簡素化

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -187,40 +187,36 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       () => textareaRef.current,
     )
 
-    const debouncedUpdateCount = useMemo(
-      () =>
-        maxLetters
-          ? debounce((newValue: TextareaValue) => {
-              startTransition(() => {
-                setCount(getStringLength(newValue))
-              })
-            }, 200)
-          : undefined,
-      [maxLetters],
-    )
+    const updateCounters = useMemo(() => {
+      if (!maxLetters) return undefined
 
-    // countが連続で更新されると、スクリーンリーダーが古い値を読み上げてしまうため、メッセージの更新を遅延しています
-    const debouncedUpdateSrCounterMessage = useMemo(
-      () =>
-        maxLetters
-          ? debounce((newValue: TextareaValue) => {
-              startTransition(() => {
-                const counterText = getCounterMessage(getStringLength(newValue))
+      const updateCount = debounce((newValue: TextareaValue) => {
+        startTransition(() => {
+          setCount(getStringLength(newValue))
+        })
+      }, 200)
 
-                if (counterText) {
-                  setSrCounterMessage(counterText)
-                }
-              })
-            }, 1000)
-          : undefined,
-      [maxLetters, getCounterMessage],
-    )
+      // countが連続で更新されると、スクリーンリーダーが古い値を読み上げてしまうため、メッセージの更新を遅延しています
+      const updateSrMessage = debounce((newValue: TextareaValue) => {
+        startTransition(() => {
+          const counterText = getCounterMessage(getStringLength(newValue))
+
+          if (counterText) {
+            setSrCounterMessage(counterText)
+          }
+        })
+      }, 1000)
+
+      return (newValue: TextareaValue) => {
+        updateCount(newValue)
+        updateSrMessage(newValue)
+      }
+    }, [maxLetters, getCounterMessage])
 
     const handleChange = useCallback(
       (e: ChangeEvent<HTMLTextAreaElement>) => {
         const newValue = e.target.value
-        debouncedUpdateCount?.(newValue)
-        debouncedUpdateSrCounterMessage?.(newValue)
+        updateCounters?.(newValue)
 
         // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
         e.target.rows = rows
@@ -234,14 +230,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
 
         onChangeRef.current?.(e)
       },
-      [
-        debouncedUpdateCount,
-        debouncedUpdateSrCounterMessage,
-        autoResize,
-        maxRows,
-        rows,
-        theme.leading.NORMAL,
-      ],
+      [updateCounters, autoResize, maxRows, rows, theme.leading.NORMAL],
     )
 
     // autoFocus時に、フォーカスを当てる
@@ -261,10 +250,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
     // value 変更時にもカウントを更新する
     useEffect(() => {
       if (value && maxLetters) {
-        debouncedUpdateCount?.(value)
-        debouncedUpdateSrCounterMessage?.(value)
+        updateCounters?.(value)
       }
-    }, [maxLetters, debouncedUpdateCount, debouncedUpdateSrCounterMessage, value])
+    }, [maxLetters, updateCounters, value])
 
     const textareaStyle = useMemo(
       () => ({ width: typeof width === 'number' ? `${width}px` : width }),


### PR DESCRIPTION
## 関連URL

なし

## 概要

Textareaコンポーネントで、2つの独立したdebounce関数を1つに統合し、依存配列を簡素化しました。

## 変更内容

- `debouncedUpdateCount`と`debouncedUpdateSrCounterMessage`を`updateCounters`に統合
  - これらの関数は常に同じタイミングで呼び出されるため、1つにまとめることで保守性を向上
- 依存配列の簡素化
  - `handleChange`の依存配列: 7つ → 5つ
  - `useEffect`の依存配列: 4つ → 3つ

### 変更前
```tsx
const debouncedUpdateCount = useMemo(/* ... */, [maxLetters])
const debouncedUpdateSrCounterMessage = useMemo(/* ... */, [maxLetters, getCounterMessage])

const handleChange = useCallback((e) => {
  debouncedUpdateCount?.(newValue)
  debouncedUpdateSrCounterMessage?.(newValue)
  // ...
}, [debouncedUpdateCount, debouncedUpdateSrCounterMessage, autoResize, maxRows, rows, theme.leading.NORMAL])
```

### 変更後
```tsx
const updateCounters = useMemo(() => {
  if (!maxLetters) return undefined
  const updateCount = debounce(/* ... */, 200)
  const updateSrMessage = debounce(/* ... */, 1000)
  return (newValue) => {
    updateCount(newValue)
    updateSrMessage(newValue)
  }
}, [maxLetters, getCounterMessage])

const handleChange = useCallback((e) => {
  updateCounters?.(newValue)
  // ...
}, [updateCounters, autoResize, maxRows, rows, theme.leading.NORMAL])
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで以下を確認：
1. Textareaコンポーネントの`maxLetters`を設定したストーリーを開く
2. テキストを入力した際、文字数カウントが正しく更新されることを確認
3. スクリーンリーダーで文字数のアナウンスが適切に遅延されることを確認