### PR TITLE
refactor: classNames生成を定数化してパフォーマンスを向上

### DIFF
--- a/packages/smarthr-ui/src/components/Button/DisabledReason.tsx
+++ b/packages/smarthr-ui/src/components/Button/DisabledReason.tsx
@@ -1,4 +1,4 @@
-import { type FC, type FunctionComponent, type JSX, type ReactNode, memo, useMemo } from 'react'
+import { type FC, type FunctionComponent, type JSX, type ReactNode, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { FaCircleInfoIcon } from '../Icon'
@@ -26,27 +26,25 @@ const classNameGenerator = tv({
   },
 })
 
-export const DisabledReason: FC<Props> = ({ button, disabledReason }) => {
-  const classNames = useMemo(() => {
-    const { wrapper, tooltip } = classNameGenerator()
+const CLASS_NAMES = (() => {
+  const { wrapper, tooltip } = classNameGenerator()
 
-    return {
-      wrapper: wrapper(),
-      tooltip: tooltip(),
-    }
-  }, [])
+  return {
+    wrapper: wrapper(),
+    tooltip: tooltip(),
+  }
+})()
 
-  return (
-    <div className={classNames.wrapper}>
-      {button}
-      <TooltipIcon
-        icon={disabledReason.icon}
-        message={disabledReason.message}
-        className={classNames.tooltip}
-      />
-    </div>
-  )
-}
+export const DisabledReason: FC<Props> = ({ button, disabledReason }) => (
+  <div className={CLASS_NAMES.wrapper}>
+    {button}
+    <TooltipIcon
+      icon={disabledReason.icon}
+      message={disabledReason.message}
+      className={CLASS_NAMES.tooltip}
+    />
+  </div>
+)
 
 const TooltipIcon = memo<{
   icon?: FunctionComponent

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -46,6 +46,17 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { overlay, container, yearButton, yearWrapper } = classNameGenerator()
+
+  return {
+    overlay: overlay(),
+    container: container(),
+    yearButton: yearButton(),
+    yearWrapper: yearWrapper(),
+  }
+})()
+
 export const YearPicker: FC<Props> = ({ isDisplayed, ...rest }) =>
   isDisplayed ? <ActualYearPicker {...rest} /> : null
 
