### PR TITLE
fix(TdCheckbox/ThCheckbox): rowSpanとcolSpanが有効にしてTd/Thコンポネントの機能パリティにしました

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
@@ -10,7 +10,7 @@ type AbstractProps = PropsWithChildren<{
   /** Checkboxのaccessible nameとして設定するテキストを参照するためのid属性値。同じ親Tr配下のTdかTh、もしくはその子孫要素のidを指定する。複数要素のテキストを指定する場合は空白区切りでidをつなぐ */
   'aria-labelledby': string
 }> &
-  Pick<ComponentProps<typeof Td>, 'vAlign' | 'fixed'>
+  Pick<ComponentProps<typeof Td>, 'vAlign' | 'fixed' | 'rowSpan' | 'colSpan'>
 type Props = Omit<CheckboxProps, keyof AbstractProps> & AbstractProps
 
 const classNameGenerator = tv({
@@ -26,7 +26,7 @@ const classNameGenerator = tv({
 })
 
 export const TdCheckbox = forwardRef<HTMLInputElement, Props>(
-  ({ vAlign, fixed, children, className, ...rest }, ref) => {
+  ({ vAlign, fixed, children, className, rowSpan, colSpan, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, inner, checkbox } = classNameGenerator()
 
@@ -39,7 +39,13 @@ export const TdCheckbox = forwardRef<HTMLInputElement, Props>(
 
     return (
       // Td に必要な属性やイベントは不要
-      <Td vAlign={vAlign} fixed={fixed} className={classNames.wrapper}>
+      <Td
+        vAlign={vAlign}
+        fixed={fixed}
+        className={classNames.wrapper}
+        rowSpan={rowSpan}
+        colSpan={colSpan}
+      >
         <label className={classNames.inner}>
           {/* eslint-disable-next-line smarthr/a11y-prohibit-checkbox-or-radio-in-table-cell */}
           <Checkbox {...rest} ref={ref} className={classNames.checkbox} />

--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -9,7 +9,7 @@ import { ControlledTooltip } from '../Tooltip'
 
 import { Th } from './Th'
 
-type AbstractProps = Pick<ComponentProps<typeof Th>, 'vAlign' | 'fixed'>
+type AbstractProps = Pick<ComponentProps<typeof Th>, 'vAlign' | 'fixed' | 'rowSpan' | 'colSpan'>
 type Props = AbstractProps & Omit<CheckboxProps, keyof AbstractProps>
 
 const classNameGenerator = tv({
@@ -31,7 +31,7 @@ const classNameGenerator = tv({
 })
 
 export const ThCheckbox = forwardRef<HTMLInputElement, Props>(
-  ({ vAlign, fixed, className, ...rest }, ref) => {
+  ({ vAlign, fixed, className, rowSpan, colSpan, ...rest }, ref) => {
     const { localize } = useIntl()
 
     const localizedText = useMemo(
@@ -66,6 +66,8 @@ export const ThCheckbox = forwardRef<HTMLInputElement, Props>(
         fixed={fixed}
         className={classNames.wrapper}
         aria-label={localizedText.checkColumnName}
+        rowSpan={rowSpan}
+        colSpan={colSpan}
       >
         <label className={classNames.inner}>
           <ControlledTooltip


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- `Td`と`Th`のコンポネントでは `colSpan`と`rowSpan`のHTML属性を使用出来ますが`Checkbox`variantに存在していないため追加しました
- テーブルのデザインによって、たまにTdCheckboxやThCheckboxがrow/colを超えないと行けないデザインが存在するために必要です。かつ、Td/Thコンポネントができるのに、checkboxのvariantが出来ないのが変です。

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

- `TdCheckbox`と `ThCheckbox`に`Td/Th`の要素が出す`rowSpan`と`colSpan`属性も有効にしました

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

- 特になし

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

実際に`ThCheckbox`と `TdCheckbox`を複数の行・列で使ってみてください。HTML要素なのでわざわざStorybookを作っていません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * テーブルのチェックボックス付きセルで、行結合（`rowSpan`）と列結合（`colSpan`）を指定できるようになりました。
  * ヘッダーセル・データセルのレイアウト調整が柔軟になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->