### PR TITLE
refactor(AppHeader): mobile MenuDialogのuseIntl+useMemoをuseLocalizeに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
@@ -7,13 +7,13 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
 } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { tv } from 'tailwind-variants'
 
-import { Localizer, useIntl } from '../../../../intl'
+import { useLocalize } from '../../../../hooks/useLocalize'
+import { Localizer } from '../../../../intl'
 import { Button } from '../../../Button'
 import { FocusTrap } from '../../../Dialog'
 import { FaXmarkIcon } from '../../../Icon'
@@ -90,20 +90,16 @@ export const Content: FC<
   const { features, isAppLauncherSelected, setIsAppLauncherSelected } =
     useContext(AppLauncherContext)
 
-  const { localize } = useIntl()
-  const translated = useMemo(
-    () => ({
-      launcherListText: localize({
-        id: 'smarthr-ui/AppHeader/Launcher/listText',
-        defaultText: 'アプリ一覧',
-      }),
-      latestReleaseNotes: localize({
-        id: 'smarthr-ui/AppHeader/MobileHeader/latestReleaseNotes',
-        defaultText: '最新のリリースノート',
-      }),
-    }),
-    [localize],
-  )
+  const translated = useLocalize({
+    launcherListText: {
+      id: 'smarthr-ui/AppHeader/Launcher/listText',
+      defaultText: 'アプリ一覧',
+    },
+    latestReleaseNotes: {
+      id: 'smarthr-ui/AppHeader/MobileHeader/latestReleaseNotes',
+      defaultText: '最新のリリースノート',
+    },
+  })
 
   const dialogClose = useCallback(() => setIsOpen(false), [setIsOpen])
   const clearAppLauncher = useCallback(


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useIntl` + `useMemo` で翻訳文字列を生成しているパターンを、共通フック `useLocalize` に置き換える。

## 変更内容

`packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx` にて:

- `useIntl` + `useMemo(() => ({ ... }), [localize])` を `useLocalize({ ... })` に置き換え
- `useIntl` のインポートを削除し、`useLocalize` のインポートを追加
- `useMemo` が不要になったため React インポートから除去

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで AppHeader モバイルメニューの動作を確認する。