### PR TITLE
refactor(Stepper): 不要なuseMemoを削除しパフォーマンス最適化

### DIFF
--- a/packages/smarthr-ui/src/components/Stepper/StepStatusIcon.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/StepStatusIcon.tsx
@@ -42,23 +42,15 @@ const ICON_MAPPER = {
 }
 
 const ActualStepStatusIcon: FC<ActualProps> = ({ status, className, ...rest }) => {
-  const actualStatus = useMemo(() => {
-    const isObject = typeof status === 'object'
-    const statusType = isObject ? status.type : status
-    const { alt, Component } = ICON_MAPPER[statusType]
-
-    return {
-      type: statusType,
-      text: isObject ? status.text || alt : alt,
-      Component,
-    }
-  }, [status])
+  const isObject = typeof status === 'object'
+  const statusType = isObject ? status.type : status
+  const { alt, Component } = ICON_MAPPER[statusType]
+  const actualAlt = isObject ? status.text || alt : alt
 
   const actualClassName = useMemo(
-    () => classNameGenerator({ status: actualStatus.type, className }),
-    [actualStatus.type, className],
+    () => classNameGenerator({ status: statusType, className }),
+    [statusType, className],
   )
-  const Component = actualStatus.Component
 
-  return <Component {...rest} alt={actualStatus.text} className={actualClassName} />
+  return <Component {...rest} alt={actualAlt} className={actualClassName} />
 }

--- a/packages/smarthr-ui/src/components/Stepper/Stepper.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/Stepper.tsx
@@ -54,14 +54,10 @@ const StepItem: FC<
     index: number
   }
 > = ({ Component, step, previousStepStatus, index, activeIndex }) => {
-  const isPrevStepCompleted = useMemo(() => {
-    if (!previousStepStatus) return false
-
-    const statusType =
-      typeof previousStepStatus === 'object' ? previousStepStatus.type : previousStepStatus
-
-    return statusType === 'completed'
-  }, [previousStepStatus])
+  const isPrevStepCompleted = previousStepStatus
+    ? (typeof previousStepStatus === 'object' ? previousStepStatus.type : previousStepStatus) ===
+      'completed'
+    : false
 
   return (
     <Component


### PR DESCRIPTION
## 関連URL

なし

## 概要

StepperコンポーネントとStepStatusIconコンポーネントの内部実装で、計算コストが低い処理に対して使用されていた不要なuseMemoを削除し、パフォーマンスを最適化する。

## 変更内容

1. **StepStatusIcon の最適化**
   - `ActualStepStatusIcon` の `actualStatus` を `useMemo` で計算していたが、単純な型チェックと値の取得のみのため削除
   - 個別の変数（`isObject`, `statusType`, `actualAlt`, `Component`）に展開してコードを簡潔化
   - `actualClassName` の `useMemo` は依存配列を最小化（`statusType` と `className` のみ）

2. **Stepper の最適化**
   - `StepItem` の `isPrevStepCompleted` 計算から `useMemo` を削除
   - 単純な型チェックと文字列比較（`=== 'completed'`）のみのため、三項演算子による直接計算に変更
   - `useMemo` のオーバーヘッドを削減

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストが通ることを確認