### PR TITLE
refactor(Browser): useCallbackをuseMemo+functionsパターンに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -3,7 +3,6 @@ import {
   type ComponentProps,
   type FC,
   type KeyboardEventHandler,
-  useCallback,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
@@ -71,10 +70,10 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
 
   const latest = useLatest({ onSelectItem, value, rootNode })
 
-  // FIXME: focusメソッドのfocusVisibleが主要ブラウザでサポートされたら使うようにしたい(現状ではマウスクリックでもfocusのoutlineが出てしまう)
-  // https://developer.mozilla.org/ja/docs/Web/API/HTMLElement/focus
-  const onDelegateKeyDown: KeyboardEventHandler = useCallback(
-    (e) => {
+  const functions = useMemo(() => {
+    // FIXME: focusメソッドのfocusVisibleが主要ブラウザでサポートされたら使うようにしたい(現状ではマウスクリックでもfocusのoutlineが出てしまう)
+    // https://developer.mozilla.org/ja/docs/Web/API/HTMLElement/focus
+    const onDelegateKeyDown: KeyboardEventHandler = (e) => {
       const selectedNode = latest.value ? latest.rootNode.findByValue(latest.value) : undefined
 
       if (!selectedNode) {
@@ -117,27 +116,31 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
         latest.onSelectItem?.(target.value)
         document.getElementById(getElementIdFromNode(target.value))?.focus()
       }
-    },
-    [latest],
-  )
+    }
 
-  const onChangeInput = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      latest.onSelectItem?.(e.currentTarget.value)
-    },
-    [latest],
-  )
+    return {
+      onDelegateKeyDown,
+      onChangeInput: (e: ChangeEvent<HTMLInputElement>) => {
+        latest.onSelectItem?.(e.currentTarget.value)
+      },
+    }
+  }, [latest])
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-    <div {...rest} role="application" onKeyDown={onDelegateKeyDown} className={classNames.wrapper}>
+    <div
+      {...rest}
+      role="application"
+      onKeyDown={functions.onDelegateKeyDown}
+      className={classNames.wrapper}
+    >
       {columns.map((colItems, index) => (
         <BrowserColumn
           key={index}
           items={colItems}
           index={index}
           value={selectedPath[index]}
-          onChangeInput={onSelectItem ? onChangeInput : undefined}
+          onChangeInput={onSelectItem ? functions.onChangeInput : undefined}
           className={classNames.column}
         />
       ))}

--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -69,6 +69,7 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
   }, [rootNode, value])
 
   const latest = useLatest({ onSelectItem, value, rootNode })
+  const hasOnSelectItem = !!onSelectItem
 
   const functions = useMemo(() => {
     // FIXME: focusメソッドのfocusVisibleが主要ブラウザでサポートされたら使うようにしたい(現状ではマウスクリックでもfocusのoutlineが出てしまう)
@@ -120,11 +121,13 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
 
     return {
       onDelegateKeyDown,
-      onChangeInput: (e: ChangeEvent<HTMLInputElement>) => {
-        latest.onSelectItem?.(e.currentTarget.value)
-      },
+      onChangeInput: hasOnSelectItem
+        ? (e: ChangeEvent<HTMLInputElement>) => {
+            latest.onSelectItem?.(e.currentTarget.value)
+          }
+        : undefined,
     }
-  }, [latest])
+  }, [hasOnSelectItem, latest])
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
@@ -140,7 +143,7 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
           items={colItems}
           index={index}
           value={selectedPath[index]}
-          onChangeInput={onSelectItem ? functions.onChangeInput : undefined}
+          onChangeInput={functions.onChangeInput}
           className={classNames.column}
         />
       ))}

