### PR TITLE
refactor(DropZone): disabled/error/filesDraggedOver のスタイルを CSS :has() と data 属性に置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -27,7 +27,7 @@ const classNameGenerator = tv({
       'shr-relative',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
       'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed',
-      'has-[[aria-invalid]]:[&&&_.smarthr-ui-DropZone-Button]:shr-border-danger',
+      'data-[error]:[&_.smarthr-ui-DropZone-Button]:shr-border-danger',
       '[&:not([data-files-dragged-over])]:shr-border-dashed',
       'data-[files-dragged-over]:shr-border-main',
     ],
@@ -125,6 +125,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         onDragOver={functions.handleDragOver}
         onDragLeave={functions.handleDragLeave}
         className={classNames.wrapper}
+        data-error={error || undefined}
         data-files-dragged-over={filesDraggedOver || undefined}
       >
         {children}

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -131,7 +131,6 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         <SelectButton
           handleClick={functions.handleClickButton}
           disabled={disabled}
-          className={CLASS_NAMES.button}
           label={selectButtonLabel}
         />
         <VisuallyHiddenText>
@@ -154,9 +153,17 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 )
 
 const SelectButton = memo<
-  ComponentPropsWithoutRef<typeof Button> & { handleClick: () => void; label?: string }
+  Omit<ComponentPropsWithoutRef<typeof Button>, 'className'> & {
+    handleClick: () => void
+    label?: string
+  }
 >(({ handleClick, label, ...rest }) => (
-  <Button {...rest} prefix={<FaFolderOpenIcon />} onClick={handleClick}>
+  <Button
+    {...rest}
+    prefix={<FaFolderOpenIcon />}
+    onClick={handleClick}
+    className={CLASS_NAMES.button}
+  >
     {label || <Localizer id="smarthr-ui/DropZone/selectButtonLabel" defaultText="ファイルを選択" />}
   </Button>
 ))

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -29,18 +29,10 @@ const classNameGenerator = tv({
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
       'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed',
       'has-[[aria-invalid]]:[&_.smarthr-ui-DropZone-Button]:shr-border-danger',
+      '[&:not([data-files-dragged-over])]:shr-border-dashed',
+      'data-[files-dragged-over]:shr-border-main',
     ],
     button: 'smarthr-ui-DropZone-Button',
-  },
-  variants: {
-    filesDraggedOver: {
-      true: {
-        wrapper: 'shr-border-main',
-      },
-      false: {
-        wrapper: 'shr-border-dashed',
-      },
-    },
   },
 })
 
@@ -81,12 +73,12 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
     const classNames = useMemo(() => {
-      const { wrapper, button } = classNameGenerator({ filesDraggedOver })
+      const { wrapper, button } = classNameGenerator()
       return {
         wrapper: wrapper(),
         button: button(),
       }
-    }, [filesDraggedOver])
+    }, [])
 
     const latest = useLatest({ onSelectFiles })
 
@@ -132,6 +124,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         onDragOver={functions.handleDragOver}
         onDragLeave={functions.handleDragLeave}
         className={classNames.wrapper}
+        data-files-dragged-over={filesDraggedOver || undefined}
       >
         {children}
         <SelectButton

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -64,14 +64,6 @@ const overrideEventDefault = (e: DragEvent<HTMLElement>) => {
   e.stopPropagation()
 }
 
