### PR TITLE
refactor(ModelessDialog): useCallbackをuseMemo+functionsパターンに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -9,7 +9,6 @@ import {
   type ReactNode,
   type RefObject,
   memo,
-  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -204,74 +203,68 @@ export const ModelessDialog: FC<Props> = ({
     [centering, top, left, right, bottom, width, height, size],
   )
 
-  const debounceLiveRegionText = useMemo(() => debounce(setDebouncedLiveRegionText, 600), [])
-
   // 外部propsをrefに保存
   const latest = useLatest({ isOpen, onClickClose, onPressEscape })
 
-  const handleArrowKey = useCallback(
-    (e: KeyboardEvent) => {
-      if (!latest.isOpen || document.activeElement !== e.currentTarget) {
-        return
-      }
+  const functions = useMemo(
+    () => ({
+      debounceLiveRegionText: debounce(setDebouncedLiveRegionText, 600),
+      handleArrowKeyDown: (e: KeyboardEvent) => {
+        if (!latest.isOpen || document.activeElement !== e.currentTarget) {
+          return
+        }
 
-      const movingDistance = 20
+        const movingDistance = 20
 
-      switch (e.key) {
-        case 'ArrowUp':
-          setPosition((prev) => ({
-            x: prev.x,
-            y: prev.y - movingDistance,
-          }))
-          e.preventDefault()
-          break
-        case 'ArrowDown':
-          setPosition((prev) => ({
-            x: prev.x,
-            y: prev.y + movingDistance,
-          }))
-          e.preventDefault()
-          break
-        case 'ArrowLeft':
-          setPosition((prev) => ({
-            x: prev.x - movingDistance,
-            y: prev.y,
-          }))
-          e.preventDefault()
-          break
-        case 'ArrowRight':
-          setPosition((prev) => ({
-            x: prev.x + movingDistance,
-            y: prev.y,
-          }))
-          e.preventDefault()
-          break
-      }
-    },
+        switch (e.key) {
+          case 'ArrowUp':
+            setPosition((prev) => ({
+              x: prev.x,
+              y: prev.y - movingDistance,
+            }))
+            e.preventDefault()
+            break
+          case 'ArrowDown':
+            setPosition((prev) => ({
+              x: prev.x,
+              y: prev.y + movingDistance,
+            }))
+            e.preventDefault()
+            break
+          case 'ArrowLeft':
+            setPosition((prev) => ({
+              x: prev.x - movingDistance,
+              y: prev.y,
+            }))
+            e.preventDefault()
+            break
+          case 'ArrowRight':
+            setPosition((prev) => ({
+              x: prev.x + movingDistance,
+              y: prev.y,
+            }))
+            e.preventDefault()
+            break
+        }
+      },
+      actualOnClickClose: (e: MouseEvent<HTMLButtonElement>) => {
+        lastFocusElementRef.current?.focus()
+        latest.onClickClose?.(e)
+      },
+      memoizedOnPressEscape: () => {
+        lastFocusElementRef.current?.focus()
+        latest.onPressEscape?.()
+      },
+      onDragStart: (_: any, data: { x: number; y: number }) => setPosition(data),
+      onDrag: (_: any, data: { deltaX: number; deltaY: number }) => {
+        setPosition((prev) => ({
+          x: prev.x + data.deltaX,
+          y: prev.y + data.deltaY,
+        }))
+      },
+    }),
     [latest],
   )
-
-  const actualOnClickClose = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      lastFocusElementRef.current?.focus()
-      latest.onClickClose?.(e)
-    },
-    [latest],
-  )
-
-  // stableなcallbackを作成
-  const memoizedOnPressEscape = useCallback(() => {
-    lastFocusElementRef.current?.focus()
-    latest.onPressEscape?.()
-  }, [latest])
-
-  const onDragStart = useCallback((_: any, data: { x: number; y: number }) => setPosition(data), [])
-  const onDrag = useCallback((_: any, data: { deltaX: number; deltaY: number }) => {
-    setPosition((prev) => ({
-      x: prev.x + data.deltaX,
-      y: prev.y + data.deltaY,
-    }))
-  }, [])
 
   useEffect(() => {
     if (!wrapperPosition) {
@@ -290,8 +283,8 @@ export const ModelessDialog: FC<Props> = ({
       },
     )
 
-    debounceLiveRegionText(txt)
-  }, [localize, wrapperPosition, debounceLiveRegionText])
+    functions.debounceLiveRegionText(txt)
+  }, [localize, wrapperPosition, functions])
 
   useEffect(() => {
     if (wrapperRef.current instanceof Element) {
@@ -341,7 +334,7 @@ export const ModelessDialog: FC<Props> = ({
     }
   }, [isOpen])
 
-  useHandleEscape(isOpen ? memoizedOnPressEscape : undefined)
+  useHandleEscape(isOpen ? functions.memoizedOnPressEscape : undefined)
 
   useEffect(() => {
     const focusHandler = (e: FocusEvent) => {
@@ -360,8 +353,8 @@ export const ModelessDialog: FC<Props> = ({
     <DialogOverlap isOpen={isOpen} className={classNames.overlap} as="section">
       <Draggable
         handle=".smarthr-ui-ModelessDialog-handle"
-        onStart={onDragStart}
-        onDrag={onDrag}
+        onStart={functions.onDragStart}
+        onDrag={functions.onDrag}
         position={position}
         bounds={draggableBounds}
         nodeRef={wrapperRef}
@@ -380,13 +373,16 @@ export const ModelessDialog: FC<Props> = ({
           {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex -- dummy element for focus management. */}
           <div tabIndex={-1} ref={focusTargetRef} />
           <div className={classNames.header}>
-            <Handler handleArrowKeyDown={handleArrowKey} className={classNames.dialogHandler} />
+            <Handler
+              handleArrowKeyDown={functions.handleArrowKeyDown}
+              className={classNames.dialogHandler}
+            />
             <div id={labelId} className={classNames.heading}>
               {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
               <Heading>{heading}</Heading>
             </div>
             <CloseButton
-              handleClick={actualOnClickClose}
+              handleClick={functions.actualOnClickClose}
               className={classNames.closeButtonLayout}
             />
           </div>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -203,7 +203,6 @@ export const ModelessDialog: FC<Props> = ({
     [centering, top, left, right, bottom, width, height, size],
   )
 
-  // 外部propsをrefに保存
   const latest = useLatest({ isOpen, onClickClose, onPressEscape })
 
   const functions = useMemo(
@@ -247,16 +246,16 @@ export const ModelessDialog: FC<Props> = ({
             break
         }
       },
-      actualOnClickClose: (e: MouseEvent<HTMLButtonElement>) => {
+      handleClickClose: (e: MouseEvent<HTMLButtonElement>) => {
         lastFocusElementRef.current?.focus()
         latest.onClickClose?.(e)
       },
-      memoizedOnPressEscape: () => {
+      handlePressEscape: () => {
         lastFocusElementRef.current?.focus()
         latest.onPressEscape?.()
       },
-      onDragStart: (_: any, data: { x: number; y: number }) => setPosition(data),
-      onDrag: (_: any, data: { deltaX: number; deltaY: number }) => {
+      handleDragStart: (_: any, data: { x: number; y: number }) => setPosition(data),
+      handleDrag: (_: any, data: { deltaX: number; deltaY: number }) => {
         setPosition((prev) => ({
           x: prev.x + data.deltaX,
           y: prev.y + data.deltaY,
@@ -334,7 +333,7 @@ export const ModelessDialog: FC<Props> = ({
     }
   }, [isOpen])
 
-  useHandleEscape(isOpen ? functions.memoizedOnPressEscape : undefined)
+  useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
 
   useEffect(() => {
     const focusHandler = (e: FocusEvent) => {
@@ -353,8 +352,8 @@ export const ModelessDialog: FC<Props> = ({
     <DialogOverlap isOpen={isOpen} className={classNames.overlap} as="section">
       <Draggable
         handle=".smarthr-ui-ModelessDialog-handle"
-        onStart={functions.onDragStart}
-        onDrag={functions.onDrag}
+        onStart={functions.handleDragStart}
+        onDrag={functions.handleDrag}
         position={position}
         bounds={draggableBounds}
         nodeRef={wrapperRef}
@@ -382,7 +381,7 @@ export const ModelessDialog: FC<Props> = ({
               <Heading>{heading}</Heading>
             </div>
             <CloseButton
-              handleClick={functions.actualOnClickClose}
+              handleClick={functions.handleClickClose}
               className={classNames.closeButtonLayout}
             />
           </div>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -380,7 +380,7 @@ export const ModelessDialog: FC<Props> = ({
           {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex -- dummy element for focus management. */}
           <div tabIndex={-1} ref={focusTargetRef} />
           <div className={classNames.header}>
-            <Handler onArrowKeyDown={handleArrowKey} className={classNames.dialogHandler} />
+            <Handler handleArrowKeyDown={handleArrowKey} className={classNames.dialogHandler} />
             <div id={labelId} className={classNames.heading}>
               {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
               <Heading>{heading}</Heading>
@@ -404,8 +404,8 @@ export const ModelessDialog: FC<Props> = ({
 
 const Handler = memo<{
   className: string
-  onArrowKeyDown: (e: KeyboardEvent) => void
-}>(({ onArrowKeyDown: onDelegateKeyDown, ...rest }) => {
+  handleArrowKeyDown: (e: KeyboardEvent) => void
+}>(({ handleArrowKeyDown, ...rest }) => {
   const { localize } = useIntl()
 
   return (
@@ -422,7 +422,7 @@ const Handler = memo<{
           defaultText: 'ドラッグ可能',
         })}
         aria-describedby="handler-description"
-        onKeyDown={onDelegateKeyDown}
+        onKeyDown={handleArrowKeyDown}
       >
         <FaGripIcon />
       </button>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -191,30 +191,6 @@ export const ModelessDialog: FC<Props> = ({
   })
   const [draggableBounds, setDraggableBounds] =
     useState<ComponentProps<typeof Draggable>['bounds']>()
-  const debounceLiveRegionText = useMemo(() => debounce(setDebouncedLiveRegionText, 600), [])
-
-  useEffect(() => {
-    if (!wrapperPosition) {
-      setDebouncedLiveRegionText('')
-      return
-    }
-
-    const txt = localize(
-      {
-        id: 'smarthr-ui/ModelessDialog/dialogHandlerLiveRegionText',
-        defaultText: '上から{top}px、左から{left}px',
-      },
-      {
-        top: Math.trunc(wrapperPosition.top).toString(),
-        left: Math.trunc(wrapperPosition.left).toString(),
-      },
-    )
-
-    debounceLiveRegionText(txt)
-  }, [localize, wrapperPosition, debounceLiveRegionText])
-
-  // 外部propsをrefに保存
-  const latest = useLatest({ isOpen, onClickClose, onPressEscape })
 
   const positionStyle = useMemo(
     () => ({
@@ -227,6 +203,11 @@ export const ModelessDialog: FC<Props> = ({
     }),
     [centering, top, left, right, bottom, width, height, size],
   )
+
+  const debounceLiveRegionText = useMemo(() => debounce(setDebouncedLiveRegionText, 600), [])
+
+  // 外部propsをrefに保存
+  const latest = useLatest({ isOpen, onClickClose, onPressEscape })
 
   const handleArrowKey = useCallback(
     (e: KeyboardEvent) => {
@@ -269,6 +250,48 @@ export const ModelessDialog: FC<Props> = ({
     },
     [latest],
   )
+
+  const actualOnClickClose = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      lastFocusElementRef.current?.focus()
+      latest.onClickClose?.(e)
+    },
+    [latest],
+  )
+
+  // stableなcallbackを作成
+  const memoizedOnPressEscape = useCallback(() => {
+    lastFocusElementRef.current?.focus()
+    latest.onPressEscape?.()
+  }, [latest])
+
+  const onDragStart = useCallback((_: any, data: { x: number; y: number }) => setPosition(data), [])
+  const onDrag = useCallback((_: any, data: { deltaX: number; deltaY: number }) => {
+    setPosition((prev) => ({
+      x: prev.x + data.deltaX,
+      y: prev.y + data.deltaY,
+    }))
+  }, [])
+
+  useEffect(() => {
+    if (!wrapperPosition) {
+      setDebouncedLiveRegionText('')
+      return
+    }
+
+    const txt = localize(
+      {
+        id: 'smarthr-ui/ModelessDialog/dialogHandlerLiveRegionText',
+        defaultText: '上から{top}px、左から{left}px',
+      },
+      {
+        top: Math.trunc(wrapperPosition.top).toString(),
+        left: Math.trunc(wrapperPosition.left).toString(),
+      },
+    )
+
+    debounceLiveRegionText(txt)
+  }, [localize, wrapperPosition, debounceLiveRegionText])
 
   useEffect(() => {
     if (wrapperRef.current instanceof Element) {
@@ -318,20 +341,6 @@ export const ModelessDialog: FC<Props> = ({
     }
   }, [isOpen])
 
-  const actualOnClickClose = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      lastFocusElementRef.current?.focus()
-      latest.onClickClose?.(e)
-    },
-    [latest],
-  )
-
-  // stableなcallbackを作成
-  const memoizedOnPressEscape = useCallback(() => {
-    lastFocusElementRef.current?.focus()
-    latest.onPressEscape?.()
-  }, [latest])
-
   useHandleEscape(isOpen ? memoizedOnPressEscape : undefined)
 
   useEffect(() => {
@@ -345,14 +354,6 @@ export const ModelessDialog: FC<Props> = ({
     document.addEventListener('focus', focusHandler, true)
 
     return () => document.removeEventListener('focus', focusHandler, true)
-  }, [])
-
-  const onDragStart = useCallback((_: any, data: { x: number; y: number }) => setPosition(data), [])
-  const onDrag = useCallback((_: any, data: { deltaX: number; deltaY: number }) => {
-    setPosition((prev) => ({
-      x: prev.x + data.deltaX,
-      y: prev.y + data.deltaY,
-    }))
   }, [])
 
   return createPortal(

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -385,7 +385,10 @@ export const ModelessDialog: FC<Props> = ({
               {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
               <Heading>{heading}</Heading>
             </div>
-            <CloseButton onClick={actualOnClickClose} className={classNames.closeButtonLayout} />
+            <CloseButton
+              handleClick={actualOnClickClose}
+              className={classNames.closeButtonLayout}
+            />
           </div>
           <DialogBody
             contentBgColor={contentBgColor}
@@ -447,13 +450,13 @@ const LiveRegion = ({ regionText }: { regionText: string | undefined }) => (
 
 const CloseButton = memo<{
   className: string
-  onClick: (e: MouseEvent<HTMLButtonElement>) => void
-}>(({ onClick, className }) => (
+  handleClick: (e: MouseEvent<HTMLButtonElement>) => void
+}>(({ handleClick, className }) => (
   <div className={className}>
     <Button
       type="button"
       size="S"
-      onClick={onClick}
+      onClick={handleClick}
       className="smarthr-ui-ModelessDialog-closeButton"
     >
       <FaXmarkIcon

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -407,38 +407,30 @@ const Handler = memo<{
   onArrowKeyDown: (e: KeyboardEvent) => void
 }>(({ onArrowKeyDown: onDelegateKeyDown, ...rest }) => {
   const { localize } = useIntl()
-  const accessibleDefaultTexts = useMemo(
-    () => ({
-      dialogHandlerAriaRoleDescription: localize({
-        id: 'smarthr-ui/ModelessDialog/dialogHandlerAriaRoleDescription',
-        defaultText: 'ドラッグ可能',
-      }),
-      dialogHandlerDescription: localize({
-        id: 'smarthr-ui/ModelessDialog/dialogHandlerDescription',
-        defaultText: '矢印キーを押して上下左右に移動できます',
-      }),
-      dialogHandlerAriaLabel: localize({
-        id: 'smarthr-ui/ModelessDialog/dialogHandlerAriaLabel',
-        defaultText: 'ダイアログの位置',
-      }),
-    }),
-    [localize],
-  )
 
   return (
     <>
       <button
         {...rest}
         type="button"
-        aria-label={accessibleDefaultTexts.dialogHandlerAriaLabel}
-        aria-roledescription={accessibleDefaultTexts.dialogHandlerAriaRoleDescription}
+        aria-label={localize({
+          id: 'smarthr-ui/ModelessDialog/dialogHandlerAriaLabel',
+          defaultText: 'ダイアログの位置',
+        })}
+        aria-roledescription={localize({
+          id: 'smarthr-ui/ModelessDialog/dialogHandlerAriaRoleDescription',
+          defaultText: 'ドラッグ可能',
+        })}
         aria-describedby="handler-description"
         onKeyDown={onDelegateKeyDown}
       >
         <FaGripIcon />
       </button>
       <div className="shr-hidden" id="handler-description">
-        {accessibleDefaultTexts.dialogHandlerDescription}
+        {localize({
+          id: 'smarthr-ui/ModelessDialog/dialogHandlerDescription',
+          defaultText: '矢印キーを押して上下左右に移動できます',
+        })}
       </div>
     </>
   )


### PR DESCRIPTION
## 関連URL

- #6646

## 概要

`ModelessDialog` の複数の `useCallback` を `useMemo` + `functions` パターンに統合した。

## 変更内容

- `handleArrowKey`、`actualOnClickClose`、`memoizedOnPressEscape`、`onDragStart`、`onDrag` の各 `useCallback` を `functions` オブジェクトにまとめ、`useMemo([latest])` で一元管理
- `debounceLiveRegionText` も `functions` 内に統合（`latest` が安定したrefのため debounce は正しく機能する）
- 不要な `useCallback` インポートを削除
- functions内のハンドラ名を `handleXxx` 規則に統一（`actualOnClickClose`→`handleClickClose`、`memoizedOnPressEscape`→`handlePressEscape`、`onDragStart`→`handleDragStart`、`onDrag`→`handleDrag`）

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で ModelessDialog の動作（ドラッグ、閉じる、Escape、位置表示）を確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * モードレスダイアログの内部処理を整理し、安定性と保守性を向上しました。
  * ダイアログのキーボード操作、閉じる操作、フォーカス復帰、ドラッグ操作、ライブリージョン更新が従来どおり機能するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->