### PR TITLE
refactor(Input): 不要なuseMemoを削除しパフォーマンスを最適化

### DIFF
--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -150,24 +150,20 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       }
     }, [disabled, readOnly, className])
 
-    const wrapperStyle = useMemo(() => {
-      const color = bgColor ? theme.backgroundColor[backgroundColor[bgColor]] : undefined
-      const maxWidth = typeof width === 'number' ? `${width}px` : width
-
-      return {
-        borderColor: color,
-        backgroundColor: color,
-        maxWidth,
-        width: maxWidth ? '100%' : undefined,
-      }
-    }, [width, bgColor, theme.backgroundColor])
+    const styleColor = bgColor ? theme.backgroundColor[backgroundColor[bgColor]] : undefined
+    const styleMaxWidth = typeof width === 'number' ? `${width}px` : width
 
     return (
       <span
         role="presentation"
         onClick={functions.handleDelegateClick}
         className={classNames.wrapper}
-        style={wrapperStyle}
+        style={{
+          borderColor: styleColor,
+          backgroundColor: styleColor,
+          maxWidth: styleMaxWidth,
+          width: styleMaxWidth ? '100%' : undefined,
+        }}
       >
         {prefix && <span className={classNames.prefix}>{prefix}</span>}
         <input

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -139,10 +139,17 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       [latest],
     )
 
-    const wrapperClassName = useMemo(
-      () => wrapperClassNameGenerator({ disabled, readOnly, className }),
-      [disabled, readOnly, className],
-    )
+    const classNames = useMemo(() => {
+      const { input, affix } = innerClassNameGenerator({ disabled })
+
+      return {
+        wrapper: wrapperClassNameGenerator({ disabled, readOnly, className }),
+        input: input(),
+        prefix: affix({ className: 'smarthr-ui-Input-prefix' }),
+        suffix: affix({ className: 'smarthr-ui-Input-suffix' }),
+      }
+    }, [disabled, readOnly, className])
+
     const wrapperStyle = useMemo(() => {
       const color = bgColor ? theme.backgroundColor[backgroundColor[bgColor]] : undefined
       const maxWidth = typeof width === 'number' ? `${width}px` : width
@@ -155,24 +162,14 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       }
     }, [width, bgColor, theme.backgroundColor])
 
