### PR TITLE
refactor(Textarea): 不要なwrapper関数を削除してコードを簡素化

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -132,52 +132,31 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
     const onChangeRef = useRef(onChange)
     onChangeRef.current = onChange
 
-    const buildAvailableLetters = useCallback(
-      (availableLetters: number): ReactNode => (
-        <Localizer
-          id="smarthr-ui/Textarea/availableLetters"
-          defaultText="あと{availableLetters}文字"
-          values={{ availableLetters }}
-        />
-      ),
-      [],
-    )
-
-    const buildmaxLettersExceeded = useCallback(
-      (exceededLetters: number): ReactNode => (
-        <Localizer
-          id="smarthr-ui/Textarea/maxLettersExceeded"
-          defaultText="{exceededLetters}文字オーバー"
-          values={{ exceededLetters }}
-        />
-      ),
-      [],
-    )
-
-    const buildScreenReaderMaxLettersDescription = useCallback(
-      (internalMaxLetters: number): ReactNode => (
-        <Localizer
-          id="smarthr-ui/Textarea/screenReaderMaxLettersDescription"
-          defaultText="最大{maxLetters}文字入力できます"
-          values={{ maxLetters: internalMaxLetters }}
-        />
-      ),
-      [],
-    )
-
     const getCounterMessage = useCallback(
       (counterValue: number) => {
         if (maxLetters === undefined) return
 
         if (counterValue > maxLetters) {
           // {count}文字オーバー
-          return <>{buildmaxLettersExceeded(counterValue - maxLetters)}</>
+          return (
+            <Localizer
+              id="smarthr-ui/Textarea/maxLettersExceeded"
+              defaultText="{exceededLetters}文字オーバー"
+              values={{ exceededLetters: counterValue - maxLetters }}
+            />
+          )
         }
 
         // あと{count}文字
-        return <>{buildAvailableLetters(maxLetters - counterValue)}</>
+        return (
+          <Localizer
+            id="smarthr-ui/Textarea/availableLetters"
+            defaultText="あと{availableLetters}文字"
+            values={{ availableLetters: maxLetters - counterValue }}
+          />
+        )
       },
-      [maxLetters, buildAvailableLetters, buildmaxLettersExceeded],
+      [maxLetters],
     )
 
     const counterVisualMessage = useMemo(() => getCounterMessage(count), [count, getCounterMessage])
@@ -235,7 +214,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
 
     // autoFocus時に、フォーカスを当てる
     useEffect(() => {
-      if (autoFocus && textareaRef && textareaRef.current) {
+      if (autoFocus && textareaRef.current) {
         textareaRef.current.focus()
       }
     }, [autoFocus])
@@ -288,7 +267,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       <span className="shr-relative">
         {body}
         <VisuallyHiddenText id={maxLettersNoticeId}>
-          {buildScreenReaderMaxLettersDescription(maxLetters)}
+          <Localizer
+            id="smarthr-ui/Textarea/screenReaderMaxLettersDescription"
+            defaultText="最大{maxLetters}文字入力できます"
+            values={{ maxLetters }}
+          />
         </VisuallyHiddenText>
         <VisuallyHiddenText aria-live="polite">{srCounterMessage}</VisuallyHiddenText>
         <span id={actualMaxLettersId} aria-hidden={true} className={classNames.counter}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

Textareaコンポーネントで、不要なwrapper関数を削除し、コードを簡素化しました。

## 変更内容

- 3つのuseCallback wrapper関数を削除
  - `buildAvailableLetters`
  - `buildmaxLettersExceeded`
  - `buildScreenReaderMaxLettersDescription`
- 使用箇所で直接Localizerコンポーネントを使用
- `getCounterMessage`の依存配列を簡素化: `[maxLetters, buildAvailableLetters, buildmaxLettersExceeded]` → `[maxLetters]`
- 軽微な修正: `textareaRef && textareaRef.current` → `textareaRef.current`（nullチェック簡素化）

### 変更前
```tsx
const buildAvailableLetters = useCallback(
  (availableLetters: number): ReactNode => (
    <Localizer
      id="smarthr-ui/Textarea/availableLetters"
      defaultText="あと{availableLetters}文字"
      values={{ availableLetters }}
    />
  ),
  [],
)

const getCounterMessage = useCallback(
  (counterValue: number) => {
    // ...
    return <>{buildAvailableLetters(maxLetters - counterValue)}</>
  },
  [maxLetters, buildAvailableLetters, buildmaxLettersExceeded],
)
```

### 変更後
```tsx
const getCounterMessage = useCallback(
  (counterValue: number) => {
    // ...
    return (
      <Localizer
        id="smarthr-ui/Textarea/availableLetters"
        defaultText="あと{availableLetters}文字"
        values={{ availableLetters: maxLetters - counterValue }}
      />
    )
  },
  [maxLetters],
)
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで以下を確認：
1. Textareaコンポーネントの`maxLetters`を設定したストーリーを開く
2. 文字数カウンターが正しく表示されることを確認
3. スクリーンリーダー用のメッセージが適切に表示されることを確認