### PR TITLE
refactor(Textarea): counterVisualMessageの不要なuseMemoを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -174,8 +174,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       [maxLetters],
     )
 
-    const counterVisualMessage = useMemo(() => getCounterMessage(count), [count, getCounterMessage])
-
     const updateCounters = useMemo(() => {
       if (!maxLetters) return undefined
 
@@ -285,7 +283,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
         </VisuallyHiddenText>
         <VisuallyHiddenText aria-live="polite">{srCounterMessage}</VisuallyHiddenText>
         <span id={actualMaxLettersId} aria-hidden={true} className={classNames.counter}>
-          {counterVisualMessage}
+          {getCounterMessage(count)}
         </span>
       </span>
     ) : (


### PR DESCRIPTION
## 関連URL

なし

## 概要

TextareaコンポーネントのcounterVisualMessageで使用している不要な`useMemo`を削除し、シンプルな関数呼び出しに変更します。

## 変更内容

### 変更前

```tsx
const counterVisualMessage = useMemo(() => getCounterMessage(count), [count, getCounterMessage])
```

### 変更後

```tsx
const counterVisualMessage = getCounterMessage(count)
```

### 変更理由

1. **getCounterMessageは既にuseCallbackでメモ化されている**
   - `getCounterMessage`自体が`useCallback`で定義されており、参照は安定している
   
2. **countはプリミティブ値（number）**
   - プリミティブ値の変更検知にuseMemoは不要

3. **計算コストが低い**
   - `getCounterMessage`は単純な条件分岐とJSX生成のみ
   - `useMemo`のオーバーヘッドの方が高い可能性がある

4. **コードがシンプルになる**
   - 依存配列の管理が不要
   - 可読性が向上

### メリット

- コードが簡潔になる
- 不要なメモ化によるオーバーヘッドを削減
- メンテナンス性が向上

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストがすべて通過することを確認
- counterVisualMessageの値が変更前と同じであることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * テキストエリアの文字数カウンター表示処理を簡素化しました。
  * カウンターの表示内容や更新タイミングに変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->