### PR TITLE
feat(BarChart): 棒グラフの柄を非表示にできる disablePatterns を追加

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -44,7 +44,7 @@ export const Playground: Story = {
     options: {
       control: 'object',
     },
-    disablePattern: {
+    disablePatterns: {
       control: 'boolean',
     },
   },
@@ -63,10 +63,10 @@ export const MultipleDatasets: Story = {
 }
 
 export const WithoutPattern: Story = {
-  name: 'disablePattern',
+  name: 'disablePatterns',
   args: {
     data: multiSmall,
-    disablePattern: true,
+    disablePatterns: true,
   },
 }
 

--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -1,4 +1,9 @@
-import { chartJsOptionsExamples, multi20Datasets, multiSmall, singleSmall } from '../__stories__/testData'
+import {
+  chartJsOptionsExamples,
+  multi20Datasets,
+  multiSmall,
+  singleSmall,
+} from '../__stories__/testData'
 
 import { BarChart } from './BarChart'
 
@@ -39,6 +44,9 @@ export const Playground: Story = {
     options: {
       control: 'object',
     },
+    disablePattern: {
+      control: 'boolean',
+    },
   },
 }
 
@@ -51,6 +59,14 @@ export const Default: Story = {
 export const MultipleDatasets: Story = {
   args: {
     data: multiSmall,
+  },
+}
+
+export const WithoutPattern: Story = {
+  name: 'disablePattern',
+  args: {
+    data: multiSmall,
+    disablePattern: true,
   },
 }
 

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -21,20 +21,20 @@ type Props = {
   /**
    * 棒グラフの柄を無効化するか
    */
-  disablePattern?: boolean
+  disablePatterns?: boolean
 }
 
 export const BarChart: React.FC<Props> = ({
   data,
   title,
   options: externalOptions,
-  disablePattern,
+  disablePatterns,
 }) => {
   const chartId = useId()
   const chartRef = useRef<Chart<'bar'>>(null)
   const chartColors = useMemo(
-    () => getChartColors(data.datasets.length, disablePattern),
-    [data.datasets.length, disablePattern],
+    () => getChartColors(data.datasets.length, disablePatterns),
+    [data.datasets.length, disablePatterns],
   )
 
   const ariaLabel = useMemo(() => {

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -18,12 +18,24 @@ type Props = {
   data: ChartData<'bar'>
   title?: string
   options?: Partial<ChartOptions<'bar'>>
+  /**
+   * 棒グラフの柄を無効化するか
+   */
+  disablePattern?: boolean
 }
 
-export const BarChart: React.FC<Props> = ({ data, title, options: externalOptions }) => {
+export const BarChart: React.FC<Props> = ({
+  data,
+  title,
+  options: externalOptions,
+  disablePattern,
+}) => {
   const chartId = useId()
   const chartRef = useRef<Chart<'bar'>>(null)
-  const chartColors = useMemo(() => getChartColors(data.datasets.length), [data.datasets.length])
+  const chartColors = useMemo(
+    () => getChartColors(data.datasets.length, disablePattern),
+    [data.datasets.length, disablePattern],
+  )
 
   const ariaLabel = useMemo(() => {
     const datasetCount = data.datasets.length

--- a/packages/charts/src/helper/data.ts
+++ b/packages/charts/src/helper/data.ts
@@ -106,6 +106,7 @@ export const getRadarChartColors = (dataLength: number): RadarChartColorConfig[]
 // TODO: SINGLE_CHART_COLORS を使うオプションを追加する
 export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
   dataLength: number,
+  disablePattern = false,
 ): Array<
   Pick<ChartDataset<T>, 'backgroundColor' | 'borderColor' | 'hoverBorderColor' | 'hoverBorderWidth'>
 > => {
@@ -120,7 +121,9 @@ export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
     const color = getColor(i)
     colors.push({
       backgroundColor:
-        i > 0 ? draw(SHAPE_TYPES[i % SHAPE_TYPES.length], color, undefined, PATTERN_SIZE) : color,
+        !disablePattern && i > 0
+          ? draw(SHAPE_TYPES[i % SHAPE_TYPES.length], color, undefined, PATTERN_SIZE)
+          : color,
       borderColor: color,
       hoverBorderColor: SMARTHR_DEFAULT_COLORS.OUTLINE,
       hoverBorderWidth: 4,

--- a/packages/charts/src/helper/data.ts
+++ b/packages/charts/src/helper/data.ts
@@ -106,7 +106,7 @@ export const getRadarChartColors = (dataLength: number): RadarChartColorConfig[]
 // TODO: SINGLE_CHART_COLORS を使うオプションを追加する
 export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
   dataLength: number,
-  disablePattern = false,
+  disablePatterns = false,
 ): Array<
   Pick<ChartDataset<T>, 'backgroundColor' | 'borderColor' | 'hoverBorderColor' | 'hoverBorderWidth'>
 > => {
@@ -121,7 +121,7 @@ export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
     const color = getColor(i)
     colors.push({
       backgroundColor:
-        !disablePattern && i > 0
+        !disablePatterns && i > 0
           ? draw(SHAPE_TYPES[i % SHAPE_TYPES.length], color, undefined, PATTERN_SIZE)
           : color,
       borderColor: color,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`BarChart` は複数データセットを見分けやすくするため、2つ目以降のデータセットの棒に柄（パターン）を重ねて表示している。この柄は色覚特性に配慮した識別手段だが、プロダクトに公開された際に柄があることで見えづらいという意見があったため、アクセシビリティ部で柄なしでも問題がないか検討したうえで、柄を無効化できる `disablePatterns` プロパティを追加しました

### 柄なしでも問題ないとした根拠

BarChart においては以下の特徴があるため、柄がなかったとしても「色だけで説明する」に当たらないと判断しました。
またこの判断はBarChartにおいてのみであり、他のチャートにおいては都度検討する必要があります。

- データセットを説明する legend と棒グラフが同じ並びであり、データが0の場合でもその幅が保たれるため、棒の並びとlegendの並びが一致している
- 現在の CHART_COLORS は色覚特性があっても見分けがつくよう配慮して配色している

## 変更内容

`BarChart` に `disablePatterns?: boolean` プロパティを追加した。`true` を渡すと全データセットの棒が単色で描画され、柄が表示されなくなる。デフォルトは `false`（従来どおり柄あり）のため、既存の利用箇所の挙動は変わらない。

- `getChartColors`（`packages/charts/src/helper/data.ts`）に第2引数 `disablePatterns`（デフォルト `false`）を追加。`true` のとき `@smarthr/patternomaly` の `draw()` による柄付与をスキップし単色にする
- `BarChart` から `getChartColors` へ `disablePatterns` を渡す
- Storybook に確認用ストーリー `disablePatterns` を追加し、Playground の Controls でも切り替えられるようにした

### 使用例

```tsx
// 柄あり（従来どおり）
<BarChart data={data} />

// 柄なし（全データセット単色）
<BarChart data={data} disablePatterns />
```

## プロダクト側で対応が必要な事項

なし（プロパティ追加のみで後方互換）

## 確認方法

Storybook（`Charts/BarChart`）で確認できる。

- `disablePatterns` ストーリー … 全データセットが単色で柄なし
- `MultipleDatasets` ストーリー … 従来どおり2つ目以降に柄あり（比較用）
- `Playground` … Controls の `disablePatterns` を on/off で切り替えて挙動を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 棒グラフで柄（パターン）表示を無効化できるオプションを追加しました。
  * 柄なしの棒グラフ表示を確認できるサンプルケースを追加しました。
  * オプションを変更すると、グラフの色表示が即時に反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->