### PR TITLE
refactor(Input): disabledとreadOnlyのスタイルをCSS :hasセレクタに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -54,7 +54,8 @@ const wrapperClassNameGenerator = tv({
     'contrast-more:shr-border-high-contrast',
     'focus-within:shr-focus-indicator',
     'has-[[aria-invalid]]:shr-border-danger',
-    'has-[:disabled]:shr-pointer-events-none has-[:disabled]:shr-bg-white-darken has-[:disabled]:[&&&]:shr-border-default/50',
+    'has-[:disabled]:[&&&]:shr-border-default/50',
+    'has-[:disabled]:shr-pointer-events-none has-[:disabled]:shr-bg-white-darken',
     'has-[[readonly]:not(:disabled)]:[&&&]:shr-border-[theme(backgroundColor.column)] has-[[readonly]:not(:disabled)]:[&&&]:shr-bg-column',
   ],
 })

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -54,15 +54,10 @@ const wrapperClassNameGenerator = tv({
     'contrast-more:shr-border-high-contrast',
     'focus-within:shr-focus-indicator',
     'has-[[aria-invalid]]:shr-border-danger',
+    'has-[:disabled]:shr-pointer-events-none has-[:disabled]:shr-bg-white-darken has-[:disabled]:[&&&]:shr-border-default/50',
+    'has-[:read-only:not(:disabled)]:[&&&]:shr-border-[theme(backgroundColor.column)] has-[:read-only:not(:disabled)]:[&&&]:shr-bg-column',
+    'group/input',
   ],
-  variants: {
-    disabled: {
-      true: 'shr-pointer-events-none shr-bg-white-darken [&&&]:shr-border-default/50',
-    },
-    readOnly: {
-      true: '[&&&]:shr-border-[theme(backgroundColor.column)] [&&&]:shr-bg-column',
-    },
-  },
 })
 const innerClassNameGenerator = tv({
   slots: {
@@ -76,14 +71,10 @@ const innerClassNameGenerator = tv({
       // マジックナンバーになるが、ほかに適切なプロパティがないため、min-widthで最低幅を指定することで防ぐ
       '[&[type="datetime-local"]]:shr-min-w-[11em] [&[type="month"]]:shr-min-w-[8em] [&[type="time"]]:shr-min-w-[5em]',
     ],
-    affix: 'shr-flex shr-shrink-0 shr-items-center shr-text-grey',
-  },
-  variants: {
-    disabled: {
-      true: {
-        affix: 'shr-text-disabled shr-opacity-100',
-      },
-    },
+    affix: [
+      'shr-flex shr-shrink-0 shr-items-center shr-text-grey',
+      'group-has-[:disabled]/input:shr-text-disabled group-has-[:disabled]/input:shr-opacity-100',
+    ],
   },
 })
 
@@ -140,15 +131,15 @@ export const Input = forwardRef<HTMLInputElement, Props>(
     )
 
     const classNames = useMemo(() => {
-      const { input, affix } = innerClassNameGenerator({ disabled })
+      const { input, affix } = innerClassNameGenerator()
 
       return {
-        wrapper: wrapperClassNameGenerator({ disabled, readOnly, className }),
+        wrapper: wrapperClassNameGenerator({ className }),
         input: input(),
         prefix: affix({ className: 'smarthr-ui-Input-prefix' }),
         suffix: affix({ className: 'smarthr-ui-Input-suffix' }),
       }
-    }, [disabled, readOnly, className])
+    }, [className])
 
     const styleColor = bgColor ? theme.backgroundColor[backgroundColor[bgColor]] : undefined
     const styleMaxWidth = typeof width === 'number' ? `${width}px` : width

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -55,7 +55,7 @@ const wrapperClassNameGenerator = tv({
     'focus-within:shr-focus-indicator',
     'has-[[aria-invalid]]:shr-border-danger',
     'has-[:disabled]:shr-pointer-events-none has-[:disabled]:shr-bg-white-darken has-[:disabled]:[&&&]:shr-border-default/50',
-    'has-[:read-only:not(:disabled)]:[&&&]:shr-border-[theme(backgroundColor.column)] has-[:read-only:not(:disabled)]:[&&&]:shr-bg-column',
+    'has-[[readonly]:not(:disabled)]:[&&&]:shr-border-[theme(backgroundColor.column)] has-[[readonly]:not(:disabled)]:[&&&]:shr-bg-column',
     'group/input',
   ],
 })

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -56,7 +56,6 @@ const wrapperClassNameGenerator = tv({
     'has-[[aria-invalid]]:shr-border-danger',
     'has-[:disabled]:shr-pointer-events-none has-[:disabled]:shr-bg-white-darken has-[:disabled]:[&&&]:shr-border-default/50',
     'has-[[readonly]:not(:disabled)]:[&&&]:shr-border-[theme(backgroundColor.column)] has-[[readonly]:not(:disabled)]:[&&&]:shr-bg-column',
-    'group/input',
   ],
 })
 const innerClassNameGenerator = tv({
@@ -73,7 +72,7 @@ const innerClassNameGenerator = tv({
     ],
     affix: [
       'shr-flex shr-shrink-0 shr-items-center shr-text-grey',
-      'group-has-[:disabled]/input:shr-text-disabled group-has-[:disabled]/input:shr-opacity-100',
+      '[.smarthr-ui-Input:has(:disabled)_&]:shr-text-disabled [.smarthr-ui-Input:has(:disabled)_&]:shr-opacity-100',
     ],
   },
 })


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Input` コンポーネントの `disabled` と `readOnly` のスタイル制御を、JavaScript の `tv()` variant から CSS の `:has()` セレクタに置き換える。

InputFile で実施した同様のリファクタリング（`has-[:disabled]` 対応）の Input 版。

## 変更内容

### `wrapperClassNameGenerator`
- `disabled` variant と `readOnly` variant を削除
- base クラスに `has-[:disabled]` と `has-[[readonly]:not(:disabled)]` セレクタを追加
  - `has-[[readonly]:not(:disabled)]` は `:read-only` が `<span>` 等の非フォーム要素にも一致するブラウザ挙動を回避するため HTML 属性セレクタを使用

### `innerClassNameGenerator`
- `disabled` variant（affix の `shr-text-disabled shr-opacity-100`）を削除
- affix の base クラスに `[.smarthr-ui-Input:has(:disabled)_&]` 親セレクタを追加

### `classNames` の useMemo
- `disabled` と `readOnly` を引数・依存配列から除去
- 依存配列が `[className]` のみになり、不要な再計算を削減

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook の Input コンポーネントで `disabled`・`readOnly` の表示・スタイルが変わっていないことを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 入力欄を無効化または読み取り専用にした際の表示を改善しました。
  * 入力欄本体だけでなく、前後に表示される補助テキストやアイコンにも、状態に応じた文字色と透明度が適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->