### PR TITLE
fix(DatePicker): Enterキー押下時のカレンダー開閉ロジックを修正

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -368,7 +368,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
           const isExpanded = e.currentTarget.getAttribute('aria-expanded') === 'true'
-          ;(isExpanded ? functions.openCalendar : functions.closeCalendar)()
+          ;(isExpanded ? functions.closeCalendar : functions.openCalendar)()
           functions.updateDate(e, functions.stringToDate(e.currentTarget.value))
         }
       },


### PR DESCRIPTION
## 関連URL

なし

## 概要

DatePickerコンポーネントでEnterキーを押したときのカレンダー開閉動作が逆になっていたため修正しました。

## 変更内容

`onKeyPressInput`内のカレンダー開閉ロジックを修正：

### Before
```typescript
;(isExpanded ? functions.openCalendar : functions.closeCalendar)()
```

### After
```typescript
;(isExpanded ? functions.closeCalendar : functions.openCalendar)()
```

**期待される動作:**
- カレンダー表示中（`aria-expanded="true"`）にEnterキーを押す → カレンダーを閉じる
- カレンダー非表示時にEnterキーを押す → カレンダーを開く

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 既存のテストが全てパスすることを確認済み
- Storybookで手動確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * DatePickerでEnterキーを押した際、カレンダーの開閉状態が正しく切り替わるよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->