### PR TITLE
refactor(AppHeader): mobile componentsのuseIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/Help.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/Help.tsx
@@ -1,6 +1,6 @@
-import { type FC, memo, useMemo } from 'react'
+import { type FC, memo } from 'react'
 
-import { Localizer, useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { Button } from '../../../Button'
 import { Dropdown, DropdownContent, DropdownTrigger } from '../../../Dropdown'
 import { FaCircleQuestionIcon, FaGraduationCapIcon } from '../../../Icon'
@@ -35,41 +35,34 @@ const MemoizedDropdownTrigger = memo(() => (
   </DropdownTrigger>
 ))
 
-const ContentBody = memo<Props>(({ helpPageUrl, schoolUrl }) => {
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      help: localize({ id: 'smarthr-ui/AppHeader/help', defaultText: 'ヘルプ' }),
-      school: localize({ id: 'smarthr-ui/AppHeader/school', defaultText: 'スクール' }),
-    }),
-    [localize],
-  )
-
-  return (
-    <div className="shr-p-0.5">
-      {helpPageUrl && (
-        <CommonButton
-          elementAs="a"
-          href={helpPageUrl}
-          target="_blank"
-          rel="help"
-          referrerPolicy="no-referrer-when-downgrade"
-          prefix={<FaCircleQuestionIcon />}
-        >
-          <Translate>{translated.help}</Translate>
-        </CommonButton>
-      )}
-      {schoolUrl && (
-        <CommonButton
-          elementAs="a"
-          href={schoolUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          prefix={<FaGraduationCapIcon />}
-        >
-          <Translate>{translated.school}</Translate>
-        </CommonButton>
-      )}
-    </div>
-  )
-})
+const ContentBody = memo<Props>(({ helpPageUrl, schoolUrl }) => (
+  <div className="shr-p-0.5">
+    {helpPageUrl && (
+      <CommonButton
+        elementAs="a"
+        href={helpPageUrl}
+        target="_blank"
+        rel="help"
+        referrerPolicy="no-referrer-when-downgrade"
+        prefix={<FaCircleQuestionIcon />}
+      >
+        <Translate>
+          <Localizer id="smarthr-ui/AppHeader/help" defaultText="ヘルプ" />
+        </Translate>
+      </CommonButton>
+    )}
+    {schoolUrl && (
+      <CommonButton
+        elementAs="a"
+        href={schoolUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        prefix={<FaGraduationCapIcon />}
+      >
+        <Translate>
+          <Localizer id="smarthr-ui/AppHeader/school" defaultText="スクール" />
+        </Translate>
+      </CommonButton>
+    )}
+  </div>
+))

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
@@ -13,7 +13,7 @@ import { tv } from 'tailwind-variants'
 
 import { useHandleEscape } from '../../../../hooks/useHandleEscape'
 import { usePortal } from '../../../../hooks/usePortal'
-import { Localizer, useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { Button } from '../../../Button'
 import { FaAngleRightIcon, FaBarsIcon, FaToolboxIcon } from '../../../Icon'
 import { Translate } from '../common/Translate'
@@ -60,25 +60,6 @@ export const Menu: FC<Props> = ({ appName, tenantSelector, additionalContent }) 
 
   const className = useMemo(() => classNameGenerator(), [])
 
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      launcherListText: localize({
-        id: 'smarthr-ui/AppHeader/Launcher/listText',
-        defaultText: 'アプリ一覧',
-      }),
-      management: localize({
-        id: 'smarthr-ui/AppHeader/MobileHeader/managementMenu',
-        defaultText: '管理メニュー',
-      }),
-      releaseNote: localize({
-        id: 'smarthr-ui/AppHeader/releaseNotes',
-        defaultText: 'リリースノート',
-      }),
-    }),
-    [localize],
-  )
-
   return (
     <>
       <OpenButton
@@ -89,14 +70,26 @@ export const Menu: FC<Props> = ({ appName, tenantSelector, additionalContent }) 
       />
       {createPortal(
         <MenuDialog isOpen={isOpen} setIsOpen={setIsOpen} tenantSelector={tenantSelector}>
-          <FeatureButton className={className}>{translated.launcherListText}</FeatureButton>
+          <FeatureButton className={className}>
+            <Localizer id="smarthr-ui/AppHeader/Launcher/listText" defaultText="アプリ一覧" />
+          </FeatureButton>
           <NavigationAccordion appName={appName} menuClose={close} className={className} />
           {additionalContent && (
-            <AdditionalContent title={translated.management} className={className}>
+            <AdditionalContent
+              title={
+                <Localizer
+                  id="smarthr-ui/AppHeader/MobileHeader/managementMenu"
+                  defaultText="管理メニュー"
+                />
+              }
+              className={className}
+            >
               {additionalContent}
             </AdditionalContent>
           )}
-          <ReleaseNoteButton className={className}>{translated.releaseNote}</ReleaseNoteButton>
+          <ReleaseNoteButton className={className}>
+            <Localizer id="smarthr-ui/AppHeader/releaseNotes" defaultText="リリースノート" />
+          </ReleaseNoteButton>
         </MenuDialog>,
       )}
     </>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/ReleaseNote.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/ReleaseNote.tsx
@@ -1,7 +1,7 @@
 import { type FC, memo, useContext, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { OpenInNewTabIcon } from '../../../Icon'
 import { Center, Stack } from '../../../Layout'
 import { Loader } from '../../../Loader'
@@ -36,21 +36,6 @@ export const ReleaseNote = memo(() => {
 const ActualReleaseNote: FC<{
   data: Exclude<Required<HeaderProps>['releaseNote'], null>
 }> = ({ data }) => {
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      error: localize({
-        id: 'smarthr-ui/AppHeader/releaseNotesLoadError',
-        defaultText: 'リリースノートの読み込みに失敗しました。\n時間をおいて、やり直してください。',
-      }),
-      seeAll: localize({
-        id: 'smarthr-ui/AppHeader/seeAllReleaseNotes',
-        defaultText: 'すべてのリリースノートを見る',
-      }),
-    }),
-    [localize],
-  )
-
   const classNames = useMemo(() => {
     const { anchor, icon, indexLinkWrapper, indexLinkAnchor } = classNameGenerator()
 
@@ -69,7 +54,13 @@ const ActualReleaseNote: FC<{
           <Loader />
         </Center>
       ) : data.error ? (
-        <Translate>{translated.error}</Translate>
+        <Translate>
+          <Localizer
+            id="smarthr-ui/AppHeader/releaseNotesLoadError"
+            defaultText={`リリースノートの読み込みに失敗しました。
+時間をおいて、やり直してください。`}
+          />
+        </Translate>
       ) : (
         <Stack>
           {data.links.slice(0, 5).map((link) => (
@@ -98,7 +89,12 @@ const ActualReleaseNote: FC<{
           className={classNames.indexLinkAnchor}
           suffix={<OpenInNewTabIcon className={classNames.icon} />}
         >
-          <Translate>{translated.seeAll}</Translate>
+          <Translate>
+            <Localizer
+              id="smarthr-ui/AppHeader/seeAllReleaseNotes"
+              defaultText="すべてのリリースノートを見る"
+            />
+          </Translate>
         </TextLink>
       </div>
     </div>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
@@ -1,7 +1,7 @@
 import { type FC, memo, useCallback, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { Localizer, useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { Button } from '../../../Button'
 import { Dialog } from '../../../Dialog'
 import { Dropdown, DropdownContent, DropdownTrigger } from '../../../Dropdown'
@@ -55,17 +55,6 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
 
   const dialogOpen = useCallback(() => setLanguageDialogOpen(true), [])
   const dialogClose = useCallback(() => setLanguageDialogOpen(false), [])
-
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      userSetting: localize({
-        id: 'smarthr-ui/AppHeader/userSettings',
-        defaultText: '個人設定',
-      }),
-    }),
-    [localize],
-  )
 
   const classNames = useMemo(() => {
     const { iconButton, iconButtonInner, dropdownUserName, dropdownButtonArea } =
@@ -125,7 +114,9 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
                   rel="noopener noreferrer"
                   prefix={<FaGearIcon />}
                 >
-                  <Translate>{translated.userSetting}</Translate>
+                  <Translate>
+                    <Localizer id="smarthr-ui/AppHeader/userSettings" defaultText="個人設定" />
+                  </Translate>
                 </CommonButton>
               )}
             </div>


### PR DESCRIPTION
## 関連URL

なし

## 概要

AppHeaderのmobileコンポーネント（UserInfo、Help、Menu、ReleaseNote）で、useIntl().localize()をLocalizerコンポーネントに置き換えるリファクタリングを実施しました。

## 変更内容

以下の4つのmobileコンポーネントで変更を実施：

1. **UserInfo.tsx**
   - useIntlとtranslated useMemoを削除
   - `<Translate>{translated.userSetting}</Translate>` を `<Translate><Localizer id="..." defaultText="個人設定" /></Translate>` に変更

2. **Help.tsx**
   - useIntlとtranslated useMemoを削除
   - `<Translate>{translated.help}</Translate>` と `<Translate>{translated.school}</Translate>` をそれぞれLocalizerに変更

3. **Menu.tsx**
   - useIntlとtranslated useMemoを削除
   - launcherListText、management、releaseNoteをそれぞれLocalizerに変更

4. **ReleaseNote.tsx**
   - useIntlとtranslated useMemoを削除
   - error、seeAllをそれぞれLocalizerに変更

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで各コンポーネントが正常に動作することを確認