### PR TITLE
refactor(Th): convertContentWidthをインライン化し不要なuseMemoを削除

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -55,15 +55,6 @@ const classNameGenerator = tv({
   },
 })
 
-const convertContentWidth = (contentWidth?: CellContentWidth) => {
-  if (typeof contentWidth === 'number') {
-    // Th は fontSize.S のため、rem で指定する
-    return `${contentWidth}rem`
-  }
-
-  return contentWidth
-}
-
 export const Th: FC<Props> = ({ sort, onSort, ...rest }) =>
   sort ? <SortableTh {...rest} sort={sort} onSort={onSort} /> : <ActualTh {...rest} />
 
@@ -105,17 +96,18 @@ const ActualTh = memo<Omit<Props, 'onSort' | 'sort'>>(
       }
 
       return `${base} ${reelShadowClassNameGenerator({ showShadow: false, direction: fixed })}`
-    }, [align, className, fixed, vAlign])
-    const actualStyle = useMemo(
-      () => ({
-        ...style,
-        width: convertContentWidth(contentWidth),
-      }),
-      [style, contentWidth],
-    )
+    }, [align, fixed, vAlign, className])
 
     return (
-      <th {...rest} data-fixed={fixed} className={actualClassName} style={actualStyle}>
+      <th
+        {...rest}
+        data-fixed={fixed}
+        className={actualClassName}
+        style={{
+          ...style,
+          width: typeof contentWidth === 'number' ? `${contentWidth}rem` : contentWidth,
+        }}
+      >
         {children}
       </th>
     )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Th` コンポーネントの小さなリファクタリング。

## 変更内容

- `convertContentWidth` ヘルパー関数を削除し、ロジックを `style` プロパティにインライン化
- `actualStyle = useMemo(...)` を削除し、JSX の `style` prop に直接展開
  - `style` と `contentWidth` は毎回変わりうる値のため `useMemo` によるメモ化の恩恵が薄い

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで Table の動作（固定列・幅指定）を確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * テーブルのヘッダー幅指定を改善し、数値で指定した幅がより正確に反映されるようになりました。
  * ヘッダーのスタイル適用を整理し、表示の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->