### PR TITLE
refactor(Dialog): DialogBodyのactualPaddingsから不要なuseMemoを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogBody.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogBody.tsx
@@ -23,11 +23,10 @@ const classNameGenerator = tv({
 })
 
 export const DialogBody: FC<Props> = ({ contentBgColor, contentPadding, className, ...rest }) => {
-  const actualPaddings = useMemo(() => {
-    const initialized = contentPadding === undefined ? 1.5 : contentPadding
+  const initialized = contentPadding === undefined ? 1.5 : contentPadding
+  const actualPaddings =
+    initialized instanceof Object ? initialized : { block: initialized, inline: initialized }
 
-    return initialized instanceof Object ? initialized : { block: initialized, inline: initialized }
-  }, [contentPadding])
   const actualClassName = useMemo(
     () =>
       classNameGenerator({


### PR DESCRIPTION
## 関連URL

## 概要

`DialogBody` の `actualPaddings` 計算から不要な `useMemo` を削除しました。

## 変更内容

`actualPaddings` の計算は単純な条件分岐のみで副作用がなく、`useMemo` によるメモ化の恩恵がないため削除しました。また中間変数 `initialized` をインラインに展開しました。

## プロダクト側で対応が必要な事項

なし（内部的なリファクタリングのみ）

## 確認方法

Storybook でダイアログのコンテンツ表示が正常に動作することを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ダイアログ本文の余白計算処理を簡素化し、レンダリング時に適切な値が算出されるよう改善しました。
  * ダイアログの表示や余白に関するユーザー向けの挙動に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->