### PR TITLE
refactor(Dropdown): DropdownContentInnerのリファクタリングとuseEffectのコメント追加

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -31,7 +31,7 @@ type DropdownContextType = {
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
   memoizedOnClickTrigger: (rect: Rect) => void
-  handleClickCloser: () => void
+  handleDelegateClickCloser: () => void
   DropdownContentRoot: FC<{ children: ReactNode }>
   contentId: string
 }
@@ -46,7 +46,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   memoizedOnClickTrigger: () => {
     /* noop */
   },
-  handleClickCloser: () => {
+  handleDelegateClickCloser: () => {
     /* noop */
   },
   DropdownContentRoot: () => null,
@@ -93,7 +93,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     })
   }, [])
 
-  const handleClickCloser = useCallback(() => {
+  const handleDelegateClickCloser = useCallback(() => {
     setActive(false)
 
     // return focus to the Trigger
@@ -134,7 +134,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
           memoizedOnClickTrigger,
-          handleClickCloser,
+          handleDelegateClickCloser,
           DropdownContentRoot,
           contentId,
         }}

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -31,7 +31,7 @@ type DropdownContextType = {
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
   memoizedOnClickTrigger: (rect: Rect) => void
-  onClickCloser: () => void
+  handleClickCloser: () => void
   DropdownContentRoot: FC<{ children: ReactNode }>
   contentId: string
 }
@@ -46,7 +46,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   memoizedOnClickTrigger: () => {
     /* noop */
   },
-  onClickCloser: () => {
+  handleClickCloser: () => {
     /* noop */
   },
   DropdownContentRoot: () => null,
@@ -93,7 +93,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     })
   }, [])
 
