### PR TITLE
refactor(Textarea): コンポーネント構造を分割し型定義を整理

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -2,8 +2,11 @@
 
 import {
   type ChangeEvent,
+  type ComponentProps,
   type ComponentPropsWithRef,
+  type FC,
   type ReactNode,
+  type Ref,
   forwardRef,
   startTransition,
   useEffect,
@@ -102,198 +105,198 @@ const calculateIdealRows = (
 
 export const Textarea = forwardRef<HTMLTextAreaElement, Props>(({ maxLetters, ...rest }, ref) =>
   maxLetters ? (
-    <MaxLettersTextarea {...rest} ref={ref} maxLetters={maxLetters} />
+    <MaxLettersTextarea {...rest} externalRef={ref} maxLetters={maxLetters} />
   ) : (
-    <ActualTextarea {...rest} ref={ref} />
+    <ActualTextarea {...rest} externalRef={ref} />
   ),
 )
 
-const MaxLettersTextarea = forwardRef<HTMLTextAreaElement, Props>((props, ref) => (
-  <ActualTextarea {...props} ref={ref} />
-))
+type LocalTextareaProps = ComponentProps<typeof Textarea> & {
+  externalRef?: Ref<HTMLTextAreaElement>
+}
 
-const ActualTextarea = forwardRef<HTMLTextAreaElement, Props>(
-  (
-    {
-      autoFocus,
-      maxLetters,
-      width,
-      className,
-      autoResize = false,
-      maxRows = Infinity,
-      rows = 2,
-      error,
-      onChange,
-      value,
-      defaultValue,
-      ...rest
-    },
-    ref,
-  ) => {
-    const theme = useTheme()
-    const maxLettersId = useId()
-    const maxLettersNoticeId = `${maxLettersId}-notice`
-    const actualMaxLettersId = maxLetters ? maxLettersId : undefined
+const MaxLettersTextarea: FC<
+  Omit<LocalTextareaProps, 'maxLetters'> & {
+    maxLetters: number
+  }
+> = (props) => <ActualTextarea {...props} />
 
-    const textareaRef = useRef<HTMLTextAreaElement | null>(null)
-    const counterSpanRef = useRef<HTMLSpanElement>(null)
-    const previousTextRef = useRef<string>('')
-    const currentValue = defaultValue || value
-    const [interimRows, setInterimRows] = useState(rows)
-    const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
-    const [srCounterMessage, setSrCounterMessage] = useState<ReactNode>('')
+const ActualTextarea: FC<LocalTextareaProps> = ({
+  autoFocus,
+  maxLetters,
+  width,
+  className,
+  autoResize = false,
+  maxRows = Infinity,
+  rows = 2,
+  error,
+  onChange,
+  value,
+  defaultValue,
+  externalRef,
+  ...rest
+}) => {
+  const theme = useTheme()
+  const maxLettersId = useId()
+  const maxLettersNoticeId = `${maxLettersId}-notice`
+  const actualMaxLettersId = maxLetters ? maxLettersId : undefined
 
-    const textareaStyle = useMemo(
-      () => ({ width: typeof width === 'number' ? `${width}px` : width }),
-      [width],
-    )
-    const countError = maxLetters && count > maxLetters
-    const classNames = useMemo(() => {
-      const { textareaEl, counter } = classNameGenerator()
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const counterSpanRef = useRef<HTMLSpanElement>(null)
+  const previousTextRef = useRef<string>('')
+  const currentValue = defaultValue || value
+  const [interimRows, setInterimRows] = useState(rows)
+  const [count, setCount] = useState(currentValue ? getStringLength(currentValue) : 0)
+  const [srCounterMessage, setSrCounterMessage] = useState<ReactNode>('')
 
-      return {
-        textarea: textareaEl({ className }),
-        counter: counter({ error: !!countError }),
-      }
-    }, [countError, className])
+  const textareaStyle = useMemo(
+    () => ({ width: typeof width === 'number' ? `${width}px` : width }),
+    [width],
+  )
+  const countError = maxLetters && count > maxLetters
+  const classNames = useMemo(() => {
+    const { textareaEl, counter } = classNameGenerator()
 
-    const latest = useLatest({
-      onChange,
-      autoFocus,
-      autoResize,
-      maxRows,
-      theme,
-      rows,
-    })
+    return {
+      textarea: textareaEl({ className }),
+      counter: counter({ error: !!countError }),
+    }
+  }, [countError, className])
 
-    const functions = useMemo(() => {
-      const updateCount = maxLetters
-        ? debounce((newValue: TextareaValue) => {
-            startTransition(() => {
-              setCount(getStringLength(newValue))
-            })
-          }, 200)
-        : undefined
+  const latest = useLatest({
+    onChange,
+    autoFocus,
+    autoResize,
+    maxRows,
+    theme,
+    rows,
+  })
 
-      return {
-        callbackRef: (element: HTMLTextAreaElement | null) => {
-          textareaRef.current = element
-          if (element) {
-            // autoFocus時に、フォーカスを当てる
-            if (latest.autoFocus) {
-              element.focus()
-            }
-            // autoResize時に、初期値での高さを指定
-            if (latest.autoResize) {
-              setInterimRows(
-                calculateIdealRows(element, latest.maxRows, latest.theme.leading.NORMAL),
-              )
-            }
-          }
-        },
-        handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
-          updateCount?.(e.target.value)
-
-          // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
-          e.target.rows = latest.rows
-
-          if (latest.autoResize) {
-            const currentRows = calculateIdealRows(
-              e.target,
-              latest.maxRows,
-              latest.theme.leading.NORMAL,
-            )
-            // rowsを直接反映 Textareaのrows propsが状態を変更しても反映されないため
-            e.target.rows = currentRows
-            setInterimRows(currentRows)
-          }
-
-          latest.onChange?.(e)
-        },
-        // countが連続で更新されると、スクリーンリーダーが古い値を読み上げてしまうため、メッセージの更新を遅延しています
-        updateSrMessage: debounce((text: string) => {
+  const functions = useMemo(() => {
+    const updateCount = maxLetters
+      ? debounce((newValue: TextareaValue) => {
           startTransition(() => {
-            setSrCounterMessage(text)
+            setCount(getStringLength(newValue))
           })
-        }, 1000),
-        updateCount,
-      }
-    }, [maxLetters, latest])
+        }, 200)
+      : undefined
 
-    useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
-      ref,
-      () => textareaRef.current,
-    )
+    return {
+      callbackRef: (element: HTMLTextAreaElement | null) => {
+        textareaRef.current = element
+        if (element) {
+          // autoFocus時に、フォーカスを当てる
+          if (latest.autoFocus) {
+            element.focus()
+          }
+          // autoResize時に、初期値での高さを指定
+          if (latest.autoResize) {
+            setInterimRows(calculateIdealRows(element, latest.maxRows, latest.theme.leading.NORMAL))
+          }
+        }
+      },
+      handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
+        updateCount?.(e.target.value)
 
-    // counter spanのテキスト変更を監視してスクリーンリーダーメッセージを更新
-    useEffect(() => {
-      if (!maxLetters || !counterSpanRef.current) return
+        // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
+        e.target.rows = latest.rows
 
-      const currentText = counterSpanRef.current.textContent || ''
+        if (latest.autoResize) {
+          const currentRows = calculateIdealRows(
+            e.target,
+            latest.maxRows,
+            latest.theme.leading.NORMAL,
+          )
+          // rowsを直接反映 Textareaのrows propsが状態を変更しても反映されないため
+          e.target.rows = currentRows
+          setInterimRows(currentRows)
+        }
 
-      if (currentText !== previousTextRef.current) {
-        previousTextRef.current = currentText
-        functions.updateSrMessage(currentText)
-      }
-    }, [count, maxLetters, functions])
+        latest.onChange?.(e)
+      },
+      // countが連続で更新されると、スクリーンリーダーが古い値を読み上げてしまうため、メッセージの更新を遅延しています
+      updateSrMessage: debounce((text: string) => {
+        startTransition(() => {
+          setSrCounterMessage(text)
+        })
+      }, 1000),
+      updateCount,
+    }
+  }, [maxLetters, latest])
 
-    // value 変更時にもカウントを更新する
-    useEffect(() => {
-      if (value && maxLetters) {
-        functions.updateCount?.(value)
-      }
-    }, [value, maxLetters, functions])
+  useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
+    externalRef,
+    () => textareaRef.current,
+  )
 
-    const body = (
-      <textarea
-        {...rest}
-        aria-describedby={maxLetters ? `${maxLettersNoticeId} ${actualMaxLettersId}` : undefined}
-        data-smarthr-ui-input="true"
-        value={value}
-        defaultValue={defaultValue}
-        onChange={functions.handleChange}
-        ref={functions.callbackRef}
-        aria-invalid={error || countError || undefined}
-        rows={interimRows}
-        className={classNames.textarea}
-        style={textareaStyle}
-      />
-    )
+  // counter spanのテキスト変更を監視してスクリーンリーダーメッセージを更新
+  useEffect(() => {
+    if (!maxLetters || !counterSpanRef.current) return
 
-    return maxLetters ? (
-      <span className="shr-relative">
-        {body}
-        <VisuallyHiddenText id={maxLettersNoticeId}>
+    const currentText = counterSpanRef.current.textContent || ''
+
+    if (currentText !== previousTextRef.current) {
+      previousTextRef.current = currentText
+      functions.updateSrMessage(currentText)
+    }
+  }, [count, maxLetters, functions])
+
+  // value 変更時にもカウントを更新する
+  useEffect(() => {
+    if (value && maxLetters) {
+      functions.updateCount?.(value)
+    }
+  }, [value, maxLetters, functions])
+
+  const body = (
+    <textarea
+      {...rest}
+      aria-describedby={maxLetters ? `${maxLettersNoticeId} ${actualMaxLettersId}` : undefined}
+      data-smarthr-ui-input="true"
+      value={value}
+      defaultValue={defaultValue}
+      onChange={functions.handleChange}
+      ref={functions.callbackRef}
+      aria-invalid={error || countError || undefined}
+      rows={interimRows}
+      className={classNames.textarea}
+      style={textareaStyle}
+    />
+  )
+
+  return maxLetters ? (
+    <span className="shr-relative">
+      {body}
+      <VisuallyHiddenText id={maxLettersNoticeId}>
+        <Localizer
+          id="smarthr-ui/Textarea/screenReaderMaxLettersDescription"
+          defaultText="最大{maxLetters}文字入力できます"
+          values={{ maxLetters }}
+        />
+      </VisuallyHiddenText>
+      <VisuallyHiddenText aria-live="polite">{srCounterMessage}</VisuallyHiddenText>
+      <span
+        ref={counterSpanRef}
+        id={actualMaxLettersId}
+        aria-hidden={true}
+        className={classNames.counter}
+      >
+        {count > maxLetters ? (
           <Localizer
-            id="smarthr-ui/Textarea/screenReaderMaxLettersDescription"
-            defaultText="最大{maxLetters}文字入力できます"
-            values={{ maxLetters }}
+            id="smarthr-ui/Textarea/maxLettersExceeded"
+            defaultText="{exceededLetters}文字オーバー"
+            values={{ exceededLetters: count - maxLetters }}
           />
-        </VisuallyHiddenText>
-        <VisuallyHiddenText aria-live="polite">{srCounterMessage}</VisuallyHiddenText>
-        <span
-          ref={counterSpanRef}
-          id={actualMaxLettersId}
-          aria-hidden={true}
-          className={classNames.counter}
-        >
-          {count > maxLetters ? (
-            <Localizer
-              id="smarthr-ui/Textarea/maxLettersExceeded"
-              defaultText="{exceededLetters}文字オーバー"
-              values={{ exceededLetters: count - maxLetters }}
-            />
-          ) : (
-            <Localizer
-              id="smarthr-ui/Textarea/availableLetters"
-              defaultText="あと{availableLetters}文字"
-              values={{ availableLetters: maxLetters - count }}
-            />
-          )}
-        </span>
+        ) : (
+          <Localizer
+            id="smarthr-ui/Textarea/availableLetters"
+            defaultText="あと{availableLetters}文字"
+            values={{ availableLetters: maxLetters - count }}
+          />
+        )}
       </span>
-    ) : (
-      body
-    )
-  },
-)
+    </span>
+  ) : (
+    body
+  )
+}

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -100,7 +100,19 @@ const calculateIdealRows = (
   return currentInputValueRows < maxRows ? currentInputValueRows : maxRows
 }
 
