### PR TITLE
refactor(Dialog): FocusTrapの2つのuseEffectを1つに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
@@ -32,6 +32,15 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
   }))
 
   useEffect(() => {
+    // FocusTrap がマウントされた時点のフォーカス要素を保存
+    const triggerElement = document.activeElement
+
+    if (firstFocusTarget?.current) {
+      firstFocusTarget.current.focus()
+    } else {
+      dummyFocusRef.current?.focus()
+    }
+
     const handleKeyDown = (e: KeyboardEvent) => {
       // IME 変換中の Tab は変換候補の選択に使われるため、フォーカストラップの対象外にする。
       // ここで preventDefault してしまうと、Dialog 内で日本語入力中に Tab を押しても
@@ -65,19 +74,6 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [])
-
-  useEffect(() => {
-    const triggerElement = document.activeElement
-
-    if (firstFocusTarget?.current) {
-      firstFocusTarget.current.focus()
-    } else {
-      dummyFocusRef.current?.focus()
-    }
-
-    return () => {
       // フォーカストラップ終了時にトリガにフォーカスを戻す
       if (triggerElement instanceof HTMLElement) {
         triggerElement.focus()


### PR DESCRIPTION
## 関連URL

## 概要

`FocusTrap` の2つの `useEffect` を1つに統合しました。

## 変更内容

以下の2つの `useEffect` を統合しました。

- キーボードナビゲーション（`keydown` リスナー登録・解除）: `[]`
- フォーカス管理（フォーカス移動・トリガへの復元）: `[firstFocusTarget]`

`firstFocusTarget` は `RefObject` のため実質安定した参照であり、2つの依存配列は事実上同等でした。

統合後の処理順序：
1. マウント時点の `document.activeElement` を保存（フォーカス移動前に取得）
2. `firstFocusTarget` または `dummyFocusRef` にフォーカス移動
3. `keydown` リスナー登録
4. cleanup: リスナー解除 → トリガにフォーカスを戻す

## プロダクト側で対応が必要な事項

なし（内部的なリファクタリングのみ）

## 確認方法

Storybook でダイアログを開閉し、フォーカストラップおよびフォーカス復元が正常に動作することを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ダイアログを開いた際、指定された初期フォーカス先へ正しく移動するよう改善しました。
  * 初期フォーカス先がない場合も、適切な位置にフォーカスが設定されます。
  * ダイアログを閉じた際、開く操作を行った要素へフォーカスが戻るようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->