### PR TITLE
refactor(Textarea): handleChangeをfunctionsパターンに統一

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -144,9 +144,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       }
     }, [countError, className])
 
-    const onChangeRef = useRef(onChange)
-    onChangeRef.current = onChange
-
     const getCounterMessage = useCallback(
       (counterValue: number) => {
         if (maxLetters === undefined) return
@@ -202,27 +199,15 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       }
     }, [maxLetters, getCounterMessage])
 
-    const handleChange = useCallback(
-      (e: ChangeEvent<HTMLTextAreaElement>) => {
-        const newValue = e.target.value
-        updateCounters?.(newValue)
-
-        // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
-        e.target.rows = rows
-
-        if (autoResize) {
-          const currentRows = calculateIdealRows(e.target, maxRows, theme.leading.NORMAL)
-          // rowsを直接反映 Textareaのrows propsが状態を変更しても反映されないため
-          e.target.rows = currentRows
-          setInterimRows(currentRows)
-        }
-
-        onChangeRef.current?.(e)
-      },
-      [updateCounters, autoResize, maxRows, rows, theme.leading.NORMAL],
-    )
-
-    const latest = useLatest({ autoFocus, autoResize, maxRows, theme })
+    const latest = useLatest({
+      onChange,
+      autoFocus,
+      autoResize,
+      maxRows,
+      theme,
+      updateCounters,
+      rows,
+    })
 
     const functions = useMemo(
       () => ({
@@ -240,6 +225,26 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
               )
             }
           }
+        },
+        handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
+          const newValue = e.target.value
+          latest.updateCounters?.(newValue)
+
+          // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
+          e.target.rows = latest.rows
+
+          if (latest.autoResize) {
+            const currentRows = calculateIdealRows(
+              e.target,
+              latest.maxRows,
+              latest.theme.leading.NORMAL,
+            )
+            // rowsを直接反映 Textareaのrows propsが状態を変更しても反映されないため
+            e.target.rows = currentRows
+            setInterimRows(currentRows)
+          }
+
+          latest.onChange?.(e)
         },
       }),
       [latest],
@@ -264,7 +269,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
         data-smarthr-ui-input="true"
         value={value}
         defaultValue={defaultValue}
-        onChange={handleChange}
+        onChange={functions.handleChange}
         ref={functions.callbackRef}
         aria-invalid={error || countError || undefined}
         rows={interimRows}


### PR DESCRIPTION
## 関連URL

なし

## 概要

TextareaコンポーネントのhandleChangeを、useCallbackパターンからfunctionsパターンに統一します。これにより、コンポーネント内のイベントハンドラの実装が一貫性を持ち、メンテナンス性が向上します。

## 変更内容

### 変更前の問題点

コンポーネント内でイベントハンドラの実装パターンが混在していました：
- `callbackRef`: functionsパターン（useMemo内で定義）
- `handleChange`: useCallbackパターン + onChangeRefパターン

```tsx
const onChangeRef = useRef(onChange)
onChangeRef.current = onChange

const handleChange = useCallback(
  (e: ChangeEvent<HTMLTextAreaElement>) => {
    // ...
    onChangeRef.current?.(e)
  },
  [updateCounters, autoResize, maxRows, rows, theme.leading.NORMAL],
)

const latest = useLatest({ autoFocus, autoResize, maxRows, theme })

const functions = useMemo(
  () => ({
    callbackRef: (element) => { /* ... */ },
  }),
  [latest],
)
```

### 変更後

すべてのイベントハンドラをfunctionsパターンに統一し、依存配列を`[latest]`のみに最適化：

```tsx
const latest = useLatest({ 
  onChange, 
  autoFocus, 
  autoResize, 
  maxRows, 
  theme,
  updateCounters,
  rows,
})

const functions = useMemo(
  () => ({
    callbackRef: (element: HTMLTextAreaElement | null) => {
      textareaRef.current = element
      if (element) {
        if (latest.autoFocus) {
          element.focus()
        }
        if (latest.autoResize) {
          setInterimRows(
            calculateIdealRows(element, latest.maxRows, latest.theme.leading.NORMAL),
          )
        }
      }
    },
    handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
      const newValue = e.target.value
      latest.updateCounters?.(newValue)

      e.target.rows = latest.rows

      if (latest.autoResize) {
        const currentRows = calculateIdealRows(
          e.target,
          latest.maxRows,
          latest.theme.leading.NORMAL,
        )
        e.target.rows = currentRows
        setInterimRows(currentRows)
      }

      latest.onChange?.(e)
    },
  }),
  [latest],
)
```

### 主な変更点

1. **onChangeRefを削除**: useLatestで一元管理
2. **useCallbackのhandleChangeを削除**: functionsのuseMemo内に移動
3. **useLatestに追加**: `onChange`, `updateCounters`, `rows`を追加
4. **依存配列を最適化**: `[latest]`のみに統一
5. **handleChange内の参照**: すべて`latest.*`経由に変更

### メリット

- イベントハンドラの実装パターンが統一される
- 依存配列が`[latest]`のみで非常にシンプル
- コードの一貫性が向上し、メンテナンスしやすくなる
- `onChangeRef`パターンと`useCallback`パターンの混在を解消

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストがすべて通過することを確認
- handleChangeの動作が変更前と同じであることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * テキストエリアの入力時に、文字数カウンターや行数、自動リサイズが最新の設定値で正しく更新されるよう改善しました。
  * 初期表示時の行数計算を安定化し、入力内容に応じた表示調整の信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->