### PR TITLE
fix(SideNav): SideNavContextにデフォルト値を設定し型の安全性を向上

### DIFF
--- a/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
@@ -6,7 +6,9 @@ type SideNavContextValue = {
   size: SideNavSizeType
 }
 
-const SideNavContext = createContext<SideNavContextValue | undefined>(undefined)
+const SideNavContext = createContext<SideNavContextValue>({
+  size: 'M',
+})
 
 export const useSideNavContext = () => useContext(SideNavContext)
 

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -98,18 +98,17 @@ export const SideNavItemButton: FC<ButtonProps> = ({
   ...rest
 }) => {
   const context = useSideNavContext()
-  const size = context?.size ?? 'M'
 
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
 
     return {
       wrapper: wrapper({ className }),
-      button: button({ size }),
+      button: button({ size: context.size }),
       body: body(),
       bodyText: bodyText(),
     }
-  }, [className, size])
+  }, [context.size, className])
 
   return (
     <li {...rest} id={id} data-current={!!current} className={classNames.wrapper}>
@@ -134,18 +133,17 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
   ...rest
 }: AnchorProps<T>) => {
   const context = useSideNavContext()
-  const size = context?.size ?? 'M'
 
   const classNames = useMemo(() => {
     const { wrapper, button, body, bodyText } = classNameGenerator()
 
     return {
       wrapper: wrapper({ className }),
-      button: button({ size }),
+      button: button({ size: context.size }),
       body: body(),
       bodyText: bodyText(),
     }
-  }, [className, size])
+  }, [context.size, className])
 
   const Anchor = elementAs || 'a'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`SideNavContext` の `createContext` にデフォルト値を設定していなかったため、`useSideNavContext()` の戻り値の型が `SideNavContextValue | undefined` になっていた。`SideNavProvider` 外での使用を考慮し、デフォルト値 `{ size: 'M' }` を設定することで型から `undefined` を除去する。

## 変更内容

### SideNavContext.tsx

```tsx
// Before
const SideNavContext = createContext<SideNavContextValue | undefined>(undefined)

// After
const SideNavContext = createContext<SideNavContextValue>({
  size: 'M',
})
```

### SideNavItemButton.tsx

`context` が非 `undefined` になったため、`context?.size ?? 'M'` の中間変数パターンを削除し `context.size` を直接使用するよう簡略化。

```tsx
// Before
const size = context?.size ?? 'M'
button: button({ size }),
// ...
}, [className, size])

// After
button: button({ size: context.size }),
// ...
}, [context.size, className])
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で SideNav コンポーネントの表示・動作を確認。