### PR TITLE
feat(charts): peerDependencies に React 18 を追加

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -43,8 +43,8 @@
     "watch:css": "tailwindcss -i ./src/styles/index.css -o ./lib/styles.css --watch"
   },
   "peerDependencies": {
-    "react": "^19.0.3",
-    "react-dom": "^19.0.3",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-intl": "^7.0.4 || ^8.0.0 || ^10.0.0",
     "smarthr-ui": "workspace:^",
     "styled-components": "^5.0.1"


### PR DESCRIPTION
## 関連URL

なし

## 概要

`@smarthr/smarthr-ui-charts` の peerDependencies が React 19 限定（`^19.0.3`）になっており、smarthr-ui 本体（`^18.0.0 || ^19.0.0`）と対応範囲がずれていました。このため React 18 系のプロダクトから charts を利用できません。本体と同じ範囲に揃えます。

## 変更内容

peerDependencies の `react` / `react-dom` を本体と同一表記の `^18.0.0 || ^19.0.0` に変更しました。

```diff
   "peerDependencies": {
-    "react": "^19.0.3",
-    "react-dom": "^19.0.3",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
```

コード変更が不要であることを以下で確認しています。

- charts が使用している React API は `useId` / `useMemo` / `useRef` のみ（`useId` は React 18.0 から利用可能なので下限 `^18.0.0` で成立）
- React 19 専用の API（`use()`, `useActionState`, `useOptimistic`, 関数コンポーネントへの `ref` prop 直渡しなど）は未使用
- 依存している `react-chartjs-2@5.3.1` の peer は `^16.8 || ^17 || ^18 || ^19`。`chart.js` / `@smarthr/patternomaly` は React 非依存
- devDependencies の `@types/react` は既に `^18.3.28` のため、型チェックは React 18 の型で通っている

`devDependencies` の `react` / `react-dom` は `^19.2.6` のままとし、開発・Storybook・テストは従来どおり React 19 で実行します（本体と同じ運用）。`pnpm-lock.yaml` の更新は不要です（peerDependencies は lockfile の importers に記録されないため、変更後の `pnpm install` も `Already up to date`）。

## プロダクト側で対応が必要な事項

なし。対応範囲の拡大のみで、React 19 利用時の挙動は変わりません。

## 確認方法

- `pnpm charts lint` / `pnpm charts test` が通ること（ローカルで eslint / prettier / stylelint / tsc / vitest 19 tests すべて確認済み）
- React 18 系のプロダクトで `@smarthr/smarthr-ui-charts` をインストールした際に peer dependency の警告が出ないこと

なお開発・CI 環境は React 19 のままのため、React 18 実環境での実行テストは本 PR のスコープ外としています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * React 18およびReact 19の環境で、チャート機能を利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->