### PR TITLE
refactor(Pagination): tvをなくしてプレーンな文字列定数に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Pagination/PaginationItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/PaginationItemButton.tsx
@@ -1,17 +1,14 @@
 import { type ElementType, type FC, useMemo } from 'react'
-import { tv } from 'tailwind-variants'
 
 import { useIntl } from '../../intl'
 import { AnchorButton, Button } from '../Button'
 
-const classNameGenerator = tv({
-  base: [
-    'shr-rounded-s',
-    'aria-current-page:[&&&]:shr-cursor-default aria-current-page:[&&&]:shr-bg-main aria-current-page:[&&&]:shr-text-white',
-    'aria-current-page:focus-visible:[&&&]:shr-focus-indicator',
-    'aria-current-page:[&&&]:shr-border-solid aria-current-page:[&&&]:shr-border-main',
-  ],
-})
+const CLASS_NAME = [
+  'shr-rounded-s',
+  'aria-current-page:[&&&]:shr-cursor-default aria-current-page:[&&&]:shr-bg-main aria-current-page:[&&&]:shr-text-white',
+  'aria-current-page:focus-visible:[&&&]:shr-focus-indicator',
+  'aria-current-page:[&&&]:shr-border-solid aria-current-page:[&&&]:shr-border-main',
+].join(' ')
 
 type Props = {
   page: number
@@ -22,7 +19,6 @@ type Props = {
 
 export const PaginationItemButton: FC<Props> = ({ page, disabled, hrefTemplate, linkAs }) => {
   const { localize } = useIntl()
-  const className = useMemo(() => classNameGenerator(), [])
 
   const ariaLabel = useMemo(
     () =>
@@ -41,7 +37,7 @@ export const PaginationItemButton: FC<Props> = ({ page, disabled, hrefTemplate, 
     size: 'S',
     'aria-label': ariaLabel,
     'aria-current': disabled ? 'page' : undefined,
-    className,
+    className: CLASS_NAME,
     children: page,
   } as const
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`PaginationItemButton` でバリアントなしの `tv()` を使っていたのを、シンプルなプレーン文字列定数に変更した。

## 変更内容

- `tv({ base: [...] })` + `useMemo(() => classNameGenerator(), [])` を `const CLASS_NAME = [...].join(' ')` に置き換え
- バリアントがないため `tv()` を使う必要がなく、モジュールロード時に一度だけ評価される定数で十分
- `tv` のインポートと空依存配列の `useMemo` 呼び出しを削除

なお、Tailwind のスタイル生成（JIT スキャン）への影響はなし。クラス名は引き続き文字列リテラルとしてソースに存在するため、Tailwind が静的スキャンで検出できる。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で `Pagination` コンポーネントのスタイルが正しく適用されることを確認。