### PR TITLE
refactor(AccordionPanel): ロジックをAccordionPanelに統合

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -14,7 +14,7 @@ import {
 import { type VariantProps, tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
-import { flatArrayToMap } from '../../libs/map'
+import { flatArrayToMap, mapToKeyArray } from '../../libs/map'
 
 import { getNewExpandedItems } from './accordionPanelHelper'
 
@@ -39,13 +39,13 @@ export const AccordionPanelContext = createContext<{
   expandedItems: Map<string, string>
   expandableMultiply: boolean
   parentRef: RefObject<HTMLDivElement> | null
-  onClickTrigger?: (itemName: string, isExpanded: boolean) => void
-  onClickProps?: (expandedItems: string[]) => void
+  handleClickTrigger: (itemName: string, isExpanded: boolean) => void
 }>({
   iconPosition: 'left',
   expandedItems: DEFAULT_EXPANDED_MAP,
   expandableMultiply: true,
   parentRef: null,
+  handleClickTrigger: () => {},
 })
 
 const ROUNDED = {
@@ -93,27 +93,28 @@ export const AccordionPanel: FC<Props> = ({
 
   const latest = useLatest({ onClick })
 
-  const onClickProps = useCallback(
-    (items: string[]) => {
-      latest.onClick?.(items)
-    },
-    [latest],
-  )
-
-  const onClickTrigger = useCallback(
+  const handleClickTrigger = useCallback(
     (itemName: string, isExpanded: boolean) => {
-      setExpanded((prevExpandedItems) =>
-        getNewExpandedItems(prevExpandedItems, itemName, isExpanded, expandableMultiply),
-      )
+      setExpanded((prevExpandedItems) => {
+        const newExpandedItems = getNewExpandedItems(
+          prevExpandedItems,
+          itemName,
+          isExpanded,
+          expandableMultiply,
+        )
+
+        latest.onClick?.(mapToKeyArray(newExpandedItems))
+
+        return newExpandedItems
+      })
     },
-    [expandableMultiply],
+    [expandableMultiply, latest],
   )
 
   return (
     <AccordionPanelContext.Provider
       value={{
-        onClickTrigger,
-        onClickProps: onClick ? onClickProps : undefined,
+        handleClickTrigger,
         expandedItems,
         iconPosition,
         expandableMultiply,

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -13,7 +13,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
-import { getIsInclude, mapToKeyArray } from '../../libs/map'
+import { getIsInclude } from '../../libs/map'
 import { Heading, type HeadingTagTypes } from '../Heading'
 import { FaCaretDownIcon, FaCaretRightIcon } from '../Icon'
 import { Cluster } from '../Layout'
@@ -25,7 +25,6 @@ import {
   focusLastSibling,
   focusNextSibling,
   focusPreviousSibling,
-  getNewExpandedItems,
 } from './accordionPanelHelper'
 
 import type { TextProps } from '../Text'
@@ -84,44 +83,23 @@ export const AccordionPanelTrigger: FC<Props> = ({
   }, [className])
 
   const { name, contentId, triggerId } = useContext(AccordionPanelItemContext)
-  const {
-    iconPosition,
-    expandedItems,
-    onClickTrigger,
-    onClickProps,
-    expandableMultiply,
-    parentRef,
-  } = useContext(AccordionPanelContext)
+  const { iconPosition, expandedItems, handleClickTrigger, parentRef } =
+    useContext(AccordionPanelContext)
 
   const isExpanded = useMemo(() => getIsInclude(expandedItems, name), [expandedItems, name])
 
   const latest = useLatest({
     expandedItems,
-    onClickTrigger,
-    onClickProps,
+    handleClickTrigger,
     parentRef,
-    expandableMultiply,
   })
-
-  const hasOnClick = !!(onClickTrigger || onClickProps)
 
   const functions = useMemo(
     () => ({
-      actualOnClick: hasOnClick
-        ? (e: MouseEvent<HTMLButtonElement>) => {
-            const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
-            latest.onClickTrigger?.(e.currentTarget.value, newIsExpanded)
-            if (latest.onClickProps) {
-              const newExpandedItems = getNewExpandedItems(
-                latest.expandedItems,
-                e.currentTarget.value,
-                newIsExpanded,
-                latest.expandableMultiply,
-              )
-              latest.onClickProps(mapToKeyArray(newExpandedItems))
-            }
-          }
-        : undefined,
+      actualOnClick: (e: MouseEvent<HTMLButtonElement>) => {
+        const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
+        latest.handleClickTrigger(e.currentTarget.value, newIsExpanded)
+      },
       handleKeyDown: (e: Parameters<KeyboardEventHandler<HTMLButtonElement>>[0]): void => {
         if (!latest.parentRef?.current) {
           return
@@ -155,7 +133,7 @@ export const AccordionPanelTrigger: FC<Props> = ({
         }
       },
     }),
-    [hasOnClick, latest],
+    [latest],
   )
 
   return (
@@ -184,7 +162,7 @@ const MemoizedHeadingButton = memo<
       triggerId: string
       isExpanded: boolean
       contentId: string
-      actualOnClick: ((e: MouseEvent<HTMLButtonElement>) => void) | undefined
+      actualOnClick: (e: MouseEvent<HTMLButtonElement>) => void
       handleKeyDown: KeyboardEventHandler<HTMLButtonElement>
       classNames: {
         button: string


### PR DESCRIPTION
## 関連URL

なし

## 概要

AccordionPanelの状態管理ロジックを整理し、AccordionPanelに集約することで、コードの重複を排除し保守性を向上させました。

## 変更内容

### AccordionPanel.tsx
- `handleClickTrigger`内で状態更新とonCallbackを実行するように統合
- `expandableMultiply`の参照をAccordionPanelに集約

### AccordionPanelTrigger.tsx
- `hasOnClick`判定を削除
- `actualOnClick`を簡素化
- `getNewExpandedItems`の重複呼び出しを排除

**主な改善点:**
- onClickTriggerとonClickPropsを単一のhandleClickTriggerに統合
- 状態管理とその更新ロジックをAccordionPanelに集約
- getNewExpandedItemsの重複呼び出しを排除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでアコーディオンの開閉動作が正常に機能することを確認