### PR TITLE
refactor(UserInfo): useCallbackをuseMemo+functionsパターンに統合

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useCallback, useMemo, useState } from 'react'
+import { type FC, memo, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../../../intl'
@@ -64,8 +64,13 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
 }) => {
   const [languageDialogOpen, setLanguageDialogOpen] = useState(false)
 
-  const dialogOpen = useCallback(() => setLanguageDialogOpen(true), [])
-  const dialogClose = useCallback(() => setLanguageDialogOpen(false), [])
+  const functions = useMemo(
+    () => ({
+      dialogOpen: () => setLanguageDialogOpen(true),
+      dialogClose: () => setLanguageDialogOpen(false),
+    }),
+    [],
+  )
 
   return (
     <>
@@ -97,7 +102,7 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
                 <CommonButton
                   elementAs="button"
                   type="button"
-                  onClick={dialogOpen}
+                  onClick={functions.dialogOpen}
                   prefix={<FaGlobeIcon />}
                   // eslint-disable-next-line smarthr/require-i18n-text
                 >
@@ -124,8 +129,8 @@ const ActualUserInfo: FC<Pick<Props, 'accountUrl' | 'locale'> & { displayName: s
       </Dropdown>
 
       {locale && (
-        <Dialog isOpen={languageDialogOpen} onClickOverlay={dialogClose} width={246}>
-          <LanguageSelector locale={locale} onClickClose={dialogClose} />
+        <Dialog isOpen={languageDialogOpen} onClickOverlay={functions.dialogClose} width={246}>
+          <LanguageSelector locale={locale} onClickClose={functions.dialogClose} />
         </Dialog>
       )}
     </>


### PR DESCRIPTION
## 関連URL

## 概要

`mobile/UserInfo` の `useCallback` を `useMemo` + `functions` パターンに統合した。

## 変更内容

- `dialogOpen`、`dialogClose` の `useCallback` x2 を `functions` オブジェクトにまとめ `useMemo([])` で管理
- 不要な `useCallback` インポートを削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で AppHeader（モバイル）の言語切り替えダイアログの開閉を確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 言語選択ダイアログの開閉処理を改善し、言語ボタンやダイアログの操作が安定して動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->