### PR TITLE
refactor: AbstractPropsをBasePropsにリネーム

### DIFF
--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanel.tsx
@@ -25,7 +25,7 @@ import {
   getNewExpandedItems,
 } from './accordionPanelHelper'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** アイコンの左右位置 */
   iconPosition?: 'left' | 'right'
   /** 複数のパネルを同時に開くことを許容するかどうか */
@@ -36,7 +36,7 @@ type AbstractProps = PropsWithChildren<{
   onClick?: (expandedItems: string[]) => void
 }> &
   VariantProps<typeof classNameGenerator>
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const DEFAULT_EXPANDED_ARRAY: string[] = []
 const DEFAULT_EXPANDED_MAP = flatArrayToMap(DEFAULT_EXPANDED_ARRAY)

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelContent.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelContent.tsx
@@ -16,8 +16,8 @@ import { getIsInclude } from '../../libs/map'
 import { AccordionPanelContext } from './AccordionPanel'
 import { AccordionPanelItemContext } from './AccordionPanelItem'
 
-type AbstractProps = PropsWithChildren
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type BaseProps = PropsWithChildren
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: [

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelItem.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelItem.tsx
@@ -11,11 +11,11 @@ import { tv } from 'tailwind-variants'
 
 import { Section } from '../SectioningContent'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** アイテムを識別するための名前 */
   name: string
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'section'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'section'>, keyof BaseProps>
 
 export const AccordionPanelItemContext = createContext<{
   name: string

--- a/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/AccordionPanelTrigger.tsx
@@ -22,7 +22,7 @@ import { AccordionPanelItemContext } from './AccordionPanelItem'
 
 import type { TextProps } from '../Text'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** ヘッダ部分のテキストのスタイル */
   headingType?: Exclude<TextProps['styleType'], 'screenTitle'>
   /**
@@ -30,7 +30,7 @@ type AbstractProps = PropsWithChildren<{
    */
   unrecommendedHeadingTag?: HeadingTagTypes
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'button'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'button'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/AppNavi/AppNavi.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNavi.tsx
@@ -20,7 +20,7 @@ import { AppNaviButton, type AppNaviButtonProps } from './AppNaviButton'
 import { AppNaviCustomTag, type AppNaviCustomTagProps } from './AppNaviCustomTag'
 import { AppNaviDropdown, type AppNaviDropdownProps } from './AppNaviDropdown'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** ラベルのテキスト */
   label?: ReactNode
   /** 表示するボタンの Props の配列
@@ -36,7 +36,7 @@ type AbstractProps = PropsWithChildren<{
   /** 追加の領域 */
   additionalArea?: ReactNode
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Badge/Badge.tsx
+++ b/packages/smarthr-ui/src/components/Badge/Badge.tsx
@@ -9,7 +9,7 @@ import { type VariantProps, tv } from 'tailwind-variants'
 
 import { Text } from '../Text'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** 件数 */
   count?: number
   /** 最大表示件数。この数を超えた場合は{最大表示件数+}と表示される */
@@ -21,7 +21,7 @@ type AbstractProps = PropsWithChildren<{
   /** ドット表示するかどうか */
   dot?: boolean
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'span'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'span'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/BottomFixedArea/BottomFixedArea.tsx
+++ b/packages/smarthr-ui/src/components/BottomFixedArea/BottomFixedArea.tsx
@@ -26,7 +26,7 @@ export type ButtonType =
   | FunctionComponentElement<ComponentProps<typeof Button>>
   | FunctionComponentElement<ComponentProps<typeof AnchorButton>>
 
-type AbstractProps = {
+type BaseProps = {
   /** この領域の説明 */
   description?: ReactNode
   /** 表示する `Button` または `AnchorButton` （`variant="primary"` である必要がある） */
@@ -45,7 +45,7 @@ type AbstractProps = {
   /** コンポーネントに適用する z-index 値 */
   zIndex?: number
 }
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -37,7 +37,7 @@ const classNameGenerator = tv({
   ],
 })
 
-type AbstractProps = {
+type BaseProps = {
   /** 表示する item の配列 */
   items: ItemNodeLike[]
   /** 選択中の item の値 */
@@ -45,7 +45,7 @@ type AbstractProps = {
   /** 選択された際に呼び出されるコールバック。第一引数に item の value を取る。 */
   onSelectItem?: (value: string) => void
 }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...rest }) => {
   const rootNode = useMemo(() => RootNode.from({ children: items }), [items])

--- a/packages/smarthr-ui/src/components/Browser/BrowserColumn.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserColumn.tsx
@@ -7,13 +7,13 @@ import type { ItemNode } from './models'
 
 const getColumnId = (column: number) => `column-${column}`
 
-type AbstractProps = {
+type BaseProps = {
   value?: string
   items: ItemNode[]
   index: number
   handleChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
 }
-type Props = AbstractProps & Omit<ComponentProps<'ul'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'ul'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: 'shr-px-0.25 shr-py-0.5',

--- a/packages/smarthr-ui/src/components/Button/AnchorButton.tsx
+++ b/packages/smarthr-ui/src/components/Button/AnchorButton.tsx
@@ -17,10 +17,10 @@ import { OpenInNewTabIcon } from '../Icon'
 import { ButtonWrapper } from './ButtonWrapper'
 import { DisabledReason } from './DisabledReason'
 
-import type { AbstractProps as ButtonProps } from './types'
+import type { BaseProps as ButtonProps } from './types'
 import type { ElementRef, ElementRefProps } from '../../types'
 
-type AbstractProps<T extends ElementType> = Omit<ButtonProps, 'variant' | 'disabledReason'> & {
+type BaseProps<T extends ElementType> = Omit<ButtonProps, 'variant' | 'disabledReason'> & {
   /** next/linkなどのカスタムコンポーネントを指定します。指定がない場合はデフォルトで `a` タグが使用されます。 */
   elementAs?: T
   // tertiaryはAnchorButtonでは使用不可
@@ -30,7 +30,7 @@ type AbstractProps<T extends ElementType> = Omit<ButtonProps, 'variant' | 'disab
 
 type ElementProps<T extends ElementType> = Omit<
   ComponentPropsWithoutRef<T>,
-  keyof AbstractProps<T> & ElementRefProps<T>
+  keyof BaseProps<T> & ElementRefProps<T>
 >
 
 const classNameGenerator = tv({
@@ -53,7 +53,7 @@ const AnchorButton = forwardRef(
       children,
       href,
       ...rest
-    }: PropsWithoutRef<AbstractProps<T>> & ElementProps<T>,
+    }: PropsWithoutRef<BaseProps<T>> & ElementProps<T>,
     ref: Ref<ElementRef<T>>,
   ): ReactElement => {
     const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
@@ -92,7 +92,7 @@ const AnchorButton = forwardRef(
 
 // 型キャストなしで ForwardRefExoticComponent に合わせた型をエクスポートするための処理
 type AnchorButtonType = <T extends ElementType = 'a'>(
-  props: AbstractProps<T> & ElementProps<T> & ElementRefProps<T>,
+  props: BaseProps<T> & ElementProps<T> & ElementRefProps<T>,
 ) => ReturnType<FC>
 
 const ForwardedAnchorButton = AnchorButton as unknown as AnchorButtonType & {

--- a/packages/smarthr-ui/src/components/Button/Button.tsx
+++ b/packages/smarthr-ui/src/components/Button/Button.tsx
@@ -10,9 +10,9 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 import { ButtonWrapper } from './ButtonWrapper'
 import { DisabledReason } from './DisabledReason'
 
-import type { AbstractProps } from './types'
+import type { BaseProps } from './types'
 
-type Props = AbstractProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof AbstractProps>
+type Props = BaseProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Button/index.ts
+++ b/packages/smarthr-ui/src/components/Button/index.ts
@@ -1,4 +1,4 @@
 export { Button } from './Button'
-export type { AbstractProps } from './types'
+export type { BaseProps } from './types'
 export { AnchorButton } from './AnchorButton'
 export { UnstyledButton } from './UnstyledButton'

--- a/packages/smarthr-ui/src/components/Button/types.ts
+++ b/packages/smarthr-ui/src/components/Button/types.ts
@@ -1,6 +1,6 @@
 import type { FunctionComponent, PropsWithChildren, ReactNode } from 'react'
 
-export type AbstractProps = PropsWithChildren<{
+export type BaseProps = PropsWithChildren<{
   /**
    * ボタンの大きさ
    */

--- a/packages/smarthr-ui/src/components/Button/useButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/useButtonWrapper.tsx
@@ -21,7 +21,7 @@ import type { Variant } from './types'
 // HINT: smarthr-ui-Icon-extendedはアイコン+α(例えば複数のアイコンをまとめて一つにしているなど)を表すclass
 const ICON_SELECTOR = '.smarthr-ui-Icon, .smarthr-ui-Icon-extended, svg, img, .smarthr-ui-Loader'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   size: 'M' | 'S'
   wide: boolean
   variant: Variant
@@ -32,19 +32,19 @@ type AbstractProps = PropsWithChildren<{
   suffix?: ReactNode
 }>
 
-type AbstractButtonProps = AbstractProps & {
+type BaseButtonProps = BaseProps & {
   isAnchor?: never
   buttonRef?: ForwardedRef<HTMLButtonElement>
 }
-type ButtonProps = AbstractButtonProps &
-  Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof AbstractButtonProps>
+type ButtonProps = BaseButtonProps &
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseButtonProps>
 
-type AbstractAnchorProps = AbstractProps & {
+type BaseAnchorProps = BaseProps & {
   isAnchor: true
   anchorRef?: ForwardedRef<HTMLAnchorElement>
 }
-type AnchorProps = AbstractAnchorProps &
-  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof AbstractAnchorProps>
+type AnchorProps = BaseAnchorProps &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseAnchorProps>
 
 export type Props = ButtonProps | AnchorProps
 

--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -24,7 +24,7 @@ import { CalendarTable } from './CalendarTable'
 import { YearPicker } from './YearPicker'
 import { getFromDate, getMonthArray, getToDate, isBetween, minDate } from './calendarHelper'
 
-type AbstractProps = {
+type BaseProps = {
   /** 選択可能な開始日 */
   from?: Date
   /** 選択可能な終了日 */
@@ -34,7 +34,7 @@ type AbstractProps = {
   /** 選択された日付 */
   value?: Date
 }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 type DayJsType = ReturnType<typeof dayjs>
 

--- a/packages/smarthr-ui/src/components/Calendar/CalendarTable.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/CalendarTable.tsx
@@ -15,7 +15,7 @@ import { UnstyledButton } from '../Button'
 
 import { isBetween } from './calendarHelper'
 
-type AbstractProps = {
+type BaseProps = {
   /** 現在の日付 */
   current: {
     day: DayJsType
@@ -30,7 +30,7 @@ type AbstractProps = {
   /** 選択された日付 */
   selectedDayText: string
 }
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'table'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'table'>, keyof BaseProps>
 
 type DayJsType = ReturnType<typeof dayjs>
 

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -14,7 +14,7 @@ import { useIntl } from '../../intl'
 import { UnstyledButton } from '../Button'
 import { Scroller } from '../Scroller'
 
-type AbstractProps = {
+type BaseProps = {
   /** 選択された年 */
   selectedYear?: number
   /** 選択可能な開始年 */
@@ -28,7 +28,7 @@ type AbstractProps = {
   /** HTMLのid属性 */
   id: string
 }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 type ActualProps = Omit<Props, 'isDisplayed'>
 
 const classNameGenerator = tv({

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -33,9 +33,9 @@ import { useMultiOptions } from '../useOptions'
 
 import { MultiSelectedItem } from './MultiSelectedItem'
 
-import type { ComboboxItem, AbstractProps as ComboboxProps } from '../types'
+import type { ComboboxItem, BaseProps as ComboboxProps } from '../types'
 
-type AbstractProps<T> = ComboboxProps<T> & {
+type BaseProps<T> = ComboboxProps<T> & {
   /**
    * 選択されているアイテムのリスト
    */
@@ -74,8 +74,7 @@ type AbstractProps<T> = ComboboxProps<T> & {
    */
   noResultText?: ReactNode
 }
-type Props<T> = AbstractProps<T> &
-  Omit<ComponentPropsWithoutRef<'input'>, keyof AbstractProps<unknown>>
+type Props<T> = BaseProps<T> & Omit<ComponentPropsWithoutRef<'input'>, keyof BaseProps<unknown>>
 
 const NOOP = () => undefined
 

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -30,9 +30,9 @@ import { Input } from '../../Input'
 import { useListbox } from '../useListbox'
 import { useSingleOptions } from '../useOptions'
 
-import type { ComboboxItem, AbstractProps as ComboboxProps } from '../types'
+import type { ComboboxItem, BaseProps as ComboboxProps } from '../types'
 
-type AbstractProps<T> = ComboboxProps<T> & {
+type BaseProps<T> = ComboboxProps<T> & {
   /**
    * 選択されているアイテム
    */
@@ -71,8 +71,7 @@ type AbstractProps<T> = ComboboxProps<T> & {
    */
   noResultText?: ReactNode
 }
-type Props<T> = AbstractProps<T> &
-  Omit<ComponentPropsWithoutRef<'input'>, keyof AbstractProps<unknown>>
+type Props<T> = BaseProps<T> & Omit<ComponentPropsWithoutRef<'input'>, keyof BaseProps<unknown>>
 
 const NOOP = () => undefined
 

--- a/packages/smarthr-ui/src/components/Combobox/types.ts
+++ b/packages/smarthr-ui/src/components/Combobox/types.ts
@@ -14,7 +14,7 @@ export type ComboboxOption<T> = {
   item: ComboboxItem<T>
 }
 
-export type AbstractProps<T> = {
+export type BaseProps<T> = {
   /**
    * 選択可能なアイテムのリスト
    */

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -29,7 +29,7 @@ import { Portal } from './Portal'
 import { parseJpnDateString } from './datePickerHelper'
 
 type ChangeLikeEvent = ChangeEvent | React.KeyboardEvent | MouseEvent
-type AbstractProps = {
+type BaseProps = {
   /** input 要素の `value` 属性の値 */
   value?: string | null
   /** input 要素の `name` 属性の値 */
@@ -62,10 +62,10 @@ type AbstractProps = {
     other: { date: Date | null; formatValue: string; errors: string[] },
   ) => void
 }
-type Props = AbstractProps &
+type Props = BaseProps &
   Omit<
     ComponentPropsWithRef<'input'>,
-    | keyof AbstractProps
+    | keyof BaseProps
     | 'type'
     | 'onChange'
     | 'onKeyPress'

--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
@@ -19,12 +19,12 @@ type ObjectTermType = {
   text: ReactNode
   styleType?: 'blockTitle' | 'subBlockTitle' | 'subSubBlockTitle'
 }
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   term: ReactNode | ObjectTermType
   fullWidth?: boolean
   maxColumns?: number
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 const termObjectConverter = (term: ReactNode): ObjectTermType => ({ text: term })
 

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
@@ -39,7 +39,7 @@ type ObjectCloseButtonType = {
   disabled?: boolean
 }
 
-export type AbstractProps = PropsWithChildren<
+export type BaseProps = PropsWithChildren<
   DialogBodyProps & {
     /** ダイアログタイトル */
     heading: DialogHeadingProps
@@ -58,7 +58,7 @@ export type AbstractProps = PropsWithChildren<
   }
 >
 
-export type ActionDialogContentInnerProps = AbstractProps & {
+export type ActionDialogContentInnerProps = BaseProps & {
   handleClickClose: () => void
   responseStatus?: ResponseStatus
 }

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ControlledActionDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ControlledActionDialog.tsx
@@ -21,7 +21,7 @@ type HeadingType = ReactNode | ObjectHeadingType
 type ObjectActionButtonType = ActionDialogContentInnerProps['actionButton']
 type ObjectCloseButtonType = ActionDialogContentInnerProps['closeButton']
 
-type AbstractProps = Omit<
+type BaseProps = Omit<
   ActionDialogContentInnerProps,
   'heading' | 'actionButton' | 'closeButton' | 'handleClickAction' | 'handleClickClose'
 > &
@@ -38,7 +38,7 @@ type AbstractProps = Omit<
      */
     onClickClose: () => void
   }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const headingObjectConverter = (text: ReactNode) => ({
   text,

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/ControlledFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/ControlledFormDialog.tsx
@@ -21,7 +21,7 @@ type HeadingType = ReactNode | ObjectHeadingType
 type ObjectActionButtonType = FormDialogContentInnerProps['actionButton']
 type ObjectCloseButtonType = FormDialogContentInnerProps['closeButton']
 
-type AbstractProps = Omit<
+type BaseProps = Omit<
   FormDialogContentInnerProps,
   'heading' | 'actionButton' | 'closeButton' | 'handleClickClose' | 'handleSubmit'
 > &
@@ -38,7 +38,7 @@ type AbstractProps = Omit<
      */
     onClickClose: () => void
   }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const headingObjectConverter = (text: ReactNode) => ({
   text,

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
@@ -31,7 +31,7 @@ type ObjectCloseButtonType = {
   disabled?: boolean
 }
 
-export type AbstractProps = PropsWithChildren<
+export type BaseProps = PropsWithChildren<
   DialogBodyProps & {
     /** ダイアログタイトル */
     heading: DialogHeadingProps
@@ -49,7 +49,7 @@ export type AbstractProps = PropsWithChildren<
   }
 >
 
-export type FormDialogContentInnerProps = AbstractProps & {
+export type FormDialogContentInnerProps = BaseProps & {
   handleClickClose: () => void
   responseStatus?: ResponseStatus
 }

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/ControlledMessageDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/ControlledMessageDialog.tsx
@@ -17,11 +17,11 @@ import type { DialogProps } from '../types'
 type ObjectHeadingType = Omit<MessageDialogContentInnerProps['heading'], 'id'>
 type HeadingType = ReactNode | ObjectHeadingType
 
-type AbstractProps = Omit<MessageDialogContentInnerProps, 'heading'> &
+type BaseProps = Omit<MessageDialogContentInnerProps, 'heading'> &
   DialogProps & {
     heading: HeadingType
   }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const headingObjectConverter = (text: ReactNode) => ({
   text,

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
@@ -8,7 +8,7 @@ import { DialogBody, type Props as DialogBodyProps } from '../DialogBody'
 import { DialogHeading, type Props as DialogHeadingProps } from '../DialogHeading'
 import { dialogContentInner } from '../dialogInnerStyle'
 
-export type AbstractProps = DialogBodyProps & {
+export type BaseProps = DialogBodyProps & {
   /** ダイアログタイトル */
   heading: DialogHeadingProps
   /** ダイアログの説明 */
@@ -17,7 +17,7 @@ export type AbstractProps = DialogBodyProps & {
   closeButton?: ReactNode
 }
 
-export type MessageDialogContentInnerProps = AbstractProps & {
+export type MessageDialogContentInnerProps = BaseProps & {
   onClickClose: () => void
 }
 

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
@@ -17,8 +17,8 @@ import { useDialogPortal } from '../useDialogPortal'
 import { useObjectHeading } from '../useObjectHeading'
 
 import {
+  type BaseProps as BaseStepFormDialogContentInnerProps,
   StepFormDialogContentInner,
-  type AbstractProps as StepFormDialogContentInnerAbstractProps,
   type StepFormDialogContentInnerProps,
 } from './StepFormDialogContentInner'
 import { StepFormDialogContext, StepFormDialogProvider } from './StepFormDialogProvider'
@@ -34,7 +34,7 @@ import type { DialogProps /** コンテンツなにもないDialogの基本props
 type ObjectHeadingType = Omit<StepFormDialogContentInnerProps['heading'], 'id'>
 type HeadingType = ReactNode | ObjectHeadingType
 
-type AbstractProps = Omit<
+type BaseProps = Omit<
   StepFormDialogContentInnerProps,
   | 'heading'
   | 'activeStep'
@@ -50,11 +50,11 @@ type AbstractProps = Omit<
     submitButton: ButtonArgType | ObjectButtonType
     closeButton?: ButtonArgType | ObjectButtonType
     backButton?: ButtonArgType | ObjectButtonType
-    onSubmit: StepFormDialogContentInnerAbstractProps['handleSubmit']
+    onSubmit: BaseStepFormDialogContentInnerProps['handleSubmit']
     onClickClose: () => void
     onClickBack?: () => void
   }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const headingObjectConverter = (text: ReactNode) => ({ text })
 

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
@@ -35,7 +35,7 @@ type StepFormHelpers = {
 
 type CommonButtonType = ReturnType<typeof useStepFormDialogButton>
 
-export type AbstractProps = PropsWithChildren<
+export type BaseProps = PropsWithChildren<
   DialogBodyProps & {
     /** ダイアログタイトル */
     heading: DialogHeadingProps
@@ -56,7 +56,7 @@ export type AbstractProps = PropsWithChildren<
   }
 >
 
-export type StepFormDialogContentInnerProps = AbstractProps & {
+export type StepFormDialogContentInnerProps = BaseProps & {
   firstStep: StepItem
   handleClickClose: () => void
   responseStatus?: ResponseStatus

--- a/packages/smarthr-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.tsx
@@ -6,8 +6,8 @@ import { useDialogPortal } from './useDialogPortal'
 import type { DialogProps, DirectChildren } from './types'
 import type { ComponentProps, FC } from 'react'
 
-type AbstractProps = DialogProps & DirectChildren
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type BaseProps = DialogProps & DirectChildren
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 export const Dialog: FC<Props> = ({ className, portalParent, id, ...rest }) => {
   const { createPortal } = useDialogPortal(portalParent, id)

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -32,7 +32,7 @@ import { useDialogPortal } from '../useDialogPortal'
 
 import type { DialogSize } from '../types'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /**
    * ダイアログのタイトルの内容
    */
@@ -87,10 +87,10 @@ type AbstractProps = PropsWithChildren<{
    */
   portalParent?: HTMLElement | RefObject<HTMLElement>
 }>
-type Props = AbstractProps &
-  Omit<DialogBodyProps, keyof AbstractProps> &
-  Omit<PanelElementProps, keyof AbstractProps> &
-  Omit<VariantProps<typeof classNameGenerator>, keyof AbstractProps>
+type Props = BaseProps &
+  Omit<DialogBodyProps, keyof BaseProps> &
+  Omit<PanelElementProps, keyof BaseProps> &
+  Omit<VariantProps<typeof classNameGenerator>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
@@ -6,7 +6,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { useDisclosure } from './useDisclosure'
 
-type BaseDisclosureContentProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** DisclosureTriggerのtargetIdと紐づけるId */
   id: string
   /** 開閉状態。デフォルトは閉じている */
@@ -15,8 +15,7 @@ type BaseDisclosureContentProps = PropsWithChildren<{
   visuallyHidden?: boolean
 }>
 
-type DisclosureContentProps = BaseDisclosureContentProps &
-  Omit<ComponentProps<'div'>, keyof BaseDisclosureContentProps>
+type DisclosureContentProps = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 export const DisclosureContent: FC<DisclosureContentProps> = ({
   id,

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
@@ -6,7 +6,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { useDisclosure } from './useDisclosure'
 
-type DisclosureContentAbstractProps = PropsWithChildren<{
+type BaseDisclosureContentProps = PropsWithChildren<{
   /** DisclosureTriggerのtargetIdと紐づけるId */
   id: string
   /** 開閉状態。デフォルトは閉じている */
@@ -15,8 +15,8 @@ type DisclosureContentAbstractProps = PropsWithChildren<{
   visuallyHidden?: boolean
 }>
 
-type DisclosureContentProps = DisclosureContentAbstractProps &
-  Omit<ComponentProps<'div'>, keyof DisclosureContentAbstractProps>
+type DisclosureContentProps = BaseDisclosureContentProps &
+  Omit<ComponentProps<'div'>, keyof BaseDisclosureContentProps>
 
 export const DisclosureContent: FC<DisclosureContentProps> = ({
   id,

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -34,7 +34,7 @@ const classNameGenerator = tv({
   },
 })
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /**
    * ボタンまたはドラッグ&ドロップでファイルが追加された時に発火するコールバック関数
    */
@@ -56,7 +56,7 @@ type AbstractProps = PropsWithChildren<{
   /** ファイル選択ボタンのラベル */
   selectButtonLabel?: string
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'div'>, keyof BaseProps>
 
 const overrideEventDefault = (e: DragEvent<HTMLElement>) => {
   e.preventDefault()

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContent.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContent.tsx
@@ -18,7 +18,7 @@ export const DropdownContentContext = createContext<{
   controllable: false,
 })
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /**
    * `true` のとき、ドロップダウン内のコンテンツをクリックしてもドロップダウンが閉じなくなる。。
    *  この場合は、 `DropdownCloser` を用いてドロップダウンを閉じることができる。
@@ -26,7 +26,7 @@ type AbstractProps = PropsWithChildren<{
   controllable?: boolean
 }>
 
-type Props = AbstractProps & Omit<InnerElementProps, keyof AbstractProps>
+type Props = BaseProps & Omit<InnerElementProps, keyof BaseProps>
 
 export const DropdownContent: FC<Props> = ({ controllable = false, ...rest }) => {
   const { DropdownContentRoot, triggerRect, handleDelegateClickCloser } =

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -28,13 +28,13 @@ const classNameGenerator = tv({
   },
 })
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   triggerRect: Rect
   controllable: boolean
 }>
 
-export type ElementProps = Omit<ComponentProps<'div'>, keyof AbstractProps>
-type Props = AbstractProps & ElementProps
+export type ElementProps = Omit<ComponentProps<'div'>, keyof BaseProps>
+type Props = BaseProps & ElementProps
 
 type DropdownContentInnerContextType = {
   maxHeight: string

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -20,7 +20,7 @@ import { tv } from 'tailwind-variants'
 
 import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
 import { Localizer } from '../../../intl'
-import { type AnchorButton, Button, type AbstractProps as ButtonProps } from '../../Button'
+import { type AnchorButton, Button, type BaseProps as ButtonProps } from '../../Button'
 import { FaCaretDownIcon, FaEllipsisIcon } from '../../Icon'
 import { Dropdown, DropdownContext } from '../Dropdown'
 import { DropdownCloser } from '../DropdownCloser'
@@ -54,7 +54,7 @@ type ObjectTriggerType = {
         component?: ComponentType<ComponentProps<typeof FaCaretDownIcon>>
       }
 }
-type AbstractProps = {
+type BaseProps = {
   /** 引き金となるボタン */
   trigger: ReactNode | ObjectTriggerType
   /** 操作群 */
@@ -64,8 +64,8 @@ type AbstractProps = {
   /** ドロップダウンメニューが閉じられた際のイベント */
   onClose?: () => void
 }
-type ElementProps = Omit<ComponentPropsWithRef<'button'>, keyof AbstractProps>
-type Props = AbstractProps & ElementProps
+type ElementProps = Omit<ComponentPropsWithRef<'button'>, keyof BaseProps>
+type Props = BaseProps & ElementProps
 
 const triggerObjectConverter = (trigger: ReactNode) => ({
   children: trigger,

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuGroup.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuGroup.tsx
@@ -13,10 +13,10 @@ import { Text } from '../../Text'
 
 import { renderButtonList } from './DropdownMenuButton'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   name?: ReactNode
 }>
-type Props = AbstractProps & Omit<ComponentProps<'li'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'li'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx
@@ -13,7 +13,7 @@ import { tv } from 'tailwind-variants'
 import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
 import { Localizer, useIntl } from '../../../intl'
-import { Button, type AbstractProps as ButtonProps } from '../../Button'
+import { Button, type BaseProps as ButtonProps } from '../../Button'
 import { FaCircleCheckIcon, FaFilterIcon, FaRotateLeftIcon } from '../../Icon'
 import { Cluster, Stack } from '../../Layout'
 import { ResponseMessage } from '../../ResponseMessage'
@@ -29,7 +29,7 @@ type ObjectTriggerType = {
   /** 引き金となるボタンをアイコンのみとするかどうか */
   onlyIcon?: boolean
 }
-type AbstractProps = {
+type BaseProps = {
   /** 引き金となるボタン */
   trigger?: ReactNode | ObjectTriggerType
   applyText?: ReactNode
@@ -48,7 +48,7 @@ type AbstractProps = {
   onOpen?: () => void
   onClose?: () => void
 }
-type Props = AbstractProps & Omit<ComponentProps<'button'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'button'>, keyof BaseProps>
 
 const triggerObjectConverter = (trigger: ReactNode): ObjectTriggerType => ({ text: trigger })
 

--- a/packages/smarthr-ui/src/components/Dropdown/SortDropdown/SortDropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/SortDropdown/SortDropdown.tsx
@@ -34,7 +34,7 @@ type ArgsOnApply = {
   newfields: SortFieldType[]
 }
 
-type AbstractProps = {
+type BaseProps = {
   /** 並び替え項目 */
   sortFields: SortFieldType[]
   /** 並び順の初期値 */
@@ -50,7 +50,7 @@ type AbstractProps = {
   /** キャンセル時に発火するイベント */
   onCancel?: MouseEventHandler<HTMLButtonElement>
 }
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'button'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'button'>, keyof BaseProps>
 
 const ON_SUBMIT = (e: FormEvent) => {
   e.preventDefault()

--- a/packages/smarthr-ui/src/components/ErrorScreen/ErrorScreen.tsx
+++ b/packages/smarthr-ui/src/components/ErrorScreen/ErrorScreen.tsx
@@ -6,7 +6,7 @@ import { Center, Stack } from '../Layout'
 import { SmartHRLogo } from '../SmartHRLogo'
 import { TextLink } from '../TextLink'
 
-type AbstractProps = {
+type BaseProps = {
   /** ロゴ */
   logo?: ReactNode
   /** コンテンツの上に表示されるタイトル */
@@ -25,7 +25,7 @@ type AbstractProps = {
   /** コンポーネントに適用するクラス名 */
   className?: string
 }
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: 'smarthr-ui-ErrorScreen shr-box-border shr-bg-background shr-p-1.5',

--- a/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
@@ -90,7 +90,7 @@ const classNameGenerator = tv({
   },
 })
 
-type AbstractProps = {
+type BaseProps = {
   /** 表示する `Button` または `AnchorButton` コンポーネント */
   primaryButton: ReactNode
   /** 表示する `Button` または `AnchorButton` コンポーネント */
@@ -104,7 +104,7 @@ type AbstractProps = {
   /** コンポーネントの `z-index` 値 */
   zIndex?: number
 }
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 export const FloatArea: FC<Props> = ({
   primaryButton,

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -42,7 +42,7 @@ type ObjectLabelType = {
   /** ラベルに適用する `id` 値 */
   id?: string
 }
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** グループのラベル名 */
   label: ReactNode | ObjectLabelType
   /** タイトル右の領域 */
@@ -65,8 +65,7 @@ type AbstractProps = PropsWithChildren<{
   disabled?: boolean
   as?: string | ComponentType<any>
 }>
-type Props = AbstractProps &
-  Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps | 'aria-labelledby'>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'aria-labelledby'>
 
 const labelObjectConverter = (label: ReactNode) => ({ text: label })
 

--- a/packages/smarthr-ui/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -21,13 +21,13 @@ type AppItem = {
   url: string
   target?: string
 }
-type AbstractProps = {
+type BaseProps = {
   apps: Category[]
   urlToShowAll?: string | null
   /** トリガーボタンのラベル。指定しない場合はIntlProviderから取得 */
   triggerLabel?: ReactNode
 } & VariantProps<typeof classNameGenerator>
-type Props = AbstractProps & Omit<HTMLAttributes<HTMLElement>, keyof AbstractProps>
+type Props = BaseProps & Omit<HTMLAttributes<HTMLElement>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Header/Header.tsx
+++ b/packages/smarthr-ui/src/components/Header/Header.tsx
@@ -52,7 +52,7 @@ type Tenant = PropsWithChildren<{
   name: ReactNode
 }>
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** ロゴ */
   logo?: ReactElement
   /** ロゴリンク */
@@ -71,7 +71,7 @@ type AbstractProps = PropsWithChildren<{
   enableNew?: boolean
 }> &
   VariantProps<typeof classNameGenerator>
-type Props = AbstractProps & Omit<ComponentProps<'header'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'header'>, keyof BaseProps>
 
 const COMMON_GAP = { column: 0.25, row: 0 } as const
 const CHILDREN_GAP = { column: 0.5, row: 0.25 } as const

--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
@@ -20,7 +20,7 @@ import { FaCaretDownIcon, FaCheckIcon, FaGlobeIcon, LanguageIcon } from '../../I
 
 import type { Locale } from '../../../intl'
 
-export type AbstractProps = {
+export type BaseProps = {
   narrow?: boolean
   localeMap: Partial<Record<Locale, string>>
   locale?: string
@@ -29,7 +29,7 @@ export type AbstractProps = {
   onLanguageSelect?: (code: string) => void
 } & VariantProps<typeof classNameGenerator>
 
-type Props = AbstractProps & Omit<HTMLAttributes<HTMLElement>, keyof AbstractProps>
+type Props = BaseProps & Omit<HTMLAttributes<HTMLElement>, keyof BaseProps>
 
 const ARROW_KEY_REGEX = /^Arrow(Up|Down|Left|Right)$/
 const ARROW_UPS_REGEX = /^Arrow(Up|Left)$/

--- a/packages/smarthr-ui/src/components/Heading/Heading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.tsx
@@ -32,7 +32,7 @@ type StylingProps =
       size?: never
     }
 
-export type AbstractProps = PropsWithChildren<{
+export type BaseProps = PropsWithChildren<{
   /**
    * 可能な限り利用せず、SectioningContent(Article, Aside, Nav, Section)を使ってHeadingと関連する範囲を明確に指定する方法を検討してください
    */
@@ -46,9 +46,9 @@ export type AbstractProps = PropsWithChildren<{
 
 export type ElementProps = Omit<
   ComponentProps<'h1'>,
-  keyof AbstractProps | keyof TextProps | 'role' | 'aria-level'
+  keyof BaseProps | keyof TextProps | 'role' | 'aria-level'
 >
-type Props = AbstractProps & ElementProps
+type Props = BaseProps & ElementProps
 
 const classNameGenerator = tv({
   base: 'smarthr-ui-Heading',

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -10,7 +10,7 @@ import { VisuallyHiddenText, visuallyHiddenTextClassName } from '../../VisuallyH
 
 import type { ElementProps } from '../Heading'
 
-export type AbstractProps = PropsWithChildren<{
+export type BaseProps = PropsWithChildren<{
   /**
    * テキストのサイズ
    *
@@ -30,7 +30,7 @@ export type AbstractProps = PropsWithChildren<{
   /** title要素のsuffix */
   pageTitleSuffix?: string
 }>
-type Props = AbstractProps & Omit<ElementProps, keyof AbstractProps>
+type Props = BaseProps & Omit<ElementProps, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: 'smarthr-ui-Heading smarthr-ui-PageHeading',

--- a/packages/smarthr-ui/src/components/Heading/index.ts
+++ b/packages/smarthr-ui/src/components/Heading/index.ts
@@ -1,4 +1,4 @@
 export { Heading } from './Heading'
-export type { AbstractProps, HeadingTagTypes } from './Heading'
+export type { BaseProps, HeadingTagTypes } from './Heading'
 
 export { PageHeading } from './PageHeading'

--- a/packages/smarthr-ui/src/components/Icon/generateIcon.tsx
+++ b/packages/smarthr-ui/src/components/Icon/generateIcon.tsx
@@ -40,12 +40,12 @@ type IconProps = {
   size?: FontSizes
 }
 
-type AbstractProps = {
+type BaseProps = {
   /**アイコンの説明テキスト*/
   alt?: ReactNode
 }
-export type Props = AbstractProps &
-  Omit<IconProps & Omit<ComponentProps<'svg'>, keyof IconProps>, keyof AbstractProps>
+export type Props = BaseProps &
+  Omit<IconProps & Omit<ComponentProps<'svg'>, keyof IconProps>, keyof BaseProps>
 
 // HINT: smarthr-ui-Icon-extendedはアイコン+α(例えば複数のアイコンをまとめて一つにしているなど)を表すclass
 // altなどもVisuallyHiddenTextで表現している関係上、squareの計算などの際に複数要素として判断されると認知と違う結果になるため使用しています

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -36,7 +36,7 @@ type ObjectHeadingType = {
   unrecommendedTag?: HeadingTagTypes
 }
 type HeadingType = ReactNode | ObjectHeadingType
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** パネルのタイトル */
   heading: HeadingType
   /** `true` のとき、開閉ボタンを表示する */
@@ -48,7 +48,7 @@ type AbstractProps = PropsWithChildren<{
 }> &
   VariantProps<typeof classNameGenerator>
 
-type Props = AbstractProps & Omit<PanelElementProps, keyof AbstractProps>
+type Props = BaseProps & Omit<PanelElementProps, keyof BaseProps>
 
 const headingObjectConverter = (text: ReactNode) => ({ text })
 

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -15,7 +15,7 @@ import { tv } from 'tailwind-variants'
 import { useLatest } from '../../hooks/useLatest'
 import { useTheme } from '../../hooks/useTheme'
 
-type AbstractProps = {
+type BaseProps = {
   /** input 要素の `type` 値 */
   type?: HTMLInputElement['type']
   /** フォームにエラーがあるかどうか */
@@ -35,7 +35,7 @@ type AbstractProps = {
    */
   placeholder?: string
 }
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'input'>, keyof AbstractProps | 'onWheel'>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'input'>, keyof BaseProps | 'onWheel'>
 
 export const backgroundColor = {
   BACKGROUND: 'background',

--- a/packages/smarthr-ui/src/components/InputFile/types.ts
+++ b/packages/smarthr-ui/src/components/InputFile/types.ts
@@ -2,7 +2,7 @@ import type { classNameGenerator } from './style'
 import type { ComponentPropsWithRef, ReactNode } from 'react'
 import type { VariantProps } from 'tailwind-variants'
 
-type AbstractProps = VariantProps<typeof classNameGenerator> & {
+type BaseProps = VariantProps<typeof classNameGenerator> & {
   /** フォームのラベル */
   label: ReactNode
   /** ファイルの選択に変更があったときに発火するコールバック関数 */
@@ -17,4 +17,4 @@ type AbstractProps = VariantProps<typeof classNameGenerator> & {
         appendable?: boolean
       }
 }
-export type Props = AbstractProps & Omit<ComponentPropsWithRef<'input'>, keyof AbstractProps>
+export type Props = BaseProps & Omit<ComponentPropsWithRef<'input'>, keyof BaseProps>

--- a/packages/smarthr-ui/src/components/Layout/Center/Center.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Center/Center.tsx
@@ -13,7 +13,7 @@ import { useSectionWrapper } from '../../SectioningContent'
 
 import type { Gap } from '../../../types'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** コンテンツの最小高さ */
   minHeight?: number | string
   /** コンテンツの最大幅 */
@@ -24,7 +24,7 @@ type AbstractProps = PropsWithChildren<{
   verticalCentering?: boolean
   as?: string | ComponentType<any>
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'div'>, keyof BaseProps>
 
 export const centerClassNameGenerator = tv({
   base: 'shr-mx-auto shr-box-content shr-flex shr-flex-col shr-items-center',

--- a/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
@@ -8,12 +8,12 @@ import { paddingBlock, paddingInline } from '../../../tailwind'
 
 import type { Gap } from '../../../types'
 
-type AbstractProps = PropsWithChildren<
+type BaseProps = PropsWithChildren<
   Omit<VariantProps<typeof classNameGenerator>, 'paddingBlock' | 'paddingInline'> & {
     padding?: Gap | SeparatePadding
   }
 >
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 type SeparatePadding = {
   block?: Gap

--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -13,8 +13,8 @@ import { type VariantProps, tv } from 'tailwind-variants'
 
 import { Tooltip } from '../Tooltip'
 
-type AbstractProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'span'>, keyof AbstractProps>
+type BaseProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'span'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Loader/Loader.tsx
+++ b/packages/smarthr-ui/src/components/Loader/Loader.tsx
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants'
 
 import { LoaderSpinner } from './LoaderSpinner'
 
-type AbstractProps = {
+type BaseProps = {
   /** ローダーの大きさ */
   size?: 'S' | 'M'
   /** 代替テキスト */
@@ -13,7 +13,7 @@ type AbstractProps = {
   /** コンポーネントの色調 */
   type?: 'primary' | 'light'
 }
-type Props = AbstractProps & Omit<ComponentProps<'span'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'span'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
@@ -136,7 +136,7 @@ const classNameGenerator = tv({
 })
 
 type StyleVariants = VariantProps<typeof classNameGenerator>
-type AbstractProps = PropsWithChildren<
+type BaseProps = PropsWithChildren<
   Omit<StyleVariants, 'type'> &
     Required<Pick<StyleVariants, 'type'>> & {
       /** コンポーネント右の領域 */
@@ -147,10 +147,10 @@ type AbstractProps = PropsWithChildren<
       role?: 'alert' | 'status'
     }
 >
-type BaseProps = Pick<ComponentProps<typeof Panel>, 'layer'>
-type Props = AbstractProps &
-  Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps> &
-  Omit<BaseProps, keyof AbstractProps>
+type PanelLayerProps = Pick<ComponentProps<typeof Panel>, 'layer'>
+type Props = PanelLayerProps &
+  Omit<ComponentPropsWithoutRef<'div'>, keyof PanelLayerProps> &
+  Omit<BaseProps, keyof PanelLayerProps>
 
 const ABSTRACT_ICON_MAPPER = {
   info: FaCircleInfoIcon,

--- a/packages/smarthr-ui/src/components/PageCounter/PageCounter.tsx
+++ b/packages/smarthr-ui/src/components/PageCounter/PageCounter.tsx
@@ -4,12 +4,12 @@ import { tv } from 'tailwind-variants'
 import { Cluster } from '../Layout'
 import { Text } from '../Text'
 
-type AbstractProps = {
+type BaseProps = {
   start: number
   end: number
   total?: number
 }
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({ base: 'shr-text-base' })
 

--- a/packages/smarthr-ui/src/components/Pagination/Pagination.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/Pagination.tsx
@@ -72,8 +72,8 @@ type AnchorProps = CommonProps & {
   linkAs?: ElementType
 }
 
-type AbstractProps = ButtonProps | AnchorProps
-type Props = AbstractProps & Omit<HTMLAttributes<HTMLElement>, keyof AbstractProps>
+type BaseProps = ButtonProps | AnchorProps
+type Props = BaseProps & Omit<HTMLAttributes<HTMLElement>, keyof BaseProps>
 
 const BUTTON_REGEX = /^button$/i
 const ANCHOR_REGEX = /^a/i

--- a/packages/smarthr-ui/src/components/Panel/Groupbox/Groupbox.tsx
+++ b/packages/smarthr-ui/src/components/Panel/Groupbox/Groupbox.tsx
@@ -4,9 +4,9 @@ import { type VariantProps, tv } from 'tailwind-variants'
 import { backgroundColor } from '../../../tailwind'
 import { Panel } from '../Panel'
 
-type AbstractProps = Omit<ComponentProps<typeof Panel>, 'radius' | 'layer'> &
+type BaseProps = Omit<ComponentProps<typeof Panel>, 'radius' | 'layer'> &
   VariantProps<typeof classNameGenerator>
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: 'shr-rounded-[unset]',

--- a/packages/smarthr-ui/src/components/Panel/Panel.tsx
+++ b/packages/smarthr-ui/src/components/Panel/Panel.tsx
@@ -49,7 +49,7 @@ export const panelClassNameGenerator = tv({
 
 type Overflow = 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto'
 
-type AbstractProps = PropsWithChildren<
+type BaseProps = PropsWithChildren<
   Omit<
     VariantProps<typeof panelClassNameGenerator>,
     'paddingBlock' | 'paddingInline' | 'overflowBlock' | 'overflowInline'
@@ -61,8 +61,8 @@ type AbstractProps = PropsWithChildren<
     as?: string | ComponentType<any>
   }
 >
-export type ElementProps = Omit<ComponentPropsWithRef<'div'>, keyof AbstractProps>
-type Props = AbstractProps & ElementProps
+export type ElementProps = Omit<ComponentPropsWithRef<'div'>, keyof BaseProps>
+type Props = BaseProps & ElementProps
 
 type SeparatePadding = {
   block?: Gap

--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -15,12 +15,12 @@ import { type VariantProps, tv } from 'tailwind-variants'
 
 import { useSectionWrapper } from '../SectioningContent'
 
-type AbstractProps = PropsWithChildren<
+type BaseProps = PropsWithChildren<
   VariantProps<typeof classNameGenerator> & {
     as?: string | ComponentType<any>
   }
 >
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps | 'tabIndex'>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'tabIndex'>
 
 const classNameGenerator = tv({
   base: 'smarthr-ui-Scroller',

--- a/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/SectioningContent.tsx
@@ -11,12 +11,12 @@ import {
 
 import { LevelContext } from './levelContext'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   // via https://html.spec.whatwg.org/multipage/dom.html#sectioning-content
   as?: 'article' | 'aside' | 'nav' | 'section'
   baseLevel?: number
 }>
-type PropsWithAs = AbstractProps & Omit<ComponentPropsWithRef<'section'>, keyof AbstractProps>
+type PropsWithAs = BaseProps & Omit<ComponentPropsWithRef<'section'>, keyof BaseProps>
 type Props = Omit<ComponentProps<typeof SectioningContent>, 'as'>
 
 const SectioningContent = forwardRef<HTMLElement, PropsWithAs>(

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -27,7 +27,7 @@ export type Option = {
   disabled?: boolean
 }
 
-type AbstractProps = {
+type BaseProps = {
   /** 選択肢の配列 */
   options: Option[]
   /** 選択中の値 */
@@ -37,7 +37,7 @@ type AbstractProps = {
   /** 各ボタンの大きさ */
   size?: 'M' | 'S'
 }
-type Props = AbstractProps & Omit<ComponentProps<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -24,7 +24,7 @@ type Optgroup<T extends string> = {
   options: Array<Option<T>>
 } & OptgroupHTMLAttributes<HTMLOptGroupElement>
 
-type AbstractProps<T extends string> = {
+type BaseProps<T extends string> = {
   /** 選択肢のデータの配列 */
   options: Array<Option<T> | Optgroup<T>>
   /** フォームの値が変わったときに発火するコールバック関数 */
@@ -41,8 +41,8 @@ type AbstractProps<T extends string> = {
   blankLabel?: string
 }
 
-type Props<T extends string> = AbstractProps<T> &
-  Omit<ComponentPropsWithoutRef<'select'>, keyof AbstractProps<string> | 'children'>
+type Props<T extends string> = BaseProps<T> &
+  Omit<ComponentPropsWithoutRef<'select'>, keyof BaseProps<string> | 'children'>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/SideMenu/SideMenuGroup.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/SideMenuGroup.tsx
@@ -10,10 +10,10 @@ import { tv } from 'tailwind-variants'
 import { Heading } from '../Heading'
 import { Section } from '../SectioningContent'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   heading: ReactNode
 }>
-type ElementProps = Omit<ComponentPropsWithoutRef<'li'>, keyof AbstractProps>
+type ElementProps = Omit<ComponentPropsWithoutRef<'li'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {
@@ -28,7 +28,7 @@ export const SideMenuGroup = ({
   children,
   className,
   ...rest
-}: AbstractProps & ElementProps) => {
+}: BaseProps & ElementProps) => {
   const classNames = useMemo(() => {
     const { wrapper, list, groupHeading } = classNameGenerator()
 

--- a/packages/smarthr-ui/src/components/SideMenu/SideMenuItem.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/SideMenuItem.tsx
@@ -9,15 +9,15 @@ import { tv } from 'tailwind-variants'
 
 import { Text } from '../Text'
 
-type AbstractProps<AsElement extends ElementType> = PropsWithChildren<{
+type BaseProps<AsElement extends ElementType> = PropsWithChildren<{
   elementAs?: AsElement
   current?: boolean
   prefix?: ReactNode
   suffix?: ReactNode
 }>
 
-type Props<AsElement extends ElementType = 'a'> = AbstractProps<AsElement> &
-  Omit<ComponentPropsWithoutRef<AsElement>, keyof AbstractProps<AsElement>>
+type Props<AsElement extends ElementType = 'a'> = BaseProps<AsElement> &
+  Omit<ComponentPropsWithoutRef<AsElement>, keyof BaseProps<AsElement>>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -5,14 +5,14 @@ import { SideNavProvider } from './SideNavContext'
 
 import type { SideNavSizeType } from './SideNavItemButton'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** 各アイテムの大きさ */
   size?: SideNavSizeType
   /** コンポーネントに適用するクラス名 */
   className?: string
 }> &
   VariantProps<typeof classNameGenerator>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'ul'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'ul'>, keyof BaseProps>
 
 const ROUNDED = {
   t_l: '[&>.smarthr-ui-SideNav-item:first-child]:shr-rounded-tl-l',

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -15,7 +15,7 @@ import { useSideNavContext } from './SideNavContext'
 
 export type SideNavSizeType = 'M' | 'S'
 
-type AbstractProps = {
+type BaseProps = {
   /** タイトルのプレフィックスの内容。通常、StatusLabelやIconの配置に用います。 */
   prefix?: ReactNode
   /** タイトルのサフィックスの内容。通常、Prefixを使用済みの場合にStatusLabelやChipの配置に用います。 */
@@ -24,12 +24,12 @@ type AbstractProps = {
   current?: boolean
 }
 
-type AbstractButtonProps = AbstractProps & {
+type AbstractButtonProps = BaseProps & {
   /** アイテムを押下したときに発火するコールバック関数 */
   onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-type AbstractAnchorProps<T extends ElementType = 'a'> = AbstractProps & {
+type AbstractAnchorProps<T extends ElementType = 'a'> = BaseProps & {
   href: string
   /** next/link などのカスタムコンポーネントを指定します。指定がない場合はデフォルトで `a` タグが使用されます。 */
   elementAs?: T
@@ -159,7 +159,7 @@ export const SideNavItemAnchor = <T extends ElementType = 'a'>({
 }
 
 const BodyCluster = memo<
-  Pick<AbstractProps, 'prefix' | 'suffix'> & {
+  Pick<BaseProps, 'prefix' | 'suffix'> & {
     children: ReactNode
     classNames: { body: string; bodyText: string }
   }

--- a/packages/smarthr-ui/src/components/SmartHRAILogo/SmartHRAILogo.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRAILogo/SmartHRAILogo.tsx
@@ -1,11 +1,11 @@
 import { type ComponentPropsWithoutRef, memo } from 'react'
 
-type AbstractProps = {
+type BaseProps = {
   alt?: string
   width?: number | string
   height?: number | string
 }
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'svg'>, keyof AbstractProps | 'fill'>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'svg'>, keyof BaseProps | 'fill'>
 
 export const SmartHRAILogo = memo<Props>(({ alt, width, height, ...rest }) => (
   <svg

--- a/packages/smarthr-ui/src/components/SmartHRLogo/SmartHRLogo.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRLogo/SmartHRLogo.tsx
@@ -1,7 +1,7 @@
 import { type ComponentPropsWithoutRef, memo } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
-type AbstractProps = {
+type BaseProps = {
   /** コンポーネントのタイトル */
   alt?: string
   /** コンポーネントの幅 */
@@ -9,7 +9,7 @@ type AbstractProps = {
   /** コンポーネントの高さ */
   height?: number | string
 } & VariantProps<typeof classNameGenerator>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'svg'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'svg'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: ['smarthr-ui-SmartHRLogo', 'shr-align-bottom'],

--- a/packages/smarthr-ui/src/components/SpreadsheetTable/SpreadsheetTable.tsx
+++ b/packages/smarthr-ui/src/components/SpreadsheetTable/SpreadsheetTable.tsx
@@ -10,10 +10,10 @@ import { tv } from 'tailwind-variants'
 
 import { SpreadsheetTableCorner } from './SpreadsheetTableCorner'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   data?: ReactNode[][]
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'table'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'table'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: [

--- a/packages/smarthr-ui/src/components/StatusLabel/StatusLabel.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/StatusLabel.tsx
@@ -62,8 +62,8 @@ const classNameGenerator = tv({
   ],
 })
 
-type AbstractProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'span'>, keyof AbstractProps>
+type BaseProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'span'>, keyof BaseProps>
 
 export const StatusLabel = memo<Props>(
   ({ type = 'grey', bold = false, className, children, ...rest }) => {

--- a/packages/smarthr-ui/src/components/Stepper/StepStatusIcon.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/StepStatusIcon.tsx
@@ -23,9 +23,9 @@ const classNameGenerator = tv({
 })
 
 type StatusProps = { status?: Step['status'] }
-type AbstractProps = ComponentProps<typeof FaCircleCheckIcon>
-type Props = AbstractProps & StatusProps
-type ActualProps = AbstractProps & Required<StatusProps>
+type BaseProps = ComponentProps<typeof FaCircleCheckIcon>
+type Props = BaseProps & StatusProps
+type ActualProps = BaseProps & Required<StatusProps>
 
 export const StepStatusIcon: FC<Props> = (props) =>
   props.status ? <ActualStepStatusIcon {...(props as ActualProps)} /> : null

--- a/packages/smarthr-ui/src/components/Stepper/types.ts
+++ b/packages/smarthr-ui/src/components/Stepper/types.ts
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef, PropsWithChildren, ReactNode } from 'react'
 
-type AbstractProps<P> = P & {
+type BaseProps<P> = P & {
   /** 現在地。0始まり。 */
   activeIndex?: number
 } & Omit<ComponentPropsWithoutRef<'ol'>, keyof P>
@@ -22,13 +22,13 @@ export type VerticalStep = PropsWithChildren<Step>
 
 export type HorizontalStep = Step
 
-export type VerticalStepper = AbstractProps<{
+export type VerticalStepper = BaseProps<{
   type: 'vertical'
   /** type=vertical では子要素を持てる */
   steps: VerticalStep[]
 }>
 
-export type HorizontalStepper = AbstractProps<{
+export type HorizontalStepper = BaseProps<{
   type: 'horizontal'
   steps: HorizontalStep[]
 }>

--- a/packages/smarthr-ui/src/components/TabBar/TabBar.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabBar.tsx
@@ -20,11 +20,11 @@ const classNameGenerator = tv({
   },
 })
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** `true` のとき、TabBar に下線を表示する */
   bordered?: boolean
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps | 'role'>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'role'>
 
 export const TabBar: FC<Props> = ({ className, bordered, children, ...rest }) => {
   const classNames = useMemo(() => {

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -41,7 +41,7 @@ const classNameGenerator = tv({
   },
 })
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** タブの ID */
   id: string
   /** ボタン内の末尾に表示する内容 */
@@ -60,8 +60,8 @@ type AbstractProps = PropsWithChildren<{
   /** タブをクリックした時に発火するコールバック関数 */
   onClick: (e: MouseEvent<HTMLButtonElement>) => void
 }>
-type Props = AbstractProps &
-  Omit<ComponentProps<typeof UnstyledButton>, keyof AbstractProps | 'aria-selected' | 'type'>
+type Props = BaseProps &
+  Omit<ComponentProps<typeof UnstyledButton>, keyof BaseProps | 'aria-selected' | 'type'>
 
 export const TabItem: FC<Props> = ({
   selected = false,

--- a/packages/smarthr-ui/src/components/Table/EmptyTableBody.tsx
+++ b/packages/smarthr-ui/src/components/Table/EmptyTableBody.tsx
@@ -10,11 +10,11 @@ import type { Gap } from '../../types'
 
 type Padding = Gap | { vertical?: Gap; horizontal?: Gap }
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** 境界とコンテンツの間の余白 */
   padding?: Padding
 }>
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'tbody'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'tbody'>, keyof BaseProps>
 
 const tdClassNameGenerator = tv({
   base: 'shr-text-center',

--- a/packages/smarthr-ui/src/components/Table/Table.tsx
+++ b/packages/smarthr-ui/src/components/Table/Table.tsx
@@ -6,12 +6,12 @@ import { type VariantProps, tv } from 'tailwind-variants'
 import { TableReel } from './TableReel'
 import { TableScroller } from './TableScroller'
 
-type AbstractProps = PropsWithChildren<
+type BaseProps = PropsWithChildren<
   VariantProps<typeof classNameGenerator> & {
     reel?: boolean
   }
 >
-type Props = AbstractProps & Omit<ComponentProps<'table'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'table'>, keyof BaseProps>
 
 const ROUNDED = {
   t_l: '[&>thead:first-child>tr:first-child>th:first-child]:shr-rounded-tl-l [&>thead:first-child>tr:first-child>td:first-child]:shr-rounded-tl-l',

--- a/packages/smarthr-ui/src/components/Table/Td.tsx
+++ b/packages/smarthr-ui/src/components/Table/Td.tsx
@@ -5,7 +5,7 @@ import { reelShadowClassNameGenerator } from './reelShadowStyle'
 
 import type { CellContentWidth } from './type'
 
-export type AbstractProps = PropsWithChildren<
+export type BaseProps = PropsWithChildren<
   VariantProps<typeof classNameGenerator> & {
     /** 横スクロール時、カラムを左右いずれかに固定 */
     fixed?: 'left' | 'right'
@@ -13,7 +13,7 @@ export type AbstractProps = PropsWithChildren<
       CellContentWidth | { base?: CellContentWidth; min?: CellContentWidth; max?: CellContentWidth }
   }
 >
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'td'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'td'>, keyof BaseProps>
 
 export const Td = memo<Props>(
   ({ align, vAlign, nullable, fixed, contentWidth, className, style, ...rest }) => {

--- a/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/TdCheckbox.tsx
@@ -6,12 +6,12 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { Td } from './Td'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** Checkboxのaccessible nameとして設定するテキストを参照するためのid属性値。同じ親Tr配下のTdかTh、もしくはその子孫要素のidを指定する。複数要素のテキストを指定する場合は空白区切りでidをつなぐ */
   'aria-labelledby': string
 }> &
   Pick<ComponentProps<typeof Td>, 'vAlign' | 'fixed' | 'rowSpan' | 'colSpan'>
-type Props = Omit<CheckboxProps, keyof AbstractProps> & AbstractProps
+type Props = Omit<CheckboxProps, keyof BaseProps> & BaseProps
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Table/Th.tsx
+++ b/packages/smarthr-ui/src/components/Table/Th.tsx
@@ -14,7 +14,7 @@ import { reelShadowClassNameGenerator } from './reelShadowStyle'
 
 import type { CellContentWidth } from './type'
 
-export type AbstractProps = PropsWithChildren<
+export type BaseProps = PropsWithChildren<
   {
     /** 並び替え状態 */
     sort?: ComponentPropsWithoutRef<typeof ThSortButton>['sort']
@@ -25,7 +25,7 @@ export type AbstractProps = PropsWithChildren<
     contentWidth?: CellContentWidth
   } & VariantProps<typeof classNameGenerator>
 >
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'th'>, keyof AbstractProps | 'onClick'>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'th'>, keyof BaseProps | 'onClick'>
 
 const classNameGenerator = tv({
   base: [

--- a/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Table/ThCheckbox.tsx
@@ -9,8 +9,8 @@ import { ControlledTooltip } from '../Tooltip'
 
 import { Th } from './Th'
 
-type AbstractProps = Pick<ComponentProps<typeof Th>, 'vAlign' | 'fixed' | 'rowSpan' | 'colSpan'>
-type Props = AbstractProps & Omit<CheckboxProps, keyof AbstractProps>
+type BaseProps = Pick<ComponentProps<typeof Th>, 'vAlign' | 'fixed' | 'rowSpan' | 'colSpan'>
+type Props = BaseProps & Omit<CheckboxProps, keyof BaseProps>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -25,7 +25,7 @@ import { debounce } from '../../libs/debounce'
 import { defaultHtmlFontSize } from '../../themes'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-type AbstractProps = {
+type BaseProps = {
   /** 入力値にエラーがあるかどうか */
   error?: boolean
   /** コンポーネントの幅 */
@@ -45,7 +45,7 @@ type AbstractProps = {
    */
   placeholder?: string
 }
-type Props = AbstractProps & Omit<ComponentPropsWithRef<'textarea'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithRef<'textarea'>, keyof BaseProps>
 type TextareaValue = string | number | readonly string[]
 
 const getStringLength = (value: TextareaValue) => {

--- a/packages/smarthr-ui/src/components/Timeline/Timeline.tsx
+++ b/packages/smarthr-ui/src/components/Timeline/Timeline.tsx
@@ -5,10 +5,10 @@ import type { TimelineItem } from './TimelineItem'
 
 type TimelineItem = ReactElement<ComponentProps<typeof TimelineItem>>
 
-type AbstractProps = {
+type BaseProps = {
   children: TimelineItem | TimelineItem[]
 }
-type Props = AbstractProps & Omit<ComponentProps<'ol'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentProps<'ol'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: 'shr-list-none',

--- a/packages/smarthr-ui/src/components/Timeline/TimelineItem.tsx
+++ b/packages/smarthr-ui/src/components/Timeline/TimelineItem.tsx
@@ -6,7 +6,7 @@ import { Cluster, Sidebar, Stack } from '../Layout'
 import { Section } from '../SectioningContent'
 import { Text } from '../Text'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   datetime: Date | string
   /** 日付の代わりに表示するテキスト */
   dateLabel?: string
@@ -19,8 +19,8 @@ type AbstractProps = PropsWithChildren<{
   /** 現在のアイテムかどうか */
   current?: boolean
 }>
-type Props = AbstractProps &
-  Omit<ComponentProps<typeof Stack>, keyof AbstractProps | 'inline' | 'gap' | 'align' | 'as'>
+type Props = BaseProps &
+  Omit<ComponentProps<typeof Stack>, keyof BaseProps | 'inline' | 'gap' | 'align' | 'as'>
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/Tooltip/ControlledTooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/ControlledTooltip.tsx
@@ -126,13 +126,13 @@ const classNameGenerator = tv({
   ],
 })
 
-type AbstractProps = PropsWithChildren<
+type BaseProps = PropsWithChildren<
   VariantProps<typeof classNameGenerator> & {
     /** レンダリングするタグ */
     as?: 'div' | 'span'
   }
 >
-type Props = AbstractProps & Omit<ComponentPropsWithoutRef<'div'>, keyof AbstractProps>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 export const ControlledTooltip = memo<Props>(
   ({ horizontal, vertical, triggerIcon, className, as: Component = 'div', ...rest }) => {

--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -33,7 +33,7 @@ const getFullscreenElementOnSSR = () => null
 const FOCUSABLE_SELECTOR =
   'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
 
-type AbstractProps = PropsWithChildren<{
+type BaseProps = PropsWithChildren<{
   /** ツールチップ内に表示するメッセージ */
   message: ReactNode
   /** ツールチップの種類。`label` の場合は children の要素に `aria-labelledby` を付与しアクセシブルネームとして機能する。`description`（デフォルト）の場合は `aria-describedby` を付与し補足説明として機能する */
@@ -47,8 +47,8 @@ type AbstractProps = PropsWithChildren<{
   /** `type` が `description` の場合に `aria-describedby` を付与する対象。children が focusable な場合は常に children に付与されるため無視される */
   ariaDescribedbyTarget?: 'wrapper' | 'inner'
 }>
-type Props = AbstractProps &
-  Omit<ComponentProps<'span'>, keyof AbstractProps | 'aria-describedby' | 'aria-labelledby'>
+type Props = BaseProps &
+  Omit<ComponentProps<'span'>, keyof BaseProps | 'aria-describedby' | 'aria-labelledby'>
 
 const classNameGenerator = tv({
   base: [


### PR DESCRIPTION
## 関連URL

## 概要

型命名の統一のため、全コンポーネントの `AbstractProps` を `BaseProps` に変更。

## 変更内容

### 基本的な変更

全コンポーネントの `type AbstractProps` / `export type AbstractProps` を `BaseProps` に一括リネーム（89ファイル）。

### プレフィックス付きの特殊ケース

| 変更前 | 変更後 |
|---|---|
| `DisclosureContentAbstractProps` | `BaseDisclosureContentProps` |
| `StepFormDialogContentInnerAbstractProps` | `BaseStepFormDialogContentInnerProps` |
| `AbstractButtonProps`（Button/useButtonWrapper） | `BaseButtonProps` |
| `AbstractAnchorProps`（Button/useButtonWrapper） | `BaseAnchorProps` |

### 競合ケースの解決

`NotificationBar.tsx` は元々 `BaseProps` を持っていたため、改名後の `AbstractProps`（`Pick<ComponentProps<typeof Panel>, 'layer'>`）を `PanelLayerProps` にリネームして競合を解消。

### 外部APIへの影響

`AbstractProps` は `src/index.ts` から直接 export されていないため、外部APIへの影響はなし。
`Button/index.ts` / `Heading/index.ts` からの export 名は `BaseProps` に変更（deep importしている利用者がいた場合は要対応）。

## プロダクト側で対応が必要な事項

なし（`src/index.ts` からの export なし）

## 確認方法

Chromatic での VRT 確認（型のみの変更のため差分なし想定）