### PR TITLE
refactor(AccordionPanel): defaultExpandedの初期化処理を最適化

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -7,7 +7,6 @@ import {
   type RefObject,
   createContext,
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -84,7 +83,7 @@ export const AccordionPanel: FC<Props> = ({
   rounded,
   ...rest
 }) => {
-  const [expandedItems, setExpanded] = useState(DEFAULT_EXPANDED_MAP)
+  const [expandedItems, setExpanded] = useState(() => flatArrayToMap(defaultExpanded))
   const parentRef = useRef<HTMLDivElement>(null)
   const actualClassName = useMemo(
     () => classNameGenerator({ className, rounded }),
@@ -97,11 +96,6 @@ export const AccordionPanel: FC<Props> = ({
     },
     [expandableMultiply, expandedItems],
   )
-
-  useEffect(() => {
-    setExpanded(flatArrayToMap(defaultExpanded))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   return (
     <AccordionPanelContext.Provider

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -31,6 +31,9 @@ type AbstractProps = PropsWithChildren<{
   VariantProps<typeof classNameGenerator>
 type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
 
+const DEFAULT_EXPANDED_ARRAY: string[] = []
+const DEFAULT_EXPANDED_MAP = new Map<string, string>()
+
 export const AccordionPanelContext = createContext<{
   iconPosition: 'left' | 'right'
   expandedItems: Map<string, string>
@@ -40,7 +43,7 @@ export const AccordionPanelContext = createContext<{
   onClickProps?: (expandedItems: string[]) => void
 }>({
   iconPosition: 'left',
-  expandedItems: new Map(),
+  expandedItems: DEFAULT_EXPANDED_MAP,
   expandableMultiply: true,
   parentRef: null,
 })
@@ -75,13 +78,13 @@ const classNameGenerator = tv({
 export const AccordionPanel: FC<Props> = ({
   iconPosition = 'left',
   expandableMultiply = true,
-  defaultExpanded = [],
+  defaultExpanded = DEFAULT_EXPANDED_ARRAY,
   className,
   onClick: onClickProps,
   rounded,
   ...rest
 }) => {
-  const [expandedItems, setExpanded] = useState(flatArrayToMap(defaultExpanded))
+  const [expandedItems, setExpanded] = useState(DEFAULT_EXPANDED_MAP)
   const parentRef = useRef<HTMLDivElement>(null)
   const actualClassName = useMemo(
     () => classNameGenerator({ className, rounded }),
@@ -96,7 +99,7 @@ export const AccordionPanel: FC<Props> = ({
   )
 
   useEffect(() => {
-    if (defaultExpanded.length > 0) setExpanded(flatArrayToMap(defaultExpanded))
+    setExpanded(flatArrayToMap(defaultExpanded))
   }, [defaultExpanded])
 
   return (

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -32,7 +32,7 @@ type AbstractProps = PropsWithChildren<{
 type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
 
 const DEFAULT_EXPANDED_ARRAY: string[] = []
-const DEFAULT_EXPANDED_MAP = new Map<string, string>()
+const DEFAULT_EXPANDED_MAP = flatArrayToMap(DEFAULT_EXPANDED_ARRAY)
 
 export const AccordionPanelContext = createContext<{
   iconPosition: 'left' | 'right'

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -92,9 +92,11 @@ export const AccordionPanel: FC<Props> = ({
 
   const onClickTrigger = useCallback(
     (itemName: string, isExpanded: boolean) => {
-      setExpanded(getNewExpandedItems(expandedItems, itemName, isExpanded, expandableMultiply))
+      setExpanded((prevExpandedItems) =>
+        getNewExpandedItems(prevExpandedItems, itemName, isExpanded, expandableMultiply),
+      )
     },
-    [expandableMultiply, expandedItems],
+    [expandableMultiply],
   )
 
   return (

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -100,7 +100,8 @@ export const AccordionPanel: FC<Props> = ({
 
   useEffect(() => {
     setExpanded(flatArrayToMap(defaultExpanded))
-  }, [defaultExpanded])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <AccordionPanelContext.Provider


### PR DESCRIPTION
## 関連URL

なし

## 概要

AccordionPanelコンポーネントのdefaultExpanded初期化処理を最適化し、不要な再レンダリングを防ぎます。

## 変更内容

以下の段階的なリファクタリングにより、AccordionPanelの初期化処理を最適化しました：

1. **defaultExpandedの初期化を最適化**
   - `DEFAULT_EXPANDED_ARRAY`と`DEFAULT_EXPANDED_MAP`を定数として定義
   - デフォルト値の再生成を防止

2. **DEFAULT_EXPANDED_MAPの定義を一貫性のある形に統一**
   - コンテキストのデフォルト値も統一された定数を使用

3. **useEffectの依存配列を空にして初期化のみに限定**
   - defaultExpandedの変更を追跡する必要がないため、初期化のみに限定

4. **useEffectを削除してuseStateの遅延初期化に変更**
   - `useState(() => flatArrayToMap(defaultExpanded))`により、useEffectが不要に

5. **setExpandedの更新関数形式でexpandedItemsの依存を解消**
   - `setExpanded((prevExpandedItems) => ...)`の形式に変更
   - `onClickTrigger`の依存配列から`expandedItems`を削除
   - コールバックの不要な再生成を防止

これらの変更により、パフォーマンスが向上し、コードがより明確になりました。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストとStorybookで動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * アコーディオンパネルの初期展開状態と表示内容の整合性を改善しました。
  * パネルの開閉操作時に、状態がより安定して更新されるようになりました。
  * 初期設定による展開状態が、意図せず再同期される問題を解消しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->