### PR TITLE
refactor(usePartialRendering): limiter廃止・Intersection分離・handleIntersect安定化

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -25,7 +25,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { ItemButton } from './ItemButton'
 import { useActiveOption } from './useActiveOption'
-import { usePartialRendering } from './usePartialRendering'
+import { Intersection, usePartialRendering } from './usePartialRendering'
 
 import type { ComboboxItem, ComboboxOption } from './types'
 
@@ -222,7 +222,7 @@ export const useListbox = <T,>({
 
   const { createPortal } = usePortal()
   const listBoxId = useId()
-  const { items: partialOptions, renderIntersection } = usePartialRendering({
+  const { items: partialOptions, onIntersect } = usePartialRendering({
     items: options,
     minLength: useMemo(
       () => (activeOption === null ? 0 : options.indexOf(activeOption)) + 1,
@@ -330,13 +330,13 @@ export const useListbox = <T,>({
                 ))
               )
             ) : null}
-            {renderIntersection()}
+            {onIntersect && <Intersection onIntersect={onIntersect} />}
           </Scroller>
         </div>,
       ),
     [
       activeOption?.id,
-      renderIntersection,
+      onIntersect,
       partialOptions,
       options.length,
       isExpanded,

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -222,7 +222,7 @@ export const useListbox = <T,>({
 
   const { createPortal } = usePortal()
   const listBoxId = useId()
-  const { items: partialOptions, onIntersect } = usePartialRendering({
+  const { items: partialOptions, handleIntersect } = usePartialRendering({
     items: options,
     minLength: useMemo(
       () => (activeOption === null ? 0 : options.indexOf(activeOption)) + 1,
@@ -330,13 +330,13 @@ export const useListbox = <T,>({
                 ))
               )
             ) : null}
-            {onIntersect && <Intersection onIntersect={onIntersect} />}
+            {handleIntersect && <Intersection handleIntersect={handleIntersect} />}
           </Scroller>
         </div>,
       ),
     [
       activeOption?.id,
-      onIntersect,
+      handleIntersect,
       partialOptions,
       options.length,
       isExpanded,

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -1,5 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { useLatest } from '../../hooks/useLatest'
+
 const OPTION_INCREMENT_AMOUNT = 100
 
 export function usePartialRendering<T>({
@@ -15,9 +17,11 @@ export function usePartialRendering<T>({
   // minLength も考慮した実際のアイテム数を算出
   const partialItems = useMemo(() => items.slice(0, currentItemLength), [currentItemLength, items])
 
+  const latest = useLatest({ minLength })
+
   const handleIntersect = useCallback(() => {
-    setCurrentItemLength((current) => Math.max(current + OPTION_INCREMENT_AMOUNT, minLength))
-  }, [minLength])
+    setCurrentItemLength((current) => Math.max(current + OPTION_INCREMENT_AMOUNT, latest.minLength))
+  }, [latest])
 
   useEffect(() => {
     setCurrentItemLength((current) => Math.max(current, minLength))

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -31,7 +31,7 @@ export function usePartialRendering<T>({
 
   return {
     items: partialItems,
-    handleIntersect: currentItemLength >= items.length ? undefined : handleIntersect,
+    handleIntersect: currentItemLength < items.length ? handleIntersect : undefined,
   }
 }
 

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -10,10 +10,9 @@ export function usePartialRendering<T>({
   items: T[]
   minLength?: number
 }) {
-  const [currentItemLength, setCurrentItemLength] = useState(
+  const [currentItemLength, setCurrentItemLength] = useState(() =>
     Math.max(OPTION_INCREMENT_AMOUNT, minLength),
   )
-
   // minLength も考慮した実際のアイテム数を算出
   const partialItems = useMemo(() => items.slice(0, currentItemLength), [currentItemLength, items])
 

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -1,7 +1,6 @@
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const OPTION_INCREMENT_AMOUNT = 100
-const RETURN_NULL = () => null
 
 export function usePartialRendering<T>({
   items,
@@ -16,16 +15,9 @@ export function usePartialRendering<T>({
   // minLength も考慮した実際のアイテム数を算出
   const partialItems = useMemo(() => items.slice(0, currentItemLength), [currentItemLength, items])
 
-  const renderIntersection = useCallback(
-    () => (
-      <Intersection
-        onIntersect={() => {
-          setCurrentItemLength((current) => Math.max(current + OPTION_INCREMENT_AMOUNT, minLength))
-        }}
-      />
-    ),
-    [minLength],
-  )
+  const onIntersect = useCallback(() => {
+    setCurrentItemLength((current) => Math.max(current + OPTION_INCREMENT_AMOUNT, minLength))
+  }, [minLength])
 
   useEffect(() => {
     setCurrentItemLength((current) => Math.max(current, minLength))
@@ -33,11 +25,11 @@ export function usePartialRendering<T>({
 
   return {
     items: partialItems,
-    renderIntersection: currentItemLength >= items.length ? RETURN_NULL : renderIntersection,
+    onIntersect: currentItemLength >= items.length ? undefined : onIntersect,
   }
 }
 
-const Intersection: FC<{ onIntersect: () => void }> = ({ onIntersect }) => {
+export const Intersection: FC<{ onIntersect: () => void }> = ({ onIntersect }) => {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const OPTION_INCREMENT_AMOUNT = 100
 
@@ -29,7 +29,7 @@ export function usePartialRendering<T>({
   }
 }
 
-export const Intersection: FC<{ handleIntersect: () => void }> = ({ handleIntersect }) => {
+export const Intersection = memo<{ handleIntersect: () => void }>(({ handleIntersect }) => {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -52,4 +52,4 @@ export const Intersection: FC<{ handleIntersect: () => void }> = ({ handleInters
   }, [handleIntersect])
 
   return <div ref={ref} />
-}
+})

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -15,7 +15,7 @@ export function usePartialRendering<T>({
   // minLength も考慮した実際のアイテム数を算出
   const partialItems = useMemo(() => items.slice(0, currentItemLength), [currentItemLength, items])
 
-  const onIntersect = useCallback(() => {
+  const handleIntersect = useCallback(() => {
     setCurrentItemLength((current) => Math.max(current + OPTION_INCREMENT_AMOUNT, minLength))
   }, [minLength])
 
@@ -25,11 +25,11 @@ export function usePartialRendering<T>({
 
   return {
     items: partialItems,
-    onIntersect: currentItemLength >= items.length ? undefined : onIntersect,
+    handleIntersect: currentItemLength >= items.length ? undefined : handleIntersect,
   }
 }
 
-export const Intersection: FC<{ onIntersect: () => void }> = ({ onIntersect }) => {
+export const Intersection: FC<{ handleIntersect: () => void }> = ({ handleIntersect }) => {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -42,14 +42,14 @@ export const Intersection: FC<{ onIntersect: () => void }> = ({ onIntersect }) =
     // スクロール最下部に到達する度に表示するアイテム数を増加させるための IntersectionObserver
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) {
-        onIntersect()
+        handleIntersect()
       }
     })
 
     observer.observe(target)
 
     return () => observer.disconnect()
-  }, [onIntersect])
+  }, [handleIntersect])
 
   return <div ref={ref} />
 }

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -10,13 +10,9 @@ export function usePartialRendering<T>({
   items: T[]
   minLength?: number
 }) {
-  const limiter = useCallback((length: number) => Math.max(length, minLength), [minLength])
-
-  const [currentItemLength, setCurrentItemLength] = useState(limiter(OPTION_INCREMENT_AMOUNT))
-
-  useEffect(() => {
-    setCurrentItemLength((current) => limiter(current))
-  }, [limiter])
+  const [currentItemLength, setCurrentItemLength] = useState(
+    Math.max(OPTION_INCREMENT_AMOUNT, minLength),
+  )
 
   // minLength も考慮した実際のアイテム数を算出
   const partialItems = useMemo(() => items.slice(0, currentItemLength), [currentItemLength, items])
@@ -25,12 +21,16 @@ export function usePartialRendering<T>({
     () => (
       <Intersection
         onIntersect={() => {
-          setCurrentItemLength((current) => limiter(current + OPTION_INCREMENT_AMOUNT))
+          setCurrentItemLength((current) => Math.max(current + OPTION_INCREMENT_AMOUNT, minLength))
         }}
       />
     ),
-    [limiter],
+    [minLength],
   )
+
+  useEffect(() => {
+    setCurrentItemLength((current) => Math.max(current, minLength))
+  }, [minLength])
 
   return {
     items: partialItems,

--- a/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/usePartialRendering.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'


### PR DESCRIPTION
## 関連URL

## 概要

`usePartialRendering` フックのリファクタリング。

## 変更内容

### 1. `limiter` useCallback を廃止

中間的な `useCallback` であった `limiter` を削除し、`Math.max(..., minLength)` を各箇所にインライン化。`minLength` はプリミティブ値のため依存配列に直接指定可能。

### 2. `useState` の初期値を lazy initializer に変更

```tsx
// before
useState(Math.max(OPTION_INCREMENT_AMOUNT, minLength))

// after
useState(() => Math.max(OPTION_INCREMENT_AMOUNT, minLength))
```

### 3. `renderIntersection` → `handleIntersect` + `Intersection` export

hook が JSX を返す責務をなくし、`handleIntersect` コールバックを返す形に変更。`Intersection` コンポーネントを export し、呼び出し元（`useListbox.tsx`）で条件レンダリングする構造に変更。

```tsx
// before（hook内部でJSXを生成）
const { renderIntersection } = usePartialRendering({ ... })
{renderIntersection()}

// after（hookはcallbackを返し、JSXは呼び出し元で展開）
const { handleIntersect } = usePartialRendering({ ... })
{handleIntersect && <Intersection handleIntersect={handleIntersect} />}
```

### 4. `Intersection` を `memo` でラップ

### 5. `handleIntersect` を `useLatest` で安定化

`minLength` を `useLatest` で包み、`handleIntersect` の依存配列から除去。`minLength` 変更時に不要な再生成が発生しないよう安定化。

### 命名規則対応

- `Intersection` は内部コンポーネントのため、props を `onIntersect` → `handleIntersect` にリネーム

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromatic での VRT 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * コンボボックスのリストをスクロールした際の追加読み込み処理を改善しました。
  * 必要な場合のみ読み込み判定を実行し、表示件数の調整をより安定させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->