### PR TITLE
refactor(StepFormDialog): stepQueueをstepQueueRefにリネーム

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
@@ -84,16 +84,17 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
   responseStatus,
   onClickBack,
 }) => {
-  const { currentStep, stepQueue, setCurrentStep, scrollerRef } = useContext(StepFormDialogContext)
+  const { currentStep, stepQueueRef, setCurrentStep, scrollerRef } =
+    useContext(StepFormDialogContext)
 
   const handleCloseAction = useCallback(() => {
     onClickClose()
     setTimeout(() => {
       // HINT: ダイアログが閉じるtransitionが完了してから初期化をしている
-      stepQueue.current = []
+      stepQueueRef.current = []
       setCurrentStep(firstStep)
     }, 300)
-  }, [firstStep, stepQueue, setCurrentStep, onClickClose])
+  }, [firstStep, stepQueueRef, setCurrentStep, onClickClose])
 
   const changeCurrentStep = useCallback(
     (step: Parameters<typeof setCurrentStep>[0]) => {
@@ -116,7 +117,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
 
       const helpers: StepFormHelpers = {
         goto: (nextStep: StepItem) => {
-          stepQueue.current.push(currentStep)
+          stepQueueRef.current.push(currentStep)
           changeCurrentStep(nextStep)
         },
         close: handleCloseAction,
@@ -125,13 +126,13 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
 
       onSubmit(e, helpers)
     },
-    [currentStep, stepQueue, onSubmit, handleCloseAction, changeCurrentStep],
+    [currentStep, stepQueueRef, onSubmit, handleCloseAction, changeCurrentStep],
   )
   const handleBackAction = useCallback(() => {
     onClickBack?.()
 
-    changeCurrentStep(stepQueue.current.pop() ?? firstStep)
-  }, [firstStep, stepQueue, onClickBack, changeCurrentStep])
+    changeCurrentStep(stepQueueRef.current.pop() ?? firstStep)
+  }, [firstStep, stepQueueRef, onClickBack, changeCurrentStep])
 
   const classNames = useMemo(() => {
     const { wrapper, actionArea, buttonArea, message } = dialogContentInner()

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogProvider.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogProvider.tsx
@@ -18,13 +18,13 @@ export type StepItem = {
 }
 
 type StepFormDialogContextType = {
-  stepQueue: MutableRefObject<StepItem[]>
+  stepQueueRef: MutableRefObject<StepItem[]>
   currentStep: StepItem
   setCurrentStep: (step: StepItem) => void
   scrollerRef: RefObject<HTMLDivElement>
 }
 export const StepFormDialogContext = createContext<StepFormDialogContextType>({
-  stepQueue: { current: [] },
+  stepQueueRef: { current: [] },
   currentStep: { id: '', stepNumber: 0 },
   setCurrentStep: () => {},
   scrollerRef: { current: null },
@@ -36,11 +36,13 @@ type Props = {
 }
 export const StepFormDialogProvider: FC<Props> = ({ children, firstStep }) => {
   const [currentStep, setCurrentStep] = useState<StepItem>(firstStep)
-  const stepQueue = useRef<StepItem[]>([])
+  const stepQueueRef = useRef<StepItem[]>([])
   const scrollerRef = useRef<HTMLDivElement>(null)
 
   return (
-    <StepFormDialogContext.Provider value={{ currentStep, stepQueue, setCurrentStep, scrollerRef }}>
+    <StepFormDialogContext.Provider
+      value={{ currentStep, stepQueueRef, setCurrentStep, scrollerRef }}
+    >
       {children}
     </StepFormDialogContext.Provider>
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`StepFormDialogContext`で管理している`stepQueue`が`useRef`で作成されたRefオブジェクトであることを明確にするため、`stepQueueRef`にリネームします。

## 変更内容

- `StepFormDialogProvider.tsx`
  - コンテキストの型定義で`stepQueue: MutableRefObject<StepItem[]>` → `stepQueueRef: MutableRefObject<StepItem[]>`
  - コンテキストのデフォルト値で`stepQueue: { current: [] }` → `stepQueueRef: { current: [] }`
  - 変数名を`stepQueue` → `stepQueueRef`に変更

- `StepFormDialogContentInner.tsx`
  - コンテキストから取得する値を`stepQueue` → `stepQueueRef`に変更
  - すべての使用箇所（`stepQueue.current` → `stepQueueRef.current`）を更新
  - 依存配列の`stepQueue` → `stepQueueRef`を更新

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで`StepFormDialog`の動作を確認し、ステップ間の移動や戻る操作が正しく動作することを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ステップフォームダイアログでのステップ移動履歴の管理を改善しました。
  * ダイアログを閉じた際に移動履歴が正しく初期化され、戻る操作やステップ遷移が安定して動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->