### PR TITLE
chore(charts): smarthr-uiへの依存をworkspaceに切り替え

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -46,7 +46,7 @@
     "react": "^19.0.3",
     "react-dom": "^19.0.3",
     "react-intl": "^7.0.4 || ^8.0.0 || ^10.0.0",
-    "smarthr-ui": "^74.0.0",
+    "smarthr-ui": "workspace:^",
     "styled-components": "^5.0.1"
   },
   "dependencies": {

--- a/packages/smarthr-ui/.storybook/main.ts
+++ b/packages/smarthr-ui/.storybook/main.ts
@@ -43,6 +43,7 @@ export default {
       alias: {
         ...config.resolve?.alias,
         '@': join(__dirname, '../src'),
+        'smarthr-ui': join(__dirname, '../src/index.ts'),
       },
     },
     define: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1(chart.js@4.5.1)(react@19.2.7)
       smarthr-ui:
-        specifier: ^74.0.0
-        version: 74.2.0(@types/react@18.3.28)(eslint@9.39.5(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react-intl@10.1.0(@types/react@18.3.28)(react@19.2.7)(typescript@5.9.3))(react@19.2.7)(styled-components@5.3.11(react-dom@19.2.7(react@19.2.7))(react-is@19.2.0)(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))(typescript@5.9.3)
+        specifier: workspace:^
+        version: link:../smarthr-ui
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^29.0.0
@@ -1490,14 +1490,8 @@ packages:
   '@formatjs/bigdecimal@0.2.0':
     resolution: {integrity: sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==}
 
-  '@formatjs/ecma402-abstract@2.3.6':
-    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
-
   '@formatjs/ecma402-abstract@3.2.0':
     resolution: {integrity: sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==}
-
-  '@formatjs/fast-memoize@2.2.7':
-    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
 
   '@formatjs/fast-memoize@3.1.1':
     resolution: {integrity: sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg==}
@@ -1505,26 +1499,17 @@ packages:
   '@formatjs/fast-memoize@3.1.7':
     resolution: {integrity: sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==}
 
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
-
   '@formatjs/icu-messageformat-parser@3.5.14':
     resolution: {integrity: sha512-jDvgtoLqe3U6yzoBlToMTkWBe38qSi7LN7kFlnXzd5ig8nn+4tSlED0xtEtdYakZVZGJJY2rW1D5xS3BFZh6kA==}
 
   '@formatjs/icu-messageformat-parser@3.5.3':
     resolution: {integrity: sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==}
 
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
-
   '@formatjs/icu-skeleton-parser@2.1.11':
     resolution: {integrity: sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==}
 
   '@formatjs/icu-skeleton-parser@2.1.3':
     resolution: {integrity: sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
   '@formatjs/intl-localematcher@0.8.2':
     resolution: {integrity: sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==}
@@ -4066,9 +4051,6 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  intl-messageformat@10.7.18:
-    resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
-
   intl-messageformat@11.2.0:
     resolution: {integrity: sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==}
 
@@ -5489,14 +5471,6 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
-
-  smarthr-ui@74.2.0:
-    resolution: {integrity: sha512-7qLYS3SPozb0/xNP7GI8VLax302XLhSv79iM5nP8M+n3BqyjoMpNjGhbphc6yQASGa0wMo9+r7rcJhgOLkqjvQ==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-      react-intl: ^7.0.4
-      styled-components: ^5.0.1
 
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
@@ -7422,32 +7396,15 @@ snapshots:
 
   '@formatjs/bigdecimal@0.2.0': {}
 
-  '@formatjs/ecma402-abstract@2.3.6':
-    dependencies:
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/intl-localematcher': 0.6.2
-      decimal.js: 10.6.0
-      tslib: 2.8.1
-
   '@formatjs/ecma402-abstract@3.2.0':
     dependencies:
       '@formatjs/bigdecimal': 0.2.0
       '@formatjs/fast-memoize': 3.1.1
       '@formatjs/intl-localematcher': 0.8.2
 
-  '@formatjs/fast-memoize@2.2.7':
-    dependencies:
-      tslib: 2.8.1
-
   '@formatjs/fast-memoize@3.1.1': {}
 
   '@formatjs/fast-memoize@3.1.7': {}
-
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/icu-skeleton-parser': 1.8.16
-      tslib: 2.8.1
 
   '@formatjs/icu-messageformat-parser@3.5.14':
     dependencies:
@@ -7458,20 +7415,11 @@ snapshots:
       '@formatjs/ecma402-abstract': 3.2.0
       '@formatjs/icu-skeleton-parser': 2.1.3
 
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      tslib: 2.8.1
-
   '@formatjs/icu-skeleton-parser@2.1.11': {}
 
   '@formatjs/icu-skeleton-parser@2.1.3':
     dependencies:
       '@formatjs/ecma402-abstract': 3.2.0
-
-  '@formatjs/intl-localematcher@0.6.2':
-    dependencies:
-      tslib: 2.8.1
 
   '@formatjs/intl-localematcher@0.8.2':
     dependencies:
@@ -10036,13 +9984,6 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  intl-messageformat@10.7.18:
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/icu-messageformat-parser': 2.11.4
-      tslib: 2.8.1
-
   intl-messageformat@11.2.0:
     dependencies:
       '@formatjs/ecma402-abstract': 3.2.0
@@ -11556,34 +11497,6 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
-
-  smarthr-ui@74.2.0(@types/react@18.3.28)(eslint@9.39.5(jiti@2.7.0))(react-dom@19.2.7(react@19.2.7))(react-intl@10.1.0(@types/react@18.3.28)(react@19.2.7)(typescript@5.9.3))(react@19.2.7)(styled-components@5.3.11(react-dom@19.2.7(react@19.2.7))(react-is@19.2.0)(react@19.2.7))(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))(typescript@5.9.3):
-    dependencies:
-      '@smarthr/wareki': 1.3.1
-      dayjs: 1.11.18
-      decimal.js: 10.6.0
-      intl-messageformat: 10.7.18
-      lodash.merge: 4.6.2
-      lodash.range: 3.2.0
-      polished: 4.3.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-draggable: 4.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-icons: 5.7.0(react@19.2.7)
-      react-innertext: 1.1.5(@types/react@18.3.28)(react@19.2.7)
-      react-intl: 10.1.0(@types/react@18.3.28)(react@19.2.7)(typescript@5.9.3)
-      react-pdf: 9.2.1(@types/react@18.3.28)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      styled-components: 5.3.11(react-dom@19.2.7(react@19.2.7))(react-is@19.2.0)(react@19.2.7)
-      tailwind-variants: 0.3.1(tailwindcss@3.4.19(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3)))
-      tailwindcss: 3.4.19(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))
-      typescript-eslint: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - eslint
-      - supports-color
-      - ts-node
-      - typescript
 
   smol-toml@1.7.0: {}
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

chart の方の smarthr-ui の依存先が大昔のものだったので、workspace依存にするようにしました。
これによって、今回のように過去のバージョンを参照し続けることがなくなります。

## 変更内容

`packages/charts/package.json` の peerDependencies の `smarthr-ui` を workspace protocol に変更した。

```diff
   "peerDependencies": {
-    "smarthr-ui": "^74.0.0",
+    "smarthr-ui": "workspace:^",
   },
```

- ローカル（モノレポ内）: pnpm が workspace protocol を解決し、`packages/charts/node_modules/smarthr-ui` が workspace の `packages/smarthr-ui` へリンクされる（`link:../smarthr-ui`）。
- 公開時: `pnpm publish` 実行時に pnpm が `workspace:^` を実バージョン（`^98.1.1`）へ自動で書き換える。
- `pnpm install` により lockfile を更新。公開版 `smarthr-ui@74.2.0` の参照は lockfile から完全に削除された。

これにより、charts のソース（`VisuallyHiddenText`・`CHART_COLORS` 等）、`tailwind.config.js` の preset（`smarthr-ui/lib/smarthr-ui-preset`）、`.storybook/preview.tsx` の CSS/ThemeProvider がすべて workspace の smarthr-ui に解決されるようになる。

## プロダクト側で対応が必要な事項

なし


## 確認方法

以下をローカルで確認済み。

- `pnpm install` 後、`packages/charts/node_modules/smarthr-ui -> ../../smarthr-ui`（workspace）にリンクが切り替わること
- `pnpm-lock.yaml` の charts 側エントリが `specifier: workspace:^` / `version: link:../smarthr-ui` になり、`smarthr-ui@74.2.0` の参照が消えること
- 型解決: `pnpm charts lint`（tsc が workspace 98.1.1 の型で通ること）
- テスト: `pnpm charts test -- --run`（19 passed）
- ビルド: `pnpm charts build`（exit 0、lib/esm/css 生成）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * チャート機能とUIライブラリ間の連携を見直し、互換性と開発環境での安定性を向上しました。
  * Storybook上で、最新のローカルUIコンポーネントを正しく参照できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->