-  const onClickCloser = useCallback(() => {
+  const handleClickCloser = useCallback(() => {
     setActive(false)
 
     // return focus to the Trigger
@@ -134,7 +134,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
           memoizedOnClickTrigger,
-          onClickCloser,
+          handleClickCloser,
           DropdownContentRoot,
           contentId,
         }}

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
@@ -18,7 +18,7 @@ const classNameGenerator = tv({
 type Props = PropsWithChildren<ComponentProps<'div'>>
 
 export const DropdownCloser: FC<Props> = ({ children, className }) => {
-  const { onClickCloser: onDelegateClick, controllable } = useContext(DropdownContentContext)
+  const { handleClickCloser: onDelegateClick, controllable } = useContext(DropdownContentContext)
   const { maxHeight } = useContext(DropdownContentInnerContext)
 
   const actualClassName = useMemo(

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
@@ -18,8 +18,7 @@ const classNameGenerator = tv({
 type Props = PropsWithChildren<ComponentProps<'div'>>
 
 export const DropdownCloser: FC<Props> = ({ children, className }) => {
-  const { handleDelegateClickCloser: onDelegateClick, controllable } =
-    useContext(DropdownContentContext)
+  const { handleDelegateClickCloser, controllable } = useContext(DropdownContentContext)
   const { maxHeight } = useContext(DropdownContentInnerContext)
 
   const actualClassName = useMemo(
@@ -30,7 +29,7 @@ export const DropdownCloser: FC<Props> = ({ children, className }) => {
   return (
     <div
       role="presentation"
-      onClick={onDelegateClick}
+      onClick={handleDelegateClickCloser}
       className={actualClassName}
       style={{
         maxHeight: controllable ? undefined : maxHeight,

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
@@ -18,7 +18,8 @@ const classNameGenerator = tv({
 type Props = PropsWithChildren<ComponentProps<'div'>>
 
 export const DropdownCloser: FC<Props> = ({ children, className }) => {
-  const { handleClickCloser: onDelegateClick, controllable } = useContext(DropdownContentContext)
+  const { handleDelegateClickCloser: onDelegateClick, controllable } =
+    useContext(DropdownContentContext)
   const { maxHeight } = useContext(DropdownContentInnerContext)
 
   const actualClassName = useMemo(

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownCloser.tsx
@@ -25,15 +25,16 @@ export const DropdownCloser: FC<Props> = ({ children, className }) => {
     () => classNameGenerator({ controllable, className }),
     [controllable, className],
   )
-  const style = useMemo(
-    () => ({
-      maxHeight: controllable ? undefined : maxHeight,
-    }),
-    [maxHeight, controllable],
-  )
 
   return (
-    <div role="presentation" onClick={onDelegateClick} className={actualClassName} style={style}>
+    <div
+      role="presentation"
+      onClick={onDelegateClick}
+      className={actualClassName}
+      style={{
+        maxHeight: controllable ? undefined : maxHeight,
+      }}
+    >
       {children}
     </div>
   )

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContent.tsx
@@ -9,10 +9,10 @@ import {
 } from './DropdownContentInner'
 
 export const DropdownContentContext = createContext<{
-  handleClickCloser: () => void
+  handleDelegateClickCloser: () => void
   controllable: boolean
 }>({
-  handleClickCloser: () => {
+  handleDelegateClickCloser: () => {
     /* noop */
   },
   controllable: false,
@@ -29,11 +29,12 @@ type AbstractProps = PropsWithChildren<{
 type Props = AbstractProps & Omit<InnerElementProps, keyof AbstractProps>
 
 export const DropdownContent: FC<Props> = ({ controllable = false, ...rest }) => {
-  const { DropdownContentRoot, triggerRect, handleClickCloser } = useContext(DropdownContext)
+  const { DropdownContentRoot, triggerRect, handleDelegateClickCloser } =
+    useContext(DropdownContext)
 
   return (
     <DropdownContentRoot>
-      <DropdownContentContext.Provider value={{ handleClickCloser, controllable }}>
+      <DropdownContentContext.Provider value={{ handleDelegateClickCloser, controllable }}>
         <DropdownContentInner {...rest} triggerRect={triggerRect} controllable={controllable} />
       </DropdownContentContext.Provider>
     </DropdownContentRoot>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContent.tsx
@@ -9,10 +9,10 @@ import {
 } from './DropdownContentInner'
 
 export const DropdownContentContext = createContext<{
-  onClickCloser: () => void
+  handleClickCloser: () => void
   controllable: boolean
 }>({
-  onClickCloser: () => {
+  handleClickCloser: () => {
     /* noop */
   },
   controllable: false,
@@ -29,11 +29,11 @@ type AbstractProps = PropsWithChildren<{
 type Props = AbstractProps & Omit<InnerElementProps, keyof AbstractProps>
 
 export const DropdownContent: FC<Props> = ({ controllable = false, ...rest }) => {
-  const { DropdownContentRoot, triggerRect, onClickCloser } = useContext(DropdownContext)
+  const { DropdownContentRoot, triggerRect, handleClickCloser } = useContext(DropdownContext)
 
   return (
     <DropdownContentRoot>
-      <DropdownContentContext.Provider value={{ onClickCloser, controllable }}>
+      <DropdownContentContext.Provider value={{ handleClickCloser, controllable }}>
         <DropdownContentInner {...rest} triggerRect={triggerRect} controllable={controllable} />
       </DropdownContentContext.Provider>
     </DropdownContentRoot>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -65,7 +65,7 @@ export const DropdownContentInner: FC<Props> = ({
     [isActive, className],
   )
 
-  const style = useMemo(() => {
+  const style = (() => {
     const defaultMargin = theme.spacingByChar(0.5)
     const leftMargin =
       contentBox.left === undefined ? defaultMargin : `max(${contentBox.left}, 0px)`
@@ -79,13 +79,7 @@ export const DropdownContentInner: FC<Props> = ({
       insetInlineEnd: contentBox.right || undefined,
       maxWidth: maxWidthStyle,
     }
-  }, [contentBox.left, contentBox.right, contentBox.top, theme])
-  const controllableWrapperStyleProps = useMemo(
-    () => ({
-      maxHeight: contentBox.maxHeight || undefined,
-    }),
-    [contentBox.maxHeight],
-  )
+  })()
 
   useEffect(() => {
     if (wrapperRef.current) {
@@ -133,7 +127,13 @@ export const DropdownContentInner: FC<Props> = ({
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex -- dummy element for focus management. */}
       <div ref={focusTargetRef} tabIndex={-1} />
       {controllable ? (
-        <div style={controllableWrapperStyleProps}>{children}</div>
+        <div
+          style={{
+            maxHeight: contentBox.maxHeight || undefined,
+          }}
+        >
+          {children}
+        </div>
       ) : (
         <DropdownContentInnerContext.Provider value={{ maxHeight: contentBox.maxHeight }}>
           <DropdownCloser>{children}</DropdownCloser>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -110,6 +110,16 @@ export const DropdownContentInner: FC<Props> = ({
     }
   }, [triggerRect])
 
+  // setIsActive(true) と同じ useEffect 内で直接 focus() を呼ぶことはできない。
+  // このコンポーネントは Dropdown が開かれた時のみマウントされるが、マウント直後は
+  // 位置計算が完了していないためコンテンツが誤った位置にちらつくのを防ぐために
+  // shr-invisible (visibility: hidden) でレンダリングされる。
+  // ちらつき防止には実寸法を保持したまま視覚的に隠せる visibility: hidden が唯一の手段となる。
+  // visibility: hidden の要素はフォーカスを受け付けないため、setIsActive(true) の直後に
+  // focus() を呼んでも DOM がまだ更新されておらず無効になる。
+  //
+  // useEffect([isActive]) であれば、isActive=true になった後の render commit 後に
+  // 必ず実行されることが保証されるため、この実装が最も信頼性が高い。
   useEffect(() => {
     if (isActive) {
       focusTargetRef.current?.focus()

--- a/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
@@ -12,14 +12,15 @@ export function useKeyboardNavigation(
   wrapperRef: RefObject<HTMLDivElement>,
   dummyFocusRef: RefObject<HTMLElement>,
 ) {
-  const { triggerElementRef, rootTriggerRef, handleClickCloser } = useContext(DropdownContext)
+  const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser } =
+    useContext(DropdownContext)
 
   const latest = useLatest({
     wrapperRef,
     triggerElementRef,
     rootTriggerRef,
     dummyFocusRef,
-    handleClickCloser,
+    handleDelegateClickCloser,
   })
 
   useEffect(() => {
@@ -58,7 +59,7 @@ export function useKeyboardNavigation(
             // focus the Trigger
             e.preventDefault()
             trigger!.focus()
-            latest.handleClickCloser()
+            latest.handleDelegateClickCloser()
           }
         } else if (e.target === tabbablesInContent.at(-1)) {
           // move focus next of the Trigger
@@ -66,12 +67,12 @@ export function useKeyboardNavigation(
 
           if (rootTrigger) {
             rootTrigger.focus()
-            latest.handleClickCloser()
+            latest.handleDelegateClickCloser()
           }
         }
       } else if (KEY_ESCAPE.test(e.key)) {
         if (e.target && e.target === latest.dummyFocusRef.current) {
-          latest.handleClickCloser()
+          latest.handleDelegateClickCloser()
 
           return
         }
@@ -80,7 +81,7 @@ export function useKeyboardNavigation(
 
         if (trigger && e.target === trigger) {
           // close the dropdown when the Trigger is focused and Esc key is pressed
-          latest.handleClickCloser()
+          latest.handleDelegateClickCloser()
 
           return
         }
@@ -89,7 +90,7 @@ export function useKeyboardNavigation(
           for (const inner of tabbable(latest.wrapperRef.current)) {
             if (inner === e.target) {
               // close the dropdown when an element that is included in dropdown content is focused and Esc key is pressed
-              latest.handleClickCloser()
+              latest.handleDelegateClickCloser()
 
               break
             }

--- a/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
+++ b/packages/smarthr-ui/src/components/Dropdown/useKeyboardNavigation.ts
@@ -12,14 +12,14 @@ export function useKeyboardNavigation(
   wrapperRef: RefObject<HTMLDivElement>,
   dummyFocusRef: RefObject<HTMLElement>,
 ) {
-  const { triggerElementRef, rootTriggerRef, onClickCloser } = useContext(DropdownContext)
+  const { triggerElementRef, rootTriggerRef, handleClickCloser } = useContext(DropdownContext)
 
   const latest = useLatest({
     wrapperRef,
     triggerElementRef,
     rootTriggerRef,
     dummyFocusRef,
-    onClickCloser,
+    handleClickCloser,
   })
 
   useEffect(() => {
@@ -58,7 +58,7 @@ export function useKeyboardNavigation(
             // focus the Trigger
             e.preventDefault()
             trigger!.focus()
-            latest.onClickCloser()
+            latest.handleClickCloser()
           }
         } else if (e.target === tabbablesInContent.at(-1)) {
           // move focus next of the Trigger
@@ -66,12 +66,12 @@ export function useKeyboardNavigation(
 
           if (rootTrigger) {
             rootTrigger.focus()
-            latest.onClickCloser()
+            latest.handleClickCloser()
           }
         }
       } else if (KEY_ESCAPE.test(e.key)) {
         if (e.target && e.target === latest.dummyFocusRef.current) {
-          latest.onClickCloser()
+          latest.handleClickCloser()
 
           return
         }
@@ -80,7 +80,7 @@ export function useKeyboardNavigation(
 
         if (trigger && e.target === trigger) {
           // close the dropdown when the Trigger is focused and Esc key is pressed
-          latest.onClickCloser()
+          latest.handleClickCloser()
 
           return
         }
@@ -89,7 +89,7 @@ export function useKeyboardNavigation(
           for (const inner of tabbable(latest.wrapperRef.current)) {
             if (inner === e.target) {
               // close the dropdown when an element that is included in dropdown content is focused and Esc key is pressed
-              latest.onClickCloser()
+              latest.handleClickCloser()
 
               break
             }


### PR DESCRIPTION
## 関連URL

## 概要

Dropdown コンポーネント群のリファクタリング。

## 変更内容

### DropdownContentInner

- `style` の計算を `useMemo` から IIFE パターンに変更し、中間変数をスコープ隔離
- `controllableWrapperStyleProps` の `useMemo` を削除しインライン化
- focus 用 `useEffect` に設計意図のコメントを追加
  - `setIsActive(true)` 直後に `focus()` が呼べない理由（`visibility: hidden` 要素はフォーカス不可）
  - `display: none` / VisuallyHidden が使えない理由（実寸法が取得できなくなる）
  - `requestAnimationFrame` が採用できない理由（タイミング保証・クリーンアップの複雑さ）

### DropdownCloser

- Prettier フォーマット修正

## プロダクト側で対応が必要な事項

なし（内部実装のリファクタリングのみ）

## 確認方法

Storybook での動作確認、または既存テストの通過で確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ドロップダウンの表示・レイアウト計算を見直し、開閉時の表示状態をより安定させました。
  * ドロップダウン内のフォーカス処理を調整し、表示時のちらつきを抑えながら適切にフォーカスできるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->