### PR TITLE
refactor(FileViewer): PDFテキスト抽出ロジックをusePDFSearchに移動

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -58,7 +58,6 @@ const options = {
 } satisfies ComponentProps<typeof Document>['options']
 
 type CustomTextRenderer = NonNullable<ComponentProps<typeof Page>['customTextRenderer']>
-type TextContent = Parameters<NonNullable<ComponentProps<typeof Page>['onGetTextSuccess']>>[number]
 
 // pdfjs が用意している CSS 変数 (--highlight-bg-color / --highlight-selected-bg-color)を .textLayer スコープで上書きし、検索ハイライト色を変更している。
 const HighlightOverrideStyle = () => (
@@ -91,7 +90,6 @@ export const PDFViewer: FC<Props> = memo(
   }) => {
     const matches = search?.matches
     const currentMatchIndex = search?.currentMatchIndex
-    const onPageTextLoaded = search?.registerPageText
     const [pdfNumPages, setPdfNumPages] = useState(1)
     const rootRef = useRef<HTMLDivElement>(null)
 
@@ -123,20 +121,6 @@ export const PDFViewer: FC<Props> = memo(
       }
       return buildCustomTextRenderer(matches)
     }, [matches])
-
-    const handleGetTextSuccess = useCallback(
-      (pageIndex: number) => (textContent: TextContent) => {
-        if (!onPageTextLoaded) return
-        const texts = textContent.items.reduce<string[]>((acc, item) => {
-          if ('str' in item) {
-            acc.push(item.str)
-          }
-          return acc
-        }, [])
-        onPageTextLoaded(pageIndex, texts)
-      },
-      [onPageTextLoaded],
-    )
 
     useEffect(() => {
       const root = rootRef.current
@@ -189,7 +173,7 @@ export const PDFViewer: FC<Props> = memo(
                 scale={scale}
                 className="shr-w-full"
                 onLoadSuccess={onPageLoad}
-                onGetTextSuccess={handleGetTextSuccess(i)}
+                onGetTextSuccess={search?.generateHandlePDFPageGetTextSuccess(i)}
                 customTextRenderer={customTextRenderer}
                 loading={null}
               />

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.test.tsx
@@ -20,7 +20,7 @@ const renderController = ({
     currentMatchIndex,
     goNext: vi.fn(),
     goPrev: vi.fn(),
-    registerPageText: vi.fn(),
+    generateHandlePDFPageGetTextSuccess: vi.fn(),
   }
   render(
     <IntlProvider locale="ja">

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.test.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.test.ts
@@ -122,7 +122,10 @@ describe('usePDFSearch', () => {
   const setup = (texts: string[]) => {
     const view = renderHook(() => usePDFSearch('file-url'))
     act(() => {
-      view.result.current.registerPageText(0, texts)
+      const textContent = {
+        items: texts.map((str) => ({ str })),
+      }
+      view.result.current.generateHandlePDFPageGetTextSuccess(0)(textContent)
     })
     return view
   }
@@ -334,6 +337,59 @@ describe('usePDFSearch', () => {
 
       expect(preventDefaultSpy).not.toHaveBeenCalled()
       expect(result.current.query).toBe('') // 変わらず空
+    })
+  })
+
+  describe('generateHandlePDFPageGetTextSuccess', () => {
+    test('PDFのテキストを抽出してページに登録する', () => {
+      const { result } = renderHook(() => usePDFSearch('file-url'))
+      const textContent = {
+        items: [{ str: 'Hello' }, { str: 'World' }],
+      }
+
+      act(() => {
+        result.current.generateHandlePDFPageGetTextSuccess(0)(textContent)
+      })
+
+      // 検索すると登録されたテキストがヒットする
+      act(() => {
+        result.current.handleChangeQuery({
+          target: { value: 'Hello' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      expect(result.current.matchCount).toBeGreaterThan(0)
+      expect(result.current.matches.length).toBeGreaterThan(0)
+    })
+
+    test('全ページ読み込み前に検索が始まっても後から読んだページがヒットする', () => {
+      const { result } = renderHook(() => usePDFSearch('file-url'))
+
+      // 最初にページ0を登録
+      act(() => {
+        result.current.generateHandlePDFPageGetTextSuccess(0)({
+          items: [{ str: 'page0' }],
+        })
+      })
+
+      // 検索開始
+      act(() => {
+        result.current.handleChangeQuery({
+          target: { value: 'page' },
+        } as React.ChangeEvent<HTMLInputElement>)
+      })
+
+      const matchCountAfterPage0 = result.current.matchCount
+
+      // 後からページ1を登録
+      act(() => {
+        result.current.generateHandlePDFPageGetTextSuccess(1)({
+          items: [{ str: 'page1' }],
+        })
+      })
+
+      // 新しいページの内容も検索結果に含まれる
+      expect(result.current.matchCount).toBeGreaterThan(matchCountAfterPage0)
     })
   })
 })

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,8 +1,21 @@
-import { type ChangeEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type ChangeEvent,
+  type ComponentProps,
+  type KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
 import type { PDFSearchMatch } from './types'
+import type { Page } from 'react-pdf'
+
+type PDFTextContent = Parameters<
+  NonNullable<ComponentProps<typeof Page>['onGetTextSuccess']>
+>[number]
 
 export const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -117,13 +130,6 @@ export const usePDFSearch = (fileUrl: string) => {
 
     return {
       resetMatchState,
-      registerPageText: (pageIndex: number, texts: string[]) => {
-        pageTextsRef.current.set(pageIndex, texts.map(normalize))
-        // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
-        if (queryRef.current !== '') {
-          recalculate(queryRef.current)
-        }
-      },
       goNext,
       goPrev,
       handleChangeQuery: (e: ChangeEvent<HTMLInputElement>) => {
@@ -158,6 +164,19 @@ export const usePDFSearch = (fileUrl: string) => {
           }
         }
       },
+      generateHandlePDFPageGetTextSuccess: (pageIndex: number) => (textContent: PDFTextContent) => {
+        const texts = textContent.items.reduce<string[]>((acc, item) => {
+          if ('str' in item) {
+            acc.push(item.str)
+          }
+          return acc
+        }, [])
+        pageTextsRef.current.set(pageIndex, texts.map(normalize))
+        // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
+        if (queryRef.current !== '') {
+          recalculate(queryRef.current)
+        }
+      },
     }
   }, [latest])
 
@@ -174,11 +193,11 @@ export const usePDFSearch = (fileUrl: string) => {
       matches,
       matchCount,
       currentMatchIndex,
-      registerPageText: functions.registerPageText,
       goNext: functions.goNext,
       goPrev: functions.goPrev,
       handleChangeQuery: functions.handleChangeQuery,
       handleKeyDownQuery: functions.handleKeyDownQuery,
+      generateHandlePDFPageGetTextSuccess: functions.generateHandlePDFPageGetTextSuccess,
     }),
     [query, matches, matchCount, currentMatchIndex, functions],
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

PDFViewer.tsxに実装されていたPDFテキスト抽出ロジックをusePDFSearch.tsに移動し、関心の分離を改善しました。

## 変更内容

- PDFViewer.tsxの`handleGetTextSuccess`ロジックをusePDFSearch.tsに移動
- 新しい公開API `generateHandlePDFPageGetTextSuccess`を追加
  - react-pdfの`onGetTextSuccess`コールバックとして直接使用可能なカリー化関数
  - PDFTextContentの型定義をreact-pdfから推論
- `registerPageText`を内部実装として統合し、公開APIから削除
- PDFViewer.tsxのコードが簡潔になり、責務が明確化
- テストを更新し、`generateHandlePDFPageGetTextSuccess`の動作を検証
  - PDFテキスト抽出・ページ登録のテストを追加
  - 全ページ読み込み前の検索開始時の動作テストを追加

## プロダクト側で対応が必要な事項

なし

## 確認方法

- テストがすべてパスすることを確認（38テスト）
- Storybookで FileViewer コンポーネントのPDF検索機能が正常に動作することを確認