### PR TITLE
refactor(FocusTrap): focus ロジックを useCallback に切り出して重複を解消

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
@@ -2,6 +2,7 @@ import {
   type PropsWithChildren,
   type RefObject,
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -21,25 +22,19 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
   const innerRef = useRef<HTMLDivElement | null>(null)
   const dummyFocusRef = useRef<HTMLDivElement>(null)
 
+  const focus = useCallback(() => {
+    ;(firstFocusTarget?.current || dummyFocusRef.current)?.focus()
+  }, [firstFocusTarget])
+
   useImperativeHandle(ref, () => ({
-    focus: () => {
-      if (firstFocusTarget?.current) {
-        firstFocusTarget.current.focus()
-      } else {
-        dummyFocusRef.current?.focus()
-      }
-    },
+    focus,
   }))
 
   useEffect(() => {
     // FocusTrap がマウントされた時点のフォーカス要素を保存
     const triggerElement = document.activeElement
 
-    if (firstFocusTarget?.current) {
-      firstFocusTarget.current.focus()
-    } else {
-      dummyFocusRef.current?.focus()
-    }
+    focus()
 
     const handleKeyDown = (e: KeyboardEvent) => {
       // IME 変換中の Tab は変換候補の選択に使われるため、フォーカストラップの対象外にする。
@@ -79,7 +74,7 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
         triggerElement.focus()
       }
     }
-  }, [firstFocusTarget])
+  }, [focus])
 
   return (
     <div ref={innerRef}>


### PR DESCRIPTION
## 関連URL

<!-- なし -->

## 概要

`useImperativeHandle` と `useEffect` で重複していたフォーカスロジックを `useCallback` に切り出してDRYにする。

## 変更内容

- `focus` 関数を `useCallback` で定義し、`firstFocusTarget` を依存配列に設定
- `useImperativeHandle` と `useEffect` の両方から `focus` を呼び出すよう変更
- `useEffect` の依存配列を `[firstFocusTarget]` → `[focus]` に変更

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic での VRT 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ダイアログ表示時のフォーカス移動を改善し、適切な要素へ安定してフォーカスされるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->