### PR TITLE
refactor(FormControl): 不要なuseMemoと処理を削除しパフォーマンスを最適化

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -387,7 +387,10 @@ const LabelCluster = memo<
       </>
     )
 
-    const attrs = {
+    const attrs: {
+      label: { 'aria-hidden': 'true' } | { as: 'label'; htmlFor: string; id: string } | null
+      visuallyHidden: { as: 'legend' | 'label'; htmlFor?: string; id?: string } | null
+    } = {
       label: null,
       visuallyHidden: null,
     }

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -409,13 +409,7 @@ const LabelCluster = memo<
     return (
       <>
         {attrs.visuallyHidden && (
-          <VisuallyHiddenText {...attrs.visuallyHidden}>
-            {
-              // HINT: innerTextでは正しく文字が取得できない場合がある
-              // 安全策としてinnerTextが空を取得してきたらbody自体を埋めこみます
-              innerText(body) || body
-            }
-          </VisuallyHiddenText>
+          <VisuallyHiddenText {...attrs.visuallyHidden}>{body}</VisuallyHiddenText>
         )}
         {attrs.label && (
           <Cluster justify="space-between">

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -387,38 +387,24 @@ const LabelCluster = memo<
       </>
     )
 
-    const attrs = useMemo(() => {
-      if (unrecommendedHideLabel) {
-        return {
-          label: null,
-          visuallyHidden: isFieldset
-            ? {
-                as: 'legend',
-              }
-            : {
-                as: 'label',
-                htmlFor: managedHtmlFor,
-                id: managedLabelId,
-              },
-        }
-      }
+    const attrs = {
+      label: null,
+      visuallyHidden: null,
+    }
 
-      if (isFieldset) {
-        return {
-          label: { 'aria-hidden': 'true' } as const,
-          visuallyHidden: { as: 'legend' },
-        }
-      }
+    if (isFieldset) {
+      attrs.visuallyHidden = { as: 'legend' }
 
-      return {
-        label: {
-          as: 'label' as const,
-          htmlFor: managedHtmlFor,
-          id: managedLabelId,
-        },
-        visuallyHidden: null,
+      if (!unrecommendedHideLabel) {
+        attrs.label = { 'aria-hidden': 'true' } as const
       }
-    }, [managedLabelId, managedHtmlFor, unrecommendedHideLabel, isFieldset])
+    } else {
+      attrs[unrecommendedHideLabel ? 'visuallyHidden' : 'label'] = {
+        as: 'label',
+        htmlFor: managedHtmlFor,
+        id: managedLabelId,
+      }
+    }
 
     return (
       <>


### PR DESCRIPTION
## 関連URL

なし

## 概要

FormControlコンポーネントで不要なuseMemoと処理を削除し、
コードをシンプル化してパフォーマンスを最適化する。

## 変更内容

### 1. attrsのuseMemo削除
- LabelCluster内のattrs生成からuseMemoを削除
- 条件分岐で直接オブジェクトを構築
- 依存配列4つ（managedLabelId, managedHtmlFor, unrecommendedHideLabel, isFieldset）の管理が不要に

### 2. innerTextの不要な処理を削除
- VisuallyHiddenTextに`body`を直接渡すよう変更
- `innerText(body) || body` のフォールバックロジックを削除
- HINTコメント削除
- innerText処理のオーバーヘッドを削減

**結果:**
- 36行削除、16行追加で20行削減
- 依存配列の管理が簡素化
- コードの可読性とパフォーマンスが向上

## プロダクト側で対応が必要な事項

なし

内部実装のリファクタリングであり、外部インタフェースに変更はありません。

## 確認方法

- Storybookで動作確認
- 既存のテストがすべてパスすることを確認