### PR TITLE
refactor(AccordionPanel): コールバック関数の安定化と最適化

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -90,6 +90,13 @@ export const AccordionPanel: FC<Props> = ({
     [rounded, className],
   )
 
+  const onClickPropsRef = useRef(onClickProps)
+  onClickPropsRef.current = onClickProps
+
+  const stableOnClickProps = useCallback((items: string[]) => {
+    onClickPropsRef.current?.(items)
+  }, [])
+
   const onClickTrigger = useCallback(
     (itemName: string, isExpanded: boolean) => {
       setExpanded((prevExpandedItems) =>
@@ -103,7 +110,7 @@ export const AccordionPanel: FC<Props> = ({
     <AccordionPanelContext.Provider
       value={{
         onClickTrigger,
-        onClickProps,
+        onClickProps: stableOnClickProps,
         expandedItems,
         iconPosition,
         expandableMultiply,

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -79,7 +79,7 @@ export const AccordionPanel: FC<Props> = ({
   expandableMultiply = true,
   defaultExpanded = DEFAULT_EXPANDED_ARRAY,
   className,
-  onClick: onClickProps,
+  onClick,
   rounded,
   ...rest
 }) => {
@@ -90,11 +90,11 @@ export const AccordionPanel: FC<Props> = ({
     [rounded, className],
   )
 
-  const onClickPropsRef = useRef(onClickProps)
-  onClickPropsRef.current = onClickProps
+  const onClickRef = useRef(onClick)
+  onClickRef.current = onClick
 
-  const stableOnClickProps = useCallback((items: string[]) => {
-    onClickPropsRef.current?.(items)
+  const onClickProps = useCallback((items: string[]) => {
+    onClickRef.current?.(items)
   }, [])
 
   const onClickTrigger = useCallback(
@@ -110,7 +110,7 @@ export const AccordionPanel: FC<Props> = ({
     <AccordionPanelContext.Provider
       value={{
         onClickTrigger,
-        onClickProps: stableOnClickProps,
+        onClickProps: onClick ? onClickProps : undefined,
         expandedItems,
         iconPosition,
         expandableMultiply,

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -95,44 +95,21 @@ export const AccordionPanelTrigger: FC<Props> = ({
 
   const isExpanded = useMemo(() => getIsInclude(expandedItems, name), [expandedItems, name])
 
-  const actualOnClickTrigger = useMemo(
-    () =>
-      onClickTrigger
-        ? (e: MouseEvent<HTMLButtonElement>) => onClickTrigger(e.currentTarget.value, !isExpanded)
-        : undefined,
-    [isExpanded, onClickTrigger],
-  )
-  const actualOnClickProps = useMemo(
-    () =>
-      onClickProps
-        ? (e: MouseEvent<HTMLButtonElement>) => {
-            const newExpandedItems = getNewExpandedItems(
-              expandedItems,
-              e.currentTarget.value,
-              !isExpanded,
-              expandableMultiply,
-            )
-            onClickProps(mapToKeyArray(newExpandedItems))
-          }
-        : undefined,
-    [isExpanded, expandedItems, expandableMultiply, onClickProps],
-  )
-  const handleClick = useMemo(() => {
-    if (actualOnClickTrigger) {
-      if (actualOnClickProps) {
-        return (e: MouseEvent<HTMLButtonElement>) => {
-          actualOnClickTrigger(e)
-          actualOnClickProps(e)
-        }
+  const handleClick = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      onClickTrigger?.(e.currentTarget.value, !isExpanded)
+      if (onClickProps) {
+        const newExpandedItems = getNewExpandedItems(
+          expandedItems,
+          e.currentTarget.value,
+          !isExpanded,
+          expandableMultiply,
+        )
+        onClickProps(mapToKeyArray(newExpandedItems))
       }
-
-      return actualOnClickTrigger
-    } else if (actualOnClickProps) {
-      return actualOnClickProps
-    }
-
-    return undefined
-  }, [actualOnClickProps, actualOnClickTrigger])
+    },
+    [isExpanded, expandedItems, expandableMultiply, onClickTrigger, onClickProps],
+  )
 
   const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
     (e): void => {
@@ -180,7 +157,7 @@ export const AccordionPanelTrigger: FC<Props> = ({
         id={triggerId}
         aria-expanded={isExpanded}
         aria-controls={contentId}
-        onClick={handleClick}
+        onClick={onClickTrigger || onClickProps ? handleClick : undefined}
         onKeyDown={handleKeyDown}
         className={classNames.button}
         data-component="AccordionHeaderButton"


### PR DESCRIPTION
## 関連URL

なし

## 概要

AccordionPanelとAccordionPanelTriggerのコールバック関数を安定化し、不要な再レンダリングを防ぐためのリファクタリングです。

## 変更内容

以下の3つの段階的な最適化を実施しました：

### 1. onClickPropsをunstableRefで安定化

- `onClick` propsをuseRefで管理し、参照を安定化
- `onClickProps`をuseCallbackで作成することで、常に同じ参照を保持
- これによりAccordionPanelContextのvalueが不要に再生成されることを防止

### 2. onClick関連の命名を整理

- props名を`onClick: onClickProps`から`onClick`に変更
- 内部で`onClickProps`を作成するように統一
- より自然な命名になり、可読性が向上

### 3. AccordionPanelTriggerのhandleClickをuseCallback化

従来の実装:
```tsx
// 複数のuseMemoで中間値を作成
const actualOnClickTrigger = useMemo(...)
const actualOnClickProps = useMemo(...)
const handleClick = useMemo(...)  // actualOnClickTrigger と actualOnClickProps を組み合わせ
```

最適化後:
```tsx
// 単一のuseCallbackで直接handleClickを作成
const handleClick = useCallback((e) => {
  onClickTrigger?.(e.currentTarget.value, !isExpanded)
  if (onClickProps) {
    const newExpandedItems = getNewExpandedItems(...)
    onClickProps(mapToKeyArray(newExpandedItems))
  }
}, [isExpanded, expandedItems, expandableMultiply, onClickTrigger, onClickProps])
```

**効果:**
- 中間的なuseMemoが不要になり、コードがシンプルに
- 依存配列が明確になり、保守性が向上
- 不要な再計算が削減される

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストとStorybookで動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * アコーディオンのクリック時に、常に最新のクリック処理が実行されるよう改善しました。
  * クリック処理が未指定の場合に不要なハンドラーが設定されないよう修正しました。
  * 展開状態の更新とクリックコールバックの処理を安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->