### PR TITLE
refactor(AccordionPanelTrigger): Heading全体をmemo化してパフォーマンスを改善

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -163,6 +163,60 @@ export const AccordionPanelTrigger: FC<Props> = ({
   )
 
   return (
+    <MemoizedHeadingButton
+      {...rest}
+      name={name}
+      triggerId={triggerId}
+      isExpanded={isExpanded}
+      contentId={contentId}
+      actualOnClick={actualOnClick}
+      handleKeyDown={handleKeyDown}
+      classNames={classNames}
+      iconPosition={iconPosition}
+      headingType={headingType}
+      unrecommendedHeadingTag={unrecommendedHeadingTag}
+    >
+      {children}
+    </MemoizedHeadingButton>
+  )
+}
+
+const MemoizedHeadingButton = memo<
+  PropsWithChildren<
+    Omit<ComponentPropsWithoutRef<'button'>, 'onClick' | 'onKeyDown'> & {
+      name: string
+      triggerId: string
+      isExpanded: boolean
+      contentId: string
+      actualOnClick: ((e: MouseEvent<HTMLButtonElement>) => void) | undefined
+      handleKeyDown: KeyboardEventHandler<HTMLButtonElement>
+      classNames: {
+        button: string
+        titleWrapper: string
+        leftIcon: string
+        rightIcon: string
+        title: string
+      }
+      iconPosition: 'left' | 'right'
+      headingType: Exclude<TextProps['styleType'], 'screenTitle'>
+      unrecommendedHeadingTag?: HeadingTagTypes
+    }
+  >
+>(
+  ({
+    children,
+    name,
+    triggerId,
+    isExpanded,
+    contentId,
+    actualOnClick,
+    handleKeyDown,
+    classNames,
+    iconPosition,
+    headingType,
+    unrecommendedHeadingTag,
+    ...rest
+  }) => (
     // eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content
     <Heading unrecommendedTag={unrecommendedHeadingTag} type={headingType}>
       <button
@@ -177,23 +231,13 @@ export const AccordionPanelTrigger: FC<Props> = ({
         className={classNames.button}
         data-component="AccordionHeaderButton"
       >
-        <MemoizedTitle iconPosition={iconPosition} classNames={classNames}>
-          {children}
-        </MemoizedTitle>
+        {/* eslint-disable-next-line smarthr/best-practice-for-layouts */}
+        <Cluster className={classNames.titleWrapper} align="center" as="span">
+          {iconPosition === 'left' && <FaCaretRightIcon className={classNames.leftIcon} />}
+          <span className={classNames.title}>{children}</span>
+          {iconPosition === 'right' && <FaCaretDownIcon className={classNames.rightIcon} />}
+        </Cluster>
       </button>
     </Heading>
-  )
-}
-
-const MemoizedTitle = memo<
-  PropsWithChildren<{
-    iconPosition: undefined | 'left' | 'right'
-    classNames: { leftIcon: string; rightIcon: string; title: string; titleWrapper: string }
-  }>
->(({ classNames, iconPosition, children }) => (
-  <Cluster className={classNames.titleWrapper} align="center" as="span">
-    {iconPosition === 'left' && <FaCaretRightIcon className={classNames.leftIcon} />}
-    <span className={classNames.title}>{children}</span>
-    {iconPosition === 'right' && <FaCaretDownIcon className={classNames.rightIcon} />}
-  </Cluster>
-))
+  ),
+)


### PR DESCRIPTION
## 関連URL

なし

## 概要

AccordionPanelTriggerコンポーネントでHeading要素全体をmemo化することで、不要な再レンダリングを防ぎパフォーマンスを改善する。

## 変更内容

- `MemoizedTitle`コンポーネントを削除
- `MemoizedHeadingButton`コンポーネントを新規作成
- memo化のスコープをCluster+アイコン+テキストから、Heading+button+Cluster全体に拡大

これにより、AccordionPanelTriggerの再レンダリング時にHeading構造全体が安定化される。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アコーディオンパネルのタイトルと展開ボタンの構成を整理し、表示や操作性を維持しながら、より安定した動作を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->