### PR TITLE
refactor(FileViewer): usePDFSearchにuseLatest+functionsパターンを適用し完全統合

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -103,30 +103,21 @@ export const usePDFSearch = (fileUrl: string) => {
 
     return {
       resetMatchState,
-      recalculate,
+      setQuery: (nextQuery: string) => {
+        queryRef.current = nextQuery
+        setQueryState(nextQuery)
+        recalculate(nextQuery, { resetSelection: true })
+      },
+      registerPageText: (pageIndex: number, texts: string[]) => {
+        pageTextsRef.current.set(pageIndex, texts.map(normalize))
+        // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
+        if (queryRef.current !== '') {
+          recalculate(queryRef.current)
+        }
+      },
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
   }, [latest])
-
-  const setQuery = useCallback(
-    (nextQuery: string) => {
-      queryRef.current = nextQuery
-      setQueryState(nextQuery)
-      functions.recalculate(nextQuery, { resetSelection: true })
-    },
-    [functions],
-  )
-
-  const registerPageText = useCallback(
-    (pageIndex: number, texts: string[]) => {
-      pageTextsRef.current.set(pageIndex, texts.map(normalize))
-      // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
-      if (queryRef.current !== '') {
-        functions.recalculate(queryRef.current)
-      }
-    },
-    [functions],
-  )
 
   const clear = useCallback(() => {
     queryRef.current = ''
@@ -160,26 +151,16 @@ export const usePDFSearch = (fileUrl: string) => {
   return useMemo(
     () => ({
       query,
-      setQuery,
+      setQuery: functions.setQuery,
       matches,
       matchCount,
       currentMatchIndex,
       goNext,
       goPrev,
       clear,
-      registerPageText,
+      registerPageText: functions.registerPageText,
     }),
-    [
-      query,
-      setQuery,
-      matches,
-      matchCount,
-      currentMatchIndex,
-      goNext,
-      goPrev,
-      clear,
-      registerPageText,
-    ],
+    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, clear, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -120,25 +120,22 @@ export const usePDFSearch = (fileUrl: string) => {
         setQueryState('')
         functions.resetMatchState()
       },
+      goNext: () => {
+        setCurrentMatchIndex((prev) => {
+          if (latest.matchCount === 0) return -1
+          if (prev < 0) return 0
+          return (prev + 1) % latest.matchCount
+        })
+      },
+      goPrev: () => {
+        setCurrentMatchIndex((prev) => {
+          if (latest.matchCount === 0) return -1
+          if (prev < 0) return latest.matchCount - 1
+          return (prev - 1 + latest.matchCount) % latest.matchCount
+        })
+      },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
   }, [latest])
-
-  const goNext = useCallback(() => {
-    setCurrentMatchIndex((prev) => {
-      if (matchCount === 0) return -1
-      if (prev < 0) return 0
-      return (prev + 1) % matchCount
-    })
-  }, [matchCount])
-
-  const goPrev = useCallback(() => {
-    setCurrentMatchIndex((prev) => {
-      if (matchCount === 0) return -1
-      if (prev < 0) return matchCount - 1
-      return (prev - 1 + matchCount) % matchCount
-    })
-  }, [matchCount])
 
   useEffect(() => {
     pageTextsRef.current.clear()
@@ -150,16 +147,16 @@ export const usePDFSearch = (fileUrl: string) => {
   return useMemo(
     () => ({
       query,
-      setQuery: functions.setQuery,
       matches,
       matchCount,
       currentMatchIndex,
-      goNext,
-      goPrev,
-      clear: functions.clear,
+      setQuery: functions.setQuery,
       registerPageText: functions.registerPageText,
+      clear: functions.clear,
+      goNext: functions.goNext,
+      goPrev: functions.goPrev,
     }),
-    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, functions],
+    [query, matches, matchCount, currentMatchIndex, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -115,15 +115,14 @@ export const usePDFSearch = (fileUrl: string) => {
           recalculate(queryRef.current)
         }
       },
+      clear: () => {
+        queryRef.current = ''
+        setQueryState('')
+        functions.resetMatchState()
+      },
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
   }, [latest])
-
-  const clear = useCallback(() => {
-    queryRef.current = ''
-    setQueryState('')
-    functions.resetMatchState()
-  }, [functions])
 
   const goNext = useCallback(() => {
     setCurrentMatchIndex((prev) => {
@@ -157,10 +156,10 @@ export const usePDFSearch = (fileUrl: string) => {
       currentMatchIndex,
       goNext,
       goPrev,
-      clear,
+      clear: functions.clear,
       registerPageText: functions.registerPageText,
     }),
-    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, clear, functions],
+    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { useLatest } from '../../hooks/useLatest'
+
 import type { PDFSearchMatch } from './types'
 
 export const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -56,13 +58,17 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const resetMatchState = useCallback(() => {
-    setMatches([])
-    setCurrentMatchIndex(-1)
-  }, [])
+  const latest = useLatest({
+    matchCount,
+  })
 
-  const recalculate = useCallback(
-    (nextQuery: string, options?: { resetSelection?: boolean }) => {
+  const functions = useMemo(() => {
+    const resetMatchState = () => {
+      setMatches([])
+      setCurrentMatchIndex(-1)
+    }
+
+    const recalculate = (nextQuery: string, options?: { resetSelection?: boolean }) => {
       if (nextQuery === '') {
         resetMatchState()
         return
@@ -93,17 +99,22 @@ export const usePDFSearch = (fileUrl: string) => {
         if (prev >= globalIndex) return globalIndex - 1
         return prev
       })
-    },
-    [resetMatchState],
-  )
+    }
+
+    return {
+      resetMatchState,
+      recalculate,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
+  }, [latest])
 
   const setQuery = useCallback(
     (nextQuery: string) => {
       queryRef.current = nextQuery
       setQueryState(nextQuery)
-      recalculate(nextQuery, { resetSelection: true })
+      functions.recalculate(nextQuery, { resetSelection: true })
     },
-    [recalculate],
+    [functions],
   )
 
   const registerPageText = useCallback(
@@ -111,17 +122,17 @@ export const usePDFSearch = (fileUrl: string) => {
       pageTextsRef.current.set(pageIndex, texts.map(normalize))
       // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
       if (queryRef.current !== '') {
-        recalculate(queryRef.current)
+        functions.recalculate(queryRef.current)
       }
     },
-    [recalculate],
+    [functions],
   )
 
   const clear = useCallback(() => {
     queryRef.current = ''
     setQueryState('')
-    resetMatchState()
-  }, [resetMatchState])
+    functions.resetMatchState()
+  }, [functions])
 
   const goNext = useCallback(() => {
     setCurrentMatchIndex((prev) => {
@@ -143,8 +154,8 @@ export const usePDFSearch = (fileUrl: string) => {
     pageTextsRef.current.clear()
     queryRef.current = ''
     setQueryState('')
-    resetMatchState()
-  }, [fileUrl, resetMatchState])
+    functions.resetMatchState()
+  }, [fileUrl, functions])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## 関連URL

なし

## 概要

usePDFSearchカスタムフックにuseLatest + functionsパターンを適用し、
すべてのコールバックをfunctionsオブジェクトに統合してコードの品質を向上させる。

## 変更内容

### 1. useLatest + functionsパターンの適用
- `resetMatchState`と`recalculate`をfunctionsオブジェクトに統合
- `useLatest`で`matchCount`を安定化
- 複数のuseCallbackの依存配列を`[functions]`に統一

### 2. recalculateの隠蔽
- `setQuery`と`registerPageText`をfunctionsオブジェクト内に移動
- `recalculate`を内部関数として隠蔽してカプセル化を向上
- 2つのuseCallbackを削減

### 3. clearのfunctions統合
- `clear`をuseCallbackからfunctionsオブジェクト内に移動
- 依存配列をさらに簡素化

### 4. goNextとgoPrevの完全統合
- すべてのコールバックをfunctionsオブジェクトに統合完了
- `latest.matchCount`を実際に使用するように変更
- ESLint disableコメント削除（不要になった）
- `useCallback`のimport削除

**結果:**
- 69行削除、57行追加で12行削減
- すべてのuseCallbackを削除
- すべての関数がfunctionsオブジェクトに統合
- latestが実際に使用されるように
- 依存配列の管理が最大限簡素化
- コードの凝集度が最高レベルに向上

## プロダクト側で対応が必要な事項

なし

内部実装のリファクタリングであり、外部インタフェースに変更はありません。

## 確認方法

- PDFビューアーの検索機能が正常に動作することを確認
- 既存のテストがすべてパスすることを確認