### PR TITLE
refactor(Th): コンポーネント分割とonSort安定化でパフォーマンスを向上

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -66,7 +66,18 @@ const convertContentWidth = (contentWidth?: CellContentWidth) => {
 export const Th: FC<Props> = ({ sort, onSort, ...rest }) =>
   sort ? <SortableTh {...rest} sort={sort} onSort={onSort} /> : <ActualTh {...rest} />
 
-const SortableTh: FC<Props> = (props) => <ActualTh {...props} />
+const SortableTh: FC<
+  Omit<Props, 'sort'> & {
+    sort: NonNullable<Props['sort']>
+  }
+> = ({ sort, ...rest }) => {
+  const ariaSort = useMemo<AriaAttributes['aria-sort'] | undefined>(
+    () => (sort === 'none' ? 'none' : `${sort}ending`),
+    [sort],
+  )
+
+  return <ActualTh {...rest} sort={sort} aria-sort={ariaSort} />
+}
 
 const ActualTh = memo<Props>(
   ({ children, sort, onSort, align, vAlign, fixed, contentWidth, className, style, ...rest }) => {
@@ -87,19 +98,8 @@ const ActualTh = memo<Props>(
       [style, contentWidth],
     )
 
-    const ariaSort = useMemo<AriaAttributes['aria-sort'] | undefined>(
-      () => (sort ? (sort === 'none' ? 'none' : `${sort}ending`) : undefined),
-      [sort],
-    )
-
     return (
-      <th
-        {...rest}
-        aria-sort={ariaSort}
-        data-fixed={fixed}
-        className={actualClassName}
-        style={actualStyle}
-      >
+      <th {...rest} data-fixed={fixed} className={actualClassName} style={actualStyle}>
         {sort ? (
           <ThSortButton align={align} onSort={onSort} sort={sort}>
             {children}

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -1,5 +1,4 @@
 import {
-  type AriaAttributes,
   type ComponentPropsWithoutRef,
   type FC,
   type PropsWithChildren,
@@ -73,11 +72,6 @@ const SortableTh: FC<
     sort: NonNullable<Props['sort']>
   }
 > = ({ sort, onSort, ...rest }) => {
-  const ariaSort = useMemo<AriaAttributes['aria-sort'] | undefined>(
-    () => (sort === 'none' ? 'none' : `${sort}ending`),
-    [sort],
-  )
-
   const latest = useLatest({ onSort })
   const hasOnSort = !!onSort
 
@@ -92,7 +86,14 @@ const SortableTh: FC<
     [hasOnSort, latest],
   )
 
-  return <ActualTh {...rest} sort={sort} handleSort={functions.handleSort} aria-sort={ariaSort} />
+  return (
+    <ActualTh
+      {...rest}
+      sort={sort}
+      handleSort={functions.handleSort}
+      aria-sort={sort === 'none' ? sort : `${sort}ending`}
+    />
+  )
 }
 
 const ActualTh = memo<

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -1,6 +1,7 @@
 import {
   type AriaAttributes,
   type ComponentPropsWithoutRef,
+  type FC,
   type PropsWithChildren,
   memo,
   useMemo,
@@ -62,7 +63,12 @@ const convertContentWidth = (contentWidth?: CellContentWidth) => {
   return contentWidth
 }
 
-export const Th = memo<Props>(
+export const Th: FC<Props> = ({ sort, onSort, ...rest }) =>
+  sort ? <SortableTh {...rest} sort={sort} onSort={onSort} /> : <ActualTh {...rest} />
+
+const SortableTh: FC<Props> = (props) => <ActualTh {...props} />
+
+const ActualTh = memo<Props>(
   ({ children, sort, onSort, align, vAlign, fixed, contentWidth, className, style, ...rest }) => {
     const actualClassName = useMemo(() => {
       const base = classNameGenerator({ className, align, vAlign })
@@ -71,9 +77,7 @@ export const Th = memo<Props>(
         return base
       }
 
-      const shadow = reelShadowClassNameGenerator({ showShadow: false, direction: fixed })
-
-      return `${base} ${shadow}`
+      return `${base} ${reelShadowClassNameGenerator({ showShadow: false, direction: fixed })}`
     }, [align, className, fixed, vAlign])
     const actualStyle = useMemo(
       () => ({

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -71,7 +71,7 @@ const SortableTh: FC<
   Omit<Props, 'sort'> & {
     sort: NonNullable<Props['sort']>
   }
-> = ({ sort, onSort, ...rest }) => {
+> = ({ sort, onSort, align, children, ...rest }) => {
   const latest = useLatest({ onSort })
   const hasOnSort = !!onSort
 
@@ -87,32 +87,16 @@ const SortableTh: FC<
   )
 
   return (
-    <ActualTh
-      {...rest}
-      sort={sort}
-      handleSort={functions.handleSort}
-      aria-sort={sort === 'none' ? sort : `${sort}ending`}
-    />
+    <ActualTh {...rest} align={align} aria-sort={sort === 'none' ? sort : `${sort}ending`}>
+      <ThSortButton align={align} handleSort={functions.handleSort} sort={sort}>
+        {children}
+      </ThSortButton>
+    </ActualTh>
   )
 }
 
-const ActualTh = memo<
-  Omit<Props, 'onSort'> & {
-    handleSort?: Props['onSort']
-  }
->(
-  ({
-    children,
-    sort,
-    handleSort,
-    align,
-    vAlign,
-    fixed,
-    contentWidth,
-    className,
-    style,
-    ...rest
-  }) => {
+const ActualTh = memo<Omit<Props, 'onSort' | 'sort'>>(
+  ({ children, align, vAlign, fixed, contentWidth, className, style, ...rest }) => {
     const actualClassName = useMemo(() => {
       const base = classNameGenerator({ className, align, vAlign })
 
@@ -132,13 +116,7 @@ const ActualTh = memo<
 
     return (
       <th {...rest} data-fixed={fixed} className={actualClassName} style={actualStyle}>
-        {sort ? (
-          <ThSortButton align={align} handleSort={handleSort} sort={sort}>
-            {children}
-          </ThSortButton>
-        ) : (
-          children
-        )}
+        {children}
       </th>
     )
   },

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
+import { useLatest } from '../../hooks/useLatest'
+
 import { ThSortButton } from './ThSortButton'
 import { reelShadowClassNameGenerator } from './reelShadowStyle'
 
@@ -70,17 +72,46 @@ const SortableTh: FC<
   Omit<Props, 'sort'> & {
     sort: NonNullable<Props['sort']>
   }
-> = ({ sort, ...rest }) => {
+> = ({ sort, onSort, ...rest }) => {
   const ariaSort = useMemo<AriaAttributes['aria-sort'] | undefined>(
     () => (sort === 'none' ? 'none' : `${sort}ending`),
     [sort],
   )
 
-  return <ActualTh {...rest} sort={sort} aria-sort={ariaSort} />
+  const latest = useLatest({ onSort })
+  const hasOnSort = !!onSort
+
+  const functions = useMemo(
+    () => ({
+      handleSort: hasOnSort
+        ? () => {
+            latest.onSort?.()
+          }
+        : undefined,
+    }),
+    [hasOnSort, latest],
+  )
+
+  return <ActualTh {...rest} sort={sort} handleSort={functions.handleSort} aria-sort={ariaSort} />
 }
 
-const ActualTh = memo<Props>(
-  ({ children, sort, onSort, align, vAlign, fixed, contentWidth, className, style, ...rest }) => {
+const ActualTh = memo<
+  Omit<Props, 'onSort'> & {
+    handleSort?: Props['onSort']
+  }
+>(
+  ({
+    children,
+    sort,
+    handleSort,
+    align,
+    vAlign,
+    fixed,
+    contentWidth,
+    className,
+    style,
+    ...rest
+  }) => {
     const actualClassName = useMemo(() => {
       const base = classNameGenerator({ className, align, vAlign })
 
@@ -101,7 +132,7 @@ const ActualTh = memo<Props>(
     return (
       <th {...rest} data-fixed={fixed} className={actualClassName} style={actualStyle}>
         {sort ? (
-          <ThSortButton align={align} onSort={onSort} sort={sort}>
+          <ThSortButton align={align} handleSort={handleSort} sort={sort}>
             {children}
           </ThSortButton>
         ) : (

--- a/packages/smarthr-ui/src/components/Table/ThSortButton.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThSortButton.tsx
@@ -22,15 +22,15 @@ type sortTypes = 'asc' | 'desc' | 'none'
 
 type Props = PropsWithChildren<{
   align?: VariantProps<typeof sortButtonClassNameGenerator>['align']
-  onSort?: () => void
+  handleSort?: () => void
   sort?: sortTypes
 }>
 
-export const ThSortButton = memo<Props>(({ align, sort, onSort, children }) => {
+export const ThSortButton = memo<Props>(({ align, sort, handleSort, children }) => {
   const className = useMemo(() => sortButtonClassNameGenerator({ align }), [align])
 
   return (
-    <UnstyledButton onClick={onSort} className={className}>
+    <UnstyledButton onClick={handleSort} className={className}>
       {children}
       <SortIcon />
       {sort && (


### PR DESCRIPTION
## 関連URL

なし

## 概要

Thコンポーネント内のsort関連処理を適切に分離し、onSortコールバックを安定化することで、不要な再レンダリングを防止しパフォーマンスを向上させる。

## 変更内容

以下の4つの段階でリファクタリングを実施：

### 1. コンポーネント分割
- Thを軽量な分岐処理のみに変更（memo化なし）
- SortableThを追加（sort関連処理を担当）
- ActualThにmemo化を維持し、重い処理を集約

### 2. aria-sort計算ロジックの移動
- SortableThでaria-sort属性を計算し、ActualThに渡す
- ActualThからsort固有の処理を削除

### 3. onSortの安定化
- useLatestとfunctionsパターンでonSortを安定化
- boolean化（hasOnSort）で関数参照の変更による再計算を防止
- ThSortButtonの命名をonSort→handleSortに変更（内部コンポーネント命名規則に準拠）

### 4. 軽量計算のインライン化
- aria-sort計算をインライン化し、不要なuseMemoを削除

### 効果
onSortがunstableでも、影響を受けるのは軽量な分岐処理のみとなり、重い処理を含むActualThは不要な再計算を防げる。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでのソート機能の動作確認
- masterブランチと比較してロジック結果が冪等であることを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * テーブルのソート可能な見出しを整理し、並び替え状態が適切にアクセシビリティ情報として反映されるよう改善しました。
  * テーブル見出しの固定状態を明示的に扱えるようになりました。
  * ソート操作時のクリック処理を安定化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->