### PR TITLE
refactor(Pagination): 不要なuseMemoを削除しコンポーネント構造を簡素化

### DIFF
--- a/packages/smarthr-ui/src/components/Pagination/Pagination.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/Pagination.tsx
@@ -198,33 +198,24 @@ const ItemButtons = memo<
     return range(Math.max(current - actualPadding, 1), Math.min(current + actualPadding, total) + 1)
   }, [current, total, padding, withoutNumbers])
 
-  const controllerAttrs = useMemo(
-    () => ({
-      prev: {
-        disabled: current === 1,
-        direction: 'prev' as const,
-        hrefTemplate,
-        linkAs,
-      },
-      next: {
-        disabled: current === total,
-        direction: 'next' as const,
-        hrefTemplate,
-        linkAs,
-      },
-    }),
-    [current, total, hrefTemplate, linkAs],
-  )
+  const prevAttrs = {
+    disabled: current === 1,
+    direction: 'prev' as const,
+    hrefTemplate,
+    linkAs,
+  }
+  const nextAttrs = {
+    disabled: current === total,
+    direction: 'next' as const,
+    hrefTemplate,
+    linkAs,
+  }
 
   return (
     <Cluster as="ul" className={classNames.list}>
-      <DoubleIconItemButton
-        {...controllerAttrs.prev}
-        targetPage={1}
-        className={classNames.firstListItem}
-      />
+      <DoubleIconItemButton {...prevAttrs} targetPage={1} className={classNames.firstListItem} />
       <li className={classNames.prevListItem}>
-        <PaginationControllerItemButton {...controllerAttrs.prev} targetPage={current - 1} />
+        <PaginationControllerItemButton {...prevAttrs} targetPage={current - 1} />
       </li>
       {pageNumbers.map((page) => (
         <NumberItemButton
@@ -236,13 +227,9 @@ const ItemButtons = memo<
         />
       ))}
       <li className={classNames.nextListItem}>
-        <PaginationControllerItemButton {...controllerAttrs.next} targetPage={current + 1} />
+        <PaginationControllerItemButton {...nextAttrs} targetPage={current + 1} />
       </li>
-      <DoubleIconItemButton
-        {...controllerAttrs.next}
-        targetPage={total}
-        className={classNames.lastListItem}
-      />
+      <DoubleIconItemButton {...nextAttrs} targetPage={total} className={classNames.lastListItem} />
     </Cluster>
   )
 })

--- a/packages/smarthr-ui/src/components/Pagination/PaginationControllerItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/PaginationControllerItemButton.tsx
@@ -1,8 +1,8 @@
-import { type ComponentProps, type ElementType, type FC, useMemo } from 'react'
-
 import { Localizer } from '../../intl'
 import { AnchorButton, Button } from '../Button'
 import { FaAnglesLeftIcon, FaAnglesRightIcon, FaChevronLeftIcon, FaChevronRightIcon } from '../Icon'
+
+import type { ElementType, FC } from 'react'
 
 type Props = {
   targetPage: number
@@ -57,36 +57,22 @@ export const PaginationControllerItemButton: FC<Props> = ({
 }) => {
   const { Icon, alt } = ICON_MAPPER[direction][double ? 'double' : 'single']
 
-  const { Component, attrs } = useMemo(() => {
-    if (hrefTemplate) {
-      return {
-        Component: AnchorButton,
-        // HINT: elementAsにnext/linkを設定した場合、hrefがundefinedでは
-        // エラーになってしまうため、undefinedで指定されていない状態にする
-        attrs: (disabled
-          ? {
-              href: undefined,
-              elementAs: undefined,
-            }
-          : {
-              href: hrefTemplate(targetPage),
-              elementAs: linkAs,
-            }) as ComponentProps<typeof AnchorButton>,
-      }
-    }
+  const commonAttrs = {
+    variant: 'secondary',
+    size: 'S',
+    className: 'shr-rounded-s',
+    children: <Icon color={disabled ? 'TEXT_DISABLED' : 'TEXT_BLACK'} alt={alt} />,
+  } as const
 
-    return {
-      Component: Button,
-      attrs: {
-        disabled,
-        value: targetPage,
-      } as ComponentProps<typeof Button>,
-    }
-  }, [targetPage, disabled, hrefTemplate, linkAs])
+  if (hrefTemplate) {
+    return (
+      <AnchorButton
+        {...commonAttrs}
+        href={disabled ? undefined : hrefTemplate(targetPage)}
+        elementAs={disabled ? undefined : linkAs}
+      />
+    )
+  }
 
-  return (
-    <Component {...attrs} variant="secondary" size="S" className="shr-rounded-s">
-      <Icon color={disabled ? 'TEXT_DISABLED' : 'TEXT_BLACK'} alt={alt} />
-    </Component>
-  )
+  return <Button {...commonAttrs} disabled={disabled} value={targetPage} />
 }

--- a/packages/smarthr-ui/src/components/Pagination/PaginationItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/PaginationItemButton.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type ElementType, type FC, useMemo } from 'react'
+import { type ElementType, type FC, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useIntl } from '../../intl'
@@ -33,48 +33,27 @@ export const PaginationItemButton: FC<Props> = ({ page, disabled, hrefTemplate, 
         },
         { page },
       ),
