### PR TITLE
refactor(Container): paddingのデフォルト値を定数化

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
@@ -88,9 +88,16 @@ const classNameGenerator = tv({
   ],
 })
 
+const DEFAULT_PADDING = {
+  block: 2,
+  inline: 2,
+  narrowModeBlock: 1.5,
+  narrowModeInline: 1,
+} as const
+
 export const Container: FC<Props> = ({
   size = 'DEFAULT',
-  padding = { block: 2, inline: 2, narrowModeBlock: 1.5, narrowModeInline: 1 },
+  padding = DEFAULT_PADDING,
   className,
   ...rest
 }) => {


### PR DESCRIPTION
## 関連URL

なし

## 概要

Containerコンポーネントの`padding`デフォルト値を定数化し、不安定な参照による不要な再実行を防ぐ。

## 変更内容

### 問題点

**Before:**
```typescript
export const Container: FC<Props> = ({
  size = 'DEFAULT',
  padding = { block: 2, inline: 2, narrowModeBlock: 1.5, narrowModeInline: 1 },
  className,
  ...rest
}) => {
```

デフォルト引数のオブジェクトリテラルは、コンポーネントが呼び出される毎に新しいオブジェクトを生成するため、不安定な参照となる：

```typescript
<Container /> // padding: { block: 2, ... } (参照A)
<Container /> // padding: { block: 2, ... } (参照B ≠ 参照A)
```

これにより、`useMemo`の依存配列`[size, className, padding, mobile]`で毎回`padding`が変わったと判定され、不要な再実行が発生する。

### 解決策

**After:**
```typescript
const DEFAULT_PADDING = {
  block: 2,
  inline: 2,
  narrowModeBlock: 1.5,
  narrowModeInline: 1,
} as const

export const Container: FC<Props> = ({
  size = 'DEFAULT',
  padding = DEFAULT_PADDING,
  className,
  ...rest
}) => {
```

定数として外出しすることで、常に同じ参照を使用し、`padding`が明示的に渡されない限り`useMemo`が不要に再実行されることを防ぐ。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * コンテナのデフォルト余白設定を整理しました。
  * 既定の余白値や表示上の動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->