### PR TITLE
refactor(DatePicker): updateDateをfunctionsオブジェクトに移動

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -179,8 +179,8 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       const updateDate = (e: ChangeLikeEvent, newDate: Date | null) => {
         if (
           !inputRef.current ||
-          newDate === selectedDate ||
-          (newDate && selectedDate && newDate.getTime() === selectedDate.getTime())
+          newDate === latest.selectedDate ||
+          (newDate && latest.selectedDate && newDate.getTime() === latest.selectedDate.getTime())
         ) {
           // Do not update date if the new date is same with the old one.
           return
@@ -233,7 +233,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         dateToAlternativeFormat,
         updateDate,
       }
-    }, [selectedDate, latest])
+    }, [latest])
 
     useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
       ref,

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -176,24 +176,11 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         return d ? latest.showAlternative(d) : null
       }
 
-      return {
-        stringToDate: (str: string | null | undefined) => stringToDate(str, latest.parseInput),
-        dateToString,
-        dateToAlternativeFormat,
-      }
-    }, [latest])
-
-    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-      ref,
-      () => inputRef.current,
-    )
-
-    const updateDate = useCallback(
-      (e: ChangeLikeEvent, newDate: Date | null) => {
+      const updateDate = (e: ChangeLikeEvent, newDate: Date | null) => {
         if (
           !inputRef.current ||
-          newDate === latest.selectedDate ||
-          (newDate && latest.selectedDate && newDate.getTime() === latest.selectedDate.getTime())
+          newDate === selectedDate ||
+          (newDate && selectedDate && newDate.getTime() === selectedDate.getTime())
         ) {
           // Do not update date if the new date is same with the old one.
           return
@@ -207,10 +194,10 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         }
 
         const nextDate = isValid ? newDate : null
-        const formatValue = functions.dateToString(nextDate)
+        const formatValue = dateToString(nextDate)
 
         inputRef.current.value = formatValue
-        setAlternativeFormat(functions.dateToAlternativeFormat(nextDate))
+        setAlternativeFormat(dateToAlternativeFormat(nextDate))
         setSelectedDate(nextDate)
 
         if (latest.onChange) {
@@ -238,8 +225,19 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         } else if (latest.onChangeDate) {
           latest.onChangeDate(nextDate, formatValue, { errors })
         }
-      },
-      [functions, latest],
+      }
+
+      return {
+        stringToDate: (str: string | null | undefined) => stringToDate(str, latest.parseInput),
+        dateToString,
+        dateToAlternativeFormat,
+        updateDate,
+      }
+    }, [selectedDate, latest])
+
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      ref,
+      () => inputRef.current,
     )
 
     const closeCalendar = useCallback(() => setIsCalendarShown(false), [])
@@ -285,10 +283,10 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
     const handleBlur = useCallback<FocusEventHandler<HTMLInputElement>>(
       (e) => {
         setIsInputFocused(false)
-        updateDate(e, e.target.value ? functions.stringToDate(e.target.value) : null)
+        functions.updateDate(e, e.target.value ? functions.stringToDate(e.target.value) : null)
         latest.onBlur?.(e)
       },
-      [functions, updateDate, latest],
+      [functions, latest],
     )
 
     useEffect(() => {
@@ -367,10 +365,10 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         if (e.key === 'Enter') {
           const isExpanded = e.currentTarget.getAttribute('aria-expanded') === 'true'
           ;(isExpanded ? openCalendar : closeCalendar)()
-          updateDate(e, functions.stringToDate(e.currentTarget.value))
+          functions.updateDate(e, functions.stringToDate(e.currentTarget.value))
         }
       },
-      [updateDate, closeCalendar, openCalendar, functions],
+      [closeCalendar, openCalendar, functions],
     )
     const onFocusInput = useCallback(() => {
       setIsInputFocused(true)
@@ -378,13 +376,13 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
     }, [openCalendar])
     const onSelectDateCalendar = useCallback(
       (e: ChangeLikeEvent, selected: Date | null) => {
-        updateDate(e, selected)
+        functions.updateDate(e, selected)
         // delay hiding calendar because calendar will be displayed when input is focused
         requestAnimationFrame(closeCalendar)
 
         if (inputRef.current) inputRef.current.focus()
       },
-      [updateDate, closeCalendar],
+      [functions, closeCalendar],
     )
 
     return (


### PR DESCRIPTION
## 関連URL

なし

## 概要

DatePickerコンポーネントのコールバック安定化のため、updateDate関数をfunctionsオブジェクトに統合します。

## 変更内容

- updateDate関数をuseCallbackからuseMemo内のfunctionsオブジェクトに移動
- updateDate内部の参照を最適化：
  - `latest.selectedDate` → `selectedDate`（クロージャ経由）
  - `functions.dateToString` → `dateToString`（ローカル関数）
  - `functions.dateToAlternativeFormat` → `dateToAlternativeFormat`（ローカル関数）
- functionsの依存配列に`selectedDate`を追加
- updateDateを使用している箇所を`functions.updateDate`経由に変更

この変更により、関連する関数群が1つのuseMemoにまとまり、依存関係が明確になります。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のStorybookとテストで動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 日付ピッカーの日付更新処理を整理し、日付入力・確定操作・カレンダー選択時の動作を一貫して扱えるように改善しました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->