### PR TITLE
fix(DropZone): className が hidden input ではなく wrapper div に適用されるよう修正

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -65,20 +65,28 @@ const overrideEventDefault = (e: DragEvent<HTMLElement>) => {
 
 export const DropZone = forwardRef<HTMLInputElement, Props>(
   (
-    { children, onSelectFiles, multiple = true, disabled, error, selectButtonLabel, ...rest },
+    {
+      children,
+      onSelectFiles,
+      multiple = true,
+      disabled,
+      error,
+      selectButtonLabel,
+      className,
+      ...rest
+    },
     ref,
   ) => {
     const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
-    // FIXME: className を wrapper に適用するバグ修正時に className を依存配列に追加する
 
     const classNames = useMemo(() => {
       const { wrapper, button } = classNameGenerator()
       return {
-        wrapper: wrapper(),
+        wrapper: wrapper({ className }),
         button: button(),
       }
-    }, [])
+    }, [className])
 
     const latest = useLatest({ onSelectFiles })
 


### PR DESCRIPTION
## 関連URL

<!-- なし -->

## 概要

`DropZone` コンポーネントに `className` props を渡すと、wrapper の `<div>` ではなく `VisuallyHiddenText` 内の hidden `<input>` に適用されていたバグを修正する。

## 変更内容

- `className` を `...rest` から分離してデストラクチャ
- `wrapper({ className })` で wrapper スロットに適用
- `classNames` の useMemo の依存配列に `className` を追加
- 対応完了につき FIXME コメントを削除

## プロダクト側で対応が必要な事項

なし（バグ修正のみ）

## 確認方法

Chromatic での VRT 確認