### PR TITLE
refactor(DropZone): イベントハンドラの命名をhandleXxx形式に統一

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -100,7 +100,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 
     const functions = useMemo(
       () => ({
-        onDrop: (e: DragEvent<HTMLElement>) => {
+        handleDrop: (e: DragEvent<HTMLElement>) => {
           overrideEventDefault(e)
           setFilesDraggedOver(false)
 
@@ -111,17 +111,17 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
             latest.onSelectFiles(e, e.dataTransfer.files)
           }
         },
-        onDragOver: (e: DragEvent<HTMLElement>) => {
+        handleDragOver: (e: DragEvent<HTMLElement>) => {
           overrideEventDefault(e)
           setFilesDraggedOver(true)
         },
-        onDragLeave: () => {
+        handleDragLeave: () => {
           setFilesDraggedOver(false)
         },
-        onChange: (e: ChangeEvent<HTMLInputElement>) => {
+        handleChange: (e: ChangeEvent<HTMLInputElement>) => {
           latest.onSelectFiles(e, e.target.files)
         },
-        onClickButton: () => {
+        handleClickButton: () => {
           fileRef.current!.click()
         },
       }),
@@ -136,14 +136,14 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
-        onDrop={functions.onDrop}
-        onDragOver={functions.onDragOver}
-        onDragLeave={functions.onDragLeave}
+        onDrop={functions.handleDrop}
+        onDragOver={functions.handleDragOver}
+        onDragLeave={functions.handleDragLeave}
         className={classNames.wrapper}
       >
         {children}
         <SelectButton
-          onClick={functions.onClickButton}
+          handleClick={functions.handleClickButton}
           disabled={disabled}
           className={classNames.button}
           label={selectButtonLabel}
@@ -159,7 +159,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
             disabled={disabled}
             tabIndex={-1}
             aria-invalid={error || undefined}
-            onChange={functions.onChange}
+            onChange={functions.handleChange}
           />
         </VisuallyHiddenText>
       </div>
@@ -168,9 +168,9 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 )
 
 const SelectButton = memo<
-  ComponentPropsWithoutRef<typeof Button> & { onClick: () => void; label?: string }
->(({ onClick, label, ...rest }) => (
-  <Button {...rest} prefix={<FaFolderOpenIcon />} onClick={onClick}>
+  ComponentPropsWithoutRef<typeof Button> & { handleClick: () => void; label?: string }
+>(({ handleClick, label, ...rest }) => (
+  <Button {...rest} prefix={<FaFolderOpenIcon />} onClick={handleClick}>
     {label || <Localizer id="smarthr-ui/DropZone/selectButtonLabel" defaultText="ファイルを選択" />}
   </Button>
 ))


### PR DESCRIPTION
## 関連URL

## 概要

DropZone コンポーネント内のイベントハンドラ命名規則を CLAUDE.md に沿った形式に統一するリファクタリング。

## 変更内容

- `functions` オブジェクト内の `onXxx` 形式のハンドラを `handleXxx` 形式にリネーム
  - `onDrop` → `handleDrop`
  - `onDragOver` → `handleDragOver`
  - `onDragLeave` → `handleDragLeave`
  - `onChange` → `handleChange`
  - `onClickButton` → `handleClickButton`
- 内部コンポーネント `SelectButton` の prop `onClick` → `handleClick` にリネーム

## プロダクト側で対応が必要な事項

なし（内部実装のリファクタリングのみ）

## 確認方法

Storybook での動作確認、または既存テストの通過で確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ファイル選択およびドラッグ＆ドロップ処理の内部構成を整理しました。
  * ユーザー向けのファイル選択・ドラッグ＆ドロップ動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->