### PR TITLE
refactor(ActionDialogContentInner): CloseButtonのuseIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
@@ -7,11 +7,10 @@ import {
   type ReactNode,
   memo,
   useCallback,
-  useMemo,
 } from 'react'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
-import { useIntl } from '../../../intl'
+import { Localizer } from '../../../intl'
 import { Button } from '../../Button'
 import { Cluster } from '../../Layout'
 import { Section } from '../../SectioningContent'
@@ -176,21 +175,8 @@ const CloseButton = memo<{
   handleClick: ActionDialogContentInnerProps['handleClickClose']
   disabled: boolean
   text: ReactNode
-}>(({ handleClick, disabled, text }) => {
-  const { localize } = useIntl()
-
-  const defaultText = useMemo(
-    () =>
-      localize({
-        id: 'smarthr-ui/ActionDialog/closeButtonLabel',
-        defaultText: 'キャンセル',
-      }),
-    [localize],
-  )
-
-  return (
-    <Button onClick={handleClick} disabled={disabled} className="smarthr-ui-Dialog-closeButton">
-      {text ?? defaultText}
-    </Button>
-  )
-})
+}>(({ handleClick, disabled, text }) => (
+  <Button onClick={handleClick} disabled={disabled} className="smarthr-ui-Dialog-closeButton">
+    {text ?? <Localizer id="smarthr-ui/ActionDialog/closeButtonLabel" defaultText="キャンセル" />}
+  </Button>
+))


### PR DESCRIPTION
## 関連URL

なし

## 概要

ActionDialogContentInnerコンポーネント内のCloseButtonで、useIntl().localize()を使用していた箇所をLocalizerコンポーネントに置き換える。

## 変更内容

- CloseButtonコンポーネント内の`useIntl`のインポートを`Localizer`に変更
- `useIntl().localize()`で生成していたデフォルトテキストを`Localizer`コンポーネントに置き換え
- 不要になった`useMemo`とそのimportを削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認