### PR TITLE
refactor(AccordionPanelTrigger): イベントハンドラの依存配列を最適化

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -97,18 +97,19 @@ export const AccordionPanelTrigger: FC<Props> = ({
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
-      onClickTrigger?.(e.currentTarget.value, !isExpanded)
+      const currentIsExpanded = e.currentTarget.getAttribute('aria-expanded') === 'true'
+      onClickTrigger?.(e.currentTarget.value, !currentIsExpanded)
       if (onClickProps) {
         const newExpandedItems = getNewExpandedItems(
           expandedItems,
           e.currentTarget.value,
-          !isExpanded,
+          !currentIsExpanded,
           expandableMultiply,
         )
         onClickProps(mapToKeyArray(newExpandedItems))
       }
     },
-    [isExpanded, expandedItems, expandableMultiply, onClickTrigger, onClickProps],
+    [expandedItems, expandableMultiply, onClickTrigger, onClickProps],
   )
 
   const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -95,21 +96,32 @@ export const AccordionPanelTrigger: FC<Props> = ({
 
   const isExpanded = useMemo(() => getIsInclude(expandedItems, name), [expandedItems, name])
 
+  const unstableRef = useRef({
+    expandedItems,
+    onClickTrigger,
+    onClickProps,
+  })
+  unstableRef.current = {
+    expandedItems,
+    onClickTrigger,
+    onClickProps,
+  }
+
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
       const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
-      onClickTrigger?.(e.currentTarget.value, newIsExpanded)
-      if (onClickProps) {
+      unstableRef.current.onClickTrigger?.(e.currentTarget.value, newIsExpanded)
+      if (unstableRef.current.onClickProps) {
         const newExpandedItems = getNewExpandedItems(
-          expandedItems,
+          unstableRef.current.expandedItems,
           e.currentTarget.value,
           newIsExpanded,
           expandableMultiply,
         )
-        onClickProps(mapToKeyArray(newExpandedItems))
+        unstableRef.current.onClickProps(mapToKeyArray(newExpandedItems))
       }
     },
-    [expandedItems, expandableMultiply, onClickTrigger, onClickProps],
+    [expandableMultiply],
   )
 
   const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -107,7 +107,7 @@ export const AccordionPanelTrigger: FC<Props> = ({
     onClickProps,
   }
 
-  const handleClick = useCallback(
+  const stableOnClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
       const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
       unstableRef.current.onClickTrigger?.(e.currentTarget.value, newIsExpanded)
@@ -123,6 +123,8 @@ export const AccordionPanelTrigger: FC<Props> = ({
     },
     [expandableMultiply],
   )
+
+  const actualOnClick = onClickTrigger || onClickProps ? stableOnClick : undefined
 
   const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
     (e): void => {
@@ -170,7 +172,7 @@ export const AccordionPanelTrigger: FC<Props> = ({
         id={triggerId}
         aria-expanded={isExpanded}
         aria-controls={contentId}
-        onClick={onClickTrigger || onClickProps ? handleClick : undefined}
+        onClick={actualOnClick}
         onKeyDown={handleKeyDown}
         className={classNames.button}
         data-component="AccordionHeaderButton"

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -97,13 +97,13 @@ export const AccordionPanelTrigger: FC<Props> = ({
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
-      const currentIsExpanded = e.currentTarget.getAttribute('aria-expanded') === 'true'
-      onClickTrigger?.(e.currentTarget.value, !currentIsExpanded)
+      const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
+      onClickTrigger?.(e.currentTarget.value, newIsExpanded)
       if (onClickProps) {
         const newExpandedItems = getNewExpandedItems(
           expandedItems,
           e.currentTarget.value,
-          !currentIsExpanded,
+          newIsExpanded,
           expandableMultiply,
         )
         onClickProps(mapToKeyArray(newExpandedItems))


### PR DESCRIPTION
## 関連URL

なし

## 概要

AccordionPanelTriggerのイベントハンドラの依存配列を最適化し、不要な再生成を防ぐリファクタリングです。

## 変更内容

以下の4つの段階的な最適化を実施しました：

### 1. aria-expandedから状態を取得して依存配列を削減

`isExpanded`を依存配列から削除し、代わりに`e.currentTarget.getAttribute('aria-expanded')`から直接取得するように変更しました。

### 2. 変数を否定形で定義して効率化

`const isExpanded = e.currentTarget.getAttribute('aria-expanded') === 'true'`から  
`const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'`に変更し、否定演算を削減しました。

### 3. unstableRefパターンでhandleClickの依存配列を最適化

unstableRefパターンを導入し、頻繁に変更される値への依存を解消しました：

**Before:**
```tsx
const handleClick = useCallback(
  (e) => {
    onClickTrigger?.(...)
    if (onClickProps) {
      const newExpandedItems = getNewExpandedItems(expandedItems, ...)
      onClickProps(mapToKeyArray(newExpandedItems))
    }
  },
  [isExpanded, expandedItems, expandableMultiply, onClickTrigger, onClickProps],
)
```

**After:**
```tsx
const unstableRef = useRef({ expandedItems, onClickTrigger, onClickProps })
unstableRef.current = { expandedItems, onClickTrigger, onClickProps }

const stableOnClick = useCallback(
  (e) => {
    unstableRef.current.onClickTrigger?.(...)
    if (unstableRef.current.onClickProps) {
      const newExpandedItems = getNewExpandedItems(unstableRef.current.expandedItems, ...)
      unstableRef.current.onClickProps(mapToKeyArray(newExpandedItems))
    }
  },
  [expandableMultiply],
)
```

### 4. handleClickをstableOnClickにリネームしactualOnClickを変数化

- `handleClick`を`stableOnClick`にリネームし、安定したコールバックであることを明示
- `actualOnClick`を変数として定義し、条件判定をJSX外に移動

**効果:**
- 依存配列が5つから1つに削減（`expandableMultiply`のみ）
- イベントハンドラの不要な再生成が防止され、パフォーマンスが向上
- コードの意図がより明確に

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストとStorybookで動作確認