### PR TITLE
fix: pnpm audit --prod の脆弱性検知に対応

### DIFF
--- a/packages/smarthr-ui/package.json
+++ b/packages/smarthr-ui/package.json
@@ -18,8 +18,7 @@
     "react-pdf": "^9.2.1",
     "react-transition-group": "^4.4.5",
     "tailwind-variants": "^0.3.1",
-    "tailwindcss": "^3.4.19",
-    "typescript-eslint": "^8.64.0"
+    "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
@@ -76,6 +75,7 @@
     "tailwind-merge": "^3.3.1",
     "tslib": "^2.8.1",
     "tsx": "^4.20.6",
+    "typescript-eslint": "^8.64.0",
     "vite": "7.3.5",
     "vitest": "^4.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   js-yaml@>=4.0.0 <=4.1.1: '>=4.3.0'
   '@babel/core@<=7.29.0': '>=7.29.7'
   sharp@<0.35.0: '>=0.35.3'
+  brace-expansion@>=5.0.0 <5.0.8: '>=5.0.8'
 
 importers:
 
@@ -239,9 +240,6 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(ts-node@10.9.2(@swc/core@1.15.17)(@types/node@20.19.35)(typescript@5.9.3))
-      typescript-eslint:
-        specifier: ^8.64.0
-        version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
     devDependencies:
       '@babel/core':
         specifier: '>=7.29.7'
@@ -405,6 +403,9 @@ importers:
       tsx:
         specifier: ^4.20.6
         version: 4.23.1
+      typescript-eslint:
+        specifier: ^8.64.0
+        version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: 7.3.5
         version: 7.3.5(@types/node@20.19.35)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -2965,9 +2966,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8720,7 +8721,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.2
 
@@ -10478,7 +10479,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,12 @@ allowBuilds:
   canvas: true
   esbuild: true
   sharp: true
+# brace-expansion@2.x は GHSA-mh99-v99m-4gvg の影響を受けないが、advisory の vulnerable versions が <=5.0.7 と広い範囲を
+# 指定しているため tailwindcss>sucrase>glob>minimatch@9>brace-expansion@2.x が誤検知される。
+# 実際の 5.x 系の脆弱バージョン (>=5.0.0 <5.0.8) は overrides で対処済みのためここで無視する。
+auditConfig:
+  ignoreGhsas:
+    - GHSA-mh99-v99m-4gvg
 overrides:
   postcss@<8.5.10: ^8.5.19
   esbuild@<=0.24.2: '>=0.28.1'
@@ -61,3 +67,4 @@ overrides:
   js-yaml@>=4.0.0 <=4.1.1: '>=4.3.0'
   '@babel/core@<=7.29.0': '>=7.29.7'
   sharp@<0.35.0: '>=0.35.3'
+  brace-expansion@>=5.0.0 <5.0.8: '>=5.0.8'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`pnpm audit --prod` が GHSA-mh99-v99m-4gvg (brace-expansion DoS) で失敗していた問題を修正します。

## 変更内容

### 1. `typescript-eslint` を `devDependencies` に移動

`packages/smarthr-ui/package.json` で `typescript-eslint` が誤って `dependencies` に含まれていたため、prod の依存チェーンに `typescript-eslint → ... → brace-expansion@5.x` のパスが生じていました。`devDependencies` に移動して解消。

### 2. `brace-expansion@5.x` 系の override を追加

`pnpm-workspace.yaml` に以下を追加:

```yaml
overrides:
  brace-expansion@>=5.0.0 <5.0.8: '>=5.0.8'
```

GHSA-mh99-v99m-4gvg の対象（`brace-expansion@5.0.0〜5.0.7`）を `>=5.0.8` に強制します。

### 3. 誤検知の advisory を `auditConfig.ignoreGhsas` で無視

`pnpm-workspace.yaml` に以下を追加:

```yaml
auditConfig:
  ignoreGhsas:
    - GHSA-mh99-v99m-4gvg
```

**誤検知の原因**: advisory の vulnerable versions が `<=5.0.7` と指定されているため、`tailwindcss>sucrase>glob>minimatch@9>brace-expansion@2.1.2` のパスが誤検知されます。`brace-expansion@2.x` はこの脆弱性（v5.0.0 で導入された新機能のバグ）とは無関係の別実装です。実際の `5.x` 系脆弱バージョンは上記 override で対処済みのため、この advisory を無視しても安全です。

## プロダクト側で対応が必要な事項

なし

## 確認方法

```sh
pnpm audit --prod
# → 1 vulnerabilities found, Severity: 1 high (1 ignored)  exit: 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 依存関係の管理を整理し、開発時にのみ必要なツールを適切に分類しました。
  - 依存パッケージの監査設定を見直し、誤検知を抑制しながら脆弱なバージョン範囲を回避しました。
  - これにより、アプリケーションの機能や画面表示に変更はありませんが、継続的な保守性と安全性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->