### PR TITLE
refactor(AppHeader): classNames生成を定数化してパフォーマンスを向上

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,46 @@ export const Wrapper: FC<{ onClick?: () => void }> = ({ onClick }) => {
   - subject は日本語で記述（`subject-case` ルールは無効化されている）
   - リリースは release-please で管理。`feat` → minor、`fix` → patch、`!` → major
 
+### スタイリング
+
+#### classNamesの定数化
+tailwind-variants (`tv()`) で生成したクラス名は、引数や依存配列が空の場合は`useMemo`ではなく定数として定義します：
+
+```typescript
+// ✅ 引数なし・依存配列なしの場合は定数化
+const CLASS_NAMES = (() => {
+  const { trigger, contentBody, contentButton } = classNameGenerator()
+
+  return {
+    trigger: trigger(),
+    contentBody: contentBody(),
+    contentButton: contentButton(),
+  }
+})()
+
+// ❌ 不要なuseMemo
+const classNames = useMemo(() => {
+  const { trigger, contentBody, contentButton } = classNameGenerator()
+
+  return {
+    trigger: trigger(),
+    contentBody: contentBody(),
+    contentButton: contentButton(),
+  }
+}, [])  // 空の依存配列
+```
+
+**命名規則:**
+- **メインのコンポーネント**: `CLASS_NAMES`
+- **サブコンポーネントやヘルパー関数内**: `XXX_CLASS_NAMES`（例: `ITEM_CLASS_NAMES`, `HEADER_CLASS_NAMES`）
+
+複数の定数化されたclassNamesが同一ファイル内に存在する場合、衝突を避けるため接頭辞を付けて区別します。
+
+**理由:**
+- 引数・依存配列がない場合、`useMemo`のオーバーヘッドが無駄
+- 即時関数（IIFE）で中間変数をスコープから隔離
+- `const`で再代入を防止
+
 ### パフォーマンス最適化パターン
 
 #### useLatest + functions パターン

--- a/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherFeatures.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherFeatures.tsx
@@ -1,4 +1,4 @@
-import { type FC, type PropsWithChildren, memo, useMemo } from 'react'
+import { type FC, type PropsWithChildren, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../../../intl'
@@ -24,6 +24,16 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { empty, list, listItem } = classNameGenerator()
+
+  return {
+    empty: empty(),
+    list: list(),
+    listItem: listItem(),
+  }
+})()
+
 type Props = {
   features: Array<Launcher['feature']>
   page: Launcher['page']
@@ -32,47 +42,30 @@ type Props = {
 export const AppLauncherFeatures: FC<Props> = ({ features, page }) =>
   features.length === 0 ? <EmptyList /> : <FeatureList features={features} page={page} />
 
-const EmptyList = memo(() => {
-  const className = useMemo(() => {
-    const { empty } = classNameGenerator()
-
-    return empty()
-  }, [])
-
-  return (
-    <div className={className}>
-      <Text size="S">
-        <Translate>
-          <Localizer
-            id="smarthr-ui/AppHeader/Launcher/emptyText"
-            defaultText="該当するアプリが見つかりませんでした。"
-          />
-        </Translate>
-      </Text>
-    </div>
-  )
-})
+const EmptyList = memo(() => (
+  <div className={CLASS_NAMES.empty}>
+    <Text size="S">
+      <Translate>
+        <Localizer
+          id="smarthr-ui/AppHeader/Launcher/emptyText"
+          defaultText="該当するアプリが見つかりませんでした。"
+        />
+      </Translate>
+    </Text>
+  </div>
+))
 
 const FeatureList: FC<Props> = ({ features, page }) => {
-  const classNames = useMemo(() => {
-    const { list, listItem } = classNameGenerator()
-
-    return {
-      list: list(),
-      listItem: listItem(),
-    }
-  }, [])
-
   const isFavorite = page === 'favorite'
 
   return (
-    <ul className={classNames.list}>
+    <ul className={CLASS_NAMES.list}>
       {features.map((feature) => (
         <FeatureListItem
           key={feature.id}
           href={feature.url}
           isFavorite={isFavorite}
-          className={classNames.listItem}
+          className={CLASS_NAMES.listItem}
         >
           {feature.name}
         </FeatureListItem>

--- a/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherSortDropdown.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherSortDropdown.tsx
@@ -36,6 +36,16 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { trigger, contentBody, contentButton } = classNameGenerator()
+
+  return {
+    trigger: trigger(),
+    contentBody: contentBody(),
+    contentButton: contentButton(),
+  }
+})()
+
 type Props = {
   sortType: Launcher['sortType']
   onSelectSortType: (sortType: Launcher['sortType']) => void
@@ -43,16 +53,6 @@ type Props = {
 
 export const AppLauncherSortDropdown: FC<Props> = ({ sortType, onSelectSortType }) => {
   const triggerRef = useRef<HTMLButtonElement>(null)
-
-  const classNames = useMemo(() => {
-    const { trigger, contentBody, contentButton } = classNameGenerator()
-
-    return {
-      trigger: trigger(),
-      contentBody: contentBody(),
-      contentButton: contentButton(),
-    }
-  }, [])
 
   const options = useMemo<Array<[Launcher['sortType'], JSX.Element]>>(
     () => [
@@ -102,18 +102,18 @@ export const AppLauncherSortDropdown: FC<Props> = ({ sortType, onSelectSortType 
 
   return (
     <Dropdown>
-      <TriggerButton triggerRef={triggerRef} className={classNames.trigger}>
+      <TriggerButton triggerRef={triggerRef} className={CLASS_NAMES.trigger}>
         <Localizer id="smarthr-ui/AppHeader/Launcher/sortDropdownLabel" defaultText="表示順" />
       </TriggerButton>
       <DropdownContent controllable>
-        <div role="listbox" className={classNames.contentBody}>
+        <div role="listbox" className={CLASS_NAMES.contentBody}>
           {options.map(([value, children], i) => (
             <OptionButton
               key={i}
               value={value}
               selected={value === sortType}
               onClick={onClickOption}
-              className={classNames.contentButton}
+              className={CLASS_NAMES.contentButton}
             >
               {children}
             </OptionButton>

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -71,6 +71,37 @@ const appLauncher = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const {
+    wrapper,
+    searchArea,
+    inner,
+    side,
+    sideNav,
+    sideNavHeading,
+    help,
+    main,
+    mainInner,
+    contentHead,
+    scrollArea,
+  } = appLauncher()
+
+  return {
+    wrapper: wrapper(),
+    searchArea: searchArea(),
+    inner: inner(),
+    side: side(),
+    unselectedSideNav: sideNav({ selected: false }),
+    selectedSideNav: sideNav({ noIcon: true, selected: true }),
+    sideNavHeading: sideNavHeading(),
+    help: help(),
+    main: main(),
+    mainInner: mainInner(),
+    contentHead: contentHead(),
+    scrollArea: scrollArea(),
+  }
+})()
+
 export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
   const {
     features,
@@ -83,37 +114,6 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
     onChangeSearchQuery,
     onClickClearSearchQuery,
   } = useAppLauncher(baseFeatures)
-
-  const classNames = useMemo(() => {
-    const {
-      wrapper,
-      searchArea,
-      inner,
-      side,
-      sideNav,
-      sideNavHeading,
-      help,
-      main,
-      mainInner,
-      contentHead,
-      scrollArea,
-    } = appLauncher()
-
-    return {
-      wrapper: wrapper(),
-      searchArea: searchArea(),
-      inner: inner(),
-      side: side(),
-      unselectedSideNav: sideNav({ selected: false }),
-      selectedSideNav: sideNav({ noIcon: true, selected: true }),
-      sideNavHeading: sideNavHeading(),
-      help: help(),
-      main: main(),
-      mainInner: mainInner(),
-      contentHead: contentHead(),
-      scrollArea: scrollArea(),
-    }
-  }, [])
 
   const { localize } = useIntl()
   const translated = useMemo(
@@ -135,8 +135,8 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
   )
 
   return (
-    <div className={classNames.wrapper}>
-      <div className={classNames.searchArea}>
+    <div className={CLASS_NAMES.wrapper}>
+      <div className={CLASS_NAMES.searchArea}>
         <SearchInput
           name="search"
           title={translated.searchInputTitle}
@@ -148,18 +148,17 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
         />
       </div>
 
-      <div className={classNames.inner}>
+      <div className={CLASS_NAMES.inner}>
         <SideNavs
           mode={mode}
           page={page}
           changePage={changePage}
           favoriteModeText={translated.favoriteModeText}
           allModeText={translated.allModeText}
-          classNames={classNames}
         />
-        <div className={classNames.main}>
-          <Section className={classNames.mainInner}>
-            <Cluster className={classNames.contentHead} align="center" justify="space-between">
+        <div className={CLASS_NAMES.main}>
+          <Section className={CLASS_NAMES.mainInner}>
+            <Cluster className={CLASS_NAMES.contentHead} align="center" justify="space-between">
               <MemoizedSubSubBlockHeading>
                 {mode === 'search' ? (
                   <Localizer
@@ -178,7 +177,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
               )}
             </Cluster>
 
-            <Scroller className={classNames.scrollArea}>
+            <Scroller className={CLASS_NAMES.scrollArea}>
               <AppLauncherFeatures features={features} page={page} />
             </Scroller>
           </Section>
@@ -198,15 +197,8 @@ const SideNavs = memo<
   Pick<ReturnType<typeof useAppLauncher>, 'mode' | 'page' | 'changePage'> & {
     favoriteModeText: string
     allModeText: string
-    classNames: {
-      side: string
-      unselectedSideNav: string
-      sideNavHeading: string
-      selectedSideNav: string
-      help: string
-    }
   }
->(({ mode, page, changePage, favoriteModeText, allModeText, classNames }) => {
+>(({ mode, page, changePage, favoriteModeText, allModeText }) => {
   const theme = useTheme()
   const listHeadingId = useId()
   const isNotSearch = mode !== 'search'
@@ -243,8 +235,8 @@ const SideNavs = memo<
   )
 
   return (
-    <div className={classNames.side}>
-      <SideNav className={classNames.unselectedSideNav} size="S" aria-label={favoriteModeText}>
+    <div className={CLASS_NAMES.side}>
+      <SideNav className={CLASS_NAMES.unselectedSideNav} size="S" aria-label={favoriteModeText}>
         {unselectedItems.map((item) => (
           <SideNavItemButton
             key={item.id}
@@ -261,8 +253,8 @@ const SideNavs = memo<
       <hr />
 
       <Section>
-        <MemoizedAppListHeading id={listHeadingId} className={classNames.sideNavHeading} />
-        <SideNav className={classNames.selectedSideNav} size="S" aria-labelledby={listHeadingId}>
+        <MemoizedAppListHeading id={listHeadingId} className={CLASS_NAMES.sideNavHeading} />
+        <SideNav className={CLASS_NAMES.selectedSideNav} size="S" aria-labelledby={listHeadingId}>
           {selectedItems.map((item) => (
             <SideNavItemButton key={item.id} id={item.id} current={item.current} onClick={onClick}>
               {item.title}
@@ -271,7 +263,7 @@ const SideNavs = memo<
         </SideNav>
       </Section>
 
-      <HelpLinkArea className={classNames.help}>
+      <HelpLinkArea className={CLASS_NAMES.help}>
         <Translate>
           <Localizer id="smarthr-ui/AppHeader/Launcher/helpText" defaultText="よく使うアプリとは" />
         </Translate>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
@@ -36,6 +36,18 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { wrapper, searchArea, headArea, scrollArea, bottomArea } = classNameGenerator()
+
+  return {
+    wrapper: wrapper(),
+    searchArea: searchArea(),
+    headArea: headArea(),
+    scrollArea: scrollArea(),
+    bottomArea: bottomArea(),
+  }
+})()
+
 export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
   const {
     features,
@@ -49,18 +61,6 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
     onClickClearSearchQuery,
   } = useAppLauncher(baseFeatures)
 
-  const classNames = useMemo(() => {
-    const { wrapper, searchArea, headArea, scrollArea, bottomArea } = classNameGenerator()
-
-    return {
-      wrapper: wrapper(),
-      searchArea: searchArea(),
-      headArea: headArea(),
-      scrollArea: scrollArea(),
-      bottomArea: bottomArea(),
-    }
-  }, [])
-
   const { localize } = useIntl()
   const searchInputTitle = useMemo(
     () =>
@@ -72,8 +72,8 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
   )
 
   return (
-    <div className={classNames.wrapper}>
-      <div className={classNames.searchArea}>
+    <div className={CLASS_NAMES.wrapper}>
+      <div className={CLASS_NAMES.searchArea}>
         <SearchInput
           name="search"
           title={searchInputTitle}
@@ -85,7 +85,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
         />
       </div>
 
-      <Cluster className={classNames.headArea} justify="space-between" align="center">
+      <Cluster className={CLASS_NAMES.headArea} justify="space-between" align="center">
         {mode === 'search' ? (
           <SearchResultText>
             <Localizer id="smarthr-ui/AppHeader/Launcher/searchResultText" defaultText="検索結果" />
@@ -99,11 +99,11 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
         )}
       </Cluster>
 
-      <Scroller className={classNames.scrollArea} styleType="scroll">
+      <Scroller className={CLASS_NAMES.scrollArea} styleType="scroll">
         <AppLauncherFeatures features={features} page={page} />
       </Scroller>
 
-      <BottomArea className={classNames.bottomArea}>
+      <BottomArea className={CLASS_NAMES.bottomArea}>
         <Localizer id="smarthr-ui/AppHeader/Launcher/helpText" defaultText="よく使うアプリとは" />
       </BottomArea>
     </div>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncherFilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncherFilterDropdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type MouseEvent, memo, useCallback, useMemo } from 'react'
+import { type MouseEvent, memo, useCallback } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useTheme } from '../../../../hooks/useTheme'
@@ -32,31 +32,29 @@ const classNameGenerator = tv({
   },
 })
 
-export const AppLauncherFilterDropdown = memo<Props>(({ page, onSelectPage }) => {
-  const classNames = useMemo(() => {
-    const { trigger, contentBody, contentButton } = classNameGenerator()
+const CLASS_NAMES = (() => {
+  const { trigger, contentBody, contentButton } = classNameGenerator()
 
-    return {
-      trigger: trigger(),
-      contentBody: contentBody(),
-      contentButton: contentButton(),
-    }
-  }, [])
+  return {
+    trigger: trigger(),
+    contentBody: contentBody(),
+    contentButton: contentButton(),
+  }
+})()
 
-  return (
-    <Dropdown>
-      <MemoizedDropdownTrigger className={classNames.trigger} page={page} />
-      <DropdownContent>
-        <ContentBody
-          page={page}
-          onSelectPage={onSelectPage}
-          className={classNames.contentBody}
-          buttonClassName={classNames.contentButton}
-        />
-      </DropdownContent>
-    </Dropdown>
-  )
-})
+export const AppLauncherFilterDropdown = memo<Props>(({ page, onSelectPage }) => (
+  <Dropdown>
+    <MemoizedDropdownTrigger className={CLASS_NAMES.trigger} page={page} />
+    <DropdownContent>
+      <ContentBody
+        page={page}
+        onSelectPage={onSelectPage}
+        className={CLASS_NAMES.contentBody}
+        buttonClassName={CLASS_NAMES.contentButton}
+      />
+    </DropdownContent>
+  </Dropdown>
+))
 
 const MemoizedDropdownTrigger = memo<{ page: Launcher['page']; className: string }>(
   ({ page, className }) => (

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/LanguageSelector.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/LanguageSelector.tsx
@@ -22,6 +22,17 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { header, headerTitle, buttonWrapper, button } = classNameGenerator()
+
+  return {
+    header: header(),
+    headerTitle: headerTitle(),
+    buttonWrapper: buttonWrapper(),
+    button: button(),
+  }
+})()
+
 type Props = {
   locale: LocaleProps
   onClickClose: () => void
@@ -38,16 +49,6 @@ export const LanguageSelector = memo<Props>(({ locale: localeProps, onClickClose
     }),
     [availableLocales],
   )
-  const classNames = useMemo(() => {
-    const { header, headerTitle, buttonWrapper, button } = classNameGenerator()
-
-    return {
-      header: header(),
-      headerTitle: headerTitle(),
-      buttonWrapper: buttonWrapper(),
-      button: button(),
-    }
-  }, [])
 
   const onClickLocale = useCallback(
     (e: MouseEvent<HTMLButtonElement>) => {
@@ -60,17 +61,17 @@ export const LanguageSelector = memo<Props>(({ locale: localeProps, onClickClose
     <Section>
       <SelectorHeading
         onClickClose={onClickClose}
-        wrapperClassName={classNames.header}
-        className={classNames.headerTitle}
+        wrapperClassName={CLASS_NAMES.header}
+        className={CLASS_NAMES.headerTitle}
       />
-      <div className={classNames.buttonWrapper}>
+      <div className={CLASS_NAMES.buttonWrapper}>
         {locales.map(([localeKey, label]) => (
           <LocaleButton
             key={localeKey}
             value={localeKey as Locale}
             onClick={onClickLocale}
             selected={localeKey === locale}
-            className={classNames.button}
+            className={CLASS_NAMES.button}
           >
             {label}
           </LocaleButton>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
@@ -44,6 +44,16 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { wrapper, header, content } = classNameGenerator()
+
+  return {
+    wrapper: wrapper(),
+    header: header(),
+    content: content(),
+  }
+})()
+
 type Props = PropsWithChildren<{
   isOpen: boolean
   setIsOpen: Dispatch<boolean>
@@ -79,16 +89,6 @@ export const Content: FC<
   const { isReleaseNoteSelected, setIsReleaseNoteSelected } = useContext(ReleaseNoteContext)
   const { features, isAppLauncherSelected, setIsAppLauncherSelected } =
     useContext(AppLauncherContext)
-
-  const classNames = useMemo(() => {
-    const { wrapper, header, content } = classNameGenerator()
-
-    return {
-      wrapper: wrapper(),
-      header: header(),
-      content: content(),
-    }
-  }, [])
 
   const { localize } = useIntl()
   const translated = useMemo(
@@ -132,8 +132,8 @@ export const Content: FC<
   )
 
   return (
-    <Section role="dialog" aria-modal="true" className={classNames.wrapper} ref={domRef}>
-      <div className={classNames.header}>
+    <Section role="dialog" aria-modal="true" className={CLASS_NAMES.wrapper} ref={domRef}>
+      <div className={CLASS_NAMES.header}>
         <Cluster justify="space-between" align="center">
           {isAppLauncherSelected ? (
             <MenuSubHeading title={translated.launcherListText} onClickBack={clearAppLauncher} />
@@ -166,7 +166,7 @@ export const Content: FC<
       {isAppLauncherSelected && features && features.length > 0 ? (
         <AppLauncher features={features} />
       ) : (
-        <Scroller direction="vertical" className={classNames.content}>
+        <Scroller direction="vertical" className={CLASS_NAMES.content}>
           {isReleaseNoteSelected ? (
             <ReleaseNote />
           ) : selectedNavigationGroup ? (

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/ReleaseNote.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/ReleaseNote.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useContext, useMemo } from 'react'
+import { type FC, memo, useContext } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../../../intl'
@@ -27,6 +27,17 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { anchor, icon, indexLinkWrapper, indexLinkAnchor } = classNameGenerator()
+
+  return {
+    anchor: anchor(),
+    icon: icon(),
+    indexLinkWrapper: indexLinkWrapper(),
+    indexLinkAnchor: indexLinkAnchor(),
+  }
+})()
+
 export const ReleaseNote = memo(() => {
   const { releaseNote } = useContext(ReleaseNoteContext)
 
@@ -35,68 +46,55 @@ export const ReleaseNote = memo(() => {
 
 const ActualReleaseNote: FC<{
   data: Exclude<Required<HeaderProps>['releaseNote'], null>
-}> = ({ data }) => {
-  const classNames = useMemo(() => {
-    const { anchor, icon, indexLinkWrapper, indexLinkAnchor } = classNameGenerator()
+}> = ({ data }) => (
+  <div>
+    {data.loading ? (
+      <Center>
+        <Loader />
+      </Center>
+    ) : data.error ? (
+      <Translate>
+        <Localizer
+          id="smarthr-ui/AppHeader/releaseNotesLoadError"
+          defaultText={`リリースノートの読み込みに失敗しました。
+時間をおいて、やり直してください。`}
+        />
+      </Translate>
+    ) : (
+      <Stack>
+        {data.links.slice(0, 5).map((link) => (
+          <div key={link.url}>
+            <TextLink
+              href={link.url}
+              target="_blank"
+              rel="noopener"
+              referrerPolicy="no-referrer-when-downgrade"
+              className={CLASS_NAMES.anchor}
+              suffix={<OpenInNewTabIcon className={CLASS_NAMES.icon} />}
+            >
+              {link.title}
+            </TextLink>
+          </div>
+        ))}
+      </Stack>
+    )}
 
-    return {
-      anchor: anchor(),
-      icon: icon(),
-      indexLinkWrapper: indexLinkWrapper(),
-      indexLinkAnchor: indexLinkAnchor(),
-    }
-  }, [])
-
-  return (
-    <div>
-      {data.loading ? (
-        <Center>
-          <Loader />
-        </Center>
-      ) : data.error ? (
+    <div className={CLASS_NAMES.indexLinkWrapper}>
+      <TextLink
+        href={data.indexUrl}
+        target="_blank"
+        rel="noopener"
+        referrerPolicy="no-referrer-when-downgrade"
+        className={CLASS_NAMES.indexLinkAnchor}
+        suffix={<OpenInNewTabIcon className={CLASS_NAMES.icon} />}
+      >
         <Translate>
           <Localizer
-            id="smarthr-ui/AppHeader/releaseNotesLoadError"
-            defaultText={`リリースノートの読み込みに失敗しました。
-時間をおいて、やり直してください。`}
+            id="smarthr-ui/AppHeader/seeAllReleaseNotes"
+            defaultText="すべてのリリースノートを見る"
           />
         </Translate>
-      ) : (
-        <Stack>
-          {data.links.slice(0, 5).map((link) => (
-            <div key={link.url}>
-              <TextLink
-                href={link.url}
-                target="_blank"
-                rel="noopener"
-                referrerPolicy="no-referrer-when-downgrade"
-                className={classNames.anchor}
-                suffix={<OpenInNewTabIcon className={classNames.icon} />}
-              >
-                {link.title}
-              </TextLink>
-            </div>
-          ))}
-        </Stack>
-      )}
-
-      <div className={classNames.indexLinkWrapper}>
-        <TextLink
-          href={data.indexUrl}
-          target="_blank"
-          rel="noopener"
-          referrerPolicy="no-referrer-when-downgrade"
-          className={classNames.indexLinkAnchor}
-          suffix={<OpenInNewTabIcon className={classNames.icon} />}
-        >
-          <Translate>
-            <Localizer
-              id="smarthr-ui/AppHeader/seeAllReleaseNotes"
-              defaultText="すべてのリリースノートを見る"
-            />
-          </Translate>
-        </TextLink>
-      </div>
+      </TextLink>
     </div>
-  )
-}
+  </div>
+)

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
@@ -25,6 +25,17 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { iconButton, iconButtonInner, dropdownUserName, dropdownButtonArea } = classNameGenerator()
+
+  return {
+    iconButton: iconButton(),
+    iconButtonInner: iconButtonInner(),
+    dropdownUserName: dropdownUserName(),
+    dropdownButtonArea: dropdownButtonArea(),
+  }
+})()
+
 type Props = UserInfoProps & Pick<HeaderProps, 'locale'>
 
 export const UserInfo = memo<Props>(
@@ -56,24 +67,12 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
   const dialogOpen = useCallback(() => setLanguageDialogOpen(true), [])
   const dialogClose = useCallback(() => setLanguageDialogOpen(false), [])
 
-  const classNames = useMemo(() => {
-    const { iconButton, iconButtonInner, dropdownUserName, dropdownButtonArea } =
-      classNameGenerator()
-
-    return {
-      iconButton: iconButton(),
-      iconButtonInner: iconButtonInner(),
-      dropdownUserName: dropdownUserName(),
-      dropdownButtonArea: dropdownButtonArea(),
-    }
-  }, [])
-
   return (
     <>
       <Dropdown>
         <DropdownTrigger>
-          <Button variant="skeleton" size="S" className={classNames.iconButton}>
-            <span className={classNames.iconButtonInner}>
+          <Button variant="skeleton" size="S" className={CLASS_NAMES.iconButton}>
+            <span className={CLASS_NAMES.iconButtonInner}>
               <FaUserLargeIcon
                 alt={
                   <Localizer
@@ -88,12 +87,12 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
         </DropdownTrigger>
 
         <DropdownContent>
-          <div className={classNames.dropdownUserName}>
+          <div className={CLASS_NAMES.dropdownUserName}>
             <p>{displayName}</p>
           </div>
 
           {(locale || accountUrl) && (
-            <div className={classNames.dropdownButtonArea}>
+            <div className={CLASS_NAMES.dropdownButtonArea}>
               {locale && (
                 <CommonButton
                   elementAs="button"


### PR DESCRIPTION
## 関連URL

なし

## 概要

AppHeader配下のコンポーネントで、依存配列が空の`useMemo`で生成していた`classNames`を、IIFEで初期化される定数`CLASS_NAMES`に変更することで、不要な再計算を排除しパフォーマンスを向上させる。

## 変更内容

以下の9つのファイルで、空の依存配列を持つ`useMemo`によるclassNames生成を定数化：

- `AppLauncherFeatures.tsx`: `CLASS_NAMES`定数に統合
- `AppLauncherSortDropdown.tsx`: `CLASS_NAMES`定数に変更
- `AppLauncher.tsx` (desktop): `CLASS_NAMES`定数に変更
- `AppLauncher.tsx` (mobile): `CLASS_NAMES`定数に変更
- `AppLauncherFilterDropdown.tsx`: `CLASS_NAMES`定数に変更
- `LanguageSelector.tsx`: `CLASS_NAMES`定数に変更
- `MenuDialog.tsx`: `CLASS_NAMES`定数に変更
- `ReleaseNote.tsx`: `CLASS_NAMES`定数に変更
- `UserInfo.tsx` (mobile): `CLASS_NAMES`定数に変更

### 変更パターン

```tsx
// Before
const Component = () => {
  const classNames = useMemo(() => {
    const { wrapper, button } = classNameGenerator()
    return {
      wrapper: wrapper(),
      button: button(),
    }
  }, [])
  
  return <div className={classNames.wrapper}>...</div>
}

// After
const CLASS_NAMES = (() => {
  const { wrapper, button } = classNameGenerator()
  return {
    wrapper: wrapper(),
    button: button(),
  }
})()

const Component = () => {
  return <div className={CLASS_NAMES.wrapper}>...</div>
}
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで各AppHeaderコンポーネントの動作を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * AppHeader各種コンポーネントのスタイルクラス生成方法を見直し、不要な再計算を削減しました。
  * 画面表示や操作、条件分岐などの既存の挙動は維持されています。
  * スタイリング定数の命名・利用に関する開発ガイドラインを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->