### PR TITLE
refactor(DatePicker): refとstateの定義をuseLatestより上に移動

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -158,17 +158,19 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       selectedDate,
     })
 
-    const { dateToString, dateToAlternativeFormat } = useMemo(
-      () => ({
-        dateToString: (date: Date | null) =>
-          latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date),
-        dateToAlternativeFormat: (d: Date | null) => {
-          if (!latest.showAlternative) return null
-          return d ? latest.showAlternative(d) : null
-        },
-      }),
-      [latest],
-    )
+    const { dateToString, dateToAlternativeFormat } = useMemo(() => {
+      const internalDateToString = (date: Date | null) =>
+        latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date)
+      const internalDateToAlternativeFormat = (d: Date | null) => {
+        if (!latest.showAlternative) return null
+        return d ? latest.showAlternative(d) : null
+      }
+
+      return {
+        dateToString: internalDateToString,
+        dateToAlternativeFormat: internalDateToAlternativeFormat,
+      }
+    }, [latest])
     const inputRef = useRef<HTMLInputElement>(null)
     const inputWrapperRef = useRef<HTMLDivElement>(null)
     const calendarPortalRef = useRef<HTMLDivElement>(null)

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -158,16 +158,15 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       selectedDate,
     })
 
-    const dateToString = useCallback(
-      (date: Date | null) =>
-        latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date),
-      [latest],
-    )
-    const dateToAlternativeFormat = useCallback(
-      (d: Date | null) => {
-        if (!latest.showAlternative) return null
-        return d ? latest.showAlternative(d) : null
-      },
+    const { dateToString, dateToAlternativeFormat } = useMemo(
+      () => ({
+        dateToString: (date: Date | null) =>
+          latest.formatDate ? latest.formatDate(date) : DEFAULT_DATE_TO_STRING(date),
+        dateToAlternativeFormat: (d: Date | null) => {
+          if (!latest.showAlternative) return null
+          return d ? latest.showAlternative(d) : null
+        },
+      }),
       [latest],
     )
     const inputRef = useRef<HTMLInputElement>(null)

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -136,6 +136,13 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
     }, [className])
 
     const [isInputFocused, setIsInputFocused] = useState(false)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const inputWrapperRef = useRef<HTMLDivElement>(null)
+    const calendarPortalRef = useRef<HTMLDivElement>(null)
+    const [inputRect, setInputRect] = useState<DOMRect | null>(null)
+    const [isCalendarShown, setIsCalendarShown] = useState(false)
+    const [alternativeFormat, setAlternativeFormat] = useState<null | ReactNode>(null)
+    const calenderId = useId()
 
     const stringToDate = useCallback(
       (str?: string | null) => {
@@ -171,14 +178,6 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         dateToAlternativeFormat: internalDateToAlternativeFormat,
       }
     }, [latest])
-    const inputRef = useRef<HTMLInputElement>(null)
-    const inputWrapperRef = useRef<HTMLDivElement>(null)
-    const calendarPortalRef = useRef<HTMLDivElement>(null)
-    const [inputRect, setInputRect] = useState<DOMRect | null>(null)
-    const [isCalendarShown, setIsCalendarShown] = useState(false)
-
-    const [alternativeFormat, setAlternativeFormat] = useState<null | ReactNode>(null)
-    const calenderId = useId()
 
     useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
       ref,


### PR DESCRIPTION
## 関連URL

なし

## 概要

可読性向上のため、DatePickerコンポーネントの `inputRef` 等のrefやstateの定義を `useLatest` の記述より上に移動しました。

## 変更内容

以下のrefとstateの定義を `useLatest` の前に移動：
- `inputRef`
- `inputWrapperRef`
- `calendarPortalRef`
- `inputRect` (state)
- `isCalendarShown` (state)
- `alternativeFormat` (state)
- `calenderId`

これにより、コンポーネントの構造がより読みやすくなります。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- DatePickerの各種操作が正常に動作することを確認
