### PR TITLE
refactor(OpenInNewTabIcon): alt属性の固定化とLocalizer化

### DIFF
--- a/packages/smarthr-ui/src/components/Icon/OpenInNewTabIcon.tsx
+++ b/packages/smarthr-ui/src/components/Icon/OpenInNewTabIcon.tsx
@@ -9,24 +9,18 @@ import { generateIcon } from './generateIcon'
 
 const FaUpRightFromSquareIcon = /*#__PURE__*/ generateIcon(FaUpRightFromSquare)
 
-// TODO: 最終的にこのコンポーネントはexportされず、TextLink, AnchorButtonからのみ
-// 参照される状態になるため、alt属性は固定される想定です。
-// type Props = Omit<ComponentProps<typeof FaUpRightFromSquareIcon>, 'alt'>
-type Props = ComponentProps<typeof FaUpRightFromSquareIcon>
+type Props = Omit<ComponentProps<typeof FaUpRightFromSquareIcon>, 'alt'>
 
-const OpenInNewTabIcon = memo<Props>(({ alt, ...rest }) => {
+const OpenInNewTabIcon = memo<Props>((props) => {
   const { localize } = useIntl()
 
   return (
     <FaUpRightFromSquareIcon
-      {...rest}
-      alt={
-        alt ||
-        localize({
-          id: 'smarthr-ui/OpenInNewTabIcon/openInNewTab',
-          defaultText: '別タブで開く',
-        })
-      }
+      {...props}
+      alt={localize({
+        id: 'smarthr-ui/OpenInNewTabIcon/openInNewTab',
+        defaultText: '別タブで開く',
+      })}
     />
   )
 })

--- a/packages/smarthr-ui/src/components/Icon/OpenInNewTabIcon.tsx
+++ b/packages/smarthr-ui/src/components/Icon/OpenInNewTabIcon.tsx
@@ -3,7 +3,7 @@
 import { type ComponentProps, memo } from 'react'
 import { FaUpRightFromSquare } from 'react-icons/fa6'
 
-import { useIntl } from '../../intl'
+import { Localizer } from '../../intl'
 
 import { generateIcon } from './generateIcon'
 
@@ -11,19 +11,12 @@ const FaUpRightFromSquareIcon = /*#__PURE__*/ generateIcon(FaUpRightFromSquare)
 
 type Props = Omit<ComponentProps<typeof FaUpRightFromSquareIcon>, 'alt'>
 
-const OpenInNewTabIcon = memo<Props>((props) => {
-  const { localize } = useIntl()
-
-  return (
-    <FaUpRightFromSquareIcon
-      {...props}
-      alt={localize({
-        id: 'smarthr-ui/OpenInNewTabIcon/openInNewTab',
-        defaultText: '別タブで開く',
-      })}
-    />
-  )
-})
+const OpenInNewTabIcon = memo<Props>((props) => (
+  <FaUpRightFromSquareIcon
+    {...props}
+    alt={<Localizer id="smarthr-ui/OpenInNewTabIcon/openInNewTab" defaultText="別タブで開く" />}
+  />
+))
 
 OpenInNewTabIcon.displayName = 'OpenInNewTabIcon'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

OpenInNewTabIconのalt属性を固定化し、国際化の実装をLocalizerに統一するリファクタリングです。

## 変更内容

### 1. alt属性の固定化

TODOコメントに記載されていた通り、OpenInNewTabIconは最終的にTextLinkやAnchorButtonからのみ参照されるため、alt属性を固定化しました。

**変更点:**
- `Props` の型定義を `Omit<ComponentProps<typeof FaUpRightFromSquareIcon>, 'alt'>` に変更
- 外部から `alt` 属性を受け取れないように制限
- 常に「別タブで開く」というローカライズされたテキストを使用
- TODOコメントを削除

**Before:**
```tsx
type Props = ComponentProps<typeof FaUpRightFromSquareIcon>

const OpenInNewTabIcon = memo<Props>(({ alt, ...rest }) => {
  // ...
  alt={alt || localize({...})}
})
```

**After:**
```tsx
type Props = Omit<ComponentProps<typeof FaUpRightFromSquareIcon>, 'alt'>

const OpenInNewTabIcon = memo<Props>((props) => {
  // ...
  alt={<Localizer id="..." defaultText="別タブで開く" />}
})
```

### 2. useIntlからLocalizerへの変更

国際化の実装を `useIntl().localize()` から `Localizer` コンポーネントに変更しました。

**効果:**
- フックの使用が不要になり、コードがよりシンプルに
- 他のコンポーネントとの一貫性が向上

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストとStorybookで動作確認