### PR TITLE
refactor(MultiCombobox): useIntl+useMemoをuseLocalizeに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -20,9 +20,9 @@ import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../../hooks/useLatest'
+import { useLocalize } from '../../../hooks/useLocalize'
 import { useOuterClick } from '../../../hooks/useOuterClick'
 import { useTheme } from '../../../hooks/useTheme'
-import { useIntl } from '../../../intl'
 import { genericsForwardRef } from '../../../libs/util'
 import { FaCaretDownIcon } from '../../Icon'
 import { Scroller } from '../../Scroller'
@@ -184,7 +184,6 @@ const ActualMultiCombobox = <T,>(
   }: Props<T>,
   ref: Ref<HTMLInputElement>,
 ) => {
-  const { localize } = useIntl()
   const outerRef = useRef<HTMLDivElement>(null)
   const [isFocused, setIsFocused] = useState(false)
   const [highlighted, setHighlighted] = useState(false)
@@ -442,14 +441,12 @@ const ActualMultiCombobox = <T,>(
     }
   }, [isFocused, disabled, className])
 
-  const selectedListAriaLabel = useMemo(
-    () =>
-      localize({
-        id: 'smarthr-ui/MultiCombobox/selectedListAriaLabel',
-        defaultText: '選択済みアイテム',
-      }),
-    [localize],
-  )
+  const { selectedListAriaLabel } = useLocalize({
+    selectedListAriaLabel: {
+      id: 'smarthr-ui/MultiCombobox/selectedListAriaLabel',
+      defaultText: '選択済みアイテム',
+    },
+  })
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useIntl` + `useMemo` で翻訳文字列を生成しているパターンを、共通フック `useLocalize` に置き換える。

## 変更内容

`packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx` にて:

- `useIntl` + `useMemo(() => localize({...}), [localize])` を `useLocalize({ ... })` に置き換え
- `useIntl` のインポートを削除し、`useLocalize` のインポートを追加

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで MultiCombobox の動作を確認する。