### PR TITLE
refactor(Tooltip): isIconとactualClassNameの定義位置をuseEnhancedEffectより前に移動

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -97,24 +97,12 @@ export const Tooltip: FC<Props> = ({
   const [actualTabIndex, setActualTabIndex] = useState<number | undefined>(tabIndex ?? 0)
 
   const isLabel = type === 'label'
+  const isIcon = triggerType === 'icon'
 
-  useEnhancedEffect(() => {
-    setPortalRoot(fullscreenElement ?? document.body)
-  }, [fullscreenElement])
-
-  useEnhancedEffect(() => {
-    const childElement = childrenWrapperRef.current?.firstElementChild as HTMLElement | undefined
-
-    const focusable = !!childElement && childElement.matches(FOCUSABLE_SELECTOR)
-
-    setIsFocusableChild(focusable)
-    setActualTabIndex(tabIndex !== undefined ? tabIndex : focusable ? undefined : 0)
-
-    // focusableな要素に直接aria属性を設定
-    if (focusable) {
-      childElement.setAttribute(isLabel ? 'aria-labelledby' : 'aria-describedby', messageId)
-    }
-  }, [tabIndex, isLabel, messageId])
+  const actualClassName = useMemo(
+    () => classNameGenerator({ isIcon, className }),
+    [isIcon, className],
+  )
 
   const toShowAction = useCallback(
     (e: BaseSyntheticEvent) => {
@@ -146,11 +134,23 @@ export const Tooltip: FC<Props> = ({
     setIsVisible(false)
   }, [])
 
-  const isIcon = triggerType === 'icon'
-  const actualClassName = useMemo(
-    () => classNameGenerator({ isIcon, className }),
-    [isIcon, className],
-  )
+  useEnhancedEffect(() => {
+    setPortalRoot(fullscreenElement ?? document.body)
+  }, [fullscreenElement])
+
+  useEnhancedEffect(() => {
+    const childElement = childrenWrapperRef.current?.firstElementChild as HTMLElement | undefined
+
+    const focusable = !!childElement && childElement.matches(FOCUSABLE_SELECTOR)
+
+    setIsFocusableChild(focusable)
+    setActualTabIndex(tabIndex !== undefined ? tabIndex : focusable ? undefined : 0)
+
+    // focusableな要素に直接aria属性を設定
+    if (focusable) {
+      childElement.setAttribute(isLabel ? 'aria-labelledby' : 'aria-describedby', messageId)
+    }
+  }, [tabIndex, isLabel, messageId])
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Tooltip.tsx` 内のコードの定義順序を整理する。

## 変更内容

- `isIcon` と `actualClassName`（useMemo）の定義を2つの `useEnhancedEffect` より前に移動
- 2つの `useEnhancedEffect` を `toShowAction`/`toHideAction` コールバックより後に移動

ロジックの変更はなく、コードの読みやすさのための整理。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromatic で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ツールチップ内部の処理順序を整理しました。
  * ツールチップの表示、フォーカス操作、キーボード操作、アクセシビリティへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->