-    [localize, page],
+    [page, localize],
   )
 
-  const { Component, attrs } = useMemo(() => {
-    if (hrefTemplate) {
-      return {
-        Component: AnchorButton,
-        attrs: {
-          // HINT: elementAsにnext/linkを設定した場合、hrefがundefinedでは
-          // エラーになってしまうため、undefinedで指定されていない状態にする
-          ...(disabled
-            ? {
-                href: undefined,
-                elementAs: undefined,
-              }
-            : {
-                href: hrefTemplate(page),
-                elementAs: linkAs,
-              }),
-        } as ComponentProps<typeof AnchorButton>,
-      }
-    }
+  const commonAttr = {
+    variant: 'secondary',
+    size: 'S',
+    'aria-label': ariaLabel,
+    'aria-current': disabled ? 'page' : undefined,
+    className,
+    children: page,
+  } as const
 
-    return {
-      Component: Button,
-      attrs: {
-        disabled,
-        value: page,
-      } as ComponentProps<typeof Button>,
-    }
-  }, [disabled, page, hrefTemplate, linkAs])
+  if (hrefTemplate) {
+    return (
+      <AnchorButton
+        {...commonAttr}
+        href={disabled ? undefined : hrefTemplate(page)}
+        elementAs={disabled ? undefined : linkAs}
+      />
+    )
+  }
 
-  return (
-    <Component
-      {...attrs}
-      variant="secondary"
-      size="S"
-      aria-label={ariaLabel}
-      aria-current={disabled ? 'page' : undefined}
-      className={className}
-    >
-      {page}
-    </Component>
-  )
+  return <Button {...commonAttr} disabled={disabled} value={page} />
 }

--- a/packages/smarthr-ui/src/components/Pagination/PaginationItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/PaginationItemButton.tsx
@@ -37,16 +37,10 @@ export const PaginationItemButton: FC<Props> = ({ page, disabled, hrefTemplate, 
   )
 
   const { Component, attrs } = useMemo(() => {
-    const common = {
-      'aria-label': ariaLabel,
-      'aria-current': disabled ? 'page' : undefined,
-    }
-
     if (hrefTemplate) {
       return {
         Component: AnchorButton,
         attrs: {
-          ...common,
           // HINT: elementAsにnext/linkを設定した場合、hrefがundefinedでは
           // エラーになってしまうため、undefinedで指定されていない状態にする
           ...(disabled
@@ -65,15 +59,21 @@ export const PaginationItemButton: FC<Props> = ({ page, disabled, hrefTemplate, 
     return {
       Component: Button,
       attrs: {
-        ...common,
         disabled,
         value: page,
       } as ComponentProps<typeof Button>,
     }
-  }, [disabled, page, hrefTemplate, linkAs, ariaLabel])
+  }, [disabled, page, hrefTemplate, linkAs])
 
   return (
-    <Component {...attrs} variant="secondary" size="S" className={className}>
+    <Component
+      {...attrs}
+      variant="secondary"
+      size="S"
+      aria-label={ariaLabel}
+      aria-current={disabled ? 'page' : undefined}
+      className={className}
+    >
       {page}
     </Component>
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

Paginationコンポーネント群で不要なuseMemoを削除し、コードの可読性とパフォーマンスを改善。

## 変更内容

以下の3つのコンポーネントでリファクタリングを実施：

### PaginationItemButton
- `useMemo`によるComponent/attrsパターンを削除
- `commonAttr`オブジェクトで共通属性を定義
- if/elseで直接`AnchorButton`と`Button`を返す構造に変更
- 不要な`ComponentProps`のimportを削除

### PaginationControllerItemButton
- PaginationItemButtonと同様のリファクタリングを実施
- `commonAttrs`オブジェクトで共通属性を定義

### Pagination
- `controllerAttrs`のuseMemoを削除
- `prevAttrs`と`nextAttrs`に分離して直接定義

これらの変更により、単純なオブジェクト生成に対するuseMemoのオーバーヘッドを削減し、コードの可読性が向上。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認