### PR TITLE
refactor(DatePicker): 関数生成をuseMemoに統合して他の関数から参照可能に

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -158,17 +158,19 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       selectedDate,
     })
 
-    const { dateToString, dateToAlternativeFormat } = useMemo(
-      () => ({
-        dateToString: (date: Date | null) =>
-          latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date),
-        dateToAlternativeFormat: (d: Date | null) => {
-          if (!latest.showAlternative) return null
-          return d ? latest.showAlternative(d) : null
-        },
-      }),
-      [latest],
-    )
+    const { dateToString, dateToAlternativeFormat } = useMemo(() => {
+      const internalDateToString = (date: Date | null) =>
+        latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date)
+      const internalDateToAlternativeFormat = (d: Date | null) => {
+        if (!latest.showAlternative) return null
+        return d ? latest.showAlternative(d) : null
+      }
+
+      return {
+        dateToString: internalDateToString,
+        dateToAlternativeFormat: internalDateToAlternativeFormat,
+      }
+    }, [latest])
     const inputRef = useRef<HTMLInputElement>(null)
     const inputWrapperRef = useRef<HTMLDivElement>(null)
     const calendarPortalRef = useRef<HTMLDivElement>(null)

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -158,16 +158,15 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       selectedDate,
     })
 
-    const dateToString = useCallback(
-      (date: Date | null) =>
-        latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date),
-      [latest],
-    )
-    const dateToAlternativeFormat = useCallback(
-      (d: Date | null) => {
-        if (!latest.showAlternative) return null
-        return d ? latest.showAlternative(d) : null
-      },
+    const { dateToString, dateToAlternativeFormat } = useMemo(
+      () => ({
+        dateToString: (date: Date | null) =>
+          latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date),
+        dateToAlternativeFormat: (d: Date | null) => {
+          if (!latest.showAlternative) return null
+          return d ? latest.showAlternative(d) : null
+        },
+      }),
       [latest],
     )
     const inputRef = useRef<HTMLInputElement>(null)


### PR DESCRIPTION
## 関連URL

なし

## 概要

DatePickerコンポーネントの `dateToString` と `dateToAlternativeFormat` の関数生成処理を、2つの `useCallback` から1つの `useMemo` に統合し、useMemo内で変数として定義することで他の関数から参照可能にしました。

## 変更内容

### 1つ目のコミット: 2つのuseCallbackを1つのuseMemoに統合

- `dateToString` と `dateToAlternativeFormat` の2つの `useCallback` を1つの `useMemo` にまとめました
- 分割代入で2つの関数を受け取る形に変更

### 2つ目のコミット: useMemo内で関数を変数化

- useMemo内で `internalDateToString` と `internalDateToAlternativeFormat` として変数定義
- returnオブジェクトで `dateToString` と `dateToAlternativeFormat` として返す形に変更
- これにより、今後このuseMemo内で他の関数を追加する際に、これらの関数を相互に参照できるようになります

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- DatePickerの日付フォーマット処理が正常に動作することを確認