### PR TITLE
refactor(FilterDropdown): triggerのオブジェクト変換をuseObjectAttributesに統一

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -6,11 +6,11 @@ import {
   type FormEvent,
   type MouseEventHandler,
   type ReactNode,
-  isValidElement,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
 import { Localizer, useIntl } from '../../../intl'
 import { Button, type AbstractProps as ButtonProps } from '../../Button'
@@ -49,6 +49,8 @@ type AbstractProps = {
   onClose?: () => void
 }
 type Props = AbstractProps & Omit<ComponentProps<'button'>, keyof AbstractProps>
+
+const triggerObjectConverter = (trigger: ReactNode): ObjectTriggerType => ({ text: trigger })
 
 const CONTROL_CLUSTER_GAP: ComponentProps<typeof Cluster>['gap'] = { column: 1, row: 0.5 }
 const ON_SUBMIT = (e: FormEvent) => {
@@ -95,15 +97,10 @@ export const FilterDropdown: FC<Props> = ({
   onClose,
   ...rest
 }) => {
-  // HINT: ReactNodeとObjectのどちらかを判定
-  // typeofはnullの場合もobject判定されてしまうため念の為falsyで判定
-  // ReactNodeの一部であるReactElementもobjectとして判定されてしまうためisValidElementで判定
-  const trigger: ObjectTriggerType =
-    !orgTrigger || typeof orgTrigger !== 'object' || isValidElement(orgTrigger)
-      ? {
-          text: orgTrigger as ReactNode,
-        }
-      : (orgTrigger as ObjectTriggerType)
+  const trigger = useObjectAttributes<ReactNode | ObjectTriggerType, ObjectTriggerType>(
+    orgTrigger,
+    triggerObjectConverter,
+  )
   const { localize } = useIntl()
 
   const filteredIconAlt = useMemo(


### PR DESCRIPTION
## 関連URL

## 概要

`trigger` propのオブジェクト変換ロジックが手動実装されており、他コンポーネントで使われている `useObjectAttributes` フックの適用漏れだったため統一する。

## 変更内容

- `isValidElement` + `typeof` による手動判定を削除
- `triggerObjectConverter` + `useObjectAttributes` に置き換え
- ロジックの変更はなし

## プロダクト側で対応が必要な事項

なし

## 確認方法

変更なし（リファクタリングのみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * フィルタードロップダウンのトリガー処理を見直し、さまざまな形式のトリガーをより一貫して扱えるようにしました。
  * これにより、トリガー表示の安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->