### PR TITLE
refactor(Loader): classNamesのuseMemoを即時関数に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Loader/Loader.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type ReactNode, memo, useMemo } from 'react'
+import { type ComponentProps, type ReactNode, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { LoaderSpinner } from './LoaderSpinner'
@@ -34,7 +34,8 @@ const classNameGenerator = tv({
 
 export const Loader = memo<Props>(
   ({ size = 'M', alt, text, type = 'primary', role = 'status', className, ...rest }) => {
-    const classNames = useMemo(() => {
+    // HINT: Loaderは一度表示されれば属性が変わる可能性はほぼ無いためuseMemoしない
+    const classNames = (() => {
       const { wrapper, textSlot } = classNameGenerator({
         type,
       })
@@ -43,7 +44,7 @@ export const Loader = memo<Props>(
         wrapper: wrapper({ className }),
         text: textSlot(),
       }
-    }, [type, className])
+    })()
 
     return (
       <span {...rest} role={role} className={classNames.wrapper}>

--- a/packages/smarthr-ui/src/components/Loader/LoaderSpinner.tsx
+++ b/packages/smarthr-ui/src/components/Loader/LoaderSpinner.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { type ReactNode, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../intl'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
+
+import type { FC, ReactNode } from 'react'
 
 type Props = {
   /** ローダーの大きさ */
@@ -116,7 +117,7 @@ const classNameGenerator = tv({
   },
 })
 
-export const LoaderSpinner = memo<Props>(({ size = 'M', alt, type = 'primary' }) => {
+export const LoaderSpinner: FC<Props> = ({ size = 'M', alt, type = 'primary' }) => {
   // HINT: LoaderSpinnerは一度表示されれば属性が変わる可能性はほぼ無いためuseMemoしない
   const classNames = (() => {
     const { spinner, line, cog, cogInner } = classNameGenerator({
@@ -158,4 +159,4 @@ export const LoaderSpinner = memo<Props>(({ size = 'M', alt, type = 'primary' })
       </VisuallyHiddenText>
     </span>
   )
-})
+}

--- a/packages/smarthr-ui/src/components/Loader/LoaderSpinner.tsx
+++ b/packages/smarthr-ui/src/components/Loader/LoaderSpinner.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ReactNode, memo, useMemo } from 'react'
+import { type ReactNode, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../intl'
@@ -117,7 +117,8 @@ const classNameGenerator = tv({
 })
 
 export const LoaderSpinner = memo<Props>(({ size = 'M', alt, type = 'primary' }) => {
-  const classNames = useMemo(() => {
+  // HINT: LoaderSpinnerは一度表示されれば属性が変わる可能性はほぼ無いためuseMemoしない
+  const classNames = (() => {
     const { spinner, line, cog, cogInner } = classNameGenerator({
       type,
       size,
@@ -133,7 +134,7 @@ export const LoaderSpinner = memo<Props>(({ size = 'M', alt, type = 'primary' })
       line3: line({ lineNum: 3 }),
       line4: line({ lineNum: 4 }),
     }
-  }, [type, size])
+  })()
 
   const lineBody = (
     <>


### PR DESCRIPTION
## 関連URL

なし

## 概要

LoaderとLoaderSpinnerコンポーネントで、classNamesのuseMemoを即時関数に変更し、パフォーマンスを改善。

## 変更内容

以下の2つのコンポーネントでリファクタリングを実施：

### LoaderSpinner
- `classNames`のuseMemoを即時関数（IIFE）に変更
- 不要になったuseMemoのimportを削除

### Loader
- `classNames`のuseMemoを即時関数（IIFE）に変更
- 不要になったuseMemoのimportを削除

**変更理由:**
- Loaderコンポーネントは一度表示されれば属性（`size`、`type`、`className`）が変わる可能性がほぼない
- useMemoの依存配列チェック（`[type, size]`、`[type, className]`の比較）のオーバーヘッドが無駄
- 即時関数で直接計算する方がシンプルで効率的

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認