### PR TITLE
refactor(Textarea): counter spanを監視してスクリーンリーダーメッセージを同期

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -6,7 +6,6 @@ import {
   type ReactNode,
   forwardRef,
   startTransition,
-  useCallback,
   useEffect,
   useId,
   useImperativeHandle,
@@ -125,6 +124,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
     const actualMaxLettersId = maxLetters ? maxLettersId : undefined
 
     const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+    const counterSpanRef = useRef<HTMLSpanElement>(null)
+    const previousTextRef = useRef<string>('')
     const currentValue = defaultValue || value
     const [interimRows, setInterimRows] = useState(rows)
     const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
@@ -144,71 +145,25 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
       }
     }, [countError, className])
 
-    const getCounterMessage = useCallback(
-      (counterValue: number) => {
-        if (maxLetters === undefined) return
-
-        if (counterValue > maxLetters) {
-          // {count}文字オーバー
-          return (
-            <Localizer
-              id="smarthr-ui/Textarea/maxLettersExceeded"
-              defaultText="{exceededLetters}文字オーバー"
-              values={{ exceededLetters: counterValue - maxLetters }}
-            />
-          )
-        }
-
-        // あと{count}文字
-        return (
-          <Localizer
-            id="smarthr-ui/Textarea/availableLetters"
-            defaultText="あと{availableLetters}文字"
-            values={{ availableLetters: maxLetters - counterValue }}
-          />
-        )
-      },
-      [maxLetters],
-    )
-
-    const updateCounters = useMemo(() => {
-      if (!maxLetters) return undefined
-
-      const updateCount = debounce((newValue: TextareaValue) => {
-        startTransition(() => {
-          setCount(getStringLength(newValue))
-        })
-      }, 200)
-
-      // countが連続で更新されると、スクリーンリーダーが古い値を読み上げてしまうため、メッセージの更新を遅延しています
-      const updateSrMessage = debounce((newValue: TextareaValue) => {
-        startTransition(() => {
-          const counterText = getCounterMessage(getStringLength(newValue))
-
-          if (counterText) {
-            setSrCounterMessage(counterText)
-          }
-        })
-      }, 1000)
-
-      return (newValue: TextareaValue) => {
-        updateCount(newValue)
-        updateSrMessage(newValue)
-      }
-    }, [maxLetters, getCounterMessage])
-
     const latest = useLatest({
       onChange,
       autoFocus,
       autoResize,
       maxRows,
       theme,
-      updateCounters,
       rows,
     })
 
-    const functions = useMemo(
-      () => ({
+    const functions = useMemo(() => {
+      const updateCount = maxLetters
+        ? debounce((newValue: TextareaValue) => {
+            startTransition(() => {
+              setCount(getStringLength(newValue))
+            })
+          }, 200)
+        : undefined
+
+      return {
         callbackRef: (element: HTMLTextAreaElement | null) => {
           textareaRef.current = element
           if (element) {
@@ -226,7 +181,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
         },
         handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
           const newValue = e.target.value
-          latest.updateCounters?.(newValue)
+          updateCount?.(newValue)
 
           // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
           e.target.rows = latest.rows
@@ -244,21 +199,39 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
 
           latest.onChange?.(e)
         },
-      }),
-      [latest],
-    )
+        // countが連続で更新されると、スクリーンリーダーが古い値を読み上げてしまうため、メッセージの更新を遅延しています
+        updateSrMessage: debounce((text: string) => {
+          startTransition(() => {
+            setSrCounterMessage(text)
+          })
+        }, 1000),
+        updateCount,
+      }
+    }, [maxLetters, latest])
 
     useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
       ref,
       () => textareaRef.current,
     )
 