-    const innerClassNames = useMemo(() => {
-      const { input, affix } = innerClassNameGenerator({ disabled })
-
-      return {
-        input: input(),
-        prefix: affix({ className: 'smarthr-ui-Input-prefix' }),
-        suffix: affix({ className: 'smarthr-ui-Input-suffix' }),
-      }
-    }, [disabled])
-
     return (
       <span
         role="presentation"
         onClick={functions.handleDelegateClick}
-        className={wrapperClassName}
+        className={classNames.wrapper}
         style={wrapperStyle}
       >
-        {prefix && <span className={innerClassNames.prefix}>{prefix}</span>}
+        {prefix && <span className={classNames.prefix}>{prefix}</span>}
         <input
           {...rest}
           type={type}
@@ -187,9 +184,9 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           readOnly={readOnly}
           ref={functions.handleInnerRef}
           aria-invalid={error || undefined}
-          className={innerClassNames.input}
+          className={classNames.input}
         />
-        {suffix && <span className={innerClassNames.suffix}>{suffix}</span>}
+        {suffix && <span className={classNames.suffix}>{suffix}</span>}
       </span>
     )
   },

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -125,17 +125,6 @@ export const Input = forwardRef<HTMLInputElement, Props>(
 
     const latest = useLatest({ autoFocus })
 
-    const attrsByType =
-      type === 'number'
-        ? {
-            max,
-            onWheel: disableWheel,
-          }
-        : {
-            max:
-              max || (type && DEFAULT_MAX_ATTR[type as keyof typeof DEFAULT_MAX_ATTR]) || undefined,
-          }
-
     const functions = useMemo(
       () => ({
         handleInnerRef: (node: HTMLInputElement | null) => {
@@ -186,9 +175,12 @@ export const Input = forwardRef<HTMLInputElement, Props>(
         {prefix && <span className={innerClassNames.prefix}>{prefix}</span>}
         <input
           {...rest}
-          {...attrsByType}
           type={type}
           data-smarthr-ui-input="true"
+          max={
+            max || (type && DEFAULT_MAX_ATTR[type as keyof typeof DEFAULT_MAX_ATTR]) || undefined
+          }
+          onWheel={type === 'number' ? disableWheel : undefined}
           onFocus={onFocus}
           onBlur={onBlur}
           disabled={disabled}

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -87,6 +87,14 @@ const innerClassNameGenerator = tv({
   },
 })
 
+// HINT: PC版ブラウザで年が6桁入力できる場合、コピー&ペーストが正常に動作しないなど、UI上の問題が発生する場合がある
+// 回避のためmaxで年四桁を指定する
+const DEFAULT_MAX_ATTR = {
+  date: '9999-12-31',
+  'datetime-local': '9999-12-31T23:59',
+  month: '9999-12',
+}
+
 export const Input = forwardRef<HTMLInputElement, Props>(
   (
     {
@@ -115,31 +123,16 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       () => innerRef.current,
     )
 
-    const attrsByType = useMemo(() => {
-      switch (type) {
-        case 'number':
-          return {
+    const attrsByType =
+      type === 'number'
+        ? {
             max,
             onWheel: disableWheel,
           }
-        // HINT: PC版ブラウザで年が6桁入力できる場合、コピー&ペーストが正常に動作しないなど、UI上の問題が発生する場合がある
-        // 回避のためmaxで年四桁を指定する
-        case 'date':
-          return {
-            max: max || '9999-12-31',
+        : {
+            max:
+              max || (type && DEFAULT_MAX_ATTR[type as keyof typeof DEFAULT_MAX_ATTR]) || undefined,
           }
-        case 'datetime-local':
-          return {
-            max: max || '9999-12-31T23:59',
-          }
-        case 'month':
-          return {
-            max: max || '9999-12',
-          }
-      }
-
-      return { max }
-    }, [max, type])
 
     const onDelegateClickFocus = useCallback(() => innerRef.current?.focus(), [])
 

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -134,7 +134,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
             node.focus()
           }
         },
-        onDelegateClickFocus: () => innerRef.current?.focus(),
+        handleDelegateClick: () => innerRef.current?.focus(),
       }),
       [latest],
     )
@@ -168,7 +168,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     return (
       <span
         role="presentation"
-        onClick={functions.onDelegateClickFocus}
+        onClick={functions.handleDelegateClick}
         className={wrapperClassName}
         style={wrapperStyle}
       >

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -2,17 +2,17 @@
 
 import {
   type ComponentPropsWithRef,
+  type MutableRefObject,
   type ReactNode,
   type WheelEvent,
   forwardRef,
-  useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useLatest } from '../../hooks/useLatest'
 import { useTheme } from '../../hooks/useTheme'
 
 type AbstractProps = {
@@ -116,12 +116,14 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     ref,
   ) => {
     const theme = useTheme()
-    const innerRef = useRef<HTMLInputElement>(null)
+    const innerRef: MutableRefObject<HTMLInputElement | null> = useRef(null)
 
     useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
       ref,
       () => innerRef.current,
     )
+
+    const latest = useLatest({ autoFocus })
 
     const attrsByType =
       type === 'number'
@@ -134,13 +136,19 @@ export const Input = forwardRef<HTMLInputElement, Props>(
               max || (type && DEFAULT_MAX_ATTR[type as keyof typeof DEFAULT_MAX_ATTR]) || undefined,
           }
 
-    const onDelegateClickFocus = useCallback(() => innerRef.current?.focus(), [])
+    const functions = useMemo(
+      () => ({
+        handleInnerRef: (node: HTMLInputElement | null) => {
+          innerRef.current = node
 
-    useEffect(() => {
-      if (autoFocus && innerRef.current) {
-        innerRef.current.focus()
-      }
-    }, [autoFocus])
+          if (latest.autoFocus && node) {
+            node.focus()
+          }
+        },
+        onDelegateClickFocus: () => innerRef.current?.focus(),
+      }),
+      [latest],
+    )
 
     const wrapperClassName = useMemo(
       () => wrapperClassNameGenerator({ disabled, readOnly, className }),
@@ -171,7 +179,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     return (
       <span
         role="presentation"
-        onClick={onDelegateClickFocus}
+        onClick={functions.onDelegateClickFocus}
         className={wrapperClassName}
         style={wrapperStyle}
       >
@@ -185,7 +193,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           onBlur={onBlur}
           disabled={disabled}
           readOnly={readOnly}
-          ref={innerRef}
+          ref={functions.handleInnerRef}
           aria-invalid={error || undefined}
           className={innerClassNames.input}
         />

--- a/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/SearchInput.tsx
@@ -27,20 +27,19 @@ const classNameGenerator = tv({
 
 export const SearchInput = forwardRef<HTMLInputElement, Props>(
   ({ width, className, ...rest }, ref) => {
-    const labelStyle = useMemo(
-      () => ({
-        width: typeof width === 'number' ? `${width}px` : width,
-      }),
-      [width],
-    )
+    const labelStyle = {
+      width: typeof width === 'number' ? `${width}px` : width,
+    }
+    const existsWidth = !!labelStyle.width
+
     const classNames = useMemo(() => {
-      const { label, input } = classNameGenerator({ existsWidth: !!labelStyle.width })
+      const { label, input } = classNameGenerator({ existsWidth })
 
       return {
         label: label({ className }),
         input: input(),
       }
-    }, [labelStyle.width, className])
+    }, [existsWidth, className])
 
     return (
       <label className={classNames.label} style={labelStyle}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

InputとSearchInputコンポーネントで、useMemoのオーバーヘッドが利益を上回るケースを特定し、
不要なuseMemoを削除してパフォーマンスとコードの可読性を向上させる。

## 変更内容

### Input.tsx

1. **attrsByTypeの最適化**
   - useMemoを削除し、`DEFAULT_MAX_ATTR`定数として定義
   - JSX属性に直接展開してコードをシンプル化

2. **autoFocusの改善**
   - useEffectからcallback refパターンに変更
   - useLatest + functionsパターンでコールバックを安定化

3. **命名規則の統一**
   - `onDelegateClickFocus` → `handleDelegateClick`に変更
   - 内部ハンドラーをhandleXxx形式に統一

4. **classNamesの統合**
   - `wrapperClassName`と`innerClassNames`の2つのuseMemoを統合
   - `disabled`が動的に切り替わるケースは稀であり、統合によるメリットが大きい

5. **wrapperStyleのuseMemo削除**
   - styleオブジェクト生成をインラインに移動
   - 生成コストが低くuseMemoのオーバーヘッドの方が大きい

### SearchInput.tsx

6. **labelStyleのuseMemo削除**
   - styleオブジェクト生成をインラインに移動
   - `existsWidth`を明示的な変数として切り出し、依存配列をプリミティブ値に変更

## プロダクト側で対応が必要な事項

なし

内部実装のリファクタリングであり、外部インタフェースに変更はありません。

## 確認方法

- Storybookで動作確認
- 既存のテストがすべてパスすることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 入力欄のフォーカス制御と属性処理を整理し、操作時の挙動を安定化しました。
  * 日付関連の入力欄で、最大値が適切に設定されるようになりました。
  * 入力欄の幅指定に応じた検索入力の表示を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->