### PR TITLE
refactor(Icon): 不要なuseMemoを削除しパフォーマンスを最適化

### DIFF
--- a/packages/smarthr-ui/src/components/Icon/generateIcon.tsx
+++ b/packages/smarthr-ui/src/components/Icon/generateIcon.tsx
@@ -71,17 +71,18 @@ export const generateIcon = (SvgIcon: IconType) => {
       size,
       ...rest
     }) => {
-      const actualAriaHidden = useMemo(() => {
-        if (ariaHidden !== undefined) {
-          return ariaHidden
-        }
-
-        if (alt !== undefined || (ariaLabel === undefined && ariaLabelledby === undefined)) {
-          return true
-        }
-
-        return undefined
-      }, [ariaHidden, alt, ariaLabel, ariaLabelledby])
+      const actualAriaHidden =
+        ariaHidden !== undefined
+          ? ariaHidden
+          : alt !== undefined || (ariaLabel === undefined && ariaLabelledby === undefined)
+            ? true
+            : undefined
+      const replacedColor =
+        color && existsColor(color)
+          ? colorSet[color] in textColor
+            ? textColor[colorSet[color] as keyof typeof textColor]
+            : (defaultColorPalette[colorSet[color] as keyof typeof defaultColorPalette] as string)
+          : color
 
       const classNames = useMemo(() => {
         const { icon, wrapperWithAlt } = classNameGenerator()
@@ -91,20 +92,6 @@ export const generateIcon = (SvgIcon: IconType) => {
           wrapperWithAlt: wrapperWithAlt(),
         }
       }, [className])
-
-      const replacedColor = useMemo(() => {
-        if (color && existsColor(color)) {
-          const colorName = colorSet[color]
-
-          if (colorName in textColor) {
-            return textColor[colorName as keyof typeof textColor]
-          }
-
-          return defaultColorPalette[colorName as keyof typeof defaultColorPalette] as string
-        }
-
-        return color
-      }, [color])
 
       const iconSize = size ? fontSize[size] : '1em' // 指定がない場合は親要素のフォントサイズを継承する
       const svgIcon = (


### PR DESCRIPTION
## 関連URL

なし

## 概要

generateIcon関数で計算コストが低い処理からuseMemoを削除し、
useMemoのオーバーヘッドを削減してパフォーマンスを最適化する。

## 変更内容

### actualAriaHiddenのuseMemo削除
- aria-hidden属性の計算ロジックを三項演算子でインライン化
- 依存配列4つ（ariaHidden, alt, ariaLabel, ariaLabelledby）の管理が不要に
- 11行を2行に削減

### replacedColorのuseMemo削除
- 色変換ロジックを三項演算子でインライン化
- 依存配列1つ（color）の管理が不要に
- 13行を6行に削減

### classNamesのuseMemoは維持
- className依存のため、useMemoの効果が期待できる

**結果:**
- 25行削除、12行追加で13行削減
- 依存配列の管理が簡素化

## プロダクト側で対応が必要な事項

なし

内部実装のリファクタリングであり、外部インタフェースに変更はありません。

## 確認方法

- Storybookで動作確認
- 既存のテストがすべてパスすることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アイコンのアクセシビリティ属性（`aria-hidden`）の判定処理を整理しました。
  * アイコンカラーの反映処理を見直し、表示結果の一貫性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->