### PR TITLE
refactor(Calendar): CalendarとYearPickerのリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -140,7 +140,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
 
     const functions = useMemo(
       () => ({
-        onSelectYear: (e: MouseEvent<HTMLButtonElement>) => {
+        handleSelectYear: (e: MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation()
 
           const year = parseInt(e.currentTarget.value, 10)
@@ -182,7 +182,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
             fromYear={formattedFrom.year}
             toYear={formattedTo.year}
             selectedYear={value?.getFullYear()}
-            onSelectYear={functions.onSelectYear}
+            handleSelectYear={functions.handleSelectYear}
             isDisplayed={isSelectingYear}
             id={yearPickerId}
           />

--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -138,14 +138,12 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
       }
     }, [currentMonth, formatDate, getWeekStartDay])
 
-    const onSelectYear = useCallback(
-      (e: MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation()
-        setCurrentMonth(currentMonth.year(parseInt(e.currentTarget.value, 10)))
-        setIsSelectingYear(false)
-      },
-      [currentMonth],
-    )
+    const onSelectYear = useCallback((e: MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      const year = parseInt(e.currentTarget.value, 10)
+      setCurrentMonth((prev) => prev.year(year))
+      setIsSelectingYear(false)
+    }, [])
 
     const onClickSelectYear = useCallback((e: MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation()

--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -148,7 +148,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
           setCurrentMonth((prev) => prev.year(year))
           setIsSelectingYear(false)
         },
-        onClickSelectYear: (e: MouseEvent<HTMLButtonElement>) => {
+        handleClickSelectYear: (e: MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation()
           setIsSelectingYear((current) => !current)
         },
@@ -165,7 +165,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
           <YearSelectButton
             aria-expanded={isSelectingYear}
             aria-controls={yearPickerId}
-            onClick={functions.onClickSelectYear}
+            handleClick={functions.handleClickSelectYear}
             className={classNames.yearSelectButton}
           />
           <MonthDirectionCluster
@@ -206,10 +206,10 @@ const YearMonthRender = memo<PropsWithChildren<{ className: string }>>(
 const YearSelectButton = memo<{
   'aria-expanded': boolean
   'aria-controls': string
-  onClick: (e: MouseEvent<HTMLButtonElement>) => void
+  handleClick: (e: MouseEvent<HTMLButtonElement>) => void
   className: string
-}>((props) => (
-  <Button {...props} size="S">
+}>(({ handleClick, ...rest }) => (
+  <Button {...rest} onClick={handleClick} size="S">
     <FaCaretDownIcon
       alt={<Localizer id="smarthr-ui/Calendar/selectYear" defaultText="年を選択する" />}
     />

--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -138,17 +138,23 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
       }
     }, [currentMonth, formatDate, getWeekStartDay])
 
-    const onSelectYear = useCallback((e: MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation()
-      const year = parseInt(e.currentTarget.value, 10)
-      setCurrentMonth((prev) => prev.year(year))
-      setIsSelectingYear(false)
-    }, [])
+    const functions = useMemo(
+      () => ({
+        onSelectYear: (e: MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation()
 
-    const onClickSelectYear = useCallback((e: MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation()
-      setIsSelectingYear((current) => !current)
-    }, [])
+          const year = parseInt(e.currentTarget.value, 10)
+
+          setCurrentMonth((prev) => prev.year(year))
+          setIsSelectingYear(false)
+        },
+        onClickSelectYear: (e: MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation()
+          setIsSelectingYear((current) => !current)
+        },
+      }),
+      [],
+    )
 
     return (
       <div {...rest} ref={ref} className={classNames.container}>
@@ -159,7 +165,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
           <YearSelectButton
             aria-expanded={isSelectingYear}
             aria-controls={yearPickerId}
-            onClick={onClickSelectYear}
+            onClick={functions.onClickSelectYear}
             className={classNames.yearSelectButton}
           />
           <MonthDirectionCluster
@@ -176,7 +182,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
             fromYear={formattedFrom.year}
             toYear={formattedTo.year}
             selectedYear={value?.getFullYear()}
-            onSelectYear={onSelectYear}
+            onSelectYear={functions.onSelectYear}
             isDisplayed={isSelectingYear}
             id={yearPickerId}
           />

--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -95,21 +95,19 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
       [value, formattedFrom.date, formattedTo.date],
     )
 
-    const [currentMonth, setCurrentMonth] = useState(
-      (() => {
-        if (isValidValue) {
-          return dayjs(value)
-        }
+    const [currentMonth, setCurrentMonth] = useState(() => {
+      if (isValidValue) {
+        return dayjs(value)
+      }
 
-        const today = dayjs()
+      const today = dayjs()
 
-        return formattedTo.day.isBefore(today)
-          ? formattedTo.day
-          : formattedFrom.day.isAfter(today)
-            ? formattedFrom.day
-            : today
-      })(),
-    )
+      return formattedTo.day.isBefore(today)
+        ? formattedTo.day
+        : formattedFrom.day.isAfter(today)
+          ? formattedFrom.day
+          : today
+    })
     const [isSelectingYear, setIsSelectingYear] = useState(false)
 
     const yearPickerId = useId()

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -22,7 +22,7 @@ type AbstractProps = {
   /** 選択可能な終了年 */
   toYear: number
   /** トリガのセレクトイベントを処理するハンドラ */
-  onSelectYear: (e: MouseEvent<HTMLButtonElement>) => void
+  handleSelectYear: (e: MouseEvent<HTMLButtonElement>) => void
   /** 表示フラグ */
   isDisplayed: boolean
   /** HTMLのid属性 */
@@ -64,7 +64,7 @@ const ActualYearPicker: FC<ActualProps> = ({
   selectedYear,
   fromYear,
   toYear,
-  onSelectYear,
+  handleSelectYear,
   id,
   ...rest
 }) => {
@@ -103,7 +103,7 @@ const ActualYearPicker: FC<ActualProps> = ({
             focusingRef={focusingRef}
             className={CLASS_NAMES.yearButton}
             childrenStyle={CLASS_NAMES.yearWrapper}
-            onClick={onSelectYear}
+            handleClick={handleSelectYear}
           />
         ))}
       </Scroller>
@@ -118,8 +118,8 @@ const YearButton = memo<{
   focusingRef: RefObject<HTMLButtonElement>
   className: string
   childrenStyle: string
-  onClick: (e: MouseEvent<HTMLButtonElement>) => void
-}>(({ year, thisYear, selected, focusingRef, onClick, className, childrenStyle }) => {
+  handleClick: (e: MouseEvent<HTMLButtonElement>) => void
+}>(({ year, thisYear, selected, focusingRef, handleClick, className, childrenStyle }) => {
   const { localize } = useIntl()
   const isThisYear = thisYear === year
 
@@ -128,7 +128,7 @@ const YearButton = memo<{
       ref={isThisYear ? focusingRef : null}
       value={year}
       aria-pressed={selected}
-      onClick={onClick}
+      onClick={handleClick}
       className={className}
       data-this-year={isThisYear}
       aria-label={


### PR DESCRIPTION
## 関連URL

## 概要

`Calendar` と `YearPicker` コンポーネントのリファクタリング。

## 変更内容

- `useState` の初期値を IIFE から lazy initializer に変更
- `onSelectYear` を `setCurrentMonth` の関数型更新でstableに変更（`YearButton` の不要な再レンダリングを防止）
- `useCallback` x2 を `useMemo` + `functions` パターンに統合
- `onSelectYear`、`onClickSelectYear`、`onClick` を `handleXxx` 規則にrename（内部コンポーネントのprop命名規則に統一）
- `YearSelectButton` の `{...props}` スプレッドを `handleClick` → `onClick` の明示的マッピングに修正

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で Calendar の年選択・月移動の動作を確認。