### PR TITLE
refactor(InputFileNative): useIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -15,7 +15,7 @@ import {
 } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
-import { useIntl } from '../../intl'
+import { Localizer } from '../../intl'
 import { BaseColumn } from '../Base'
 import { Button } from '../Button'
 import { FaFolderOpenIcon, FaTrashCanIcon } from '../Icon'
@@ -38,16 +38,6 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
   ) => {
     const [files, setFiles] = useState<File[]>([])
     const labelId = useId()
-    const { localize } = useIntl()
-
-    const destroyLabel = useMemo(
-      () =>
-        localize({
-          id: 'smarthr-ui/InputFile/destroy',
-          defaultText: '削除',
-        }),
-      [localize],
-    )
 
     const classNames = useMemo(() => {
       const { wrapper, fileList, fileItem, inputWrapper, input, prefix } = classNameGenerator()
@@ -117,7 +107,6 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
                 key={index}
                 value={index}
                 handleDeleteClick={functions.handleDelete}
-                destroyLabel={destroyLabel}
                 className={classNames.fileItem}
               >
                 {file.name}
@@ -148,12 +137,11 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
 type FileListItemProps = PropsWithChildren<{
   value: number
   handleDeleteClick: (e: MouseEvent<HTMLButtonElement>) => void
-  destroyLabel: string
   className: string
 }>
 
 const FileListItem = memo<FileListItemProps>(
-  ({ value, handleDeleteClick, destroyLabel, className, children }) => (
+  ({ value, handleDeleteClick, className, children }) => (
     <li className={className}>
       <span className="smarthr-ui-InputFile-fileName shr-wrap-break-word shr-min-w-[0]">
         {children}
@@ -165,7 +153,7 @@ const FileListItem = memo<FileListItemProps>(
         onClick={handleDeleteClick}
         className="smarthr-ui-InputFile-deleteButton"
       >
-        {destroyLabel}
+        <Localizer id="smarthr-ui/InputFile/destroy" defaultText="削除" />
       </Button>
     </li>
   ),


### PR DESCRIPTION
## 関連URL

なし

## 概要

InputFileNativeの国際化実装を`useIntl().localize()`から`Localizer`コンポーネントに統一するリファクタリングです。

## 変更内容

削除ボタンのラベルテキストの実装を変更しました。

**Before:**
```tsx
const { localize } = useIntl()

const destroyLabel = useMemo(
  () =>
    localize({
      id: 'smarthr-ui/InputFile/destroy',
      defaultText: '削除',
    }),
  [localize],
)

// destroyLabelをpropsとして渡す
<FileListItem destroyLabel={destroyLabel} ... />

// FileListItem内
const FileListItem = ({ destroyLabel, ... }) => (
  <Button>{destroyLabel}</Button>
)
```

**After:**
```tsx
// useIntlとuseMemoが不要に

// propsとして渡さない
<FileListItem ... />

// FileListItem内で直接Localizerを使用
const FileListItem = ({ ... }) => (
  <Button>
    <Localizer id="smarthr-ui/InputFile/destroy" defaultText="削除" />
  </Button>
)
```

**効果:**
- `useIntl()`フックが不要になり、コードがよりシンプルに
- `destroyLabel`のuseMemoや、propsとしての受け渡しが不要に
- 他のコンポーネントとの国際化実装の一貫性が向上

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストとStorybookで動作確認