### PR TITLE
refactor(Dialog): useDialogPortalのuseRefをuseState lazyInitializerに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/useDialogPortal.ts
+++ b/packages/smarthr-ui/src/components/Dialog/useDialogPortal.ts
@@ -1,12 +1,12 @@
 'use client'
 
-import { type ReactNode, type RefObject, useCallback, useLayoutEffect, useRef } from 'react'
+import { type ReactNode, type RefObject, useCallback, useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 export function useDialogPortal(parent?: HTMLElement | RefObject<HTMLElement>, id?: string) {
-  const portalContainer = useRef<HTMLDivElement | null>(
-    typeof document === 'undefined' ? null : (document.createElement('div') as HTMLDivElement),
-  ).current
+  const [portalContainer] = useState<HTMLDivElement | null>(() =>
+    typeof document === 'undefined' ? null : document.createElement('div'),
+  )
 
   useLayoutEffect(() => {
     if (!portalContainer) {


### PR DESCRIPTION
## 関連URL

## 概要

`useDialogPortal` の `portalContainer` 初期化を `useRef(...).current` パターンから `useState` lazy initializer に変更しました。

## 変更内容

### `useRef(...).current` → `useState` lazy initializer

```ts
// Before
const portalContainer = useRef<HTMLDivElement | null>(
  typeof document === 'undefined' ? null : (document.createElement('div') as HTMLDivElement),
).current

// After
const [portalContainer] = useState<HTMLDivElement | null>(() =>
  typeof document === 'undefined' ? null : document.createElement('div'),
)
```

`useRef(initialValue)` の `initialValue` は初回レンダリング以降も毎回評価されますが、`useState` の lazy initializer は初回レンダリング時のみ実行されます。`document.createElement('div')` を毎レンダリングで実行しないようにするために `useState` lazy initializer を使用しています。

## プロダクト側で対応が必要な事項

なし（内部的なリファクタリングのみ）

## 確認方法

Storybook での動作確認、および既存テストの通過を確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * サーバーサイドレンダリング環境でもダイアログを安全に表示できるよう、ポータル処理の互換性を改善しました。
  * クライアント環境でのダイアログ表示や終了時の後処理は従来どおりです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->