### PR TITLE
refactor(FileViewer): SearchControllerから検索ロジックを分離しusePDFSearchに集約

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
@@ -11,16 +11,42 @@ const renderController = ({
   matchCount = 10,
   currentMatchIndex = 0,
 }: { query?: string; matchCount?: number; currentMatchIndex?: number } = {}) => {
+  const goNext = vi.fn()
+  const goPrev = vi.fn()
+  const clear = vi.fn()
+
   const search: UsePDFSearch = {
     query,
     handleChangeQuery: vi.fn(),
-    handleKeyDownQuery: vi.fn(),
+    handleKeyDownQuery: vi.fn((e) => {
+      if (e.nativeEvent.isComposing) {
+        return
+      }
+      switch (e.key) {
+        case 'Enter': {
+          e.preventDefault()
+          if (e.shiftKey) {
+            goPrev()
+          } else {
+            goNext()
+          }
+          break
+        }
+        case 'Escape': {
+          if (query !== '') {
+            e.preventDefault()
+            clear()
+          }
+          break
+        }
+      }
+    }),
     matches: [],
     matchCount,
     currentMatchIndex,
-    goNext: vi.fn(),
-    goPrev: vi.fn(),
-    clear: vi.fn(),
+    goNext,
+    goPrev,
+    clear,
     registerPageText: vi.fn(),
   }
   render(
@@ -32,11 +58,44 @@ const renderController = ({
 }
 
 describe('SearchController', () => {
-  describe('キーボード操作', () => {
-    test('キー入力時に handleKeyDownQuery が呼ばれる', () => {
+  describe('IME 変換確定中のキー操作', () => {
+    test('変換確定中（isComposing）の Enter ではナビゲーションしない', () => {
+      const { input, search } = renderController()
+      fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+      expect(search.goNext).not.toHaveBeenCalled()
+      expect(search.goPrev).not.toHaveBeenCalled()
+    })
+
+    test('変換確定中（isComposing）の Escape では検索をクリアしない', () => {
+      const { input, search } = renderController()
+      fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+      expect(search.clear).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('通常のキー操作', () => {
+    test('Enter では次の検索結果へ移動する', () => {
       const { input, search } = renderController()
       fireEvent.keyDown(input, { key: 'Enter' })
-      expect(search.handleKeyDownQuery).toHaveBeenCalledTimes(1)
+      expect(search.goNext).toHaveBeenCalledTimes(1)
+    })
+
+    test('Shift+Enter では前の検索結果へ移動する', () => {
+      const { input, search } = renderController()
+      fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+      expect(search.goPrev).toHaveBeenCalledTimes(1)
+    })
+
+    test('Escape では検索をクリアする', () => {
+      const { input, search } = renderController()
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(search.clear).toHaveBeenCalledTimes(1)
+    })
+
+    test('query が空の場合は Escape でクリアしない', () => {
+      const { input, search } = renderController({ query: '' })
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(search.clear).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
@@ -11,42 +11,15 @@ const renderController = ({
   matchCount = 10,
   currentMatchIndex = 0,
 }: { query?: string; matchCount?: number; currentMatchIndex?: number } = {}) => {
-  const goNext = vi.fn()
-  const goPrev = vi.fn()
-  const clear = vi.fn()
-
   const search: UsePDFSearch = {
     query,
     handleChangeQuery: vi.fn(),
-    handleKeyDownQuery: vi.fn((e) => {
-      if (e.nativeEvent.isComposing) {
-        return
-      }
-      switch (e.key) {
-        case 'Enter': {
-          e.preventDefault()
-          if (e.shiftKey) {
-            goPrev()
-          } else {
-            goNext()
-          }
-          break
-        }
-        case 'Escape': {
-          if (query !== '') {
-            e.preventDefault()
-            clear()
-          }
-          break
-        }
-      }
-    }),
+    handleKeyDownQuery: vi.fn(),
     matches: [],
     matchCount,
     currentMatchIndex,
-    goNext,
-    goPrev,
-    clear,
+    goNext: vi.fn(),
+    goPrev: vi.fn(),
     registerPageText: vi.fn(),
   }
   render(
@@ -58,44 +31,20 @@ const renderController = ({
 }
 
 describe('SearchController', () => {
-  describe('IME 変換確定中のキー操作', () => {
-    test('変換確定中（isComposing）の Enter ではナビゲーションしない', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
-      expect(search.goNext).not.toHaveBeenCalled()
-      expect(search.goPrev).not.toHaveBeenCalled()
-    })
-
-    test('変換確定中（isComposing）の Escape では検索をクリアしない', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
-      expect(search.clear).not.toHaveBeenCalled()
-    })
+  test('キー入力時に handleKeyDownQuery が呼ばれる', () => {
+    const { input, search } = renderController()
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(search.handleKeyDownQuery).toHaveBeenCalledTimes(1)
   })
 
-  describe('通常のキー操作', () => {
-    test('Enter では次の検索結果へ移動する', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Enter' })
-      expect(search.goNext).toHaveBeenCalledTimes(1)
-    })
-
-    test('Shift+Enter では前の検索結果へ移動する', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
-      expect(search.goPrev).toHaveBeenCalledTimes(1)
-    })
-
-    test('Escape では検索をクリアする', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Escape' })
-      expect(search.clear).toHaveBeenCalledTimes(1)
-    })
-
-    test('query が空の場合は Escape でクリアしない', () => {
-      const { input, search } = renderController({ query: '' })
-      fireEvent.keyDown(input, { key: 'Escape' })
-      expect(search.clear).not.toHaveBeenCalled()
-    })
+  test('キーイベントオブジェクトが handleKeyDownQuery に渡される', () => {
+    const { input, search } = renderController()
+    fireEvent.keyDown(input, { key: 'Escape', shiftKey: true })
+    expect(search.handleKeyDownQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'Escape',
+        shiftKey: true,
+      }),
+    )
   })
 })

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
@@ -13,7 +13,7 @@ const renderController = ({
 }: { query?: string; matchCount?: number; currentMatchIndex?: number } = {}) => {
   const search: UsePDFSearch = {
     query,
-    setQuery: vi.fn(),
+    handleChangeQuery: vi.fn(),
     matches: [],
     matchCount,
     currentMatchIndex,

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
@@ -14,6 +14,7 @@ const renderController = ({
   const search: UsePDFSearch = {
     query,
     handleChangeQuery: vi.fn(),
+    handleKeyDownQuery: vi.fn(),
     matches: [],
     matchCount,
     currentMatchIndex,
@@ -31,44 +32,11 @@ const renderController = ({
 }
 
 describe('SearchController', () => {
-  describe('IME 変換確定中のキー操作', () => {
-    test('変換確定中（isComposing）の Enter ではナビゲーションしない', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
-      expect(search.goNext).not.toHaveBeenCalled()
-      expect(search.goPrev).not.toHaveBeenCalled()
-    })
-
-    test('変換確定中（isComposing）の Escape では検索をクリアしない', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
-      expect(search.clear).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('通常のキー操作', () => {
-    test('Enter では次の検索結果へ移動する', () => {
+  describe('キーボード操作', () => {
+    test('キー入力時に handleKeyDownQuery が呼ばれる', () => {
       const { input, search } = renderController()
       fireEvent.keyDown(input, { key: 'Enter' })
-      expect(search.goNext).toHaveBeenCalledTimes(1)
-    })
-
-    test('Shift+Enter では前の検索結果へ移動する', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
-      expect(search.goPrev).toHaveBeenCalledTimes(1)
-    })
-
-    test('Escape では検索をクリアする', () => {
-      const { input, search } = renderController()
-      fireEvent.keyDown(input, { key: 'Escape' })
-      expect(search.clear).toHaveBeenCalledTimes(1)
-    })
-
-    test('query が空の場合は Escape でクリアしない', () => {
-      const { input, search } = renderController({ query: '' })
-      fireEvent.keyDown(input, { key: 'Escape' })
-      expect(search.clear).not.toHaveBeenCalled()
+      expect(search.handleKeyDownQuery).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ChangeEvent, type FC, type KeyboardEvent, memo, useMemo } from 'react'
+import { type FC, type KeyboardEvent, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
@@ -34,7 +34,7 @@ const classNameGenerator = tv({
 })
 
 export const SearchController: FC<Props> = memo(({ search }) => {
-  const { query, setQuery, matchCount, currentMatchIndex, goNext, goPrev, clear } = search
+  const { query, handleChangeQuery, matchCount, currentMatchIndex, goNext, goPrev, clear } = search
   const { mobile } = useEnvironment()
   const classNames = useMemo(() => {
     const { wrapper, inputArea } = classNameGenerator({ mobile })
@@ -44,7 +44,6 @@ export const SearchController: FC<Props> = memo(({ search }) => {
   const noMatches = matchCount === 0
 
   const latest = useLatest({
-    setQuery,
     goNext,
     goPrev,
     clear,
@@ -53,9 +52,6 @@ export const SearchController: FC<Props> = memo(({ search }) => {
 
   const functions = useMemo(
     () => ({
-      handleChange: (e: ChangeEvent<HTMLInputElement>) => {
-        latest.setQuery(e.target.value)
-      },
       handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
         if (e.nativeEvent.isComposing) {
           return
@@ -95,7 +91,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
             />
           }
           value={query}
-          onChange={functions.handleChange}
+          onChange={handleChangeQuery}
           onKeyDown={functions.handleKeyDown}
           width="100%"
           suffix={

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -33,15 +33,7 @@ const classNameGenerator = tv({
 })
 
 export const SearchController: FC<Props> = memo(({ search }) => {
-  const {
-    query,
-    setQuery,
-    matchCount,
-    currentMatchIndex,
-    goNext: onClickNext,
-    goPrev: onClickPrev,
-    clear: onClickClear,
-  } = search
+  const { query, setQuery, matchCount, currentMatchIndex, goNext, goPrev, clear } = search
   const { mobile } = useEnvironment()
   const classNames = useMemo(() => {
     const { wrapper, inputArea } = classNameGenerator({ mobile })
@@ -66,22 +58,22 @@ export const SearchController: FC<Props> = memo(({ search }) => {
         case 'Enter': {
           e.preventDefault()
           if (e.shiftKey) {
-            onClickPrev()
+            goPrev()
           } else {
-            onClickNext()
+            goNext()
           }
           break
         }
         case 'Escape': {
           if (query !== '') {
             e.preventDefault()
-            onClickClear()
+            clear()
           }
           break
         }
       }
     },
-    [onClickNext, onClickPrev, onClickClear, query],
+    [goNext, goPrev, clear, query],
   )
 
   return (
@@ -110,7 +102,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
         />
       </div>
       <Button
-        onClick={onClickPrev}
+        onClick={goPrev}
         disabled={noMatches}
         className="shr-rounded-none shr-border-s-0 shr-p-0.75 aria-disabled:!shr-border-default"
       >
@@ -121,7 +113,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
         />
       </Button>
       <Button
-        onClick={onClickNext}
+        onClick={goNext}
         disabled={noMatches}
         className="shr-rounded-s-none shr-border-s-0 shr-p-0.75 aria-disabled:!shr-border-default"
       >

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { type ChangeEvent, type FC, type KeyboardEvent, memo, useCallback, useMemo } from 'react'
+import { type ChangeEvent, type FC, type KeyboardEvent, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
+import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { FaAngleDownIcon, FaAngleUpIcon } from '../Icon'
@@ -42,38 +43,44 @@ export const SearchController: FC<Props> = memo(({ search }) => {
 
   const noMatches = matchCount === 0
 
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      setQuery(e.target.value)
-    },
-    [setQuery],
-  )
+  const latest = useLatest({
+    setQuery,
+    goNext,
+    goPrev,
+    clear,
+    query,
+  })
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.nativeEvent.isComposing) {
-        return
-      }
-      switch (e.key) {
-        case 'Enter': {
-          e.preventDefault()
-          if (e.shiftKey) {
-            goPrev()
-          } else {
-            goNext()
-          }
-          break
+  const functions = useMemo(
+    () => ({
+      handleChange: (e: ChangeEvent<HTMLInputElement>) => {
+        latest.setQuery(e.target.value)
+      },
+      handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.nativeEvent.isComposing) {
+          return
         }
-        case 'Escape': {
-          if (query !== '') {
+        switch (e.key) {
+          case 'Enter': {
             e.preventDefault()
-            clear()
+            if (e.shiftKey) {
+              latest.goPrev()
+            } else {
+              latest.goNext()
+            }
+            break
           }
-          break
+          case 'Escape': {
+            if (latest.query !== '') {
+              e.preventDefault()
+              latest.clear()
+            }
+            break
+          }
         }
-      }
-    },
-    [goNext, goPrev, clear, query],
+      },
+    }),
+    [latest],
   )
 
   return (
@@ -88,8 +95,8 @@ export const SearchController: FC<Props> = memo(({ search }) => {
             />
           }
           value={query}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
+          onChange={functions.handleChange}
+          onKeyDown={functions.handleKeyDown}
           width="100%"
           suffix={
             query !== '' ? (

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { type FC, type KeyboardEvent, memo, useMemo } from 'react'
+import { type FC, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
-import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { FaAngleDownIcon, FaAngleUpIcon } from '../Icon'
@@ -34,7 +33,15 @@ const classNameGenerator = tv({
 })
 
 export const SearchController: FC<Props> = memo(({ search }) => {
-  const { query, handleChangeQuery, matchCount, currentMatchIndex, goNext, goPrev, clear } = search
+  const {
+    query,
+    handleChangeQuery,
+    handleKeyDownQuery,
+    matchCount,
+    currentMatchIndex,
+    goNext,
+    goPrev,
+  } = search
   const { mobile } = useEnvironment()
   const classNames = useMemo(() => {
     const { wrapper, inputArea } = classNameGenerator({ mobile })
@@ -42,42 +49,6 @@ export const SearchController: FC<Props> = memo(({ search }) => {
   }, [mobile])
 
   const noMatches = matchCount === 0
-
-  const latest = useLatest({
-    goNext,
-    goPrev,
-    clear,
-    query,
-  })
-
-  const functions = useMemo(
-    () => ({
-      handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-        if (e.nativeEvent.isComposing) {
-          return
-        }
-        switch (e.key) {
-          case 'Enter': {
-            e.preventDefault()
-            if (e.shiftKey) {
-              latest.goPrev()
-            } else {
-              latest.goNext()
-            }
-            break
-          }
-          case 'Escape': {
-            if (latest.query !== '') {
-              e.preventDefault()
-              latest.clear()
-            }
-            break
-          }
-        }
-      },
-    }),
-    [latest],
-  )
 
   return (
     <div className={classNames.wrapper}>
@@ -92,7 +63,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
           }
           value={query}
           onChange={handleChangeQuery}
-          onKeyDown={functions.handleKeyDown}
+          onKeyDown={handleKeyDownQuery}
           width="100%"
           suffix={
             query !== '' ? (

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -48,8 +48,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
     return { wrapper: wrapper(), inputArea: inputArea() }
   }, [mobile])
 
-  const hasMatches = matchCount > 0
-  const displayedCurrent = hasMatches ? currentMatchIndex + 1 : 0
+  const noMatches = matchCount === 0
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -103,7 +102,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
           suffix={
             query !== '' ? (
               <Text size="S" aria-live="polite" className="shr-tabular-nums">
-                {`${displayedCurrent}/${matchCount}`}
+                {`${noMatches ? 0 : currentMatchIndex + 1}/${matchCount}`}
               </Text>
             ) : undefined
           }
@@ -112,7 +111,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
       </div>
       <Button
         onClick={onClickPrev}
-        disabled={!hasMatches}
+        disabled={noMatches}
         className="shr-rounded-none shr-border-s-0 shr-p-0.75 aria-disabled:!shr-border-default"
       >
         <FaAngleUpIcon
@@ -123,7 +122,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
       </Button>
       <Button
         onClick={onClickNext}
-        disabled={!hasMatches}
+        disabled={noMatches}
         className="shr-rounded-s-none shr-border-s-0 shr-p-0.75 aria-disabled:!shr-border-default"
       >
         <FaAngleDownIcon

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.test.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.test.ts
@@ -130,7 +130,9 @@ describe('usePDFSearch', () => {
   test('入力時はハイライトのみ表示し、未選択(-1)のままにする（スクロールしない）', () => {
     const { result } = setup(['abc abc abc'])
     act(() => {
-      result.current.setQuery('abc')
+      result.current.handleChangeQuery({
+        target: { value: 'abc' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     expect(result.current.matchCount).toBe(3)
     expect(result.current.matches.length).toBeGreaterThan(0)
@@ -140,7 +142,9 @@ describe('usePDFSearch', () => {
   test('未選択から goNext で先頭ヒット(0)へ移動する', () => {
     const { result } = setup(['abc abc abc'])
     act(() => {
-      result.current.setQuery('abc')
+      result.current.handleChangeQuery({
+        target: { value: 'abc' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     act(() => {
       result.current.goNext()
@@ -151,7 +155,9 @@ describe('usePDFSearch', () => {
   test('未選択から goPrev で末尾ヒットへ移動する', () => {
     const { result } = setup(['abc abc abc'])
     act(() => {
-      result.current.setQuery('abc')
+      result.current.handleChangeQuery({
+        target: { value: 'abc' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     act(() => {
       result.current.goPrev()
@@ -162,7 +168,9 @@ describe('usePDFSearch', () => {
   test('goNext は末尾の次で先頭へループする', () => {
     const { result } = setup(['abc abc'])
     act(() => {
-      result.current.setQuery('abc')
+      result.current.handleChangeQuery({
+        target: { value: 'abc' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     act(() => {
       result.current.goNext()
@@ -179,7 +187,9 @@ describe('usePDFSearch', () => {
   test('検索語を変更すると選択がリセットされ、次の Enter で再び先頭から始まる', () => {
     const { result } = setup(['abc abc xyz'])
     act(() => {
-      result.current.setQuery('abc')
+      result.current.handleChangeQuery({
+        target: { value: 'abc' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     act(() => {
       result.current.goNext()
@@ -190,21 +200,29 @@ describe('usePDFSearch', () => {
     expect(result.current.currentMatchIndex).toBe(1)
 
     act(() => {
-      result.current.setQuery('xyz')
+      result.current.handleChangeQuery({
+        target: { value: 'xyz' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     expect(result.current.currentMatchIndex).toBe(-1)
   })
 
-  test('clear で query・matches・選択がすべてリセットされる', () => {
+  test('Escape キーで query・matches・選択がすべてリセットされる', () => {
     const { result } = setup(['abc'])
     act(() => {
-      result.current.setQuery('abc')
+      result.current.handleChangeQuery({
+        target: { value: 'abc' },
+      } as React.ChangeEvent<HTMLInputElement>)
     })
     act(() => {
       result.current.goNext()
     })
     act(() => {
-      result.current.clear()
+      result.current.handleKeyDownQuery({
+        key: 'Escape',
+        nativeEvent: { isComposing: false },
+        preventDefault: vi.fn(),
+      } as unknown as React.KeyboardEvent<HTMLInputElement>)
     })
     expect(result.current.query).toBe('')
     expect(result.current.matches).toEqual([])

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.test.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.test.ts
@@ -229,4 +229,111 @@ describe('usePDFSearch', () => {
     expect(result.current.matchCount).toBe(0)
     expect(result.current.currentMatchIndex).toBe(-1)
   })
+
+  describe('handleKeyDownQuery のキーボード操作', () => {
+    test('IME変換確定中（isComposing）のEnterではナビゲーションしない', () => {
+      const { result } = setup(['abc'])
+      act(() => {
+        result.current.handleChangeQuery({
+          target: { value: 'abc' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+      act(() => {
+        result.current.goNext() // 初期選択を設定
+      })
+
+      const beforeIndex = result.current.currentMatchIndex
+
+      act(() => {
+        result.current.handleKeyDownQuery({
+          key: 'Enter',
+          nativeEvent: { isComposing: true },
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.currentMatchIndex).toBe(beforeIndex) // 変わらない
+    })
+
+    test('IME変換確定中のEscapeでは検索をクリアしない', () => {
+      const { result } = setup(['abc'])
+      act(() => {
+        result.current.handleChangeQuery({
+          target: { value: 'abc' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      const beforeQuery = result.current.query
+
+      act(() => {
+        result.current.handleKeyDownQuery({
+          key: 'Escape',
+          nativeEvent: { isComposing: true },
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.query).toBe(beforeQuery)
+    })
+
+    test('EnterでgoNextが呼ばれ次の検索結果へ移動する', () => {
+      const { result } = setup(['abc abc'])
+      act(() => {
+        result.current.handleChangeQuery({
+          target: { value: 'abc' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      const preventDefaultSpy = vi.fn()
+      act(() => {
+        result.current.handleKeyDownQuery({
+          key: 'Enter',
+          nativeEvent: { isComposing: false },
+          preventDefault: preventDefaultSpy,
+        } as unknown as React.KeyboardEvent<HTMLInputElement>)
+      })
+
+      expect(preventDefaultSpy).toHaveBeenCalled()
+      expect(result.current.currentMatchIndex).toBe(0) // goNextが呼ばれて0に
+    })
+
+    test('Shift+EnterでgoPrevが呼ばれ前の検索結果へ移動する', () => {
+      const { result } = setup(['abc abc'])
+      act(() => {
+        result.current.handleChangeQuery({
+          target: { value: 'abc' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      const preventDefaultSpy = vi.fn()
+      act(() => {
+        result.current.handleKeyDownQuery({
+          key: 'Enter',
+          shiftKey: true,
+          nativeEvent: { isComposing: false },
+          preventDefault: preventDefaultSpy,
+        } as unknown as React.KeyboardEvent<HTMLInputElement>)
+      })
+
+      expect(preventDefaultSpy).toHaveBeenCalled()
+      expect(result.current.currentMatchIndex).toBe(1) // goPrevが呼ばれて末尾(1)に
+    })
+
+    test('queryが空の場合はEscapeで検索をクリアしない', () => {
+      const { result } = setup(['abc'])
+      // queryは空のまま
+
+      const preventDefaultSpy = vi.fn()
+      act(() => {
+        result.current.handleKeyDownQuery({
+          key: 'Escape',
+          nativeEvent: { isComposing: false },
+          preventDefault: preventDefaultSpy,
+        } as unknown as React.KeyboardEvent<HTMLInputElement>)
+      })
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled()
+      expect(result.current.query).toBe('') // 変わらず空
+    })
+  })
 })

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -103,30 +103,21 @@ export const usePDFSearch = (fileUrl: string) => {
 
     return {
       resetMatchState,
-      recalculate,
+      setQuery: (nextQuery: string) => {
+        queryRef.current = nextQuery
+        setQueryState(nextQuery)
+        recalculate(nextQuery, { resetSelection: true })
+      },
+      registerPageText: (pageIndex: number, texts: string[]) => {
+        pageTextsRef.current.set(pageIndex, texts.map(normalize))
+        // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
+        if (queryRef.current !== '') {
+          recalculate(queryRef.current)
+        }
+      },
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
   }, [latest])
-
-  const setQuery = useCallback(
-    (nextQuery: string) => {
-      queryRef.current = nextQuery
-      setQueryState(nextQuery)
-      functions.recalculate(nextQuery, { resetSelection: true })
-    },
-    [functions],
-  )
-
-  const registerPageText = useCallback(
-    (pageIndex: number, texts: string[]) => {
-      pageTextsRef.current.set(pageIndex, texts.map(normalize))
-      // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
-      if (queryRef.current !== '') {
-        functions.recalculate(queryRef.current)
-      }
-    },
-    [functions],
-  )
 
   const clear = useCallback(() => {
     queryRef.current = ''
@@ -160,26 +151,16 @@ export const usePDFSearch = (fileUrl: string) => {
   return useMemo(
     () => ({
       query,
-      setQuery,
+      setQuery: functions.setQuery,
       matches,
       matchCount,
       currentMatchIndex,
       goNext,
       goPrev,
       clear,
-      registerPageText,
+      registerPageText: functions.registerPageText,
     }),
-    [
-      query,
-      setQuery,
-      matches,
-      matchCount,
-      currentMatchIndex,
-      goNext,
-      goPrev,
-      clear,
-      registerPageText,
-    ],
+    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, clear, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -120,25 +120,22 @@ export const usePDFSearch = (fileUrl: string) => {
         setQueryState('')
         functions.resetMatchState()
       },
+      goNext: () => {
+        setCurrentMatchIndex((prev) => {
+          if (latest.matchCount === 0) return -1
+          if (prev < 0) return 0
+          return (prev + 1) % latest.matchCount
+        })
+      },
+      goPrev: () => {
+        setCurrentMatchIndex((prev) => {
+          if (latest.matchCount === 0) return -1
+          if (prev < 0) return latest.matchCount - 1
+          return (prev - 1 + latest.matchCount) % latest.matchCount
+        })
+      },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
   }, [latest])
-
-  const goNext = useCallback(() => {
-    setCurrentMatchIndex((prev) => {
-      if (matchCount === 0) return -1
-      if (prev < 0) return 0
-      return (prev + 1) % matchCount
-    })
-  }, [matchCount])
-
-  const goPrev = useCallback(() => {
-    setCurrentMatchIndex((prev) => {
-      if (matchCount === 0) return -1
-      if (prev < 0) return matchCount - 1
-      return (prev - 1 + matchCount) % matchCount
-    })
-  }, [matchCount])
 
   useEffect(() => {
     pageTextsRef.current.clear()
@@ -150,16 +147,16 @@ export const usePDFSearch = (fileUrl: string) => {
   return useMemo(
     () => ({
       query,
-      setQuery: functions.setQuery,
       matches,
       matchCount,
       currentMatchIndex,
-      goNext,
-      goPrev,
-      clear: functions.clear,
+      setQuery: functions.setQuery,
       registerPageText: functions.registerPageText,
+      clear: functions.clear,
+      goNext: functions.goNext,
+      goPrev: functions.goPrev,
     }),
-    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, functions],
+    [query, matches, matchCount, currentMatchIndex, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
+import { type ChangeEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -60,6 +60,7 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const latest = useLatest({
     matchCount,
+    query,
   })
 
   const functions = useMemo(() => {
@@ -107,6 +108,28 @@ export const usePDFSearch = (fileUrl: string) => {
       recalculate(nextQuery, { resetSelection: true })
     }
 
+    const goNext = () => {
+      setCurrentMatchIndex((prev) => {
+        if (latest.matchCount === 0) return -1
+        if (prev < 0) return 0
+        return (prev + 1) % latest.matchCount
+      })
+    }
+
+    const goPrev = () => {
+      setCurrentMatchIndex((prev) => {
+        if (latest.matchCount === 0) return -1
+        if (prev < 0) return latest.matchCount - 1
+        return (prev - 1 + latest.matchCount) % latest.matchCount
+      })
+    }
+
+    const clear = () => {
+      queryRef.current = ''
+      setQueryState('')
+      resetMatchState()
+    }
+
     return {
       resetMatchState,
       setQuery,
@@ -117,27 +140,34 @@ export const usePDFSearch = (fileUrl: string) => {
           recalculate(queryRef.current)
         }
       },
-      clear: () => {
-        queryRef.current = ''
-        setQueryState('')
-        functions.resetMatchState()
-      },
-      goNext: () => {
-        setCurrentMatchIndex((prev) => {
-          if (latest.matchCount === 0) return -1
-          if (prev < 0) return 0
-          return (prev + 1) % latest.matchCount
-        })
-      },
-      goPrev: () => {
-        setCurrentMatchIndex((prev) => {
-          if (latest.matchCount === 0) return -1
-          if (prev < 0) return latest.matchCount - 1
-          return (prev - 1 + latest.matchCount) % latest.matchCount
-        })
-      },
+      clear,
+      goNext,
+      goPrev,
       handleChangeQuery: (e: ChangeEvent<HTMLInputElement>) => {
         setQuery(e.target.value)
+      },
+      handleKeyDownQuery: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.nativeEvent.isComposing) {
+          return
+        }
+        switch (e.key) {
+          case 'Enter': {
+            e.preventDefault()
+            if (e.shiftKey) {
+              goPrev()
+            } else {
+              goNext()
+            }
+            break
+          }
+          case 'Escape': {
+            if (queryRef.current !== '') {
+              e.preventDefault()
+              clear()
+            }
+            break
+          }
+        }
       },
     }
   }, [latest])
@@ -155,13 +185,15 @@ export const usePDFSearch = (fileUrl: string) => {
       matches,
       matchCount,
       currentMatchIndex,
-      // TODO: テストのために公開している。整理する
+      // TODO: テストのために公開している。handleKeyDownQueryに統合後、整理する
       setQuery: functions.setQuery,
       registerPageText: functions.registerPageText,
+      // TODO: テストのために公開している。handleKeyDownQueryに統合後、整理する
       clear: functions.clear,
       goNext: functions.goNext,
       goPrev: functions.goPrev,
       handleChangeQuery: functions.handleChangeQuery,
+      handleKeyDownQuery: functions.handleKeyDownQuery,
     }),
     [query, matches, matchCount, currentMatchIndex, functions],
   )

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -115,15 +115,14 @@ export const usePDFSearch = (fileUrl: string) => {
           recalculate(queryRef.current)
         }
       },
+      clear: () => {
+        queryRef.current = ''
+        setQueryState('')
+        functions.resetMatchState()
+      },
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
   }, [latest])
-
-  const clear = useCallback(() => {
-    queryRef.current = ''
-    setQueryState('')
-    functions.resetMatchState()
-  }, [functions])
 
   const goNext = useCallback(() => {
     setCurrentMatchIndex((prev) => {
@@ -157,10 +156,10 @@ export const usePDFSearch = (fileUrl: string) => {
       currentMatchIndex,
       goNext,
       goPrev,
-      clear,
+      clear: functions.clear,
       registerPageText: functions.registerPageText,
     }),
-    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, clear, functions],
+    [query, matches, matchCount, currentMatchIndex, goNext, goPrev, functions],
   )
 }
 

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -132,7 +132,6 @@ export const usePDFSearch = (fileUrl: string) => {
 
     return {
       resetMatchState,
-      setQuery,
       registerPageText: (pageIndex: number, texts: string[]) => {
         pageTextsRef.current.set(pageIndex, texts.map(normalize))
         // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
@@ -140,7 +139,6 @@ export const usePDFSearch = (fileUrl: string) => {
           recalculate(queryRef.current)
         }
       },
-      clear,
       goNext,
       goPrev,
       handleChangeQuery: (e: ChangeEvent<HTMLInputElement>) => {
@@ -185,11 +183,7 @@ export const usePDFSearch = (fileUrl: string) => {
       matches,
       matchCount,
       currentMatchIndex,
-      // TODO: テストのために公開している。handleKeyDownQueryに統合後、整理する
-      setQuery: functions.setQuery,
       registerPageText: functions.registerPageText,
-      // TODO: テストのために公開している。handleKeyDownQueryに統合後、整理する
-      clear: functions.clear,
       goNext: functions.goNext,
       goPrev: functions.goPrev,
       handleChangeQuery: functions.handleChangeQuery,

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -101,13 +101,15 @@ export const usePDFSearch = (fileUrl: string) => {
       })
     }
 
+    const setQuery = (nextQuery: string) => {
+      queryRef.current = nextQuery
+      setQueryState(nextQuery)
+      recalculate(nextQuery, { resetSelection: true })
+    }
+
     return {
       resetMatchState,
-      setQuery: (nextQuery: string) => {
-        queryRef.current = nextQuery
-        setQueryState(nextQuery)
-        recalculate(nextQuery, { resetSelection: true })
-      },
+      setQuery,
       registerPageText: (pageIndex: number, texts: string[]) => {
         pageTextsRef.current.set(pageIndex, texts.map(normalize))
         // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
@@ -134,6 +136,9 @@ export const usePDFSearch = (fileUrl: string) => {
           return (prev - 1 + latest.matchCount) % latest.matchCount
         })
       },
+      handleChangeQuery: (e: ChangeEvent<HTMLInputElement>) => {
+        setQuery(e.target.value)
+      },
     }
   }, [latest])
 
@@ -150,11 +155,13 @@ export const usePDFSearch = (fileUrl: string) => {
       matches,
       matchCount,
       currentMatchIndex,
+      // TODO: テストのために公開している。整理する
       setQuery: functions.setQuery,
       registerPageText: functions.registerPageText,
       clear: functions.clear,
       goNext: functions.goNext,
       goPrev: functions.goPrev,
+      handleChangeQuery: functions.handleChangeQuery,
     }),
     [query, matches, matchCount, currentMatchIndex, functions],
   )

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -58,10 +58,7 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const latest = useLatest({
-    matchCount,
-    query,
-  })
+  const latest = useLatest({ matchCount })
 
   const functions = useMemo(() => {
     const resetMatchState = () => {

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { useLatest } from '../../hooks/useLatest'
+
 import type { PDFSearchMatch } from './types'
 
 export const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -56,13 +58,17 @@ export const usePDFSearch = (fileUrl: string) => {
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const resetMatchState = useCallback(() => {
-    setMatches([])
-    setCurrentMatchIndex(-1)
-  }, [])
+  const latest = useLatest({
+    matchCount,
+  })
 
-  const recalculate = useCallback(
-    (nextQuery: string, options?: { resetSelection?: boolean }) => {
+  const functions = useMemo(() => {
+    const resetMatchState = () => {
+      setMatches([])
+      setCurrentMatchIndex(-1)
+    }
+
+    const recalculate = (nextQuery: string, options?: { resetSelection?: boolean }) => {
       if (nextQuery === '') {
         resetMatchState()
         return
@@ -93,17 +99,22 @@ export const usePDFSearch = (fileUrl: string) => {
         if (prev >= globalIndex) return globalIndex - 1
         return prev
       })
-    },
-    [resetMatchState],
-  )
+    }
+
+    return {
+      resetMatchState,
+      recalculate,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 将来的にlatest.matchCountを使用する予定
+  }, [latest])
 
   const setQuery = useCallback(
     (nextQuery: string) => {
       queryRef.current = nextQuery
       setQueryState(nextQuery)
-      recalculate(nextQuery, { resetSelection: true })
+      functions.recalculate(nextQuery, { resetSelection: true })
     },
-    [recalculate],
+    [functions],
   )
 
   const registerPageText = useCallback(
@@ -111,17 +122,17 @@ export const usePDFSearch = (fileUrl: string) => {
       pageTextsRef.current.set(pageIndex, texts.map(normalize))
       // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
       if (queryRef.current !== '') {
-        recalculate(queryRef.current)
+        functions.recalculate(queryRef.current)
       }
     },
-    [recalculate],
+    [functions],
   )
 
   const clear = useCallback(() => {
     queryRef.current = ''
     setQueryState('')
-    resetMatchState()
-  }, [resetMatchState])
+    functions.resetMatchState()
+  }, [functions])
 
   const goNext = useCallback(() => {
     setCurrentMatchIndex((prev) => {
@@ -143,8 +154,8 @@ export const usePDFSearch = (fileUrl: string) => {
     pageTextsRef.current.clear()
     queryRef.current = ''
     setQueryState('')
-    resetMatchState()
-  }, [fileUrl, resetMatchState])
+    functions.resetMatchState()
+  }, [fileUrl, functions])
 
   return useMemo(
     () => ({

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -102,12 +102,6 @@ export const usePDFSearch = (fileUrl: string) => {
       })
     }
 
-    const setQuery = (nextQuery: string) => {
-      queryRef.current = nextQuery
-      setQueryState(nextQuery)
-      recalculate(nextQuery, { resetSelection: true })
-    }
-
     const goNext = () => {
       setCurrentMatchIndex((prev) => {
         if (latest.matchCount === 0) return -1
@@ -124,12 +118,6 @@ export const usePDFSearch = (fileUrl: string) => {
       })
     }
 
-    const clear = () => {
-      queryRef.current = ''
-      setQueryState('')
-      resetMatchState()
-    }
-
     return {
       resetMatchState,
       registerPageText: (pageIndex: number, texts: string[]) => {
@@ -142,7 +130,11 @@ export const usePDFSearch = (fileUrl: string) => {
       goNext,
       goPrev,
       handleChangeQuery: (e: ChangeEvent<HTMLInputElement>) => {
-        setQuery(e.target.value)
+        const nextQuery = e.target.value
+
+        queryRef.current = nextQuery
+        setQueryState(nextQuery)
+        recalculate(nextQuery, { resetSelection: true })
       },
       handleKeyDownQuery: (e: KeyboardEvent<HTMLInputElement>) => {
         if (e.nativeEvent.isComposing) {
@@ -161,7 +153,9 @@ export const usePDFSearch = (fileUrl: string) => {
           case 'Escape': {
             if (queryRef.current !== '') {
               e.preventDefault()
-              clear()
+              queryRef.current = ''
+              setQueryState('')
+              resetMatchState()
             }
             break
           }


### PR DESCRIPTION
## 関連URL

なし

## 概要

SearchControllerに含まれていた検索ロジックをusePDFSearchに移動し、コンポーネント間の責任を明確化しました。

## 変更内容

- SearchControllerから`useLatest`+`functions`パターンを削除
- `handleChangeQuery`、`handleKeyDownQuery`をusePDFSearchに追加
- SearchControllerはプレゼンテーション層に専念（UIの表示のみ）
- usePDFSearchに検索関連のすべてのロジックを集約
- テストを新しいインターフェースに対応（`setQuery`→`handleChangeQuery`、`clear`→`handleKeyDownQuery`）

### 主な変更ファイル

- `SearchController.tsx`: 検索ロジックを削除し、propsとして受け取った関数を呼び出すのみに簡略化
- `usePDFSearch.ts`: `handleChangeQuery`、`handleKeyDownQuery`を追加し、検索ロジックを集約
- テストファイル: 新しいインターフェースに対応

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストがすべて通過することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - PDF内検索で、Enterキーによる次の一致箇所への移動、Shift+Enterによる前の一致箇所への移動に対応しました。
  - Escapeキーで検索語と検索結果をクリアできるようになりました。
  - IME変換中のキー操作が誤って実行されないようになりました。

- **改善**
  - 検索結果がない場合、該当件数を「0」と表示し、前後移動ボタンを無効化します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->