### PR TITLE
refactor(AppHeader): mobile AppLauncherのuseIntl+useMemoをuseLocalizeに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
@@ -1,7 +1,8 @@
-import { type FC, type PropsWithChildren, memo, useMemo } from 'react'
+import { type FC, type PropsWithChildren, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { Localizer, useIntl } from '../../../../intl'
+import { useLocalize } from '../../../../hooks/useLocalize'
+import { Localizer } from '../../../../intl'
 import { UnstyledButton } from '../../../Button'
 import { FaCircleXmarkIcon } from '../../../Icon'
 import { SearchInput } from '../../../Input'
@@ -61,15 +62,12 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
     onClickClearSearchQuery,
   } = useAppLauncher(baseFeatures)
 
-  const { localize } = useIntl()
-  const searchInputTitle = useMemo(
-    () =>
-      localize({
-        id: 'smarthr-ui/AppHeader/Launcher/searchInputTitle',
-        defaultText: 'アプリ名を入力してください。',
-      }),
-    [localize],
-  )
+  const { searchInputTitle } = useLocalize({
+    searchInputTitle: {
+      id: 'smarthr-ui/AppHeader/Launcher/searchInputTitle',
+      defaultText: 'アプリ名を入力してください。',
+    },
+  })
 
   return (
     <div className={CLASS_NAMES.wrapper}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useIntl` + `useMemo` で翻訳文字列を生成しているパターンを、共通フック `useLocalize` に置き換える。

## 変更内容

`packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx` にて:

- `useIntl` + `useMemo(() => localize({...}), [localize])` を `useLocalize({ ... })` に置き換え
- `useIntl` と `useMemo` のインポートを削除し、`useLocalize` のインポートを追加

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで AppHeader モバイルのアプリランチャーの動作を確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * モバイルのアプリランチャーで、検索入力のタイトルが表示言語に応じて適切にローカライズされるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->