### PR TITLE
refactor(NotificationBar): 不要なuseMemoとサブコンポーネントを削除

### DIFF
--- a/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
@@ -226,7 +226,18 @@ export const NotificationBar: FC<Props> = ({
             </Cluster>
           )}
         </Cluster>
-        <CloseButton onClose={onClose} className={classNames.closeButton} />
+        {onClose && (
+          <Button variant="text" size="S" onClick={onClose} className={classNames.closeButton}>
+            <FaXmarkIcon
+              alt={
+                <Localizer
+                  id="smarthr-ui/NotificationBar/closeButtonIconAlt"
+                  defaultText="閉じる"
+                />
+              }
+            />
+          </Button>
+        )}
       </div>
     </WrapBase>
   )
@@ -252,16 +263,3 @@ const MessageArea = memo<
     </Text>
   )
 })
-
-const CloseButton = memo<Pick<Props, 'onClose'> & { className: string }>(
-  ({ onClose, className }) =>
-    onClose && (
-      <Button variant="text" size="S" onClick={onClose} className={className}>
-        <FaXmarkIcon
-          alt={
-            <Localizer id="smarthr-ui/NotificationBar/closeButtonIconAlt" defaultText="閉じる" />
-          }
-        />
-      </Button>
-    ),
-)

--- a/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
@@ -185,22 +185,17 @@ export const NotificationBar: FC<Props> = ({
   ...rest
 }) => {
   const actualRole = role || (ROLE_STATUS_TYPE_REGEX.test(type) ? 'status' : 'alert')
-  const { WrapBase, baseProps } = useMemo(
-    () =>
-      base === 'base'
-        ? {
-            WrapBase: Base,
-            baseProps: {
-              layer,
-              overflow: 'hidden' as ComponentProps<typeof Base>['overflow'],
-            },
-          }
-        : {
-            WrapBase: Fragment,
-            baseProps: {},
-          },
-    [base, layer],
-  )
+  let WrapBase = Fragment
+  let baseProps = {}
+
+  if (base === 'base') {
+    WrapBase = Base
+    baseProps = {
+      layer,
+      overflow: 'hidden' as ComponentProps<typeof Base>['overflow'],
+    }
+  }
+
   const classNames = useMemo(() => {
     const { wrapper, inner, messageArea, icon, actionArea, closeButton } = classNameGenerator({
       type,

--- a/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
@@ -184,13 +184,7 @@ export const NotificationBar: FC<Props> = ({
   className,
   ...rest
 }) => {
-  const actualRole = useMemo(() => {
-    if (role) {
-      return role
-    }
-
-    return ROLE_STATUS_TYPE_REGEX.test(type) ? 'status' : 'alert'
-  }, [role, type])
+  const actualRole = role || (ROLE_STATUS_TYPE_REGEX.test(type) ? 'status' : 'alert')
   const { WrapBase, baseProps } = useMemo(
     () =>
       base === 'base'


### PR DESCRIPTION
## 関連URL

なし

## 概要

NotificationBarコンポーネントで不要なuseMemoとサブコンポーネントを削除し、コードの可読性とパフォーマンスを改善。

## 変更内容

以下の3つのリファクタリングを実施：

### 1. actualRoleのuseMemo削除
- 単純な条件分岐なのでuseMemoを削除
- 直接条件演算子で評価

### 2. WrapBase/basePropsのuseMemo削除
- 単純な条件分岐とオブジェクト生成なのでuseMemoを削除
- if文で直接評価

### 3. CloseButtonコンポーネントの削除
- 単純なボタンコンポーネントなのでmemo化が不要
- メインコンポーネント内にインライン化してコードを簡潔化

これらの変更により、計算コストが低い処理に対するuseMemoのオーバーヘッドを削減し、コードの可読性が向上。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認