### PR TITLE
refactor(ThSortButton): useIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Table/ThSortButton.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThSortButton.tsx
@@ -3,7 +3,7 @@
 import { type PropsWithChildren, memo, useMemo } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
-import { useIntl } from '../../intl'
+import { Localizer } from '../../intl'
 import { UnstyledButton } from '../Button'
 import { FaSortDownIcon, FaSortUpIcon } from '../Icon'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
@@ -27,37 +27,23 @@ type Props = PropsWithChildren<{
 }>
 
 export const ThSortButton = memo<Props>(({ align, sort, onSort, children }) => {
-  const { localize } = useIntl()
-
-  const sortLabel = useMemo(() => {
-    switch (sort) {
-      case 'asc':
-        return localize({
-          id: 'smarthr-ui/Th/sortDirectionAsc',
-          defaultText: '昇順',
-        })
-      case 'desc':
-        return localize({
-          id: 'smarthr-ui/Th/sortDirectionDesc',
-          defaultText: '降順',
-        })
-      case 'none':
-        return localize({
-          id: 'smarthr-ui/Th/sortDirectionNone',
-          defaultText: '並び替えなし',
-        })
-    }
-
-    return undefined
-  }, [sort, localize])
-
   const className = useMemo(() => sortButtonClassNameGenerator({ align }), [align])
 
   return (
     <UnstyledButton onClick={onSort} className={className}>
       {children}
       <SortIcon />
-      {sortLabel && <VisuallyHiddenText>{sortLabel}</VisuallyHiddenText>}
+      {sort && (
+        <VisuallyHiddenText>
+          {sort === 'asc' ? (
+            <Localizer id="smarthr-ui/Th/sortDirectionAsc" defaultText="昇順" />
+          ) : sort === 'desc' ? (
+            <Localizer id="smarthr-ui/Th/sortDirectionDesc" defaultText="降順" />
+          ) : (
+            <Localizer id="smarthr-ui/Th/sortDirectionNone" defaultText="並び替えなし" />
+          )}
+        </VisuallyHiddenText>
+      )}
     </UnstyledButton>
   )
 })


### PR DESCRIPTION
## 関連URL

なし

## 概要

ThSortButtonの国際化実装を`useIntl().localize()`から`Localizer`コンポーネントに統一するリファクタリングです。

## 変更内容

ソート方向のラベルテキストの実装を変更しました。

**Before:**
```tsx
const { localize } = useIntl()

const sortLabel = useMemo(() => {
  switch (sort) {
    case 'asc':
      return localize({ id: 'smarthr-ui/Th/sortDirectionAsc', defaultText: '昇順' })
    case 'desc':
      return localize({ id: 'smarthr-ui/Th/sortDirectionDesc', defaultText: '降順' })
    case 'none':
      return localize({ id: 'smarthr-ui/Th/sortDirectionNone', defaultText: '並び替えなし' })
  }
  return undefined
}, [sort, localize])

// 使用箇所
{sortLabel && <VisuallyHiddenText>{sortLabel}</VisuallyHiddenText>}
```

**After:**
```tsx
// useIntlとuseMemoが不要に

// JSX内で直接Localizerを使用
{sort && (
  <VisuallyHiddenText>
    {sort === 'asc' ? (
      <Localizer id="smarthr-ui/Th/sortDirectionAsc" defaultText="昇順" />
    ) : sort === 'desc' ? (
      <Localizer id="smarthr-ui/Th/sortDirectionDesc" defaultText="降順" />
    ) : (
      <Localizer id="smarthr-ui/Th/sortDirectionNone" defaultText="並び替えなし" />
    )}
  </VisuallyHiddenText>
)}
```

**効果:**
- `useIntl()`フックが不要になり、コードがよりシンプルに
- `sortLabel`のuseMemoが削減され、メモ化の管理が不要に
- 条件分岐がJSX内で明示的になり、可読性が向上
- 他のコンポーネントとの国際化実装の一貫性が向上

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストとStorybookで動作確認