-export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
+export const Textarea = forwardRef<HTMLTextAreaElement, Props>(({ maxLetters, ...rest }, ref) =>
+  maxLetters ? (
+    <MaxLettersTextarea {...rest} ref={ref} maxLetters={maxLetters} />
+  ) : (
+    <ActualTextarea {...rest} ref={ref} />
+  ),
+)
+
+const MaxLettersTextarea = forwardRef<HTMLTextAreaElement, Props>((props, ref) => (
+  <ActualTextarea {...props} ref={ref} />
+))
+
+const ActualTextarea = forwardRef<HTMLTextAreaElement, Props>(
   (
     {
       autoFocus,
@@ -180,8 +192,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(
           }
         },
         handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
-          const newValue = e.target.value
-          updateCount?.(newValue)
+          updateCount?.(e.target.value)
 
           // rowsを初期化 TextareaのscrollHeightが文字列削除時に変更されないため
           e.target.rows = latest.rows


### PR DESCRIPTION
## 関連URL

なし

## 概要

Textareaコンポーネントの内部構造を整理し、将来的にmaxLetters関連の処理を分離しやすくするための基盤を作成しました。

## 変更内容

### 1. コンポーネント構造の分割

Textareaコンポーネントの内部を3つに分割：
- **Textarea**: エントリーポイント（maxLettersの有無で振り分け）
- **MaxLettersTextarea**: maxLettersありの場合の実装（現在はActualTextareaへのpass-through）
- **ActualTextarea**: 実際のtextarea実装（現在は全ての処理を含む）

### 2. 型定義の整理

- 内部コンポーネント（MaxLettersTextarea、ActualTextarea）からforwardRefを削除し、通常のFCに変更
- refは`externalRef`というpropで受け渡すように統一
- `LocalTextareaProps`を定義し、内部コンポーネント間で共通の型を統一
- MaxLettersTextareaで`maxLetters`を必須化

### 変更の意図

この変更により、次のステップでMaxLettersTextarea固有の処理（文字数カウント、スクリーンリーダー対応など）を移動しやすくなります。現時点では動作に変更はなく、型定義とコンポーネント構造のみの整理です。

## プロダクト側で対応が必要な事項

なし

外部公開APIは一切変更していないため、既存の使用方法をそのまま継続できます。

## 確認方法

Storybookで既存のTextareaストーリーが正常に動作することを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * テキストエリアの内部処理を整理し、文字数上限の有無に応じて適切に動作する構成へ改善しました。
  * 文字数カウント、残り文字数・超過表示、スクリーンリーダー向け通知、自動リサイズ、外部参照の連携を従来どおり利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->