-const CLASS_NAMES = (() => {
-  const { wrapper, button } = classNameGenerator()
-  return {
-    wrapper: wrapper(),
-    button: button(),
-  }
-})()
-
 export const DropZone = forwardRef<HTMLInputElement, Props>(
   (
     { children, onSelectFiles, multiple = true, disabled, error, selectButtonLabel, ...rest },
@@ -79,6 +71,15 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
   ) => {
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
+    // FIXME: className を wrapper に適用するバグ修正時に className を依存配列に追加する
+
+    const classNames = useMemo(() => {
+      const { wrapper, button } = classNameGenerator()
+      return {
+        wrapper: wrapper(),
+        button: button(),
+      }
+    }, [])
 
     const latest = useLatest({ onSelectFiles })
 
@@ -123,7 +124,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         onDrop={functions.handleDrop}
         onDragOver={functions.handleDragOver}
         onDragLeave={functions.handleDragLeave}
-        className={CLASS_NAMES.wrapper}
+        className={classNames.wrapper}
         data-files-dragged-over={filesDraggedOver || undefined}
       >
         {children}
@@ -131,6 +132,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
           handleClick={functions.handleClickButton}
           disabled={disabled}
           label={selectButtonLabel}
+          className={classNames.button}
         />
         <VisuallyHiddenText>
           {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
@@ -155,12 +157,13 @@ const SelectButton = memo<{
   handleClick: () => void
   disabled?: boolean
   label?: string
-}>(({ handleClick, disabled, label }) => (
+  className: string
+}>(({ handleClick, disabled, label, className }) => (
   <Button
     prefix={<FaFolderOpenIcon />}
     onClick={handleClick}
     disabled={disabled}
-    className={CLASS_NAMES.button}
+    className={className}
   >
     {label || <Localizer id="smarthr-ui/DropZone/selectButtonLabel" defaultText="ファイルを選択" />}
   </Button>

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -27,6 +27,7 @@ const classNameGenerator = tv({
       'smarthr-ui-DropZone',
       'shr-relative',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
+      'has-[:disabled]:shr-cursor-not-allowed',
     ],
     button: '',
   },
@@ -37,11 +38,6 @@ const classNameGenerator = tv({
       },
       false: {
         wrapper: 'shr-border-dashed',
-      },
-    },
-    disabled: {
-      true: {
-        wrapper: 'shr-cursor-not-allowed',
       },
     },
     error: {
@@ -89,12 +85,12 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
     const classNames = useMemo(() => {
-      const { wrapper, button } = classNameGenerator({ filesDraggedOver, disabled, error })
+      const { wrapper, button } = classNameGenerator({ filesDraggedOver, error })
       return {
         wrapper: wrapper(),
         button: button(),
       }
-    }, [disabled, error, filesDraggedOver])
+    }, [error, filesDraggedOver])
 
     const latest = useLatest({ onSelectFiles })
 

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -27,11 +27,10 @@ const classNameGenerator = tv({
       'shr-relative',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
       'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed',
-      'data-[error]:[&_.smarthr-ui-DropZone-Button]:shr-border-danger',
       '[&:not([data-files-dragged-over])]:shr-border-dashed',
       'data-[files-dragged-over]:shr-border-main',
     ],
-    button: 'smarthr-ui-DropZone-Button',
+    button: ['smarthr-ui-DropZone-Button', 'data-[error]:shr-border-danger'],
   },
 })
 
@@ -125,13 +124,13 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         onDragOver={functions.handleDragOver}
         onDragLeave={functions.handleDragLeave}
         className={classNames.wrapper}
-        data-error={error || undefined}
         data-files-dragged-over={filesDraggedOver || undefined}
       >
         {children}
         <SelectButton
           label={selectButtonLabel}
           disabled={disabled}
+          error={error}
           handleClick={functions.handleClickButton}
           className={classNames.button}
         />
@@ -158,12 +157,14 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 const SelectButton = memo<{
   label?: string
   disabled?: boolean
+  error?: boolean
   handleClick: () => void
   className: string
-}>(({ label, disabled, handleClick, className }) => (
+}>(({ label, disabled, error, handleClick, className }) => (
   <Button
     prefix={<FaFolderOpenIcon />}
     disabled={disabled}
+    data-error={error || undefined}
     onClick={handleClick}
     className={className}
   >

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -3,7 +3,6 @@
 import {
   type ChangeEvent,
   type ComponentPropsWithRef,
-  type ComponentPropsWithoutRef,
   type DragEvent,
   type PropsWithChildren,
   forwardRef,
@@ -152,16 +151,15 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
   },
 )
 
-const SelectButton = memo<
-  Omit<ComponentPropsWithoutRef<typeof Button>, 'className' | 'onClick'> & {
-    handleClick: () => void
-    label?: string
-  }
->(({ handleClick, label, ...rest }) => (
+const SelectButton = memo<{
+  handleClick: () => void
+  disabled?: boolean
+  label?: string
+}>(({ handleClick, disabled, label }) => (
   <Button
-    {...rest}
     prefix={<FaFolderOpenIcon />}
     onClick={handleClick}
+    disabled={disabled}
     className={CLASS_NAMES.button}
   >
     {label || <Localizer id="smarthr-ui/DropZone/selectButtonLabel" defaultText="ファイルを選択" />}

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -27,7 +27,7 @@ const classNameGenerator = tv({
       'shr-relative',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
       'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed',
-      'has-[[aria-invalid]]:[&_.smarthr-ui-DropZone-Button]:shr-border-danger',
+      'has-[[aria-invalid]]:[&&&_.smarthr-ui-DropZone-Button]:shr-border-danger',
       '[&:not([data-files-dragged-over])]:shr-border-dashed',
       'data-[files-dragged-over]:shr-border-main',
     ],

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -129,16 +129,15 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
       >
         {children}
         <SelectButton
-          handleClick={functions.handleClickButton}
-          disabled={disabled}
           label={selectButtonLabel}
+          disabled={disabled}
+          handleClick={functions.handleClickButton}
           className={classNames.button}
         />
         <VisuallyHiddenText>
           {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
           <input
             {...rest}
-            data-smarthr-ui-input="true"
             ref={fileRef}
             type="file"
             multiple={multiple}
@@ -146,6 +145,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
             tabIndex={-1}
             aria-invalid={error || undefined}
             onChange={functions.handleChange}
+            data-smarthr-ui-input="true"
           />
         </VisuallyHiddenText>
       </div>
@@ -154,15 +154,15 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 )
 
 const SelectButton = memo<{
-  handleClick: () => void
-  disabled?: boolean
   label?: string
+  disabled?: boolean
+  handleClick: () => void
   className: string
-}>(({ handleClick, disabled, label, className }) => (
+}>(({ label, disabled, handleClick, className }) => (
   <Button
     prefix={<FaFolderOpenIcon />}
-    onClick={handleClick}
     disabled={disabled}
+    onClick={handleClick}
     className={className}
   >
     {label || <Localizer id="smarthr-ui/DropZone/selectButtonLabel" defaultText="ファイルを選択" />}

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -27,9 +27,10 @@ const classNameGenerator = tv({
       'smarthr-ui-DropZone',
       'shr-relative',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
-      'has-[:disabled]:shr-cursor-not-allowed',
+      'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed',
+      'has-[[aria-invalid]]:[&_.smarthr-ui-DropZone-Button]:shr-border-danger',
     ],
-    button: '',
+    button: 'smarthr-ui-DropZone-Button',
   },
   variants: {
     filesDraggedOver: {
@@ -38,11 +39,6 @@ const classNameGenerator = tv({
       },
       false: {
         wrapper: 'shr-border-dashed',
-      },
-    },
-    error: {
-      true: {
-        button: 'shr-border-danger',
       },
     },
   },
@@ -85,12 +81,12 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
     const classNames = useMemo(() => {
-      const { wrapper, button } = classNameGenerator({ filesDraggedOver, error })
+      const { wrapper, button } = classNameGenerator({ filesDraggedOver })
       return {
         wrapper: wrapper(),
         button: button(),
       }
-    }, [error, filesDraggedOver])
+    }, [filesDraggedOver])
 
     const latest = useLatest({ onSelectFiles })
 

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -153,7 +153,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 )
 
 const SelectButton = memo<
-  Omit<ComponentPropsWithoutRef<typeof Button>, 'className'> & {
+  Omit<ComponentPropsWithoutRef<typeof Button>, 'className' | 'onClick'> & {
     handleClick: () => void
     label?: string
   }

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -65,6 +65,14 @@ const overrideEventDefault = (e: DragEvent<HTMLElement>) => {
   e.stopPropagation()
 }
 
+const CLASS_NAMES = (() => {
+  const { wrapper, button } = classNameGenerator()
+  return {
+    wrapper: wrapper(),
+    button: button(),
+  }
+})()
+
 export const DropZone = forwardRef<HTMLInputElement, Props>(
   (
     { children, onSelectFiles, multiple = true, disabled, error, selectButtonLabel, ...rest },
@@ -72,13 +80,6 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
   ) => {
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
-    const classNames = useMemo(() => {
-      const { wrapper, button } = classNameGenerator()
-      return {
-        wrapper: wrapper(),
-        button: button(),
-      }
-    }, [])
 
     const latest = useLatest({ onSelectFiles })
 
@@ -123,14 +124,14 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         onDrop={functions.handleDrop}
         onDragOver={functions.handleDragOver}
         onDragLeave={functions.handleDragLeave}
-        className={classNames.wrapper}
+        className={CLASS_NAMES.wrapper}
         data-files-dragged-over={filesDraggedOver || undefined}
       >
         {children}
         <SelectButton
           handleClick={functions.handleClickButton}
           disabled={disabled}
-          className={classNames.button}
+          className={CLASS_NAMES.button}
           label={selectButtonLabel}
         />
         <VisuallyHiddenText>

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -135,6 +135,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
           className={classNames.button}
         />
         <VisuallyHiddenText>
+          {/* TODO: この input にアクセシブルネームが設定されていない。VisuallyHiddenText で視覚的に隠されているが aria-hidden ではないためアクセシビリティツリーに残る。aria-label 等で適切なラベルを付与する必要がある */}
           {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
           <input
             {...rest}


### PR DESCRIPTION
## 関連URL

<!-- なし -->

## 概要

`DropZone` コンポーネントの `classNames` useMemo が `disabled`・`error`・`filesDraggedOver` に依存していたため、これらの props/state が変化するたびにクラス名を再計算していた。CSS の `:has()` セレクタと `data-*` 属性を活用することで、JavaScript 側の再計算を排除しリファクタリングする。

また、`SelectButton` の型定義を明示的にし、`...rest` による暗黙の props 受け渡しを廃止する。

## 変更内容

- `disabled` → `has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed` で wrapper に適用
  - 誤検知を避けるため `smarthr-ui-DropZone-Button` クラスを button スロットに付与して限定
- `error` → `has-[[aria-invalid]]:[&_.smarthr-ui-DropZone-Button]:shr-border-danger` で wrapper 経由に変更
- `filesDraggedOver` → `data-files-dragged-over` 属性 + `data-[files-dragged-over]:shr-border-main` / `[&:not([data-files-dragged-over])]:shr-border-dashed` に変更
- `classNames` useMemo の依存配列が空になったため、IIFE 定数（`CLASS_NAMES`）への変換を試みたが、`className` props を wrapper に渡すバグ（現状は hidden input に渡っている）が未修正のため useMemo のまま残し FIXME コメントを付与
- `SelectButton` の型を `Omit<ComponentPropsWithoutRef<typeof Button>, ...>` から明示的な型定義に変更し、受け渡す props を限定
- 属性の順序を整理

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic での VRT 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ドラッグ＆ドロップ時の表示を改善し、ファイルをドラッグ中・入力無効・エラー時の状態がより適切に反映されるようになりました。
  * エラー状態がボタンにも反映され、入力状況を確認しやすくなりました。
  * ドラッグ中の状態を支援技術でも認識しやすいよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->