### PR TITLE
refactor(DefinitionListItem): termのオブジェクト変換をuseObjectAttributesに統一

### DIFF
--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
@@ -5,12 +5,12 @@ import {
   type FC,
   type PropsWithChildren,
   type ReactNode,
-  isValidElement,
   memo,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { useTheme } from '../../hooks/useTheme'
 import { Stack } from '../Layout'
 import { Text } from '../Text'
@@ -25,6 +25,8 @@ type AbstractProps = PropsWithChildren<{
   maxColumns?: number
 }>
 type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+
+const termObjectConverter = (term: ReactNode): ObjectTermType => ({ text: term })
 
 const classNameGenerator = tv({
   slots: {
@@ -53,15 +55,10 @@ export const DefinitionListItem: FC<Props> = ({
   className,
 }) => {
   const theme = useTheme()
-  // HINT: ReactNodeとObjectのどちらかを判定
-  // typeofはnullの場合もobject判定されてしまうため念の為falsyで判定
-  // ReactNodeの一部であるReactElementもobjectとして判定されてしまうためisValidElementで判定
-  const term: ObjectTermType =
-    !orgTerm || typeof orgTerm !== 'object' || isValidElement(orgTerm)
-      ? {
-          text: orgTerm as ReactNode,
-        }
-      : (orgTerm as ObjectTermType)
+  const term = useObjectAttributes<ReactNode | ObjectTermType, ObjectTermType>(
+    orgTerm,
+    termObjectConverter,
+  )
 
   const classNames = useMemo(() => {
     const cs = classNameGenerator()


### PR DESCRIPTION
## 関連URL

## 概要

`term` propのオブジェクト変換ロジックが手動実装されており、他コンポーネントで使われている `useObjectAttributes` フックの適用漏れだったため統一する。

## 変更内容

- `isValidElement` + `typeof` による手動判定を削除
- `termObjectConverter` + `useObjectAttributes` に置き換え
- ロジックの変更はなし

## プロダクト側で対応が必要な事項

なし

## 確認方法

変更なし（リファクタリングのみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * DefinitionList の項目名が、さまざまな形式のデータでも一貫して表示されるようになりました。
  * 項目名のテキストとスタイルが適切に反映され、表示の安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->