+    // counter spanのテキスト変更を監視してスクリーンリーダーメッセージを更新
+    useEffect(() => {
+      if (!maxLetters || !counterSpanRef.current) return
+
+      const currentText = counterSpanRef.current.textContent || ''
+
+      if (currentText !== previousTextRef.current) {
+        previousTextRef.current = currentText
+        functions.updateSrMessage(currentText)
+      }
+    }, [count, maxLetters, functions])
+
     // value 変更時にもカウントを更新する
     useEffect(() => {
       if (value && maxLetters) {
-        updateCounters?.(value)
+        functions.updateCount?.(value)
       }
-    }, [maxLetters, updateCounters, value])
+    }, [value, maxLetters, functions])
 
     const body = (
       <textarea
@@ -287,8 +260,25 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
           />
         </VisuallyHiddenText>
         <VisuallyHiddenText aria-live="polite">{srCounterMessage}</VisuallyHiddenText>
-        <span id={actualMaxLettersId} aria-hidden={true} className={classNames.counter}>
-          {getCounterMessage(count)}
+        <span
+          ref={counterSpanRef}
+          id={actualMaxLettersId}
+          aria-hidden={true}
+          className={classNames.counter}
+        >
+          {count > maxLetters ? (
+            <Localizer
+              id="smarthr-ui/Textarea/maxLettersExceeded"
+              defaultText="{exceededLetters}文字オーバー"
+              values={{ exceededLetters: count - maxLetters }}
+            />
+          ) : (
+            <Localizer
+              id="smarthr-ui/Textarea/availableLetters"
+              defaultText="あと{availableLetters}文字"
+              values={{ availableLetters: maxLetters - count }}
+            />
+          )}
         </span>
       </span>
     ) : (


### PR DESCRIPTION
## 関連URL

なし

## 概要

Textareaコンポーネントのスクリーンリーダーメッセージを、視覚表示（counter span）の実際のテキスト変更を検知して更新することで、完全な同期を保証します。

## 変更内容

### 変更前の問題点

視覚表示とスクリーンリーダーメッセージが独立して計算されており、同期がずれる可能性がありました：

```tsx
const updateCounters = useMemo(() => {
  if (!maxLetters) return undefined

  const updateCount = debounce((newValue: TextareaValue) => {
    startTransition(() => {
      setCount(getStringLength(newValue))
    })
  }, 200)

  const updateSrMessage = debounce((newValue: TextareaValue) => {
    startTransition(() => {
      const counterText = getCounterMessage(getStringLength(newValue))
      if (counterText) {
        setSrCounterMessage(counterText)
      }
    })
  }, 1000)

  return (newValue: TextareaValue) => {
    updateCount(newValue)
    updateSrMessage(newValue)
  }
}, [maxLetters, getCounterMessage])
```

**問題:**
1. 視覚表示は`count`から計算、スクリーンリーダーは`newValue`から直接計算
2. 200ms後と1000ms後でそれぞれ計算されるため、入力値が異なる可能性
3. `getCounterMessage`の実装変更時に両方を修正する必要がある

### 変更後

視覚表示のspan要素を監視し、実際のテキスト変更を検知してスクリーンリーダーメッセージを更新：

```tsx
const counterSpanRef = useRef<HTMLSpanElement>(null)
const previousTextRef = useRef<string>('')

const updateCounters = useMemo(() => {
  if (!maxLetters) return undefined

  return debounce((newValue: TextareaValue) => {
    startTransition(() => {
      setCount(getStringLength(newValue))
    })
  }, 200)
}, [maxLetters])

const functions = useMemo(
  () => ({
    // ... 既存のcallbackRef, handleChange
    updateSrMessage: debounce((text: string) => {
      startTransition(() => {
        setSrCounterMessage(text)
      })
    }, 1000),
  }),
  [latest],
)

// counter spanのテキスト変更を監視してスクリーンリーダーメッセージを更新
useEffect(() => {
  if (!maxLetters || !counterSpanRef.current) return

  const currentText = counterSpanRef.current.textContent || ''

  if (currentText !== previousTextRef.current) {
    previousTextRef.current = currentText
    functions.updateSrMessage(currentText)
  }
}, [count, maxLetters, functions])

// JSX
<span
  ref={counterSpanRef}
  id={actualMaxLettersId}
  aria-hidden={true}
  className={classNames.counter}
>
  {getCounterMessage(count)}
</span>
```

### 主な変更点

1. **updateCountersをシンプル化**: count更新のみに専念
2. **counterSpanRefを追加**: 視覚表示のspan要素への参照
3. **previousTextRefを追加**: 前回のテキストを記憶
4. **updateSrMessageをfunctionsに追加**: debounce関数をuseMemoでメモ化
5. **useEffectで監視**: countが変わったときにspan要素のtextContentを確認し、変更があればupdateSrMessageを呼び出す

### メリット

1. **完全な同期保証**: 視覚表示とスクリーンリーダーメッセージが必ず同じテキストになる
2. **本質的に正しい**: 「実際に表示されているもの」を基準にする
3. **updateCountersがシンプルに**: 単一責任になり、理解しやすい
4. **将来の変更に強い**: `getCounterMessage`の実装が変わっても、視覚表示さえ正しければスクリーンリーダーも正しい

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストがすべて通過することを確認
- maxLettersを設定したTextareaで、視覚表示とスクリーンリーダーメッセージが同期していることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * テキストエリアの文字数カウンター更新を改善し、入力時や値変更時によりスムーズに反映されるようになりました。
  * 上限文字数を超えた場合の表示が明確になりました。
  * スクリーンリーダー向けの文字数案内を改善し、カウンターの変更内容が適切に読み上げられるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->