### PR TITLE
refactor(AppHeader): desktop componentsのuseIntlをLocalizerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
@@ -1,7 +1,7 @@
 import { type FC, type PropsWithChildren, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { localeMap, useIntl } from '../../../../intl'
+import { Localizer, localeMap, useIntl } from '../../../../intl'
 import { Button } from '../../../Button'
 import { Dropdown, DropdownContent, DropdownTrigger } from '../../../Dropdown'
 import { Header, HeaderLink, LanguageSwitcher } from '../../../Header'
@@ -59,18 +59,7 @@ export const DesktopHeader: FC<HeaderProps> = ({
     }
   }, [className])
 
-  const { localize, locale } = useIntl()
-  const translated = useMemo(
-    () => ({
-      appLauncherLabel: localize({
-        id: 'smarthr-ui/AppHeader/DesktopHeader/appLauncherLabel',
-        defaultText: 'アプリ',
-      }),
-      school: localize({ id: 'smarthr-ui/AppHeader/school', defaultText: 'スクール' }),
-      help: localize({ id: 'smarthr-ui/AppHeader/help', defaultText: 'ヘルプ' }),
-    }),
-    [localize],
-  )
+  const { locale } = useIntl()
 
   return (
     <>
@@ -88,7 +77,10 @@ export const DesktopHeader: FC<HeaderProps> = ({
               {features && features.length > 0 && (
                 <Dropdown>
                   <AppLauncherButton enableNew={enableNew} className={classNames.appsButton}>
-                    {translated.appLauncherLabel}
+                    <Localizer
+                      id="smarthr-ui/AppHeader/DesktopHeader/appLauncherLabel"
+                      defaultText="アプリ"
+                    />
                   </AppLauncherButton>
                   <DropdownContent controllable>
                     <AppLauncher features={features} />
@@ -102,7 +94,9 @@ export const DesktopHeader: FC<HeaderProps> = ({
                   prefix={<FaGraduationCapIcon />}
                   className="shr-flex shr-items-center shr-py-0.75 shr-leading-none"
                 >
-                  <Translate>{translated.school}</Translate>
+                  <Translate>
+                    <Localizer id="smarthr-ui/AppHeader/school" defaultText="スクール" />
+                  </Translate>
                 </HeaderLink>
               )}
             </>
@@ -119,7 +113,9 @@ export const DesktopHeader: FC<HeaderProps> = ({
               }
               enableNew={enableNew}
             >
-              <Translate>{translated.help}</Translate>
+              <Translate>
+                <Localizer id="smarthr-ui/AppHeader/help" defaultText="ヘルプ" />
+              </Translate>
             </HeaderLink>
           )}
 

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/ReleaseNotesDropdown.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/ReleaseNotesDropdown.tsx
@@ -31,16 +31,7 @@ export const ReleaseNotesDropdown: FC<ReleaseNoteProps> = ({ indexUrl, links, lo
   return (
     <div className="shr-border-l-shorthand shr-ms-0.5">
       <Dropdown>
-        <DropdownTrigger>
-          <Button
-            suffix={<FaCaretDownIcon />}
-            className="shr-rounded-none shr-border-none shr-font-normal [&[aria-expanded='true']_.smarthr-ui-Icon:last-child]:shr-rotate-180"
-          >
-            <Translate>
-              <Localizer id="smarthr-ui/AppHeader/releaseNotes" defaultText="リリースノート" />
-            </Translate>
-          </Button>
-        </DropdownTrigger>
+        <ReleaseNoteDropdownTrigger />
         <DropdownContent className="shr-mr-1.25" controllable>
           <div className="shr-w-[400px]">
             {loading ? (
@@ -74,6 +65,19 @@ export const ReleaseNotesDropdown: FC<ReleaseNoteProps> = ({ indexUrl, links, lo
     </div>
   )
 }
+
+const ReleaseNoteDropdownTrigger = memo(() => (
+  <DropdownTrigger>
+    <Button
+      suffix={<FaCaretDownIcon />}
+      className="shr-rounded-none shr-border-none shr-font-normal [&[aria-expanded='true']_.smarthr-ui-Icon:last-child]:shr-rotate-180"
+    >
+      <Translate>
+        <Localizer id="smarthr-ui/AppHeader/releaseNotes" defaultText="リリースノート" />
+      </Translate>
+    </Button>
+  </DropdownTrigger>
+))
 
 const StyledLoader = memo(() => (
   <Center className="shr-py-3">

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/ReleaseNotesDropdown.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/ReleaseNotesDropdown.tsx
@@ -3,7 +3,7 @@
 import { type FC, type PropsWithChildren, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { Button } from '../../../Button'
 import { Dropdown, DropdownContent, DropdownTrigger } from '../../../Dropdown'
 import { FaCaretDownIcon } from '../../../Icon'
@@ -28,35 +28,31 @@ const BOX_SHADOW_STYLE = { boxShadow: 'none' }
 export const ReleaseNotesDropdown: FC<ReleaseNoteProps> = ({ indexUrl, links, loading, error }) => {
   const wrapperClassName = useMemo(() => wrapperClassNameGenerator(), [])
 
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      releaseNote: localize({
-        id: 'smarthr-ui/AppHeader/releaseNotes',
-        defaultText: 'リリースノート',
-      }),
-      loadError: localize({
-        id: 'smarthr-ui/AppHeader/releaseNotesLoadError',
-        defaultText: 'リリースノートの読み込みに失敗しました。\n時間をおいて、やり直してください。',
-      }),
-      seeAll: localize({
-        id: 'smarthr-ui/AppHeader/seeAllReleaseNotes',
-        defaultText: 'すべてのリリースノートを見る',
-      }),
-    }),
-    [localize],
-  )
-
   return (
     <div className="shr-border-l-shorthand shr-ms-0.5">
       <Dropdown>
-        <ReleaseNoteDropdownTrigger>{translated.releaseNote}</ReleaseNoteDropdownTrigger>
+        <DropdownTrigger>
+          <Button
+            suffix={<FaCaretDownIcon />}
+            className="shr-rounded-none shr-border-none shr-font-normal [&[aria-expanded='true']_.smarthr-ui-Icon:last-child]:shr-rotate-180"
+          >
+            <Translate>
+              <Localizer id="smarthr-ui/AppHeader/releaseNotes" defaultText="リリースノート" />
+            </Translate>
+          </Button>
+        </DropdownTrigger>
         <DropdownContent className="shr-mr-1.25" controllable>
           <div className="shr-w-[400px]">
             {loading ? (
               <StyledLoader />
             ) : error || !links ? (
-              <LoadErrorText>{translated.loadError}</LoadErrorText>
+              <LoadErrorText>
+                <Localizer
+                  id="smarthr-ui/AppHeader/releaseNotesLoadError"
+                  defaultText={`リリースノートの読み込みに失敗しました。
+時間をおいて、やり直してください。`}
+                />
+              </LoadErrorText>
             ) : (
               <div className={wrapperClassName}>
                 {links.slice(0, 5).map(({ title, url }, index) => (
@@ -64,7 +60,12 @@ export const ReleaseNotesDropdown: FC<ReleaseNoteProps> = ({ indexUrl, links, lo
                     {title}
                   </ArticleLink>
                 ))}
-                <SeeAllTextLink href={indexUrl}>{translated.seeAll}</SeeAllTextLink>
+                <SeeAllTextLink href={indexUrl}>
+                  <Localizer
+                    id="smarthr-ui/AppHeader/seeAllReleaseNotes"
+                    defaultText="すべてのリリースノートを見る"
+                  />
+                </SeeAllTextLink>
               </div>
             )}
           </div>
@@ -73,17 +74,6 @@ export const ReleaseNotesDropdown: FC<ReleaseNoteProps> = ({ indexUrl, links, lo
     </div>
   )
 }
-
-const ReleaseNoteDropdownTrigger = memo<PropsWithChildren>(({ children }) => (
-  <DropdownTrigger>
-    <Button
-      suffix={<FaCaretDownIcon />}
-      className="shr-rounded-none shr-border-none shr-font-normal [&[aria-expanded='true']_.smarthr-ui-Icon:last-child]:shr-rotate-180"
-    >
-      <Translate>{children}</Translate>
-    </Button>
-  </DropdownTrigger>
-))
 
 const StyledLoader = memo(() => (
   <Center className="shr-py-3">

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/UserInfo.tsx
@@ -1,7 +1,7 @@
 import { type FC, type PropsWithChildren, type ReactNode, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { AnchorButton, Button } from '../../../Button'
 import { Dropdown, DropdownContent, DropdownMenuButton, DropdownTrigger } from '../../../Dropdown'
 import { FaCaretDownIcon, FaGearIcon, FaUserIcon } from '../../../Icon'
@@ -139,14 +139,6 @@ export const ActualUserInfo: FC<Props & { displayName: string }> = ({
     }
   }, [enableNew])
 
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      userSetting: localize({ id: 'smarthr-ui/AppHeader/userSettings', defaultText: '個人設定' }),
-    }),
-    [localize],
-  )
-
   const currentTenantName = useMemo(
     () => tenants?.find((tenant) => tenant.id === currentTenantId)?.name,
     [tenants, currentTenantId],
@@ -177,7 +169,7 @@ export const ActualUserInfo: FC<Props & { displayName: string }> = ({
           className={classNames.userSummary}
         />
         <DropdownContentButton href={accountUrl} className={classNames.dropdownContentButton}>
-          {translated.userSetting}
+          <Localizer id="smarthr-ui/AppHeader/userSettings" defaultText="個人設定" />
         </DropdownContentButton>
         {desktopAdditionalContent}
       </DropdownMenuButton>
@@ -190,7 +182,9 @@ export const ActualUserInfo: FC<Props & { displayName: string }> = ({
         {displayName}
       </DisplayNameDropdownTrigger>
       <DropdownContent className={classNames.dropdownContent}>
-        <AccountLink href={accountUrl}>{translated.userSetting}</AccountLink>
+        <AccountLink href={accountUrl}>
+          <Localizer id="smarthr-ui/AppHeader/userSettings" defaultText="個人設定" />
+        </AccountLink>
         {desktopAdditionalContent}
       </DropdownContent>
     </Dropdown>


### PR DESCRIPTION
## 関連URL

なし

## 概要

AppHeaderのdesktopコンポーネント（UserInfo、ReleaseNotesDropdown、DesktopHeader）で、useIntl().localize()をLocalizerコンポーネントに置き換えるリファクタリングを実施しました。

## 変更内容

以下の3つのdesktopコンポーネントで変更を実施：

1. **UserInfo.tsx**
   - useIntlとtranslated useMemoを削除
   - `{translated.userSetting}` を `<Localizer id="..." defaultText="個人設定" />` に変更

2. **ReleaseNotesDropdown.tsx**
   - useIntlとtranslated useMemoを削除
   - releaseNote、loadError、seeAllをそれぞれLocalizerに変更
   - 不要なReleaseNoteDropdownTriggerコンポーネントを削除し、インライン展開

3. **DesktopHeader.tsx**
   - useIntlのlocalizeを削除（localeは言語切り替えで使用するため残す）
   - translated useMemoを削除
   - appLauncherLabel、school、helpをそれぞれLocalizerに変更

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで各コンポーネントが正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アプリヘッダー内のアプリ、スクール、ヘルプ、個人設定などの表示を、より安定したローカライズ方式に更新しました。
  * リリースノートのメニュー、読み込みエラー、一覧リンクの翻訳表示を改善しました。
  * 言語設定に応じて、各ラベルやメッセージが適切に表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->