--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -74,7 +74,7 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
   const functions = useMemo(() => {
     // FIXME: focusメソッドのfocusVisibleが主要ブラウザでサポートされたら使うようにしたい(現状ではマウスクリックでもfocusのoutlineが出てしまう)
     // https://developer.mozilla.org/ja/docs/Web/API/HTMLElement/focus
-    const onDelegateKeyDown: KeyboardEventHandler = (e) => {
+    const handleDelegateKeyDown: KeyboardEventHandler = (e) => {
       const selectedNode = latest.value ? latest.rootNode.findByValue(latest.value) : undefined
 
       if (!selectedNode) {
@@ -120,8 +120,8 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
     }
 
     return {
-      onDelegateKeyDown,
-      onChangeInput: hasOnSelectItem
+      handleDelegateKeyDown,
+      handleChangeInput: hasOnSelectItem
         ? (e: ChangeEvent<HTMLInputElement>) => {
             latest.onSelectItem?.(e.currentTarget.value)
           }
@@ -134,7 +134,7 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
     <div
       {...rest}
       role="application"
-      onKeyDown={functions.onDelegateKeyDown}
+      onKeyDown={functions.handleDelegateKeyDown}
       className={classNames.wrapper}
     >
       {columns.map((colItems, index) => (
@@ -143,7 +143,7 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
           items={colItems}
           index={index}
           value={selectedPath[index]}
-          onChangeInput={functions.onChangeInput}
+          handleChangeInput={functions.handleChangeInput}
           className={classNames.column}
         />
       ))}

--- a/packages/smarthr-ui/src/components/Browser/BrowserColumn.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserColumn.tsx
@@ -11,7 +11,7 @@ type AbstractProps = {
   value?: string
   items: ItemNode[]
   index: number
-  onChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
+  handleChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
 }
 type Props = AbstractProps & Omit<ComponentProps<'ul'>, keyof AbstractProps>
 
@@ -23,7 +23,7 @@ export const BrowserColumn: FC<Props> = ({
   items,
   index: columnIndex,
   value,
-  onChangeInput,
+  handleChangeInput,
   className,
   ...rest
 }) => {
@@ -40,14 +40,14 @@ export const BrowserColumn: FC<Props> = ({
           value={value}
           columnIndex={columnIndex}
           rowIndex={rowIndex}
-          onChangeInput={onChangeInput}
+          handleChangeInput={handleChangeInput}
         />
       ))}
     </ul>
   )
 }
 
-type ListItemProps = Pick<Props, 'value' | 'onChangeInput'> & {
+type ListItemProps = Pick<Props, 'value' | 'handleChangeInput'> & {
   itemValue: ItemNode['value']
   itemLabel: ItemNode['label']
   itemHasChildren: boolean
@@ -56,7 +56,7 @@ type ListItemProps = Pick<Props, 'value' | 'onChangeInput'> & {
 }
 
 const ListItem = memo<ListItemProps>(
-  ({ itemValue, itemLabel, itemHasChildren, value, columnIndex, rowIndex, onChangeInput }) => {
+  ({ itemValue, itemLabel, itemHasChildren, value, columnIndex, rowIndex, handleChangeInput }) => {
     const selected = itemValue === value
     const ariaOwns = selected && itemHasChildren ? getColumnId(columnIndex + 1) : undefined
     const tabIndex = selected || (!value && columnIndex === 0 && rowIndex === 0) ? 0 : -1
@@ -70,7 +70,7 @@ const ListItem = memo<ListItemProps>(
           itemHasChildren={itemHasChildren}
           columnIndex={columnIndex}
           tabIndex={tabIndex}
-          onChangeInput={onChangeInput}
+          handleChangeInput={handleChangeInput}
         />
       </li>
     )

--- a/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
@@ -52,7 +52,7 @@ type Props = {
   itemHasChildren: boolean
   tabIndex: 0 | -1
   columnIndex: number
-  onChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
+  handleChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
 const KEYDOWN_REGEX = /^((Arrow(Right|Left|Up|Down))|Enter| )$/
@@ -69,7 +69,7 @@ export const BrowserItem: FC<Props> = ({
   itemHasChildren,
   tabIndex,
   columnIndex,
-  onChangeInput,
+  handleChangeInput,
 }) => {
   const inputId = useMemo(() => getElementIdFromNode(itemValue), [itemValue])
   const classNames = useMemo(() => {
@@ -90,7 +90,7 @@ export const BrowserItem: FC<Props> = ({
         value={itemValue}
         tabIndex={tabIndex}
         onKeyDown={HANDLE_KEYDOWN}
-        onChange={onChangeInput}
+        onChange={handleChangeInput}
         checked={selected}
       />
       <BodyCluster label={itemLabel} hasChildren={itemHasChildren} />


### PR DESCRIPTION
## 関連URL

## 概要

`Browser` コンポーネントの `useCallback` を `useMemo` + `functions` パターンに統合した。

## 変更内容

- `onDelegateKeyDown`、`onChangeInput` の `useCallback` x2 を `functions` オブジェクトにまとめ `useMemo([latest])` で管理
- 不要な `useCallback` インポートを削除
- `onSelectItem`（外部prop）を boolean 化して `hasOnSelectItem` とし、`functions` の依存配列を安定化
- `onChangeInput` の `undefined` 判定を JSX から `functions` 内に移動し JSX をシンプル化

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で Browser のキーボード操作・選択動作を確認。