### PR TITLE
refactor(Cluster): gapsのuseMemoを削除し、actualClassNameに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
@@ -106,29 +106,24 @@ const ActualCluster = <T extends ElementType = 'div'>(
   { as, gap = 0.5, inline = false, align, justify, className, ...rest }: Props<T>,
   ref: ForwardedRef<HTMLElement>,
 ) => {
-  const gaps = useMemo(() => {
-    if (gap instanceof Object) {
-      return gap
-    }
+  const actualClassName = useMemo(() => {
+    const gaps =
+      gap instanceof Object
+        ? gap
+        : {
+            row: gap,
+            column: gap,
+          }
 
-    return {
-      row: gap,
-      column: gap,
-    }
-  }, [gap])
-
-  const actualClassName = useMemo(
-    () =>
-      clusterClassNameGenerator({
-        inline,
-        rowGap: gaps.row,
-        columnGap: gaps.column,
-        align,
-        justify,
-        className,
-      }),
-    [inline, gaps.row, gaps.column, align, justify, className],
-  )
+    return clusterClassNameGenerator({
+      inline,
+      rowGap: gaps.row,
+      columnGap: gaps.column,
+      align,
+      justify,
+      className,
+    })
+  }, [gap, inline, align, justify, className])
 
   const Component = as || 'div'
   const Wrapper = useSectionWrapper(Component)


### PR DESCRIPTION
## 関連URL

なし

## 概要

ClusterコンポーネントでgapsのuseMemoを削除し、actualClassNameのuseMemo内に統合してコードを簡潔化。

## 変更内容

### 問題点

**Before:**
```typescript
const gaps = useMemo(() => {
  if (gap instanceof Object) {
    return gap
  }
  return {
    row: gap,
    column: gap,
  }
}, [gap])

const actualClassName = useMemo(
  () =>
    clusterClassNameGenerator({
      inline,
      rowGap: gaps.row,
      columnGap: gaps.column,
      align,
      justify,
      className,
    }),
  [inline, gaps.row, gaps.column, align, justify, className],
)
```

2つのuseMemoを使用し、依存配列も`[gaps.row, gaps.column]`と間接的。

### 解決策

**After:**
```typescript
const actualClassName = useMemo(() => {
  const gaps =
    gap instanceof Object
      ? gap
      : {
          row: gap,
          column: gap,
        }

  return clusterClassNameGenerator({
    inline,
    rowGap: gaps.row,
    columnGap: gaps.column,
    align,
    justify,
    className,
  })
}, [gap, inline, align, justify, className])
```

### 主な改善点

1. **useMemoの削減**
   - 2つのuseMemoを1つに統合
   - `gaps`の計算は単純な条件分岐とオブジェクト生成で、useMemo内で毎回実行してもオーバーヘッドは低い

2. **依存配列の改善**
   - `[gaps.row, gaps.column]`ではなく`[gap]`を直接依存
   - より明確で、元のpropsに近い依存関係

3. **コードの簡潔化**
   - 中間変数を減らし、ロジックが1箇所に集約
   - コードの見通しが向上

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認