### PR TITLE
test(Input): VRTにreadOnlyケースを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Input/stories/VRTInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/stories/VRTInput.stories.tsx
@@ -15,6 +15,13 @@ import type { ComponentProps } from 'react'
  * true     true  なし    あり    なし    あり         なし
  * false    true  あり    なし    あり    あり         あり
  * false    true  あり    なし    なし    なし         なし
+ *
+ * readOnly cases (disabled と readOnly は両立させない)
+ * readOnly error prefix suffix bgColor placeholder width
+ * true     false なし    なし    なし    なし         なし
+ * true     false あり    なし    なし    なし         なし
+ * true     false なし    あり    なし    なし         なし
+ * true     false なし    なし    あり    なし         なし
  */
 const _cases: Array<ComponentProps<typeof Input>> = [
   {
@@ -77,6 +84,43 @@ const _cases: Array<ComponentProps<typeof Input>> = [
     prefix: <FaMagnifyingGlassIcon alt="検索" />,
     suffix: undefined,
     bgColor: undefined,
+    placeholder: undefined,
+    width: undefined,
+  },
+  // readOnly cases
+  {
+    readOnly: true,
+    error: undefined,
+    prefix: undefined,
+    suffix: undefined,
+    bgColor: undefined,
+    placeholder: undefined,
+    width: undefined,
+  },
+  {
+    readOnly: true,
+    error: undefined,
+    prefix: <FaMagnifyingGlassIcon alt="検索" />,
+    suffix: undefined,
+    bgColor: undefined,
+    placeholder: undefined,
+    width: undefined,
+  },
+  {
+    readOnly: true,
+    error: undefined,
+    prefix: undefined,
+    suffix: <FaMagnifyingGlassIcon alt="検索" />,
+    bgColor: undefined,
+    placeholder: undefined,
+    width: undefined,
+  },
+  {
+    readOnly: true,
+    error: undefined,
+    prefix: undefined,
+    suffix: undefined,
+    bgColor: 'BACKGROUND',
     placeholder: undefined,
     width: undefined,
   },

--- a/packages/smarthr-ui/src/components/Input/stories/input.pict
+++ b/packages/smarthr-ui/src/components/Input/stories/input.pict
@@ -1,4 +1,5 @@
 disabled: false, true
+readOnly: false, true
 error: false, true
 prefix: なし (10), あり
 suffix: なし (10), あり
@@ -8,3 +9,5 @@ width: なし (10), あり
 
 # prefix / suffix は両立させない
 IF [prefix] = "あり" THEN [suffix] = "なし";
+# disabled と readOnly は両立させない
+IF [disabled] = "true" THEN [readOnly] = "false";


### PR DESCRIPTION
## 関連URL

- #6691 (refactor/input-has-disabled-readonly)

## 概要

`refactor/input-has-disabled-readonly` でInputのdisabled/readOnlyスタイルをCSS `:has()` セレクタに置き換える対応を行っている。
readOnlyのVRTケースがなかったため、masterベースで先行して追加し、UIに差分がないことをChromaticで確認する。

## 変更内容

`VRTInput.stories.tsx` にreadOnlyケースを4パターン追加した。

- 基本（prefix/suffix なし）
- prefix あり（affix の color 確認）
- suffix あり（affix の color 確認）
- `bgColor: 'BACKGROUND'`（背景色の重ね合わせ確認）

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromaticで差分がないことを確認する。