### PR TITLE
refactor(ThCheckbox): useIntl+useMemoをuseLocalizeフックに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -3,7 +3,7 @@
 import { type ComponentProps, forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useIntl } from '../../intl'
+import { useLocalize } from '../../hooks/useLocalize'
 import { Checkbox, type Props as CheckboxProps } from '../Checkbox'
 import { ControlledTooltip } from '../Tooltip'
 
@@ -32,21 +32,16 @@ const classNameGenerator = tv({
 
 export const ThCheckbox = forwardRef<HTMLInputElement, Props>(
   ({ vAlign, fixed, className, rowSpan, colSpan, ...rest }, ref) => {
-    const { localize } = useIntl()
-
-    const localizedText = useMemo(
-      () => ({
-        checkAllInvisibleLabel: localize({
-          id: 'smarthr-ui/ThCheckbox/checkAllInvisibleLabel',
-          defaultText: 'すべての項目を選択/解除',
-        }),
-        checkColumnName: localize({
-          id: 'smarthr-ui/ThCheckbox/checkColumnName',
-          defaultText: '選択',
-        }),
-      }),
-      [localize],
-    )
+    const localized = useLocalize({
+      checkAllInvisibleLabel: {
+        id: 'smarthr-ui/ThCheckbox/checkAllInvisibleLabel',
+        defaultText: 'すべての項目を選択/解除',
+      },
+      checkColumnName: {
+        id: 'smarthr-ui/ThCheckbox/checkColumnName',
+        defaultText: '選択',
+      },
+    })
 
     const classNames = useMemo(() => {
       const { wrapper, inner, balloon, checkbox } = classNameGenerator()
@@ -65,7 +60,7 @@ export const ThCheckbox = forwardRef<HTMLInputElement, Props>(
         vAlign={vAlign}
         fixed={fixed}
         className={classNames.wrapper}
-        aria-label={localizedText.checkColumnName}
+        aria-label={localized.checkColumnName}
         rowSpan={rowSpan}
         colSpan={colSpan}
       >
@@ -76,7 +71,7 @@ export const ThCheckbox = forwardRef<HTMLInputElement, Props>(
             vertical="middle"
             className={classNames.balloon}
           >
-            <span className="shr-block shr-p-0.5">{localizedText.checkAllInvisibleLabel}</span>
+            <span className="shr-block shr-p-0.5">{localized.checkAllInvisibleLabel}</span>
           </ControlledTooltip>
           {/* eslint-disable-next-line smarthr/a11y-prohibit-checkbox-or-radio-in-table-cell */}
           <Checkbox {...rest} ref={ref} className={classNames.checkbox} />

--- a/packages/smarthr-ui/src/hooks/useLocalize.ts
+++ b/packages/smarthr-ui/src/hooks/useLocalize.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react'
+
+import { useIntl } from '../intl'
+
+type LocalizeProps = Parameters<ReturnType<typeof useIntl>['localize']>[0]
+
+export const useLocalize = (props: { [key: string]: LocalizeProps }) => {
+  const { localize } = useIntl()
+
+  const localized = useMemo(() => {
+    const result: { [key: string]: string } = {}
+
+    for (const i in props) {
+      result[i] = localize(props[i])
+    }
+
+    return result
+    // HINT: 利用方法としてpropsはliteral objectになる
+    // 依存配列からは意図的に排除している
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localize])
+
+  return localized
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useIntl` + `useMemo` でローカライズ文字列を生成するパターンを共通フック `useLocalize` に置き換える。まず `ThCheckbox` を対象とし、他コンポーネントは順次対応する。

## 変更内容

- `src/hooks/useLocalize.ts` を新規追加
  - `useIntl` の `localize` をラップし、オブジェクト形式でローカライズ文字列をまとめて取得できるフック
  - ロケール変更時のみ再計算（`props` は literal object のため依存配列から意図的に除外）
- `ThCheckbox`: `useIntl` + `useMemo` を `useLocalize` に置き換え

### 変更例

```tsx
// Before
const { localize } = useIntl()
const localizedText = useMemo(
  () => ({
    checkAllInvisibleLabel: localize({ id: '...', defaultText: '...' }),
    checkColumnName: localize({ id: '...', defaultText: '...' }),
  }),
  [localize],
)

// After
const localized = useLocalize({
  checkAllInvisibleLabel: { id: '...', defaultText: '...' },
  checkColumnName: { id: '...', defaultText: '...' },
})
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromatic で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ**
  * テーブルのチェックボックス列に表示されるラベルを、ローカライズ設定に応じてより安定して取得できるよう改善しました。
  * 画面上の文言や公開されている操作方法に変更はありません。

* **改善**
  * 多言語表示におけるラベル処理の一貫性と保守性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->