### PR TITLE
refactor(AppHeader): desktop AppLauncherのuseIntl+useMemoをuseLocalizeに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -3,8 +3,9 @@
 import { type FC, type PropsWithChildren, memo, useCallback, useId, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useLocalize } from '../../../../hooks/useLocalize'
 import { useTheme } from '../../../../hooks/useTheme'
-import { Localizer, useIntl } from '../../../../intl'
+import { Localizer } from '../../../../intl'
 import { UnstyledButton } from '../../../Button'
 import { Heading } from '../../../Heading'
 import { FaCircleXmarkIcon, FaStarIcon } from '../../../Icon'
@@ -115,24 +116,20 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
     onClickClearSearchQuery,
   } = useAppLauncher(baseFeatures)
 
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      searchInputTitle: localize({
-        id: 'smarthr-ui/AppHeader/Launcher/searchInputTitle',
-        defaultText: 'アプリ名を入力してください。',
-      }),
-      favoriteModeText: localize({
-        id: 'smarthr-ui/AppHeader/Launcher/favoriteModeText',
-        defaultText: 'よく使うアプリ',
-      }),
-      allModeText: localize({
-        id: 'smarthr-ui/AppHeader/Launcher/allModeText',
-        defaultText: 'すべてのアプリ',
-      }),
-    }),
-    [localize],
-  )
+  const translated = useLocalize({
+    searchInputTitle: {
+      id: 'smarthr-ui/AppHeader/Launcher/searchInputTitle',
+      defaultText: 'アプリ名を入力してください。',
+    },
+    favoriteModeText: {
+      id: 'smarthr-ui/AppHeader/Launcher/favoriteModeText',
+      defaultText: 'よく使うアプリ',
+    },
+    allModeText: {
+      id: 'smarthr-ui/AppHeader/Launcher/allModeText',
+      defaultText: 'すべてのアプリ',
+    },
+  })
 
   return (
     <div className={CLASS_NAMES.wrapper}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useIntl` + `useMemo` で翻訳文字列を生成しているパターンを、共通フック `useLocalize` に置き換える。

## 変更内容

`packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx` にて:

- `useIntl` + `useMemo(() => ({ ... }), [localize])` を `useLocalize({ ... })` に置き換え
- `useIntl` のインポートを削除し、`useLocalize` のインポートを追加

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで AppHeader の動作を確認する。