### PR TITLE
refactor(SideMenuItem): aria-current計算の不要なuseMemoを削除

### DIFF
--- a/packages/smarthr-ui/src/components/SideMenu/SideMenuItem.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/SideMenuItem.tsx
@@ -58,13 +58,6 @@ export const SideMenuItem = <AsElement extends ElementType = 'a'>({
   ...rest
 }: Props<AsElement>) => {
   const Component = elementAs ?? 'a'
-  const ariaCurrent = useMemo(() => {
-    if (!current || !href) {
-      return undefined
-    }
-
-    return href[0] === '#' ? true : 'page'
-  }, [current, href])
 
   const classNames = useMemo(() => {
     const { wrapper, content, iconWrapper } = classNameGenerator()
@@ -78,7 +71,11 @@ export const SideMenuItem = <AsElement extends ElementType = 'a'>({
 
   return (
     <li className={classNames.wrapper}>
-      <Component {...rest} href={href} aria-current={ariaCurrent}>
+      <Component
+        {...rest}
+        href={href}
+        aria-current={current && href ? (href[0] === '#' ? true : 'page') : undefined}
+      >
         <Text size="M" leading="TIGHT" className={classNames.content}>
           {prefix && <span className={classNames.iconWrapper}>{prefix}</span>}
           <Text weight={current ? 'bold' : undefined}>{children}</Text>


### PR DESCRIPTION
## 関連URL

なし

## 概要

SideMenuItemコンポーネントのaria-current計算は単純な条件分岐のみで計算コストが低いため、不要なuseMemoを削除してパフォーマンスを最適化する。

## 変更内容

- `ariaCurrent` 変数の `useMemo` を削除
- `aria-current` 属性に直接インライン計算を適用：`current && href ? (href[0] === '#' ? true : 'page') : undefined`
- 単純な条件分岐のため、`useMemo` のオーバーヘッドを削減してパフォーマンス向上

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Storybookでの動作確認
- 既存のテストが通ることを確認