@@ -57,16 +68,6 @@ const ActualYearPicker: FC<ActualProps> = ({
   id,
   ...rest
 }) => {
-  const classNames = useMemo(() => {
-    const { overlay, container, yearButton, yearWrapper } = classNameGenerator()
-
-    return {
-      overlay: overlay(),
-      container: container(),
-      yearButton: yearButton(),
-      yearWrapper: yearWrapper(),
-    }
-  }, [])
   const focusingRef = useRef<HTMLButtonElement>(null)
 
   const thisYear = useMemo(() => new Date().getFullYear(), [])
@@ -91,8 +92,8 @@ const ActualYearPicker: FC<ActualProps> = ({
   }, [])
 
   return (
-    <div {...rest} id={id} className={classNames.overlay}>
-      <Scroller className={classNames.container}>
+    <div {...rest} id={id} className={CLASS_NAMES.overlay}>
+      <Scroller className={CLASS_NAMES.container}>
         {yearArray.map((year) => (
           <YearButton
             key={year}
@@ -100,8 +101,8 @@ const ActualYearPicker: FC<ActualProps> = ({
             thisYear={thisYear}
             selected={selectedYear === year}
             focusingRef={focusingRef}
-            className={classNames.yearButton}
-            childrenStyle={classNames.yearWrapper}
+            className={CLASS_NAMES.yearButton}
+            childrenStyle={CLASS_NAMES.yearWrapper}
             onClick={onSelectYear}
           />
         ))}

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -69,6 +69,18 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { wrapper, dropdownList, helpMessage, loaderWrapper, noItems } = classNameGenerator()
+
+  return {
+    wrapper: wrapper(),
+    dropdownList: dropdownList(),
+    helpMessage: helpMessage(),
+    loaderWrapper: loaderWrapper(),
+    noItems: noItems(),
+  }
+})()
+
 export const useListbox = <T,>({
   options,
   dropdownHelpMessage,
@@ -265,22 +277,10 @@ export const useListbox = <T,>({
     }
   }, [listBoxRect, triggerWidth, dropdownWidth, theme])
 
-  const classNames = useMemo(() => {
-    const { wrapper, dropdownList, helpMessage, loaderWrapper, noItems } = classNameGenerator()
-
-    return {
-      wrapper: wrapper(),
-      dropdownList: dropdownList(),
-      helpMessage: helpMessage(),
-      loaderWrapper: loaderWrapper(),
-      noItems: noItems(),
-    }
-  }, [])
-
   const renderListBox = useCallback(
     () =>
       createPortal(
-        <div className={classNames.wrapper} style={wrapperStyle}>
+        <div className={CLASS_NAMES.wrapper} style={wrapperStyle}>
           {isExpanded && isLoading && (
             <VisuallyHiddenText role="status">
               <Localizer id="smarthr-ui/Combobox/loadingText" defaultText="処理中" />
@@ -291,12 +291,12 @@ export const useListbox = <T,>({
             ref={listBoxRef}
             role="listbox"
             aria-hidden={!isExpanded}
-            className={classNames.dropdownList}
+            className={CLASS_NAMES.dropdownList}
             style={dropdownListStyle}
           >
             {dropdownHelpMessage && (
               <Text
-                className={classNames.helpMessage}
+                className={CLASS_NAMES.helpMessage}
                 icon={<FaCircleInfoIcon color="TEXT_GREY" />}
                 as="p"
               >
@@ -305,11 +305,11 @@ export const useListbox = <T,>({
             )}
             {isExpanded ? (
               isLoading ? (
-                <div className={classNames.loaderWrapper}>
+                <div className={CLASS_NAMES.loaderWrapper}>
                   <Loader aria-hidden />
                 </div>
               ) : options.length === 0 ? (
-                <p role="alert" aria-live="polite" className={classNames.noItems}>
+                <p role="alert" aria-live="polite" className={CLASS_NAMES.noItems}>
                   {orgNoResultText ?? (
                     <Localizer
                       id="smarthr-ui/Combobox/noResultsText"
@@ -347,7 +347,6 @@ export const useListbox = <T,>({
       handleAdd,
       handleHoverOption,
       handleSelect,
-      classNames,
       dropdownListStyle,
       wrapperStyle,
       createPortal,

--- a/packages/smarthr-ui/src/components/Table/ThSortButton.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThSortButton.tsx
@@ -68,21 +68,19 @@ const sortIconClassNameGenerator = tv({
   },
 })
 
-const SortIcon = memo(() => {
-  const classNames = useMemo(() => {
-    const { wrapper, upIcon, downIcon } = sortIconClassNameGenerator()
+const SORT_ICON_CLASS_NAMES = (() => {
+  const { wrapper, upIcon, downIcon } = sortIconClassNameGenerator()
 
-    return {
-      wrapper: wrapper(),
-      upIcon: upIcon(),
-      downIcon: downIcon(),
-    }
-  }, [])
+  return {
+    wrapper: wrapper(),
+    upIcon: upIcon(),
+    downIcon: downIcon(),
+  }
+})()
 
-  return (
-    <span className={classNames.wrapper}>
-      <FaSortUpIcon className={classNames.upIcon} />
-      <FaSortDownIcon className={classNames.downIcon} />
-    </span>
-  )
-})
+const SortIcon = memo(() => (
+  <span className={SORT_ICON_CLASS_NAMES.wrapper}>
+    <FaSortUpIcon className={SORT_ICON_CLASS_NAMES.upIcon} />
+    <FaSortDownIcon className={SORT_ICON_CLASS_NAMES.downIcon} />
+  </span>
+))

--- a/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FC, type ReactNode, useCallback, useMemo, useState } from 'react'
+import { type FC, type ReactNode, useCallback, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useTheme } from '../../hooks/useTheme'
@@ -23,6 +23,16 @@ const classNameGenerator = tv({
     balloonText: 'shr-m-0 shr-px-1 shr-py-0.5',
   },
 })
+
+const CLASS_NAMES = (() => {
+  const { container, balloon, balloonText } = classNameGenerator()
+
+  return {
+    container: container(),
+    balloon: balloon(),
+    balloonText: balloonText(),
+  }
+})()
 
 const OUTER_MARGIN = 10
 const SPACING = 5
@@ -69,31 +79,21 @@ export const TooltipPortal: FC<Props> = ({ messageId, message, isVisible, parent
     [parentRect, theme],
   )
 
-  const classNames = useMemo(() => {
-    const { container, balloon, balloonText } = classNameGenerator()
-
-    return {
-      container: container(),
-      balloon: balloon(),
-      balloonText: balloonText(),
-    }
-  }, [])
-
   return (
     <div
       ref={portalRef}
       role="tooltip"
       aria-hidden={!isVisible}
-      className={classNames.container}
+      className={CLASS_NAMES.container}
       style={isVisible ? style : undefined}
     >
       <ControlledTooltip
         horizontal={actualHorizontal}
         vertical={actualVertical}
         triggerIcon={isIcon}
-        className={classNames.balloon}
+        className={CLASS_NAMES.balloon}
       >
-        <div id={messageId} className={classNames.balloonText}>
+        <div id={messageId} className={CLASS_NAMES.balloonText}>
           {message}
         </div>
       </ControlledTooltip>


### PR DESCRIPTION
## 関連URL

なし

## 概要

依存配列が空の`useMemo`で生成していた`classNames`を、IIFEで初期化される定数`CLASS_NAMES`に変更することで、不要な再計算を排除しパフォーマンスを向上させる。

## 変更内容

以下の5つのファイルで、空の依存配列を持つ`useMemo`によるclassNames生成を定数化：

- `DisabledReason.tsx`: `CLASS_NAMES`定数に変更
- `YearPicker.tsx`: `CLASS_NAMES`定数に変更
- `ThSortButton.tsx`: サブコンポーネント用に`SORT_ICON_CLASS_NAMES`定数に変更
- `TooltipPortal.tsx`: `CLASS_NAMES`定数に変更
- `useListbox.tsx`: `CLASS_NAMES`定数に変更

### 変更パターン

```tsx
// Before
const Component = () => {
  const classNames = useMemo(() => {
    const { wrapper, button } = classNameGenerator()
    return {
      wrapper: wrapper(),
      button: button(),
    }
  }, [])
  
  return <div className={classNames.wrapper}>...</div>
}

// After
const CLASS_NAMES = (() => {
  const { wrapper, button } = classNameGenerator()
  return {
    wrapper: wrapper(),
    button: button(),
  }
})()

const Component = () => {
  return <div className={CLASS_NAMES.wrapper}>...</div>
}
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで各コンポーネントの動作を確認