### PR TITLE
refactor(MessageDialogContentInner): styles useMemoをCLASS_NAMES定数に変換、onClickCloseをhandleClickCloseにリネーム

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/ControlledMessageDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/ControlledMessageDialog.tsx
@@ -17,9 +17,10 @@ import type { DialogProps } from '../types'
 type ObjectHeadingType = Omit<MessageDialogContentInnerProps['heading'], 'id'>
 type HeadingType = ReactNode | ObjectHeadingType
 
-type AbstractProps = Omit<MessageDialogContentInnerProps, 'heading'> &
+type AbstractProps = Omit<MessageDialogContentInnerProps, 'heading' | 'handleClickClose'> &
   DialogProps & {
     heading: HeadingType
+    onClickClose: MessageDialogContentInnerProps['handleClickClose']
   }
 type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
 
@@ -73,7 +74,7 @@ export const ControlledMessageDialog: FC<Props> = ({
         heading={heading}
         contentBgColor={contentBgColor}
         contentPadding={contentPadding}
-        onClickClose={functions.handleClickClose}
+        handleClickClose={functions.handleClickClose}
         closeButton={closeButton}
       >
         {children}

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, memo, useMemo } from 'react'
+import { type FC, type ReactNode, memo } from 'react'
 
 import { Localizer } from '../../../intl'
 import { Button } from '../../Button'
@@ -21,6 +21,15 @@ export type MessageDialogContentInnerProps = AbstractProps & {
   onClickClose: () => void
 }
 
+const CLASS_NAMES = (() => {
+  const { wrapper, actionArea } = dialogContentInner()
+
+  return {
+    wrapper: wrapper(),
+    actionArea: actionArea(),
+  }
+})()
+
 export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
   heading,
   contentBgColor,
@@ -28,39 +37,24 @@ export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
   children,
   onClickClose,
   closeButton,
-}) => {
-  const styles = useMemo(() => {
-    const { wrapper, actionArea } = dialogContentInner()
+}) => (
+  <Section className={CLASS_NAMES.wrapper}>
+    <DialogHeading {...heading} />
+    <DialogBody contentPadding={contentPadding} contentBgColor={contentBgColor}>
+      {children}
+    </DialogBody>
+    <FooterCluster onClickClose={onClickClose} closeButton={closeButton} />
+  </Section>
+)
 
-    return {
-      wrapper: wrapper(),
-      actionArea: actionArea(),
-    }
-  }, [])
-
-  return (
-    <Section className={styles.wrapper}>
-      <DialogHeading {...heading} />
-      <DialogBody contentPadding={contentPadding} contentBgColor={contentBgColor}>
-        {children}
-      </DialogBody>
-      <FooterCluster
-        onClickClose={onClickClose}
-        closeButton={closeButton}
-        className={styles.actionArea}
-      />
-    </Section>
-  )
-}
-
-const FooterCluster = memo<
-  Pick<MessageDialogContentInnerProps, 'onClickClose' | 'closeButton'> & { className: string }
->(({ onClickClose, closeButton, className }) => (
-  <Cluster as="footer" justify="flex-end" className={className}>
-    <Button onClick={onClickClose} className="smarthr-ui-Dialog-closeButton">
-      {closeButton ?? (
-        <Localizer id="smarthr-ui/MessageDialog/closeButtonLabel" defaultText="閉じる" />
-      )}
-    </Button>
-  </Cluster>
-))
+const FooterCluster = memo<Pick<MessageDialogContentInnerProps, 'onClickClose' | 'closeButton'>>(
+  ({ onClickClose, closeButton }) => (
+    <Cluster as="footer" justify="flex-end" className={CLASS_NAMES.actionArea}>
+      <Button onClick={onClickClose} className="smarthr-ui-Dialog-closeButton">
+        {closeButton ?? (
+          <Localizer id="smarthr-ui/MessageDialog/closeButtonLabel" defaultText="閉じる" />
+        )}
+      </Button>
+    </Cluster>
+  ),
+)

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
@@ -18,7 +18,7 @@ export type AbstractProps = DialogBodyProps & {
 }
 
 export type MessageDialogContentInnerProps = AbstractProps & {
-  onClickClose: () => void
+  handleClickClose: () => void
 }
 
 const CLASS_NAMES = (() => {
@@ -35,7 +35,7 @@ export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
   contentBgColor,
   contentPadding,
   children,
-  onClickClose,
+  handleClickClose,
   closeButton,
 }) => (
   <Section className={CLASS_NAMES.wrapper}>
@@ -43,18 +43,18 @@ export const MessageDialogContentInner: FC<MessageDialogContentInnerProps> = ({
     <DialogBody contentPadding={contentPadding} contentBgColor={contentBgColor}>
       {children}
     </DialogBody>
-    <FooterCluster onClickClose={onClickClose} closeButton={closeButton} />
+    <FooterCluster handleClickClose={handleClickClose} closeButton={closeButton} />
   </Section>
 )
 
-const FooterCluster = memo<Pick<MessageDialogContentInnerProps, 'onClickClose' | 'closeButton'>>(
-  ({ onClickClose, closeButton }) => (
-    <Cluster as="footer" justify="flex-end" className={CLASS_NAMES.actionArea}>
-      <Button onClick={onClickClose} className="smarthr-ui-Dialog-closeButton">
-        {closeButton ?? (
-          <Localizer id="smarthr-ui/MessageDialog/closeButtonLabel" defaultText="閉じる" />
-        )}
-      </Button>
-    </Cluster>
-  ),
-)
+const FooterCluster = memo<
+  Pick<MessageDialogContentInnerProps, 'handleClickClose' | 'closeButton'>
+>(({ handleClickClose, closeButton }) => (
+  <Cluster as="footer" justify="flex-end" className={CLASS_NAMES.actionArea}>
+    <Button onClick={handleClickClose} className="smarthr-ui-Dialog-closeButton">
+      {closeButton ?? (
+        <Localizer id="smarthr-ui/MessageDialog/closeButtonLabel" defaultText="閉じる" />
+      )}
+    </Button>
+  </Cluster>
+))


### PR DESCRIPTION
## 関連URL

## 概要

`MessageDialogContentInner` コンポーネントのリファクタリング。

1. `styles` の `useMemo` を `CLASS_NAMES` IIFE定数に変換し、不要なフックオーバーヘッドを排除
2. `onClickClose` を `handleClickClose` にリネームし、命名規則（内部コンポーネントは `handleXxx`）に準拠

## 変更内容

### CLASS_NAMES定数化

依存配列が空の `useMemo` を IIFE で生成した `CLASS_NAMES` 定数に変換。

- `FooterCluster` へ `className` を props で渡す必要がなくなり、`CLASS_NAMES.actionArea` を直接参照するシンプルな構造に変更
- `useMemo` のインポートを削除

### onClickClose → handleClickClose リネーム

`MessageDialogContentInner` は `src/index.ts` から export されていない内部コンポーネントのため、受け取るハンドラー名を命名規則に従い `handleClickClose` に変更。

`ControlledMessageDialog` 側の型定義を調整し、ユーザー向けの `onClickClose` プロパティは維持したまま、内部へ `handleClickClose` として渡す構造を明確化。

```ts
// ControlledMessageDialog の AbstractProps
type AbstractProps = Omit<MessageDialogContentInnerProps, 'heading' | 'handleClickClose'> &
  DialogProps & {
    heading: HeadingType
    onClickClose: MessageDialogContentInnerProps['handleClickClose']  // ユーザー向けは onClickClose のまま
  }
```

## プロダクト側で対応が必要な事項

なし（外部向けインターフェースの変更なし）

## 確認方法

Chromatic での VRT 確認