### PR TITLE
refactor(DropZone): SelectButtonのuseIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -16,7 +16,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
-import { useIntl } from '../../intl'
+import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { FaFolderOpenIcon } from '../Icon'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
@@ -169,22 +169,8 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 
 const SelectButton = memo<
   ComponentPropsWithoutRef<typeof Button> & { onClick: () => void; label?: string }
->(({ onClick, label, ...rest }) => {
-  const { localize } = useIntl()
-
-  const buttonLabel = useMemo(
-    () =>
-      label ||
-      localize({
-        id: 'smarthr-ui/DropZone/selectButtonLabel',
-        defaultText: 'ファイルを選択',
-      }),
-    [label, localize],
-  )
-
-  return (
-    <Button {...rest} prefix={<FaFolderOpenIcon />} onClick={onClick}>
-      {buttonLabel}
-    </Button>
-  )
-})
+>(({ onClick, label, ...rest }) => (
+  <Button {...rest} prefix={<FaFolderOpenIcon />} onClick={onClick}>
+    {label || <Localizer id="smarthr-ui/DropZone/selectButtonLabel" defaultText="ファイルを選択" />}
+  </Button>
+))


### PR DESCRIPTION
## 関連URL

なし

## 概要

DropZoneコンポーネント内のSelectButtonで、useIntl().localize()を使用していた箇所をLocalizerコンポーネントに置き換える。

## 変更内容

- SelectButtonコンポーネント内の`useIntl`のインポートを`Localizer`に変更
- `useIntl().localize()`で生成していたボタンラベルを`Localizer`コンポーネントに置き換え
- 不要になった`useMemo`を削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認