### PR TITLE
refactor(LineClamp): MutationObserverでDOM変更を監視するように変更

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -79,14 +79,23 @@ export const LineClamp: FC<Props> = ({ maxLines = 3, children, className, ...res
 
     checkOverflow()
 
+    const observer = new MutationObserver(checkOverflow)
+
+    if (shadowRef.current) {
+      observer.observe(shadowRef.current, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      })
+    }
+
     window.addEventListener('resize', checkOverflow)
 
     return () => {
+      observer.disconnect()
       window.removeEventListener('resize', checkOverflow)
     }
-    // TODO: 将来的にMutationObserverに置き換えて、children の変更を監視する実装に変更する
-    // eslint-disable-next-line smarthr/best-practice-for-unstable-dependencies
-  }, [children, maxLines])
+  }, [maxLines])
 
   const classNames = useMemo(() => {
     const { base, clampedLine, shadowElementWrapper, shadowElement } = classNameGenerator({


### PR DESCRIPTION
## 関連URL

なし

## 概要

LineClampコンポーネントのTODOを解消し、`children`の変更監視をMutationObserverで実装。不安定な依存を削除してパフォーマンスを改善。

## 変更内容

### TODOの解消
コード内のTODOコメントを解消：
```typescript
// TODO: 将来的にMutationObserverに置き換えて、children の変更を監視する実装に変更する
```

### 実装内容

**Before:**
```typescript
useEffect(() => {
  const checkOverflow = () => { /* ... */ }
  checkOverflow()
  window.addEventListener('resize', checkOverflow)
  return () => {
    window.removeEventListener('resize', checkOverflow)
  }
  // eslint-disable-next-line smarthr/best-practice-for-unstable-dependencies
}, [children, maxLines])
```

**After:**
```typescript
useEffect(() => {
  const checkOverflow = () => { /* ... */ }
  checkOverflow()
  
  const observer = new MutationObserver(checkOverflow)
  if (shadowRef.current) {
    observer.observe(shadowRef.current, {
      childList: true,
      characterData: true,
      subtree: true,
    })
  }
  
  window.addEventListener('resize', checkOverflow)
  return () => {
    observer.disconnect()
    window.removeEventListener('resize', checkOverflow)
  }
}, [maxLines])
```

### 主な改善点

1. **不安定な依存を削除**
   - 依存配列から`children`（ReactNode）を削除
   - `smarthr/best-practice-for-unstable-dependencies`のESLint無効化が不要に

2. **パフォーマンス向上**
   - propsの`children`が変わっても、DOM内容が同じなら不要な再チェックを回避
   - 実際にDOM要素が変更された時のみ`checkOverflow`を実行

3. **より正確な変更検知**
   - MutationObserverでDOM変更を直接監視
   - `childList`、`characterData`、`subtree`のオプションで包括的に監視

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認：
- テキストが省略される場合にTooltipが表示されることを確認
- ウィンドウリサイズ時に適切に再チェックされることを確認
- 動的にchildrenが変更される場合の動作確認