### PR TITLE
refactor(Textarea): textareaStyleのuseMemoをインライン化

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -242,10 +242,6 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const [interimRows, setInterimRows] = useState(rows)
 
-  const textareaStyle = useMemo(
-    () => ({ width: typeof width === 'number' ? `${width}px` : width }),
-    [width],
-  )
   const classNames = useMemo(() => {
     const { textareaEl } = classNameGenerator()
 
@@ -313,7 +309,7 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
       aria-invalid={error || undefined}
       rows={interimRows}
       className={classNames.textarea}
-      style={textareaStyle}
+      style={{ width: typeof width === 'number' ? `${width}px` : width }}
     />
   )
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`ActualTextarea` 内の `textareaStyle` useMemo を削除し、style をJSXにインライン化する。

## 変更内容

- `useMemo` で計算していた `{ width: ... }` スタイルオブジェクトをJSXに直接インライン化
- 計算コストが低いオブジェクトに対する不要な useMemo を削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromatic で確認