### PR TITLE
refactor(Tooltip): calculateHorizontalの計算式を変数に抽出して重複を解消

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/TooltipPortal.tsx
@@ -157,12 +157,12 @@ const calculateHorizontal = (
   const portalHalfWidth = portalWidth / 2
   const edgeSpacing = theme.spacingByChar(0.5)
 
+  const leftSpacing = triggerAlignCenter - portalHalfWidth
+  const rightSpacingEdge = document.body.clientWidth - SPACING
+
   // トリガを中心に左右に十分な余白がある場合
-  if (
-    triggerAlignCenter - portalHalfWidth > SPACING &&
-    triggerAlignCenter + portalHalfWidth < document.body.clientWidth - SPACING
-  ) {
-    const insetInlineStart = `${triggerAlignCenter - portalHalfWidth}px`
+  if (leftSpacing > SPACING && triggerAlignCenter + portalHalfWidth < rightSpacingEdge) {
+    const insetInlineStart = `${leftSpacing}px`
 
     return {
       insetInlineStart,
@@ -185,7 +185,7 @@ const calculateHorizontal = (
   }
 
   // トリガが画面右寄りの場合
-  const insetInlineEnd = `${document.body.clientWidth - parentRect.right - scrollX - SPACING}px`
+  const insetInlineEnd = `${rightSpacingEdge - parentRect.right - scrollX}px`
 
   return {
     insetInlineStart: undefined,


### PR DESCRIPTION
## 関連URL

## 概要

`calculateHorizontal` 関数内で重複して計算されていた式を変数に抽出し、コードの重複を解消する。

## 変更内容

- `triggerAlignCenter - portalHalfWidth` を `leftSpacing` 変数に抽出（if条件と `insetInlineStart` の2箇所で使用していた重複を解消）
- `document.body.clientWidth - SPACING` を `rightSpacingEdge` 変数に抽出（if条件と「右寄り」ケースの2箇所で使用していた重複を解消）

ロジックの変更はなし。

## プロダクト側で対応が必要な事項

なし

## 確認方法

変更なし（リファクタリングのみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ツールチップの水平方向の位置計算を見直し、左右の余白を基準にした配置処理を整理しました。
  * 中央寄せ・右寄せ時の表示位置をより一貫して計算できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->