### PR TITLE
refactor(Td): actualStyleのuseMemoを三項演算子にインライン化

### DIFF
--- a/packages/smarthr-ui/src/components/Table/Td.tsx
+++ b/packages/smarthr-ui/src/components/Table/Td.tsx
@@ -28,21 +28,18 @@ export const Td = memo<Props>(
 
       return `${base} ${shadow}`
     }, [align, className, fixed, nullable, vAlign])
-    const actualStyle = useMemo(() => {
-      if (typeof contentWidth === 'object') {
-        return {
-          ...style,
-          width: convertContentWidth(contentWidth.base),
-          minWidth: convertContentWidth(contentWidth.min),
-          maxWidth: convertContentWidth(contentWidth.max),
-        }
-      }
-
-      return {
-        ...style,
-        width: convertContentWidth(contentWidth),
-      }
-    }, [style, contentWidth])
+    const actualStyle =
+      typeof contentWidth === 'object'
+        ? {
+            ...style,
+            width: convertContentWidth(contentWidth.base),
+            minWidth: convertContentWidth(contentWidth.min),
+            maxWidth: convertContentWidth(contentWidth.max),
+          }
+        : {
+            ...style,
+            width: convertContentWidth(contentWidth),
+          }
 
     return <td {...rest} data-fixed={fixed} className={actualClassName} style={actualStyle} />
   },


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Td` コンポーネントの小さなリファクタリング。

## 変更内容

- `actualStyle = useMemo(...)` を三項演算子によるインライン式に置き換え
  - `style` と `contentWidth` は毎回変わりうる値のため `useMemo` によるメモ化の恩恵が薄い
  - ロジックを簡潔に表現

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで Table の動作（固定列・幅指定）を確認する。