### PR TITLE
refactor(DatePicker): PortalのisPortalRootMountedをportalRootに変更し不要なuseMemoを削除

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
@@ -1,12 +1,4 @@
-import {
-  type PropsWithChildren,
-  forwardRef,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
-import { tv } from 'tailwind-variants'
+import { type PropsWithChildren, forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'
 import { usePortal } from '../../hooks/usePortal'
@@ -17,17 +9,13 @@ type Props = PropsWithChildren<{
   inputRect: DOMRect
 }>
 
-const classNameGenerator = tv({
-  base: 'smarthr-ui-DatePicker-calendarContainer shr-absolute shr-z-overlap shr-leading-none',
-})
-
 const initialPosition = {
   top: '0px',
   left: '0px',
 }
 
 export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, ...rest }, ref) => {
-  const { isPortalRootMounted, createPortal } = usePortal()
+  const { portalRoot, createPortal } = usePortal()
   const containerRef = useRef<HTMLDivElement>(null)
 
   useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(ref, () => containerRef.current)
@@ -43,9 +31,14 @@ export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, ...rest },
         left: `${position.left}px`,
       })
     }
-  }, [inputRect, isPortalRootMounted])
+  }, [inputRect, portalRoot])
 
-  const className = useMemo(() => classNameGenerator(), [])
-
-  return createPortal(<div {...rest} ref={containerRef} className={className} style={style} />)
+  return createPortal(
+    <div
+      {...rest}
+      ref={containerRef}
+      className="smarthr-ui-DatePicker-calendarContainer shr-absolute shr-z-overlap shr-leading-none"
+      style={style}
+    />,
+  )
 })


### PR DESCRIPTION
## 関連URL

## 概要

`DatePicker/Portal.tsx` の依存配列に関数 `isPortalRootMounted` ではなく、その参照元である値 `portalRoot` を直接使用するよう変更した。

## 変更内容

- `usePortal()` から `isPortalRootMounted` の代わりに `portalRoot` を取得
- `useEnhancedEffect` の依存配列を `[inputRect, isPortalRootMounted]` → `[inputRect, portalRoot]` に変更
  - `isPortalRootMounted` は `portalRoot` をラップした関数であり、`portalRoot` を直接使う方が意図が明確
- 未使用の `useMemo` インポートを削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で DatePicker のカレンダーの表示位置が正しく計算されることを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 日付選択UIのポータル表示処理を整理し、表示時の安定性と一貫性を向上しました。
  * ポータル要素のスタイル適用を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->