### PR TITLE
refactor(AccordionPanel): actualOnClickを削除しhandleClickTriggerに統合

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -3,6 +3,7 @@
 import {
   type ComponentProps,
   type FC,
+  type MouseEvent,
   type PropsWithChildren,
   type RefObject,
   createContext,
@@ -39,7 +40,7 @@ export const AccordionPanelContext = createContext<{
   expandedItems: Map<string, string>
   expandableMultiply: boolean
   parentRef: RefObject<HTMLDivElement> | null
-  handleClickTrigger: (itemName: string, isExpanded: boolean) => void
+  handleClickTrigger: (e: MouseEvent<HTMLButtonElement>) => void
 }>({
   iconPosition: 'left',
   expandedItems: DEFAULT_EXPANDED_MAP,
@@ -94,12 +95,15 @@ export const AccordionPanel: FC<Props> = ({
   const latest = useLatest({ onClick })
 
   const handleClickTrigger = useCallback(
-    (itemName: string, isExpanded: boolean) => {
+    (e: MouseEvent<HTMLButtonElement>) => {
+      const itemName = e.currentTarget.value
+      const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
+
       setExpanded((prevExpandedItems) => {
         const newExpandedItems = getNewExpandedItems(
           prevExpandedItems,
           itemName,
-          isExpanded,
+          newIsExpanded,
           expandableMultiply,
         )
 

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -89,18 +89,12 @@ export const AccordionPanelTrigger: FC<Props> = ({
   const isExpanded = useMemo(() => getIsInclude(expandedItems, name), [expandedItems, name])
 
   const latest = useLatest({
-    expandedItems,
-    handleClickTrigger,
     parentRef,
   })
 
-  const functions = useMemo(
-    () => ({
-      actualOnClick: (e: MouseEvent<HTMLButtonElement>) => {
-        const newIsExpanded = e.currentTarget.getAttribute('aria-expanded') !== 'true'
-        latest.handleClickTrigger(e.currentTarget.value, newIsExpanded)
-      },
-      handleKeyDown: (e: Parameters<KeyboardEventHandler<HTMLButtonElement>>[0]): void => {
+  const handleKeyDown = useMemo(
+    () =>
+      (e: Parameters<KeyboardEventHandler<HTMLButtonElement>>[0]): void => {
         if (!latest.parentRef?.current) {
           return
         }
@@ -132,7 +126,6 @@ export const AccordionPanelTrigger: FC<Props> = ({
           }
         }
       },
-    }),
     [latest],
   )
 
@@ -143,8 +136,8 @@ export const AccordionPanelTrigger: FC<Props> = ({
       triggerId={triggerId}
       isExpanded={isExpanded}
       contentId={contentId}
-      actualOnClick={functions.actualOnClick}
-      handleKeyDown={functions.handleKeyDown}
+      handleClickTrigger={handleClickTrigger}
+      handleKeyDown={handleKeyDown}
       classNames={classNames}
       iconPosition={iconPosition}
       headingType={headingType}
@@ -162,7 +155,7 @@ const MemoizedHeadingButton = memo<
       triggerId: string
       isExpanded: boolean
       contentId: string
-      actualOnClick: (e: MouseEvent<HTMLButtonElement>) => void
+      handleClickTrigger: (e: MouseEvent<HTMLButtonElement>) => void
       handleKeyDown: KeyboardEventHandler<HTMLButtonElement>
       classNames: {
         button: string
@@ -183,7 +176,7 @@ const MemoizedHeadingButton = memo<
     triggerId,
     isExpanded,
     contentId,
-    actualOnClick,
+    handleClickTrigger,
     handleKeyDown,
     classNames,
     iconPosition,
@@ -200,7 +193,7 @@ const MemoizedHeadingButton = memo<
         id={triggerId}
         aria-expanded={isExpanded}
         aria-controls={contentId}
-        onClick={actualOnClick}
+        onClick={handleClickTrigger}
         onKeyDown={handleKeyDown}
         className={classNames.button}
         data-component="AccordionHeaderButton"


### PR DESCRIPTION
## 関連URL

なし

## 概要

AccordionPanelTriggerのactualOnClickは、handleClickTriggerを呼び出すだけの中間層だったため削除し、イベント処理ロジックをAccordionPanelに完全統合しました。

## 変更内容

### AccordionPanel.tsx
- `handleClickTrigger`がMouseEventを直接受け取るように変更
- イベントから`value`と`aria-expanded`属性を直接取得

### AccordionPanelTrigger.tsx
- `actualOnClick`関数を削除
- `functions`オブジェクトと`useMemo`を削除
- `latest`から不要な`expandedItems`と`handleClickTrigger`を削除
- `handleClickTrigger`を直接buttonの`onClick`に接続

**主な改善点:**
- 中間層を削除してコードを簡素化
- AccordionPanelに処理を集約し、責務を明確化

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでアコーディオンの開閉動作が正常に機能することを確認