### PR TITLE
refactor(StepFormDialog): classNamesをCLASS_NAMESに抽出

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
@@ -1,13 +1,6 @@
 'use client'
 
-import {
-  type FC,
-  type FormEvent,
-  type PropsWithChildren,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react'
+import { type FC, type FormEvent, type PropsWithChildren, useCallback, useContext } from 'react'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
 import { Button } from '../../Button'
@@ -67,6 +60,17 @@ const BUTTON_COLUMN_GAP = {
   row: 0.5,
   column: 1,
 } as const
+
+const CLASS_NAMES = (() => {
+  const { wrapper, actionArea, buttonArea, message } = dialogContentInner()
+
+  return {
+    wrapper: wrapper(),
+    actionArea: actionArea(),
+    buttonArea: buttonArea(),
+    message: message(),
+  }
+})()
 
 export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = ({
   children,
@@ -133,17 +137,6 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
     changeCurrentStep(stepQueue.current.pop() ?? firstStep)
   }, [firstStep, stepQueue, onClickBack, changeCurrentStep])
 
-  const classNames = useMemo(() => {
-    const { wrapper, actionArea, buttonArea, message } = dialogContentInner()
-
-    return {
-      wrapper: wrapper(),
-      actionArea: actionArea(),
-      buttonArea: buttonArea(),
-      message: message(),
-    }
-  }, [])
-
   const stepText = stepLength > 1 ? `（${activeStep}/${stepLength}）` : ''
 
   const calcedResponseStatus = useResponseStatus(responseStatus)
@@ -152,7 +145,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
     // eslint-disable-next-line smarthr/a11y-prohibit-sectioning-content-in-form
     <Section>
       <form onSubmit={handleSubmitAction}>
-        <div className={classNames.wrapper}>
+        <div className={CLASS_NAMES.wrapper}>
           <DialogHeading
             id={heading.id}
             sub={heading.sub ? `${heading.sub}${stepText}` : undefined}
@@ -165,7 +158,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
           >
             {children}
           </DialogBody>
-          <div className={classNames.actionArea}>
+          <div className={CLASS_NAMES.actionArea}>
             <Cluster justify="space-between" gap={{ row: 0.5, column: 2 }}>
               {!backButton.hidden && activeStep > 1 && (
                 <Button
@@ -177,7 +170,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
                   {backButton.text}
                 </Button>
               )}
-              <Cluster gap={BUTTON_COLUMN_GAP} className={classNames.buttonArea}>
+              <Cluster gap={BUTTON_COLUMN_GAP} className={CLASS_NAMES.buttonArea}>
                 {!closeButton.hidden && (
                   <Button
                     onClick={handleCloseAction}
@@ -203,7 +196,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
             </Cluster>
             <DialogContentResponseStatusMessage
               responseStatus={calcedResponseStatus}
-              className={classNames.message}
+              className={CLASS_NAMES.message}
             />
           </div>
         </div>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`StepFormDialogContentInner`コンポーネント内で`useMemo`で定義していた`classNames`を、コンポーネント外で定数として定義する`CLASS_NAMES`に変更します。

## 変更内容

- `useMemo`のimportを削除
- コンポーネント外に`CLASS_NAMES`を定数として定義（IIFEで初期化）
- コンポーネント内の`classNames`の`useMemo`定義を削除
- JSX内のすべての`classNames.xxx`参照を`CLASS_NAMES.xxx`に変更

この変更により、レンダリング毎にクラス名オブジェクトを再生成する必要がなくなり、パフォーマンスが向上します。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで`StepFormDialog`の表示と動作を確認し、スタイルが正しく適用されていることを確認してください。