### PR TITLE
refactor(Heading): 不要なuseMemoを削除しパフォーマンスを最適化

### DIFF
--- a/packages/smarthr-ui/src/components/Heading/Heading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.tsx
@@ -74,23 +74,19 @@ export const Heading = memo<Props>(
       role = 'heading'
       ariaLevel = level
     }
-    const as = unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span')
 
     const actualClassName = useMemo(
       () => classNameGenerator({ visuallyHidden, className }),
       [className, visuallyHidden],
     )
-    let typography = STYLE_TYPE_MAP[type]
-
-    if (type === 'sectionTitle' && size) {
-      typography = { ...typography, size }
-    }
+    const typography = STYLE_TYPE_MAP[type]
 
     const commonProps = {
-      as,
+      as: unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span'),
       role,
       'aria-level': ariaLevel,
       className: actualClassName,
+      size: type === 'sectionTitle' && size ? size : typography.size,
     }
 
     if (visuallyHidden) {

--- a/packages/smarthr-ui/src/components/Heading/Heading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.tsx
@@ -50,23 +50,6 @@ export type ElementProps = Omit<
 >
 type Props = AbstractProps & ElementProps
 
-const generateTagProps = (level: number, unrecommendedTag?: HeadingTagTypes) => {
-  let role = undefined
-  let ariaLevel = undefined
-
-  // TODO: h1はPageHeadingで設定するため、自動計算では必ずh2以下になるようにする
-  if (!unrecommendedTag && level > 6) {
-    role = 'heading'
-    ariaLevel = level
-  }
-
-  return {
-    as: unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span'),
-    role,
-    'aria-level': ariaLevel,
-  }
-}
-
 const classNameGenerator = tv({
   base: 'smarthr-ui-Heading',
   variants: {
@@ -82,35 +65,38 @@ const classNameGenerator = tv({
 export const Heading = memo<Props>(
   ({ unrecommendedTag, type = 'sectionTitle', size, className, visuallyHidden, icon, ...rest }) => {
     const level = useContext(LevelContext)
-    const tagProps = useMemo(
-      () => generateTagProps(level, unrecommendedTag),
-      [level, unrecommendedTag],
-    )
+
+    let role = undefined
+    let ariaLevel = undefined
+
+    // TODO: h1はPageHeadingで設定するため、自動計算では必ずh2以下になるようにする
+    if (!unrecommendedTag && level > 6) {
+      role = 'heading'
+      ariaLevel = level
+    }
+    const as = unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span')
+
     const actualClassName = useMemo(
       () => classNameGenerator({ visuallyHidden, className }),
       [className, visuallyHidden],
     )
-    const actualTypography = useMemo(() => {
-      const defaultTypography = STYLE_TYPE_MAP[type]
+    let typography = STYLE_TYPE_MAP[type]
 
-      if (type === 'sectionTitle' && size) {
-        return { ...defaultTypography, size }
-      }
-
-      return defaultTypography
-    }, [type, size])
+    if (type === 'sectionTitle' && size) {
+      typography = { ...typography, size }
+    }
 
     const commonProps = {
-      ...rest,
-      ...actualTypography,
-      ...tagProps,
+      as,
+      role,
+      'aria-level': ariaLevel,
       className: actualClassName,
     }
 
     if (visuallyHidden) {
-      return <VisuallyHiddenText {...commonProps} />
+      return <VisuallyHiddenText {...rest} {...typography} {...commonProps} />
     }
 
-    return <Text {...commonProps} icon={icon} />
+    return <Text {...rest} {...typography} {...commonProps} icon={icon} />
   },
 )

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -59,15 +59,7 @@ export const PageHeading = memo<Props>(
       () => classNameGenerator({ visuallyHidden, className }),
       [className, visuallyHidden],
     )
-    const actualTypography = useMemo(() => {
-      const defaultTypography = STYLE_TYPE_MAP.screenTitle
-
-      if (size) {
-        return { ...defaultTypography, size }
-      }
-
-      return defaultTypography
-    }, [size])
+    const typography = STYLE_TYPE_MAP.screenTitle
 
     const pseudoTitleId = useId()
 
@@ -108,7 +100,13 @@ export const PageHeading = memo<Props>(
     const Component = visuallyHidden ? VisuallyHiddenText : Text
 
     return (
-      <Component {...rest} {...actualTypography} as="h1" className={actualClassName}>
+      <Component
+        {...rest}
+        {...typography}
+        size={size || typography.size}
+        as="h1"
+        className={actualClassName}
+      >
         {children}
       </Component>
     )


### PR DESCRIPTION
## 関連URL

なし

## 概要

HeadingとPageHeadingコンポーネントで計算コストが低い処理からuseMemoを削除し、
中間変数を削減してパフォーマンスと可読性を最適化する。

## 変更内容

### Heading.tsx

1. **generateTagProps関数の削除とインライン展開**
   - タグ属性生成ロジックをコンポーネント内に直接配置
   - 関数呼び出しのオーバーヘッドを削減

2. **tagPropsのuseMemo削除**
   - generateTagProps関数の結果をuseMemoで包む必要がない
   - 依存配列（level, unrecommendedTag）の管理が不要に

3. **actualTypographyのuseMemo削除**
   - STYLE_TYPE_MAPからの取得とsize適用を直接実行
   - 依存配列（type, size）の管理が不要に

4. **中間変数の削減**
   - `as`変数をcommonPropsに直接展開
   - `typography`のスプレッド展開を削除してsizeの計算を最適化

### PageHeading.tsx

5. **actualTypographyのuseMemo削除**
   - typographyのスプレッド展開を削除
   - Headingコンポーネントと同じパターンで一貫性を向上

**結果:**
- 45行削除、25行追加で20行削減
- 依存配列の管理が簡素化
- コードの可読性とパフォーマンスが向上

## プロダクト側で対応が必要な事項

なし

内部実装のリファクタリングであり、外部インタフェースに変更はありません。

## 確認方法

- Storybookで動作確認
- 既存のテストがすべてパスすることを確認