### PR TITLE
refactor(DatePicker): containerStyleのuseMemoを削除しインライン化

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -123,12 +123,6 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
     ref,
   ) => {
     const theme = useTheme()
-    const containerStyle = useMemo(
-      () => ({
-        width: typeof width === 'number' ? `${width}px` : width,
-      }),
-      [width],
-    )
     const classNames = useMemo(() => {
       const { container, inputSuffixLayout, inputSuffixWrapper, inputSuffixText } =
         classNameGenerator()
@@ -381,7 +375,9 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         onKeyDown={isCalendarShown ? functions.handleDelegateKeyDown : undefined}
         role="presentation"
         className={classNames.container}
-        style={containerStyle}
+        style={{
+          width: typeof width === 'number' ? `${width}px` : width,
+        }}
       >
         <div ref={inputWrapperRef}>
           <Input


### PR DESCRIPTION
## 関連URL

## 概要

`DatePicker` の `containerStyle` に使われていた不要な `useMemo` を削除した。

## 変更内容

- `containerStyle` の `useMemo` を削除し、`style` 属性にインラインで記述するよう変更
- `width` の変換（`number → px文字列`）は単純な計算であり、`useMemo` によるメモ化は不要

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で DatePicker の `width` prop が正しく適用されることを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * DatePickerの幅指定処理を簡素化し、設定した幅がより安定して反映されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->