### PR TITLE
refactor(Tooltip): getTooltipRectのリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -45,17 +45,19 @@ export function getTooltipRect({
   switch (vertical) {
     case 'top':
     case 'bottom': {
-      const iconGap = isIcon ? BALLOON_ARROW_POSITION - parentRect.width / 2 : 0 // to align center of Balloon arrow and icon
-
       switch (horizontal) {
         case 'right':
-          left = parentRect.left + parentRect.width - tooltipSize.width + iconGap
+          left =
+            parentRect.left +
+            parentRect.width -
+            tooltipSize.width +
+            calculateIconGap(isIcon, parentRect.width)
           break
         case 'center':
           left = parentRect.left + (parentRect.width - tooltipSize.width) / 2
           break
         case 'left':
-          left = parentRect.left - iconGap
+          left = parentRect.left - calculateIconGap(isIcon, parentRect.width)
           break
       }
 
@@ -70,3 +72,6 @@ export function getTooltipRect({
     $height: tooltipSize.height,
   }
 }
+
+const calculateIconGap = (isIcon: boolean, parentRectWidth: number) =>
+  isIcon ? BALLOON_ARROW_POSITION - parentRectWidth / 2 : 0 // to align center of Balloon arrow and icon

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -18,6 +18,7 @@ export function getTooltipRect({
   outerMargin: number
 }): { top: number; left: number; $width: number; $height: number } {
   let top: number = 0
+  let left: number = 0
 
   switch (vertical) {
     case 'top':
@@ -25,16 +26,7 @@ export function getTooltipRect({
       break
     case 'middle':
       top = parentRect.top + (parentRect.height - tooltipSize.height) / 2
-      break
-    case 'bottom':
-      top = parentRect.top - tooltipSize.height - outerMargin
-      break
-  }
 
-  let left: number = 0
-
-  switch (vertical) {
-    case 'middle':
       switch (horizontal) {
         case 'right':
           left = parentRect.left - tooltipSize.width - outerMargin
@@ -43,7 +35,14 @@ export function getTooltipRect({
           left = parentRect.left + parentRect.width + outerMargin
           break
       }
+
       break
+    case 'bottom':
+      top = parentRect.top - tooltipSize.height - outerMargin
+      break
+  }
+
+  switch (vertical) {
     case 'top':
     case 'bottom': {
       const iconGap = isIcon ? BALLOON_ARROW_POSITION - parentRect.width / 2 : 0 // to align center of Balloon arrow and icon

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -43,12 +43,20 @@ export function getTooltipRect({
         break
     }
 
-    left = calculateLeftWithVerticalTopOrBottom({
-      horizontal,
-      parentRect,
-      tooltipSize,
-      isIcon,
-    })
+    if (horizontal === 'center') {
+      left = parentRect.left + (parentRect.width - tooltipSize.width) / 2
+    } else {
+      const iconGap = isIcon ? BALLOON_ARROW_POSITION - parentRect.width / 2 : 0 // to align center of Balloon arrow and icon
+
+      switch (horizontal) {
+        case 'right':
+          left = parentRect.left + parentRect.width - tooltipSize.width + iconGap
+          break
+        case 'left':
+          left = parentRect.left - iconGap
+          break
+      }
+    }
   }
 
   return {
@@ -56,25 +64,5 @@ export function getTooltipRect({
     left: left + scrollOffset.left,
     $width: tooltipSize.width,
     $height: tooltipSize.height,
-  }
-}
-
-const calculateLeftWithVerticalTopOrBottom = ({
-  horizontal,
-  parentRect,
-  tooltipSize,
-  isIcon,
-}: Pick<Props, 'horizontal' | 'parentRect' | 'tooltipSize' | 'isIcon'>) => {
-  if (horizontal === 'center') {
-    return parentRect.left + (parentRect.width - tooltipSize.width) / 2
-  }
-
-  const iconGap = isIcon ? BALLOON_ARROW_POSITION - parentRect.width / 2 : 0 // to align center of Balloon arrow and icon
-
-  switch (horizontal) {
-    case 'right':
-      return parentRect.left + parentRect.width - tooltipSize.width + iconGap
-    case 'left':
-      return parentRect.left - iconGap
   }
 }

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -25,6 +25,21 @@ export function getTooltipRect({
   switch (vertical) {
     case 'top':
       top = parentRect.top + parentRect.height + outerMargin
+      left = calculateLeftWithVerticalTopOrBottom({
+        horizontal,
+        parentRect,
+        tooltipSize,
+        isIcon,
+      })
+      break
+    case 'bottom':
+      top = parentRect.top - tooltipSize.height - outerMargin
+      left = calculateLeftWithVerticalTopOrBottom({
+        horizontal,
+        parentRect,
+        tooltipSize,
+        isIcon,
+      })
       break
     case 'middle':
       top = parentRect.top + (parentRect.height - tooltipSize.height) / 2
@@ -39,23 +54,6 @@ export function getTooltipRect({
       }
 
       break
-    case 'bottom':
-      top = parentRect.top - tooltipSize.height - outerMargin
-      break
-  }
-
-  switch (vertical) {
-    case 'top':
-    case 'bottom': {
-      left = calculateLeftWithVerticalTopOrBottom({
-        horizontal,
-        parentRect,
-        tooltipSize,
-        isIcon,
-      })
-
-      break
-    }
   }
 
   return {

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -1,3 +1,5 @@
+const BALLOON_ARROW_POSITION = 29 // length between Balloon edge and center of arrow
+
 export function getTooltipRect({
   parentRect,
   scrollOffset,
@@ -15,87 +17,57 @@ export function getTooltipRect({
   isIcon: boolean
   outerMargin: number
 }): { top: number; left: number; $width: number; $height: number } {
-  const top = getTop({
-    parentRect,
-    tooltipHeight: tooltipSize.height,
-    vertical,
-    outerMargin,
-  })
-  const left = getLeft({
-    parentRect,
-    tooltipWidth: tooltipSize.width,
-    horizontal,
-    vertical,
-    isIcon,
-    outerMargin,
-  })
+  let top: number = 0
 
-  return {
-    top: top + scrollOffset.top,
-    left: left + scrollOffset.left,
-    $width: tooltipSize.width,
-    $height: tooltipSize.height,
-  }
-}
-
-function getTop({
-  parentRect,
-  tooltipHeight,
-  vertical,
-  outerMargin,
-}: {
-  parentRect: DOMRect
-  tooltipHeight: number
-  vertical: 'top' | 'middle' | 'bottom'
-  outerMargin: number
-}): number {
   switch (vertical) {
     case 'top':
-      return parentRect.top + parentRect.height + outerMargin
+      top = parentRect.top + parentRect.height + outerMargin
+      break
     case 'middle':
-      return parentRect.top + (parentRect.height - tooltipHeight) / 2
+      top = parentRect.top + (parentRect.height - tooltipSize.height) / 2
+      break
     case 'bottom':
-      return parentRect.top - tooltipHeight - outerMargin
+      top = parentRect.top - tooltipSize.height - outerMargin
+      break
   }
-}
 
-const BALLOON_ARROW_POSITION = 29 // length between Balloon edge and center of arrow
+  let left: number = 0
 
-function getLeft({
-  parentRect,
-  tooltipWidth,
-  horizontal,
-  vertical,
-  isIcon,
-  outerMargin,
-}: {
-  parentRect: DOMRect
-  tooltipWidth: number
-  horizontal: 'left' | 'center' | 'right'
-  vertical: 'top' | 'middle' | 'bottom'
-  isIcon: boolean
-  outerMargin: number
-}): number {
   switch (vertical) {
     case 'middle':
       switch (horizontal) {
         case 'right':
-          return parentRect.left - tooltipWidth - outerMargin
+          left = parentRect.left - tooltipSize.width - outerMargin
+          break
         default:
-          return parentRect.left + parentRect.width + outerMargin
+          left = parentRect.left + parentRect.width + outerMargin
+          break
       }
+      break
     case 'top':
     case 'bottom': {
       const iconGap = isIcon ? BALLOON_ARROW_POSITION - parentRect.width / 2 : 0 // to align center of Balloon arrow and icon
 
       switch (horizontal) {
         case 'right':
-          return parentRect.left + parentRect.width - tooltipWidth + iconGap
+          left = parentRect.left + parentRect.width - tooltipSize.width + iconGap
+          break
         case 'center':
-          return parentRect.left + (parentRect.width - tooltipWidth) / 2
+          left = parentRect.left + (parentRect.width - tooltipSize.width) / 2
+          break
         case 'left':
-          return parentRect.left - iconGap
+          left = parentRect.left - iconGap
+          break
       }
+
+      break
     }
+  }
+
+  return {
+    top: top + scrollOffset.top,
+    left: left + scrollOffset.left,
+    $width: tooltipSize.width,
+    $height: tooltipSize.height,
   }
 }

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -24,15 +24,10 @@ export function getTooltipRect({
 
   if (vertical === 'middle') {
     top = parentRect.top + (parentRect.height - tooltipSize.height) / 2
-
-    switch (horizontal) {
-      case 'right':
-        left = parentRect.left - tooltipSize.width - outerMargin
-        break
-      default:
-        left = parentRect.left + parentRect.width + outerMargin
-        break
-    }
+    left =
+      horizontal === 'right'
+        ? parentRect.left - tooltipSize.width - outerMargin
+        : parentRect.left + parentRect.width + outerMargin
   } else {
     switch (vertical) {
       case 'top':

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -22,38 +22,33 @@ export function getTooltipRect({
   let top: number = 0
   let left: number = 0
 
-  switch (vertical) {
-    case 'top':
-      top = parentRect.top + parentRect.height + outerMargin
-      left = calculateLeftWithVerticalTopOrBottom({
-        horizontal,
-        parentRect,
-        tooltipSize,
-        isIcon,
-      })
-      break
-    case 'bottom':
-      top = parentRect.top - tooltipSize.height - outerMargin
-      left = calculateLeftWithVerticalTopOrBottom({
-        horizontal,
-        parentRect,
-        tooltipSize,
-        isIcon,
-      })
-      break
-    case 'middle':
-      top = parentRect.top + (parentRect.height - tooltipSize.height) / 2
+  if (vertical === 'middle') {
+    top = parentRect.top + (parentRect.height - tooltipSize.height) / 2
 
-      switch (horizontal) {
-        case 'right':
-          left = parentRect.left - tooltipSize.width - outerMargin
-          break
-        default:
-          left = parentRect.left + parentRect.width + outerMargin
-          break
-      }
+    switch (horizontal) {
+      case 'right':
+        left = parentRect.left - tooltipSize.width - outerMargin
+        break
+      default:
+        left = parentRect.left + parentRect.width + outerMargin
+        break
+    }
+  } else {
+    switch (vertical) {
+      case 'top':
+        top = parentRect.top + parentRect.height + outerMargin
+        break
+      case 'bottom':
+        top = parentRect.top - tooltipSize.height - outerMargin
+        break
+    }
 
-      break
+    left = calculateLeftWithVerticalTopOrBottom({
+      horizontal,
+      parentRect,
+      tooltipSize,
+      isIcon,
+    })
   }
 
   return {

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -70,20 +70,16 @@ const calculateLeftWithVerticalTopOrBottom = ({
   tooltipSize,
   isIcon,
 }: Pick<Props, 'horizontal' | 'parentRect' | 'tooltipSize' | 'isIcon'>) => {
+  if (horizontal === 'center') {
+    return parentRect.left + (parentRect.width - tooltipSize.width) / 2
+  }
+
+  const iconGap = isIcon ? BALLOON_ARROW_POSITION - parentRect.width / 2 : 0 // to align center of Balloon arrow and icon
+
   switch (horizontal) {
     case 'right':
-      return (
-        parentRect.left +
-        parentRect.width -
-        tooltipSize.width +
-        calculateIconGap(isIcon, parentRect.width)
-      )
-    case 'center':
-      return parentRect.left + (parentRect.width - tooltipSize.width) / 2
+      return parentRect.left + parentRect.width - tooltipSize.width + iconGap
     case 'left':
-      return parentRect.left - calculateIconGap(isIcon, parentRect.width)
+      return parentRect.left - iconGap
   }
 }
-
-const calculateIconGap = (isIcon: boolean | undefined, parentRectWidth: number) =>
-  isIcon ? BALLOON_ARROW_POSITION - parentRectWidth / 2 : 0 // to align center of Balloon arrow and icon

--- a/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
+++ b/packages/smarthr-ui/src/components/Tooltip/tooltipHelper.ts
@@ -1,22 +1,24 @@
 const BALLOON_ARROW_POSITION = 29 // length between Balloon edge and center of arrow
 
+type Props = {
+  parentRect: DOMRect
+  scrollOffset: { top: number; left: number }
+  tooltipSize: { width: number; height: number }
+  vertical: 'top' | 'middle' | 'bottom'
+  horizontal: 'left' | 'center' | 'right'
+  isIcon?: boolean
+  outerMargin: number
+}
+
 export function getTooltipRect({
   parentRect,
   scrollOffset,
   tooltipSize,
   vertical,
   horizontal,
-  isIcon = false,
+  isIcon,
   outerMargin,
-}: {
-  parentRect: DOMRect
-  scrollOffset: { top: number; left: number }
-  tooltipSize: { width: number; height: number }
-  vertical: 'top' | 'middle' | 'bottom'
-  horizontal: 'left' | 'center' | 'right'
-  isIcon: boolean
-  outerMargin: number
-}): { top: number; left: number; $width: number; $height: number } {
+}: Props): { top: number; left: number; $width: number; $height: number } {
   let top: number = 0
   let left: number = 0
 
@@ -45,21 +47,12 @@ export function getTooltipRect({
   switch (vertical) {
     case 'top':
     case 'bottom': {
-      switch (horizontal) {
-        case 'right':
-          left =
-            parentRect.left +
-            parentRect.width -
-            tooltipSize.width +
-            calculateIconGap(isIcon, parentRect.width)
-          break
-        case 'center':
-          left = parentRect.left + (parentRect.width - tooltipSize.width) / 2
-          break
-        case 'left':
-          left = parentRect.left - calculateIconGap(isIcon, parentRect.width)
-          break
-      }
+      left = calculateLeftWithVerticalTopOrBottom({
+        horizontal,
+        parentRect,
+        tooltipSize,
+        isIcon,
+      })
 
       break
     }
@@ -73,5 +66,26 @@ export function getTooltipRect({
   }
 }
 
-const calculateIconGap = (isIcon: boolean, parentRectWidth: number) =>
+const calculateLeftWithVerticalTopOrBottom = ({
+  horizontal,
+  parentRect,
+  tooltipSize,
+  isIcon,
+}: Pick<Props, 'horizontal' | 'parentRect' | 'tooltipSize' | 'isIcon'>) => {
+  switch (horizontal) {
+    case 'right':
+      return (
+        parentRect.left +
+        parentRect.width -
+        tooltipSize.width +
+        calculateIconGap(isIcon, parentRect.width)
+      )
+    case 'center':
+      return parentRect.left + (parentRect.width - tooltipSize.width) / 2
+    case 'left':
+      return parentRect.left - calculateIconGap(isIcon, parentRect.width)
+  }
+}
+
+const calculateIconGap = (isIcon: boolean | undefined, parentRectWidth: number) =>
   isIcon ? BALLOON_ARROW_POSITION - parentRectWidth / 2 : 0 // to align center of Balloon arrow and icon


### PR DESCRIPTION
## 関連URL

なし

## 概要

`tooltipHelper.ts` の `getTooltipRect` 関数およびそのヘルパー関数（`getTop` / `getLeft`）をリファクタリングする。

## 変更内容

- `getTop` / `getLeft` のヘルパー関数を `getTooltipRect` 内にインライン化して削除
- パラメータの型定義を `Props` 型として切り出し
- `isIcon` を `boolean` から `isIcon?: boolean` に変更（デフォルトは `false` 相当の `undefined`）
- `BALLOON_ARROW_POSITION` 定数をファイル先頭に移動
- `vertical === 'middle'` を `if/else` で分岐し、`top`/`bottom` の `left` 計算の重複を排除
- 2択の `switch` 文を ternary に変換

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromatic で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ツールチップの表示位置計算を整理し、従来どおりの垂直・水平位置、アイコンとの間隔、スクロール位置、サイズを維持しました。
  * アイコン向け設定を省略した場合も、適切に表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->