### PR TITLE
refactor(FormDialogContentInner): CloseButtonのuseIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
@@ -1,15 +1,8 @@
-import {
-  type FC,
-  type FormEvent,
-  type PropsWithChildren,
-  type ReactNode,
-  memo,
-  useMemo,
-} from 'react'
+import { type FC, type FormEvent, type PropsWithChildren, type ReactNode, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
-import { useIntl } from '../../../intl'
+import { Localizer } from '../../../intl'
 import { Button } from '../../Button'
 import { Cluster } from '../../Layout'
 import { Section } from '../../SectioningContent'
@@ -167,21 +160,8 @@ const CloseButton = memo<{
   handleClick: FormDialogContentInnerProps['handleClickClose']
   disabled: boolean
   text: ReactNode
-}>(({ handleClick, disabled, text }) => {
-  const { localize } = useIntl()
-
-  const defaultText = useMemo(
-    () =>
-      localize({
-        id: 'smarthr-ui/FormDialog/closeButtonLabel',
-        defaultText: 'キャンセル',
-      }),
-    [localize],
-  )
-
-  return (
-    <Button onClick={handleClick} disabled={disabled} className="smarthr-ui-Dialog-closeButton">
-      {text ?? defaultText}
-    </Button>
-  )
-})
+}>(({ handleClick, disabled, text }) => (
+  <Button onClick={handleClick} disabled={disabled} className="smarthr-ui-Dialog-closeButton">
+    {text ?? <Localizer id="smarthr-ui/FormDialog/closeButtonLabel" defaultText="キャンセル" />}
+  </Button>
+))


### PR DESCRIPTION
## 関連URL

なし

## 概要

FormDialogContentInnerコンポーネント内のCloseButtonで、useIntl().localize()を使用していた箇所をLocalizerコンポーネントに置き換える。

## 変更内容

- CloseButtonコンポーネント内の`useIntl`のインポートを`Localizer`に変更
- `useIntl().localize()`で生成していたデフォルトテキストを`Localizer`コンポーネントに置き換え
- 不要になった`useMemo`とそのimportを削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * フォームダイアログの閉じるボタンで、未指定時の「キャンセル」ラベルがローカライズされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->