### PR TITLE
refactor(ControlledStepFormDialog): useIntl+useMemoをuseLocalizeに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react'
 
 import { useLatest } from '../../../hooks/useLatest'
-import { useIntl } from '../../../intl'
+import { useLocalize } from '../../../hooks/useLocalize'
 import { DialogContentInner } from '../DialogContentInner'
 import { useDialogPortal } from '../useDialogPortal'
 import { useObjectHeading } from '../useObjectHeading'
@@ -33,11 +33,6 @@ import type { DialogProps /** コンテンツなにもないDialogの基本props
 
 type ObjectHeadingType = Omit<StepFormDialogContentInnerProps['heading'], 'id'>
 type HeadingType = ReactNode | ObjectHeadingType
-
-type DefaultTextsType = Record<
-  'closeButtonLabel' | 'nextButtonLabel' | 'backButtonLabel',
-  ReactNode
->
 
 type AbstractProps = Omit<
   StepFormDialogContentInnerProps,
@@ -92,24 +87,20 @@ const ActualControlledStepFormDialog: FC<Omit<Props, 'portalParent'>> = ({
   isOpen,
   ...rest
 }) => {
-  const { localize } = useIntl()
-  const defaultTexts: DefaultTextsType = useMemo(
-    () => ({
-      closeButtonLabel: localize({
-        id: 'smarthr-ui/StepFormDialog/closeButtonLabel',
-        defaultText: 'キャンセル',
-      }),
-      nextButtonLabel: localize({
-        id: 'smarthr-ui/StepFormDialog/nextButtonLabel',
-        defaultText: '次へ',
-      }),
-      backButtonLabel: localize({
-        id: 'smarthr-ui/StepFormDialog/backButtonLabel',
-        defaultText: '戻る',
-      }),
-    }),
-    [localize],
-  )
+  const defaultTexts = useLocalize({
+    closeButtonLabel: {
+      id: 'smarthr-ui/StepFormDialog/closeButtonLabel',
+      defaultText: 'キャンセル',
+    },
+    nextButtonLabel: {
+      id: 'smarthr-ui/StepFormDialog/nextButtonLabel',
+      defaultText: '次へ',
+    },
+    backButtonLabel: {
+      id: 'smarthr-ui/StepFormDialog/backButtonLabel',
+      defaultText: '戻る',
+    },
+  })
   const { currentStep } = useContext(StepFormDialogContext)
   const activeStep = currentStep?.stepNumber ?? 1
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useIntl` + `useMemo` で翻訳文字列を生成しているパターンを、共通フック `useLocalize` に置き換える。

## 変更内容

`packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx` にて:

- `useIntl` + `useMemo(() => ({ ... }), [localize])` を `useLocalize({ ... })` に置き換え
- `useIntl` のインポートを削除し、`useLocalize` のインポートを追加
- 不要になった `DefaultTextsType` 型定義を削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで StepFormDialog の動作を確認する。