### PR TITLE
refactor(Picker): disabled/readOnlyを...restに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Picker/DatetimeLocalPicker.tsx
+++ b/packages/smarthr-ui/src/components/Picker/DatetimeLocalPicker.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 /** @deprecated DatetimeLocalPicker は非推奨です。Input[type="datetime-local"] を使ってください。 */
 export const DatetimeLocalPicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
-  ({ disabled, error, readOnly, className, ...rest }, ref) => {
+  ({ error, className, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, inner } = classNameGenerator('DatetimeLocal')
 
@@ -28,10 +28,8 @@ export const DatetimeLocalPicker = forwardRef<HTMLInputElement, PickerProps<Prop
           {...rest}
           ref={ref}
           type="datetime-local"
-          disabled={disabled}
-          readOnly={readOnly}
-          aria-invalid={error || undefined}
           className={classNames.inner}
+          aria-invalid={error || undefined}
           data-smarthr-ui-input="true"
         />
       </span>

--- a/packages/smarthr-ui/src/components/Picker/MonthPicker.tsx
+++ b/packages/smarthr-ui/src/components/Picker/MonthPicker.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 /** @deprecated MonthPicker は非推奨です。Input[type="month"] を使ってください。 */
 export const MonthPicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
-  ({ disabled, error, readOnly, className, ...rest }, ref) => {
+  ({ error, className, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, inner } = classNameGenerator('Month')
 
@@ -26,13 +26,11 @@ export const MonthPicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
         {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
         <input
           {...rest}
-          data-smarthr-ui-input="true"
           ref={ref}
           type="month"
-          disabled={disabled}
-          readOnly={readOnly}
-          aria-invalid={error || undefined}
           className={classNames.inner}
+          aria-invalid={error || undefined}
+          data-smarthr-ui-input="true"
         />
       </span>
     )

--- a/packages/smarthr-ui/src/components/Picker/TimePicker.tsx
+++ b/packages/smarthr-ui/src/components/Picker/TimePicker.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 /** @deprecated TimePicker は非推奨です。Input[type="time"] を使ってください。 */
 export const TimePicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
-  ({ disabled, error, readOnly, className, ...rest }, ref) => {
+  ({ error, className, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, inner } = classNameGenerator('Time')
 
@@ -27,10 +27,8 @@ export const TimePicker = forwardRef<HTMLInputElement, PickerProps<Props>>(
           {...rest}
           ref={ref}
           type="time"
-          disabled={disabled}
-          readOnly={readOnly}
-          aria-invalid={error || undefined}
           className={classNames.inner}
+          aria-invalid={error || undefined}
           data-smarthr-ui-input="true"
         />
       </span>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DatetimeLocalPicker`・`MonthPicker`・`TimePicker` の3コンポーネントで、`disabled` と `readOnly` を明示的に destructure して `<input>` に再渡ししていたのを、`...rest` 経由で流れるようにシンプル化した。

## 変更内容

各 Picker コンポーネントで以下を統一:

- `disabled`・`readOnly` の props を destructure から除外し、`...rest` に含める
- `<input>` への渡し方は `{...rest}` のスプレッドで代替（動作は同じ）
- `aria-invalid={error || undefined}` は変換が必要なため引き続き明示的に渡す

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で各 Picker コンポーネントの disabled・readOnly 状態が正しく動作することを確認。