### PR TITLE
refactor(Dialog): useBodyScrollLockの不要なuseRefを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/useBodyScrollLock.ts
+++ b/packages/smarthr-ui/src/components/Dialog/useBodyScrollLock.ts
@@ -6,9 +6,8 @@ export const useBodyScrollLock = (isOpen: boolean) => {
 
     const scrollBarWidth = window.innerWidth - document.body.clientWidth
     const originalPaddingRight = getComputedStyle(document.body).getPropertyValue('padding-right')
-    const paddingRight = `${scrollBarWidth + parseInt(originalPaddingRight, 10)}px`
 
-    document.body.style.paddingInlineEnd = paddingRight
+    document.body.style.paddingInlineEnd = `${scrollBarWidth + parseInt(originalPaddingRight, 10)}px`
     document.body.style.overflow = 'hidden'
 
     return () => {

--- a/packages/smarthr-ui/src/components/Dialog/useBodyScrollLock.ts
+++ b/packages/smarthr-ui/src/components/Dialog/useBodyScrollLock.ts
@@ -1,19 +1,14 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 export const useBodyScrollLock = (isOpen: boolean) => {
-  const paddingRightRef = useRef<string | null>(null)
-
   useEffect(() => {
     if (!isOpen) return
 
-    if (paddingRightRef.current === null) {
-      const scrollBarWidth = window.innerWidth - document.body.clientWidth
-      const originalPaddingRight = getComputedStyle(document.body).getPropertyValue('padding-right')
+    const scrollBarWidth = window.innerWidth - document.body.clientWidth
+    const originalPaddingRight = getComputedStyle(document.body).getPropertyValue('padding-right')
+    const paddingRight = `${scrollBarWidth + parseInt(originalPaddingRight, 10)}px`
 
-      paddingRightRef.current = `${scrollBarWidth + parseInt(originalPaddingRight, 10)}px`
-    }
-
-    document.body.style.paddingInlineEnd = paddingRightRef.current
+    document.body.style.paddingInlineEnd = paddingRight
     document.body.style.overflow = 'hidden'
 
     return () => {


### PR DESCRIPTION
## 関連URL

## 概要

`useBodyScrollLock` の `paddingRightRef` を削除し、コードをシンプルにしました。

## 変更内容

`useEffect` の依存配列が `[isOpen]` であるため、`isOpen` が `true` になったタイミングで1回しか実行されません。そのためスクロールバー幅の計算結果をキャッシュする目的の `paddingRightRef` は不要でした。

`useRef` を削除し、計算を `useEffect` 内に直接記述しました。また `paddingRight` 中間変数もインライン化しました。

## プロダクト側で対応が必要な事項

なし（内部的なリファクタリングのみ）

## 確認方法

Storybook でダイアログを開閉して、スクロールロック・アンロックが正常に動作することを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ダイアログ表示時のスクロールバー幅の計算と余白調整を改善しました。
  * 既存の右側余白を考慮し、画面レイアウトのずれや不要な横揺れが発生しにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->