### PR TITLE
refactor(Dialog): DialogContentInnerのfunctionsリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentInner.tsx
@@ -127,27 +127,24 @@ export const DialogContentInner: FC<Props> = ({
 
   const latest = useLatest({ onPressEscape, onClickOverlay })
 
-  const functions = useMemo(() => {
-    if (!isOpen) {
-      return {
-        onPressEscape: undefined,
-        onClickOverlay: undefined,
-      }
-    }
+  const functions = useMemo(
+    () => ({
+      handlePressEscape: () => latest.onPressEscape?.(),
+      handleClickOverlay: () => latest.onClickOverlay?.(),
+    }),
+    [latest],
+  )
 
-    return {
-      onPressEscape: () => latest.onPressEscape?.(),
-      onClickOverlay: () => latest.onClickOverlay?.(),
-    }
-  }, [isOpen, latest])
-
-  useHandleEscape(functions.onPressEscape)
+  useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
   useBodyScrollLock(isOpen)
 
   return (
     <DialogOverlap isOpen={isOpen}>
       <div id={id} className={classNames.layout} style={style}>
-        <Overlay onClickOverlay={functions.onClickOverlay} className={classNames.background} />
+        <Overlay
+          handleClickOverlay={isOpen ? functions.handleClickOverlay : undefined}
+          className={classNames.background}
+        />
         <div
           {...rest}
           ref={innerRef}
@@ -166,9 +163,9 @@ export const DialogContentInner: FC<Props> = ({
   )
 }
 
-const Overlay = memo<{ onClickOverlay: (() => void) | undefined; className: string }>(
-  ({ onClickOverlay, className }) => (
+const Overlay = memo<{ handleClickOverlay: (() => void) | undefined; className: string }>(
+  ({ handleClickOverlay, className }) => (
     // eslint-disable-next-line smarthr/best-practice-for-interactive-element
-    <div onClick={onClickOverlay} className={className} role="presentation" />
+    <div onClick={handleClickOverlay} className={className} role="presentation" />
   ),
 )


### PR DESCRIPTION
## 関連URL

## 概要

`DialogContentInner` の `functions` useMemo を整理し、handler命名を修正しました。

## 変更内容

### `functions` から `isOpen` 条件分岐を除去

`functions` の useMemo 内で `isOpen` に応じてハンドラを `undefined` にする条件分岐を削除し、依存配列から `isOpen` を除去しました。代わりに呼び出し側でチェックするようにしました。

```ts
// Before: isOpenをuseMemo内で判定
const functions = useMemo(() => {
  if (!isOpen) return { onPressEscape: undefined, onClickOverlay: undefined }
  return { onPressEscape: () => ..., onClickOverlay: () => ... }
}, [isOpen, latest])

// After: 呼び出し側でisOpenを判定
const functions = useMemo(() => ({
  handlePressEscape: () => latest.onPressEscape?.(),
  handleClickOverlay: () => latest.onClickOverlay?.(),
}), [latest])

useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
<Overlay handleClickOverlay={isOpen ? functions.handleClickOverlay : undefined} />
```

### handler命名を修正

- `onPressEscape` → `handlePressEscape`
- `onClickOverlay` → `handleClickOverlay`
- 内部コンポーネント `Overlay` のprop名も同様にリネーム

## プロダクト側で対応が必要な事項

なし（内部的なリファクタリングのみ）

## 確認方法

Storybook でダイアログのオーバーレイクリックおよびEscapeキーによる閉じる動作を確認してください。