### PR TITLE
fix(Tooltip): ツールチップを閉じる際にrectをリセット

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 
 import { Button } from '../Button'
 import { FaPencilIcon } from '../Icon'
@@ -77,6 +77,57 @@ describe('Tooltip', () => {
         </Tooltip>,
       )
       expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
+    })
+  })
+
+  // 非表示中に幅計算が走って壊れた maxWidth が inline style に残り、再表示しても直らない不具合の回帰テスト
+  describe('非表示時の位置計算スタイルのクリア', () => {
+    const showTooltip = (wrapper: Element) => fireEvent.pointerEnter(wrapper)
+    const hideTooltip = (wrapper: Element) => fireEvent.pointerLeave(wrapper)
+    const getPopup = () => document.querySelector('.smarthr-ui-Tooltip-popup') as HTMLElement
+
+    it('ツールチップを閉じると、表示中に算出した位置計算の inline style が残らない', () => {
+      render(
+        <Tooltip message="説明">
+          <Button>ボタン</Button>
+        </Tooltip>,
+      )
+      const wrapper = screen.getByRole('button', { name: 'ボタン' }).closest('.smarthr-ui-Tooltip')!
+
+      showTooltip(wrapper)
+      // 表示中は位置計算の style が付与される
+      expect(getPopup().style.maxWidth).not.toBe('')
+
+      hideTooltip(wrapper)
+      // 非表示になったら位置計算の style を引きずらない
+      expect(getPopup().style.maxWidth).toBe('')
+    })
+
+    it('非表示中に window の resize が発火しても、位置計算の inline style が付与されない', () => {
+      vi.useFakeTimers()
+      try {
+        render(
+          <Tooltip message="説明">
+            <Button>ボタン</Button>
+          </Tooltip>,
+        )
+        const wrapper = screen
+          .getByRole('button', { name: 'ボタン' })
+          .closest('.smarthr-ui-Tooltip')!
+
+        showTooltip(wrapper)
+        hideTooltip(wrapper)
+
+        // 非表示中の resize（debounce 100ms）を発火させる
+        act(() => {
+          window.dispatchEvent(new Event('resize'))
+          vi.advanceTimersByTime(100)
+        })
+
+        expect(getPopup().style.maxWidth).toBe('')
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 })

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -141,7 +141,10 @@ export const Tooltip: FC<Props> = ({
     },
     [ellipsisOnly],
   )
-  const toCloseAction = useCallback(() => setIsVisible(false), [])
+  const toCloseAction = useCallback(() => {
+    setRect(null)
+    setIsVisible(false)
+  }, [])
 
   const isIcon = triggerType === 'icon'
   const actualClassName = useMemo(

--- a/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
@@ -85,7 +85,7 @@ export const TooltipPortal: FC<Props> = ({ messageId, message, isVisible, parent
       role="tooltip"
       aria-hidden={!isVisible}
       className={classNames.container}
-      style={style}
+      style={isVisible ? style : undefined}
     >
       <ControlledTooltip
         horizontal={actualHorizontal}


### PR DESCRIPTION
## 関連URL

https://smarthr.slack.com/archives/C04V8V4JYFD/p1738302848854559

## 概要

DropdownMenuButton（onlyIcon指定）でツールチップの幅が数pxに潰れ、再ホバーしても直らない問題を修正します。

## 変更内容

`toCloseAction`でツールチップを閉じる際に、`setRect(null)`を呼び出してrectをクリアするようにしました。

### 問題の原因

1. `toCloseAction`が`setIsVisible(false)`だけで、rectと計算済みstyleをクリアしていなかった
2. 壊れたmaxWidthのinline styleが残った状態で再ホバー時のoffsetWidthを測るため、数pxしか返らず、壊れた値を再計算し続けていた

### 修正内容

```tsx
// Before
const toCloseAction = useCallback(() => setIsVisible(false), [])

// After
const toCloseAction = useCallback(() => {
  setRect(null)
  setIsVisible(false)
}, [])
```

これにより、ツールチップを閉じる際にrectもクリアされ、次回表示時に正しい幅が計算されるようになります。

## プロダクト側で対応が必要な事項

なし

## 確認方法

1. DropdownMenuButton（onlyIcon指定）を含むページを開く
2. DropdownMenuButtonにホバーしてツールチップを表示
3. 何らかのダイアログを開く
4. ダイアログを閉じる
5. 再度DropdownMenuButtonにホバーしてツールチップを表示
6. ツールチップの幅が正しく表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ツールチップを非表示にした際、位置計算で追加されたスタイルが残り続ける問題を修正しました。
  * 非表示中の画面サイズ変更後も、不要なスタイルが適用されないよう改善しました。
  * 次回表示時にツールチップの位置が正しく再計算されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->