### PR TITLE
refactor(WarekiPicker): useLatestでshowAlternativeを安定化

### DIFF
--- a/packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx
@@ -1,7 +1,8 @@
+import { type ComponentProps, type FC, useCallback } from 'react'
+
+import { useLatest } from '../../hooks/useLatest'
 import { useIntl } from '../../intl'
 import { DatePicker } from '../DatePicker'
-
-import type { ComponentProps, FC } from 'react'
 
 type Props = Omit<ComponentProps<typeof DatePicker>, 'showAlternative'>
 
@@ -18,11 +19,11 @@ const handleShowWareki = (date: Date | null, locale: string) => {
 
 export const WarekiPicker: FC<Props> = (props) => {
   const { locale } = useIntl()
-
-  return (
-    <DatePicker
-      {...props}
-      showAlternative={(date: Date | null) => handleShowWareki(date, locale)}
-    />
+  const latest = useLatest({ locale })
+  const showAlternative = useCallback(
+    (date: Date | null) => handleShowWareki(date, latest.locale),
+    [latest],
   )
+
+  return <DatePicker {...props} showAlternative={showAlternative} />
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

WarekiPickerコンポーネントのshowAlternativeコールバックをuseCallbackで安定化し、localeをuseLatestで管理する。

## 変更内容

- `showAlternative`をuseCallbackで安定化
- `locale`をuseLatestで管理することで依存配列を最適化
- インポート順序を修正（react → hooks → intl → components）

これにより、localeが変更されても不要な再レンダリングが発生せず、パフォーマンスが向上する。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 暦選択時に、現在の表示言語（ロケール）が正しく反映されるよう改善しました。
  * 言語切り替え後も、最新のロケールに基づいて暦の表示を切り替えられるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->