### PR TITLE
refactor(Dialog): DialogHeadingのtv()をインラインclassNameに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogHeading.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogHeading.tsx
@@ -1,5 +1,4 @@
-import { type ReactNode, memo, useMemo } from 'react'
-import { tv } from 'tailwind-variants'
+import { type ReactNode, memo } from 'react'
 
 import { Heading } from '../Heading'
 import { Stack } from '../Layout'
@@ -13,33 +12,17 @@ export type Props = {
   id?: string
 }
 
-const classNameGenerator = tv({
-  base: [
-    'smarthr-ui-Dialog-titleArea',
-    'shr-border-b-shorthand shr-flex-[0_0_auto] shr-px-1.5 shr-py-1',
-  ],
-})
-
-export const DialogHeading = memo<Props>(({ text, sub, id }) => {
-  const className = useMemo(() => classNameGenerator(), [])
-
-  return (
-    <Heading className={className}>
-      <Stack gap={0.25} as="span">
-        {sub && (
-          <Text
-            size="S"
-            leading="TIGHT"
-            color="TEXT_GREY"
-            className="smarthr-ui-Dialog-heading-sub"
-          >
-            {sub}
-          </Text>
-        )}
-        <Text id={id} size="L" leading="TIGHT" className="smarthr-ui-Dialog-heading">
-          {text}
+export const DialogHeading = memo<Props>(({ text, sub, id }) => (
+  <Heading className="smarthr-ui-Dialog-titleArea shr-border-b-shorthand shr-flex-[0_0_auto] shr-px-1.5 shr-py-1">
+    <Stack gap={0.25} as="span">
+      {sub && (
+        <Text size="S" leading="TIGHT" color="TEXT_GREY" className="smarthr-ui-Dialog-heading-sub">
+          {sub}
         </Text>
-      </Stack>
-    </Heading>
-  )
-})
+      )}
+      <Text id={id} size="L" leading="TIGHT" className="smarthr-ui-Dialog-heading">
+        {text}
+      </Text>
+    </Stack>
+  </Heading>
+))


### PR DESCRIPTION
## 関連URL

## 概要

`DialogHeading` の `tv()` によるクラス名生成をインラインの `className` 文字列に変更しました。

## 変更内容

クラス名の生成に `tv()` と `useMemo` を使用していましたが、バリアントなしの単純な静的クラス文字列のため、インライン化しました。

- `tv` / `useMemo` のimportを削除
- `classNameGenerator` を削除
- `className` を直接インライン文字列に変更
- コンポーネントをシンプルな関数式に変更

## プロダクト側で対応が必要な事項

なし（内部的なリファクタリングのみ）

## 確認方法

Storybook でダイアログのタイトル表示が正常に動作することを確認してください。