### PR TITLE
refactor(useListbox): renderListBoxをListBoxコンポーネントに分離

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -28,7 +28,7 @@ import { FaCaretDownIcon } from '../../Icon'
 import { Scroller } from '../../Scroller'
 import { areItemsEqual } from '../helper'
 import { useFocusControl } from '../useFocusControl'
-import { useListbox } from '../useListbox'
+import { ListBox, useListbox } from '../useListbox'
 import { useMultiOptions } from '../useOptions'
 
 import { MultiSelectedItem } from './MultiSelectedItem'
@@ -263,7 +263,7 @@ const ActualMultiCombobox = <T,>(
     [actualOnDelete, latest],
   )
 
-  const { renderListBox, activeOption, onKeyDownListBox, listBoxId, listBoxRef } = useListbox({
+  const { listBoxProps, activeOption, onKeyDownListBox, listBoxId, listBoxRef } = useListbox({
     options,
     dropdownHelpMessage,
     dropdownWidth,
@@ -518,7 +518,7 @@ const ActualMultiCombobox = <T,>(
         iconStyle={classNames.suffixIcon}
       />
 
-      {renderListBox()}
+      <ListBox {...listBoxProps} />
     </div>
   )
 }

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -27,7 +27,7 @@ import { genericsForwardRef } from '../../../libs/util'
 import { UnstyledButton } from '../../Button'
 import { FaCaretDownIcon, FaCircleXmarkIcon } from '../../Icon'
 import { Input } from '../../Input'
-import { useListbox } from '../useListbox'
+import { ListBox, useListbox } from '../useListbox'
 import { useSingleOptions } from '../useOptions'
 
 import type { ComboboxItem, BaseProps as ComboboxProps } from '../types'
@@ -238,7 +238,7 @@ const ActualSingleCombobox = <T,>(
     isFilteringDisabled: !isEditing,
   })
 
-  const { renderListBox, activeOption, onKeyDownListBox, listBoxId, listBoxRef } = useListbox<T>({
+  const { listBoxProps, activeOption, onKeyDownListBox, listBoxId, listBoxRef } = useListbox<T>({
     options,
     dropdownHelpMessage,
     dropdownWidth,
@@ -494,7 +494,7 @@ const ActualSingleCombobox = <T,>(
         className={classNames.input}
         data-smarthr-ui-input="true"
       />
-      {!readOnly && renderListBox()}
+      {!readOnly && <ListBox {...listBoxProps} />}
     </div>
   )
 }

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -249,26 +249,24 @@ export const useListbox = <T,>({
     [setActiveOption],
   )
 
-  const listBoxProps = {
-    activeOptionId: activeOption?.id,
-    options,
-    isExpanded,
-    isLoading,
-    dropdownHelpMessage,
-    noResultText,
-    listBoxId,
-    listBoxRef,
-    handleAdd,
-    handleHoverOption,
-    handleSelect,
-    activeRef,
-    listBoxRect,
-    triggerWidth,
-    dropdownWidth,
-  }
-
   return {
-    listBoxProps,
+    listBoxProps: {
+      activeOptionId: activeOption?.id,
+      options,
+      isExpanded,
+      isLoading,
+      dropdownHelpMessage,
+      noResultText,
+      listBoxId,
+      listBoxRef,
+      handleAdd,
+      handleHoverOption,
+      handleSelect,
+      activeRef,
+      listBoxRect,
+      triggerWidth,
+      dropdownWidth,
+    },
     activeOption,
     onKeyDownListBox,
     listBoxId,

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -221,13 +221,6 @@ export const useListbox = <T,>({
   )
 
   const listBoxId = useId()
-  const { items: partialOptions, handleIntersect } = usePartialRendering({
-    items: options,
-    minLength: useMemo(
-      () => (activeOption === null ? 0 : options.indexOf(activeOption)) + 1,
-      [activeOption, options],
-    ),
-  })
 
   const handleAdd = useMemo(
     () =>
@@ -258,9 +251,7 @@ export const useListbox = <T,>({
 
   const listBoxProps = {
     activeOptionId: activeOption?.id,
-    handleIntersect,
-    partialOptions,
-    optionsLength: options.length,
+    options,
     isExpanded,
     isLoading,
     dropdownHelpMessage,
@@ -287,9 +278,7 @@ export const useListbox = <T,>({
 
 type ListBoxProps<T> = {
   activeOptionId: string | undefined
-  handleIntersect: (() => void) | undefined
-  partialOptions: Array<ComboboxOption<T>>
-  optionsLength: number
+  options: Array<ComboboxOption<T>>
   isExpanded: boolean
   isLoading?: boolean
   noResultText?: ReactNode
@@ -308,9 +297,7 @@ type ListBoxProps<T> = {
 export const ListBox = memo(
   <T,>({
     activeOptionId,
-    handleIntersect,
-    partialOptions,
-    optionsLength,
+    options,
     isExpanded,
     isLoading,
     noResultText,
@@ -327,6 +314,16 @@ export const ListBox = memo(
   }: ListBoxProps<T>) => {
     const { createPortal } = usePortal()
     const theme = useTheme()
+
+    const { items: partialOptions, handleIntersect } = usePartialRendering({
+      items: options,
+      minLength: useMemo(
+        () =>
+          (activeOptionId === undefined ? 0 : options.findIndex((o) => o.id === activeOptionId)) +
+          1,
+        [activeOptionId, options],
+      ),
+    })
 
     const wrapperStyle = useMemo(() => {
       const { top, left } = listBoxRect
@@ -378,7 +375,7 @@ export const ListBox = memo(
               <div className={CLASS_NAMES.loaderWrapper}>
                 <Loader aria-hidden />
               </div>
-            ) : optionsLength === 0 ? (
+            ) : options.length === 0 ? (
               <p role="alert" aria-live="polite" className={CLASS_NAMES.noItems}>
                 {noResultText ?? (
                   <Localizer

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -325,29 +325,27 @@ export const ListBox = memo(
       ),
     })
 
-    const wrapperStyle = useMemo(() => {
-      const { top, left } = listBoxRect
-
-      return {
-        top: `${top}px`,
-        left: `${left}px`,
-        width: `${triggerWidth}px`,
-      }
-    }, [listBoxRect, triggerWidth])
-
-    const dropdownListStyle = useMemo(() => {
-      const { left, height } = listBoxRect
+    const styles = useMemo(() => {
+      const { top, left, height } = listBoxRect
       const dropdownListWidth = dropdownWidth || triggerWidth
 
       return {
-        width: typeof dropdownListWidth === 'string' ? dropdownListWidth : `${dropdownListWidth}px`,
-        maxWidth: `calc(100vw - ${left}px - ${theme.spacingByChar(0.5)})`,
-        height: height ? `${height}px` : undefined,
+        wrapper: {
+          top: `${top}px`,
+          left: `${left}px`,
+          width: `${triggerWidth}px`,
+        },
+        dropdownList: {
+          width:
+            typeof dropdownListWidth === 'string' ? dropdownListWidth : `${dropdownListWidth}px`,
+          maxWidth: `calc(100vw - ${left}px - ${theme.spacingByChar(0.5)})`,
+          height: height ? `${height}px` : undefined,
+        },
       }
     }, [listBoxRect, triggerWidth, dropdownWidth, theme])
 
     return createPortal(
-      <div className={CLASS_NAMES.wrapper} style={wrapperStyle}>
+      <div className={CLASS_NAMES.wrapper} style={styles.wrapper}>
         {isExpanded && isLoading && (
           <VisuallyHiddenText role="status">
             <Localizer id="smarthr-ui/Combobox/loadingText" defaultText="処理中" />
@@ -359,7 +357,7 @@ export const ListBox = memo(
           role="listbox"
           aria-hidden={!isExpanded}
           className={CLASS_NAMES.dropdownList}
-          style={dropdownListStyle}
+          style={styles.dropdownList}
         >
           {dropdownHelpMessage && (
             <Text

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -4,6 +4,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
   type RefObject,
+  memo,
   useCallback,
   useEffect,
   useId,
@@ -92,7 +93,6 @@ export const useListbox = <T,>({
   triggerRef,
   noResultText: orgNoResultText,
 }: Props<T>) => {
-  const theme = useTheme()
   const [navigationType, setNavigationType] = useState<'pointer' | 'key'>('pointer')
   const { activeOption, setActiveOption, moveActiveOptionIndex } = useActiveOption({ options })
 
@@ -220,7 +220,6 @@ export const useListbox = <T,>({
     [activeOption, moveActiveOptionIndex, onAdd, onSelect, setActiveOption],
   )
 
-  const { createPortal } = usePortal()
   const listBoxId = useId()
   const { items: partialOptions, handleIntersect } = usePartialRendering({
     items: options,
@@ -257,107 +256,153 @@ export const useListbox = <T,>({
     [setActiveOption],
   )
 
-  const wrapperStyle = useMemo(() => {
-    const { top, left } = listBoxRect
-
-    return {
-      top: `${top}px`,
-      left: `${left}px`,
-      width: `${triggerWidth}px`,
-    }
-  }, [listBoxRect, triggerWidth])
-  const dropdownListStyle = useMemo(() => {
-    const { left, height } = listBoxRect
-    const dropdownListWidth = dropdownWidth || triggerWidth
-
-    return {
-      width: typeof dropdownListWidth === 'string' ? dropdownListWidth : `${dropdownListWidth}px`,
-      maxWidth: `calc(100vw - ${left}px - ${theme.spacingByChar(0.5)})`,
-      height: height ? `${height}px` : undefined,
-    }
-  }, [listBoxRect, triggerWidth, dropdownWidth, theme])
-
-  const renderListBox = useCallback(
-    () =>
-      createPortal(
-        <div className={CLASS_NAMES.wrapper} style={wrapperStyle}>
-          {isExpanded && isLoading && (
-            <VisuallyHiddenText role="status">
-              <Localizer id="smarthr-ui/Combobox/loadingText" defaultText="処理中" />
-            </VisuallyHiddenText>
-          )}
-          <Scroller
-            id={listBoxId}
-            ref={listBoxRef}
-            role="listbox"
-            aria-hidden={!isExpanded}
-            className={CLASS_NAMES.dropdownList}
-            style={dropdownListStyle}
-          >
-            {dropdownHelpMessage && (
-              <Text
-                className={CLASS_NAMES.helpMessage}
-                icon={<FaCircleInfoIcon color="TEXT_GREY" />}
-                as="p"
-              >
-                {dropdownHelpMessage}
-              </Text>
-            )}
-            {isExpanded ? (
-              isLoading ? (
-                <div className={CLASS_NAMES.loaderWrapper}>
-                  <Loader aria-hidden />
-                </div>
-              ) : options.length === 0 ? (
-                <p role="alert" aria-live="polite" className={CLASS_NAMES.noItems}>
-                  {orgNoResultText ?? (
-                    <Localizer
-                      id="smarthr-ui/Combobox/noResultsText"
-                      defaultText="一致する選択肢がありません。"
-                    />
-                  )}
-                </p>
-              ) : (
-                partialOptions.map((option) => (
-                  <ItemButton
-                    key={option.id}
-                    option={option}
-                    onAdd={handleAdd}
-                    onSelect={handleSelect}
-                    onMouseOver={handleHoverOption}
-                    activeRef={option.id === activeOption?.id ? activeRef : undefined}
-                  />
-                ))
-              )
-            ) : null}
-            {handleIntersect && <Intersection handleIntersect={handleIntersect} />}
-          </Scroller>
-        </div>,
-      ),
-    [
-      activeOption?.id,
-      handleIntersect,
-      partialOptions,
-      options.length,
-      isExpanded,
-      isLoading,
-      dropdownHelpMessage,
-      listBoxId,
-      orgNoResultText,
-      handleAdd,
-      handleHoverOption,
-      handleSelect,
-      dropdownListStyle,
-      wrapperStyle,
-      createPortal,
-    ],
-  )
+  const listBoxProps = {
+    activeOptionId: activeOption?.id,
+    handleIntersect,
+    partialOptions,
+    optionsLength: options.length,
+    isExpanded,
+    isLoading,
+    dropdownHelpMessage,
+    noResultText: orgNoResultText,
+    listBoxId,
+    listBoxRef,
+    handleAdd,
+    handleHoverOption,
+    handleSelect,
+    activeRef,
+    listBoxRect,
+    triggerWidth,
+    dropdownWidth,
+  }
 
   return {
-    renderListBox,
+    listBoxProps,
     activeOption,
     onKeyDownListBox,
     listBoxId,
     listBoxRef,
   }
 }
+
+type ListBoxProps<T> = {
+  activeOptionId: string | undefined
+  handleIntersect: (() => void) | undefined
+  partialOptions: Array<ComboboxOption<T>>
+  optionsLength: number
+  isExpanded: boolean
+  isLoading?: boolean
+  noResultText?: ReactNode
+  dropdownHelpMessage?: ReactNode
+  listBoxId: string
+  listBoxRef: RefObject<HTMLDivElement>
+  handleAdd: ((option: ComboboxOption<T>) => void) | undefined
+  handleHoverOption: (option: ComboboxOption<T>) => void
+  handleSelect: (option: ComboboxOption<T>) => void
+  activeRef: RefObject<HTMLButtonElement>
+  listBoxRect: { top: number; left: number; height?: number }
+  triggerWidth: number
+  dropdownWidth?: string | number
+}
+
+export const ListBox = memo(
+  <T,>({
+    activeOptionId,
+    handleIntersect,
+    partialOptions,
+    optionsLength,
+    isExpanded,
+    isLoading,
+    noResultText,
+    dropdownHelpMessage,
+    listBoxId,
+    listBoxRef,
+    handleAdd,
+    handleHoverOption,
+    handleSelect,
+    activeRef,
+    listBoxRect,
+    triggerWidth,
+    dropdownWidth,
+  }: ListBoxProps<T>) => {
+    const { createPortal } = usePortal()
+    const theme = useTheme()
+
+    const wrapperStyle = useMemo(() => {
+      const { top, left } = listBoxRect
+
+      return {
+        top: `${top}px`,
+        left: `${left}px`,
+        width: `${triggerWidth}px`,
+      }
+    }, [listBoxRect, triggerWidth])
+
+    const dropdownListStyle = useMemo(() => {
+      const { left, height } = listBoxRect
+      const dropdownListWidth = dropdownWidth || triggerWidth
+
+      return {
+        width: typeof dropdownListWidth === 'string' ? dropdownListWidth : `${dropdownListWidth}px`,
+        maxWidth: `calc(100vw - ${left}px - ${theme.spacingByChar(0.5)})`,
+        height: height ? `${height}px` : undefined,
+      }
+    }, [listBoxRect, triggerWidth, dropdownWidth, theme])
+
+    return createPortal(
+      <div className={CLASS_NAMES.wrapper} style={wrapperStyle}>
+        {isExpanded && isLoading && (
+          <VisuallyHiddenText role="status">
+            <Localizer id="smarthr-ui/Combobox/loadingText" defaultText="処理中" />
+          </VisuallyHiddenText>
+        )}
+        <Scroller
+          id={listBoxId}
+          ref={listBoxRef}
+          role="listbox"
+          aria-hidden={!isExpanded}
+          className={CLASS_NAMES.dropdownList}
+          style={dropdownListStyle}
+        >
+          {dropdownHelpMessage && (
+            <Text
+              className={CLASS_NAMES.helpMessage}
+              icon={<FaCircleInfoIcon color="TEXT_GREY" />}
+              as="p"
+            >
+              {dropdownHelpMessage}
+            </Text>
+          )}
+          {isExpanded ? (
+            isLoading ? (
+              <div className={CLASS_NAMES.loaderWrapper}>
+                <Loader aria-hidden />
+              </div>
+            ) : optionsLength === 0 ? (
+              <p role="alert" aria-live="polite" className={CLASS_NAMES.noItems}>
+                {noResultText ?? (
+                  <Localizer
+                    id="smarthr-ui/Combobox/noResultsText"
+                    defaultText="一致する選択肢がありません。"
+                  />
+                )}
+              </p>
+            ) : (
+              partialOptions.map((option) => (
+                <ItemButton
+                  key={option.id}
+                  option={option}
+                  onAdd={handleAdd}
+                  onSelect={handleSelect}
+                  onMouseOver={handleHoverOption}
+                  activeRef={option.id === activeOptionId ? activeRef : undefined}
+                />
+              ))
+            )
+          ) : null}
+          {handleIntersect && <Intersection handleIntersect={handleIntersect} />}
+        </Scroller>
+      </div>,
+    )
+  },
+) as <T>(props: ListBoxProps<T>) => ReactNode

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -91,7 +91,7 @@ export const useListbox = <T,>({
   isExpanded,
   isLoading,
   triggerRef,
-  noResultText: orgNoResultText,
+  noResultText,
 }: Props<T>) => {
   const [navigationType, setNavigationType] = useState<'pointer' | 'key'>('pointer')
   const { activeOption, setActiveOption, moveActiveOptionIndex } = useActiveOption({ options })
@@ -255,7 +255,7 @@ export const useListbox = <T,>({
     isExpanded,
     isLoading,
     dropdownHelpMessage,
-    noResultText: orgNoResultText,
+    noResultText,
     listBoxId,
     listBoxRef,
     handleAdd,

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -315,7 +315,7 @@ export const ListBox = memo(
     const { createPortal } = usePortal()
     const theme = useTheme()
 
-    const { items: partialOptions, handleIntersect } = usePartialRendering({
+    const { items, handleIntersect } = usePartialRendering({
       items: options,
       minLength: useMemo(
         () =>
@@ -383,7 +383,7 @@ export const ListBox = memo(
                 )}
               </p>
             ) : (
-              partialOptions.map((option) => (
+              items.map((option) => (
                 <ItemButton
                   key={option.id}
                   option={option}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useListbox` フックが `renderListBox` というレンダー関数を返し、呼び出し側が `renderListBox()` として使用するパターンを、`Intersection` コンポーネントと同様に `ListBox` コンポーネントとして分離するリファクタリング。

## 変更内容

### `useListbox.tsx`

- `renderListBox` useCallback を削除
- 代わりに `listBoxProps` プレーンオブジェクトを返すよう変更
- `ListBox` memo コンポーネントを新規追加・export
  - `wrapperStyle` / `dropdownListStyle` の計算を `ListBox` 内に移動
  - `usePortal` / `useTheme` の呼び出しを `ListBox` 内に移動
  - `usePartialRendering` の呼び出しを `ListBox` 内に移動（`indexOf` → `findIndex` で等価）

### `MultiCombobox.tsx` / `SingleCombobox.tsx`

- `renderListBox()` → `<ListBox {...listBoxProps} />` に変更

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で Combobox（Single / Multi）の動作に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コンボボックスのリスト表示処理を整理し、複数選択・単一選択の両方で表示の安定性を向上しました。
  * 部分表示、ローディング中や該当項目がない場合の表示、選択中項目の制御を一貫して処理できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->