### PR TITLE
refactor(Center): styleのuseMemoを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Center/Center.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Center/Center.tsx
@@ -64,20 +64,23 @@ export const Center = forwardRef<HTMLDivElement, Props>(
     { minHeight, maxWidth, padding, verticalCentering, as: Component = 'div', className, ...rest },
     ref,
   ) => {
-    const style = useMemo(
-      () => ({
-        minHeight: minHeight ?? undefined,
-        maxWidth: maxWidth ?? undefined,
-      }),
-      [minHeight, maxWidth],
-    )
     const actualClassName = useMemo(
       () => centerClassNameGenerator({ padding, verticalCentering, className }),
       [padding, verticalCentering, className],
     )
 
     const Wrapper = useSectionWrapper(Component)
-    const body = <Component {...rest} ref={ref} className={actualClassName} style={style} />
+    const body = (
+      <Component
+        {...rest}
+        ref={ref}
+        className={actualClassName}
+        style={{
+          minHeight: minHeight ?? undefined,
+          maxWidth: maxWidth ?? undefined,
+        }}
+      />
+    )
 
     if (Wrapper) {
       return <Wrapper>{body}</Wrapper>


### PR DESCRIPTION
## 関連URL

なし

## 概要

CenterコンポーネントでstyleのuseMemoを削除し、インラインで直接定義してコードを簡潔化。

## 変更内容

### 問題点

**Before:**
```typescript
const style = useMemo(
  () => ({
    minHeight: minHeight ?? undefined,
    maxWidth: maxWidth ?? undefined,
  }),
  [minHeight, maxWidth],
)
// ...
<Component {...rest} ref={ref} className={actualClassName} style={style} />
```

styleの計算は非常に単純（2つのプロパティのnullish coalescingのみ）なのに、useMemoを使用している。

### 解決策

**After:**
```typescript
<Component
  {...rest}
  ref={ref}
  className={actualClassName}
  style={{
    minHeight: minHeight ?? undefined,
    maxWidth: maxWidth ?? undefined,
  }}
/>
```

### 主な改善点

1. **useMemoの削減**
   - styleの計算は単純で、useMemoのオーバーヘッド（依存配列の比較、関数呼び出し）の方が高い

2. **コードの簡潔化**
   - 中間変数を削除
   - JSX内で直接styleを定義し、見通しが向上

3. **実用上の問題なし**
   - インラインオブジェクトは毎回新しい参照を生成するが、ReactはstyleプロパティをDOM diffで効率的に処理
   - `minHeight`や`maxWidth`が頻繁に変わることは少ない

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookでの動作確認