### PR TITLE
refactor(MultiSelectedItem): useLatest + functionsパターンを適用

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -519,7 +519,7 @@ const ActualMultiCombobox = <T,>(
               <MultiSelectedItem
                 item={selectedItem}
                 disabled={disabled}
-                onDelete={actualOnDelete}
+                handleDelete={actualOnDelete}
                 enableEllipsis={selectedItemEllipsis}
                 buttonRef={deletionButtonRefs[i]}
               />

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -2,7 +2,6 @@ import {
   type KeyboardEvent,
   type RefObject,
   memo,
-  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -58,7 +57,36 @@ const classNameGenerator = tv({
   },
 })
 
-export function MultiSelectedItem<T>({ enableEllipsis, disabled, ...rest }: Props<T>) {
+export function MultiSelectedItem<T>({
+  item,
+  enableEllipsis,
+  disabled,
+  onDelete,
+  ...rest
+}: Props<T>) {
+  const onDeleteRef = useRef(onDelete)
+  onDeleteRef.current = onDelete
+  const itemRef = useRef(item)
+  itemRef.current = item
+
+  const functions = useMemo(
+    () => ({
+      handleClick: () => {
+        onDeleteRef.current(itemRef.current)
+      },
+      handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
+        if (EXEC_DESTROY_KEY.test(e.key)) {
+          e.stopPropagation()
+
+          // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
+          // このタイミングで明示的に削除処理を実行する
+          onDeleteRef.current(itemRef.current)
+        }
+      },
+    }),
+    [],
+  )
+
   const classNames = useMemo(() => {
     const { wrapper, itemLabel, deleteButton, deleteButtonIcon } = classNameGenerator()
 
@@ -71,7 +99,9 @@ export function MultiSelectedItem<T>({ enableEllipsis, disabled, ...rest }: Prop
   }, [disabled, enableEllipsis])
 
   const commonAttrs = {
+    item,
     disabled,
+    functions,
     classNames,
   }
 
@@ -82,8 +112,12 @@ export function MultiSelectedItem<T>({ enableEllipsis, disabled, ...rest }: Prop
   )
 }
 
-type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'enableEllipsis'> & {
+type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'enableEllipsis' | 'onDelete'> & {
   labelRef?: RefObject<HTMLSpanElement>
+  functions: {
+    handleClick: () => void
+    handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
+  }
   classNames: {
     wrapper: string
     itemLabel: string
@@ -118,7 +152,7 @@ const ActualMultiSelectedItem = <T,>({
   labelRef,
   item,
   disabled,
-  onDelete,
+  functions,
   classNames,
 }: LowerMultiSelectedItemProps<T>) => {
   const idPrefix = useId()
@@ -137,8 +171,7 @@ const ActualMultiSelectedItem = <T,>({
         <DestroyButton
           labelId={labelId}
           suffixTextId={destroySuffixTextId}
-          item={item}
-          onDelete={onDelete}
+          functions={functions}
           disabled={disabled}
           buttonRef={buttonRef}
           className={classNames.deleteButton}
@@ -153,54 +186,32 @@ const typedMemo: <T>(c: T) => T = memo
 const EXEC_DESTROY_KEY = /^(Enter|Backspace| )$/
 
 const BaseDestroyButton = <T,>({
+  buttonRef,
   labelId,
   suffixTextId,
-  item,
-  onDelete,
   disabled,
-  buttonRef,
+  functions,
   className,
   iconStyle,
-}: Pick<Props<T>, 'item' | 'onDelete' | 'disabled' | 'buttonRef'> & {
+}: Pick<LowerMultiSelectedItemProps<T>, 'disabled' | 'functions' | 'buttonRef'> & {
   labelId: string
   suffixTextId: string
   className: string
   iconStyle: string
-}) => {
-  const onDeleteRef = useRef(onDelete)
-  onDeleteRef.current = onDelete
-  const itemRef = useRef(item)
-  itemRef.current = item
-
-  const onClick = useCallback(() => {
-    onDeleteRef.current(itemRef.current)
-  }, [])
-
-  const onKeyDown = useCallback((e: KeyboardEvent<HTMLButtonElement>) => {
-    if (EXEC_DESTROY_KEY.test(e.key)) {
-      e.stopPropagation()
-
-      // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
-      // このタイミングで明示的に削除処理を実行する
-      onDeleteRef.current(itemRef.current)
-    }
-  }, [])
-
-  return (
-    <UnstyledButton
-      ref={buttonRef}
-      disabled={disabled}
-      tabIndex={-1}
-      aria-labelledby={`${labelId} ${suffixTextId}`}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-      className={className}
-    >
-      <VisuallyHiddenText id={suffixTextId}>
-        <Localizer id="smarthr-ui/MultiCombobox/destroyButtonIconAltSuffix" defaultText="を削除" />
-      </VisuallyHiddenText>
-      <FaCircleXmarkIcon color={disabled ? 'TEXT_DISABLED' : 'inherit'} className={iconStyle} />
-    </UnstyledButton>
-  )
-}
+}) => (
+  <UnstyledButton
+    ref={buttonRef}
+    disabled={disabled}
+    tabIndex={-1}
+    aria-labelledby={`${labelId} ${suffixTextId}`}
+    onClick={functions.handleClick}
+    onKeyDown={functions.handleKeyDown}
+    className={className}
+  >
+    <VisuallyHiddenText id={suffixTextId}>
+      <Localizer id="smarthr-ui/MultiCombobox/destroyButtonIconAltSuffix" defaultText="を削除" />
+    </VisuallyHiddenText>
+    <FaCircleXmarkIcon color={disabled ? 'TEXT_DISABLED' : 'inherit'} className={iconStyle} />
+  </UnstyledButton>
+)
 const DestroyButton = typedMemo(BaseDestroyButton)

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -128,7 +128,12 @@ type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' |
   }
 }
 
-const EllipsisMultiSelectedItem = <T,>({ itemLabel, ...rest }: LowerMultiSelectedItemProps<T>) => {
+const typedMemo: <T>(c: T) => T = memo
+
+const BaseEllipsisMultiSelectedItem = <T,>({
+  itemLabel,
+  ...rest
+}: LowerMultiSelectedItemProps<T>) => {
   const [needsTooltip, setNeedsTooltip] = useState(false)
   const labelRef = useRef<HTMLSpanElement>(null)
 
@@ -148,8 +153,9 @@ const EllipsisMultiSelectedItem = <T,>({ itemLabel, ...rest }: LowerMultiSelecte
 
   return body
 }
+const EllipsisMultiSelectedItem = typedMemo(BaseEllipsisMultiSelectedItem)
 
-const ActualMultiSelectedItem = <T,>({
+const BaseActualMultiSelectedItem = <T,>({
   buttonRef,
   labelRef,
   itemLabel,
@@ -180,11 +186,11 @@ const ActualMultiSelectedItem = <T,>({
     </Chip>
   )
 }
+const ActualMultiSelectedItem = typedMemo(BaseActualMultiSelectedItem)
 
-const typedMemo: <T>(c: T) => T = memo
 const EXEC_DESTROY_KEY = /^(Enter|Backspace| )$/
 
-const BaseDestroyButton = <T,>({
+const DestroyButton = <T,>({
   buttonRef,
   labelId,
   suffixTextId,
@@ -213,4 +219,3 @@ const BaseDestroyButton = <T,>({
     />
   </UnstyledButton>
 )
-const DestroyButton = typedMemo(BaseDestroyButton)

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -1,6 +1,5 @@
 import {
   type KeyboardEvent,
-  type PropsWithChildren,
   type RefObject,
   memo,
   useCallback,
@@ -67,10 +66,12 @@ export function MultiSelectedItem<T>({
   buttonRef,
 }: Props<T>) {
   const [needsTooltip, setNeedsTooltip] = useState(false)
-  const { deletable = true } = item
+  const labelRef = useRef<HTMLDivElement>(null)
   const idPrefix = useId()
   const labelId = `${idPrefix}-item-label`
   const destroySuffixTextId = `${idPrefix}-item-destroy-button-suffix`
+
+  const { deletable = true } = item
 
   const classNames = useMemo(() => {
     const { wrapper, itemLabel, deleteButton, deleteButtonIcon } = classNameGenerator()
@@ -83,11 +84,19 @@ export function MultiSelectedItem<T>({
     }
   }, [disabled, enableEllipsis])
 
+  useEffect(() => {
+    if (enableEllipsis && labelRef.current) {
+      const elem = labelRef.current
+
+      setNeedsTooltip(elem.offsetWidth < elem.scrollWidth)
+    }
+  }, [enableEllipsis])
+
   const body = (
     <Chip disabled={disabled} className={classNames.wrapper}>
-      <ItemLabel id={labelId} className={classNames.itemLabel} setNeedsTooltip={setNeedsTooltip}>
+      <span ref={labelRef} id={labelId} className={classNames.itemLabel}>
         {item.label}
-      </ItemLabel>
+      </span>
 
       {deletable && (
         <DestroyButton
@@ -110,31 +119,6 @@ export function MultiSelectedItem<T>({
 
   return body
 }
-
-const ItemLabel = memo<
-  PropsWithChildren<{
-    id: string
-    enableEllipsis?: boolean
-    setNeedsTooltip: (flg: boolean) => void
-    className: string
-  }>
->(({ children, id, enableEllipsis, setNeedsTooltip, className }) => {
-  const labelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (enableEllipsis && labelRef.current) {
-      const elem = labelRef.current
-
-      setNeedsTooltip(elem.offsetWidth < elem.scrollWidth)
-    }
-  }, [enableEllipsis, setNeedsTooltip])
-
-  return (
-    <span ref={labelRef} id={id} className={className}>
-      {children}
-    </span>
-  )
-})
 
 const typedMemo: <T>(c: T) => T = memo
 const EXEC_DESTROY_KEY = /^(Enter|Backspace| )$/

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -99,7 +99,8 @@ export function MultiSelectedItem<T>({
   }, [disabled, enableEllipsis])
 
   const commonAttrs = {
-    item,
+    itemLabel: item.label,
+    itemDeletable: item.deletable ?? true,
     disabled,
     functions,
     classNames,
@@ -112,8 +113,10 @@ export function MultiSelectedItem<T>({
   )
 }
 
-type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'enableEllipsis' | 'onDelete'> & {
+type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' | 'onDelete'> & {
   labelRef?: RefObject<HTMLSpanElement>
+  itemLabel: ComboboxItem<T>['label']
+  itemDeletable: boolean
   functions: {
     handleClick: () => void
     handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
@@ -126,7 +129,7 @@ type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'enableEllipsis' | 'onDelet
   }
 }
 
-const EllipsisMultiSelectedItem = <T,>({ item, ...rest }: LowerMultiSelectedItemProps<T>) => {
+const EllipsisMultiSelectedItem = <T,>({ itemLabel, ...rest }: LowerMultiSelectedItemProps<T>) => {
   const [needsTooltip, setNeedsTooltip] = useState(false)
   const labelRef = useRef<HTMLSpanElement>(null)
 
@@ -138,10 +141,10 @@ const EllipsisMultiSelectedItem = <T,>({ item, ...rest }: LowerMultiSelectedItem
     }
   }, [])
 
-  const body = <ActualMultiSelectedItem {...rest} labelRef={labelRef} item={item} />
+  const body = <ActualMultiSelectedItem {...rest} labelRef={labelRef} itemLabel={itemLabel} />
 
   if (needsTooltip) {
-    return <Tooltip message={item.label}>{body}</Tooltip>
+    return <Tooltip message={itemLabel}>{body}</Tooltip>
   }
 
   return body
@@ -150,30 +153,28 @@ const EllipsisMultiSelectedItem = <T,>({ item, ...rest }: LowerMultiSelectedItem
 const ActualMultiSelectedItem = <T,>({
   buttonRef,
   labelRef,
-  item,
+  itemLabel,
+  itemDeletable,
   disabled,
   functions,
   classNames,
 }: LowerMultiSelectedItemProps<T>) => {
   const idPrefix = useId()
   const labelId = `${idPrefix}-item-label`
-  const destroySuffixTextId = `${idPrefix}-item-destroy-button-suffix`
-
-  const { deletable = true } = item
 
   return (
     <Chip disabled={disabled} className={classNames.wrapper}>
       <span ref={labelRef} id={labelId} className={classNames.itemLabel}>
-        {item.label}
+        {itemLabel}
       </span>
 
-      {deletable && (
+      {itemDeletable && (
         <DestroyButton
+          buttonRef={buttonRef}
           labelId={labelId}
-          suffixTextId={destroySuffixTextId}
+          suffixTextId={`${idPrefix}-item-destroy-button-suffix`}
           functions={functions}
           disabled={disabled}
-          buttonRef={buttonRef}
           classNames={classNames}
         />
       )}

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -174,8 +174,7 @@ const ActualMultiSelectedItem = <T,>({
           functions={functions}
           disabled={disabled}
           buttonRef={buttonRef}
-          className={classNames.deleteButton}
-          iconStyle={classNames.deleteButtonIcon}
+          classNames={classNames}
         />
       )}
     </Chip>
@@ -191,13 +190,10 @@ const BaseDestroyButton = <T,>({
   suffixTextId,
   disabled,
   functions,
-  className,
-  iconStyle,
-}: Pick<LowerMultiSelectedItemProps<T>, 'disabled' | 'functions' | 'buttonRef'> & {
+  classNames,
+}: Pick<LowerMultiSelectedItemProps<T>, 'disabled' | 'functions' | 'buttonRef' | 'classNames'> & {
   labelId: string
   suffixTextId: string
-  className: string
-  iconStyle: string
 }) => (
   <UnstyledButton
     ref={buttonRef}
@@ -206,12 +202,15 @@ const BaseDestroyButton = <T,>({
     aria-labelledby={`${labelId} ${suffixTextId}`}
     onClick={functions.handleClick}
     onKeyDown={functions.handleKeyDown}
-    className={className}
+    className={classNames.deleteButton}
   >
     <VisuallyHiddenText id={suffixTextId}>
       <Localizer id="smarthr-ui/MultiCombobox/destroyButtonIconAltSuffix" defaultText="を削除" />
     </VisuallyHiddenText>
-    <FaCircleXmarkIcon color={disabled ? 'TEXT_DISABLED' : 'inherit'} className={iconStyle} />
+    <FaCircleXmarkIcon
+      color={disabled ? 'TEXT_DISABLED' : 'inherit'}
+      className={classNames.deleteButtonIcon}
+    />
   </UnstyledButton>
 )
 const DestroyButton = typedMemo(BaseDestroyButton)

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -58,6 +58,8 @@ const classNameGenerator = tv({
   },
 })
 
+const EXEC_DESTROY_KEY = /^(Enter|Backspace| )$/
+
 export function MultiSelectedItem<T>({
   item,
   enableEllipsis,
@@ -69,10 +71,10 @@ export function MultiSelectedItem<T>({
 
   const functions = useMemo(
     () => ({
-      handleClick: () => {
+      handleDestroyClick: () => {
         latest.onDelete(latest.item)
       },
-      handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
+      handleDestroyKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
         if (EXEC_DESTROY_KEY.test(e.key)) {
           e.stopPropagation()
 
@@ -115,8 +117,8 @@ type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' |
   itemLabel: ComboboxItem<T>['label']
   itemDeletable: boolean
   functions: {
-    handleClick: () => void
-    handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
+    handleDestroyClick: () => void
+    handleDestroyKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
   }
   classNames: {
     wrapper: string
@@ -186,8 +188,6 @@ const BaseActualMultiSelectedItem = <T,>({
 }
 const ActualMultiSelectedItem = typedMemo(BaseActualMultiSelectedItem)
 
-const EXEC_DESTROY_KEY = /^(Enter|Backspace| )$/
-
 const DestroyButton = <T,>({
   buttonRef,
   labelId,
@@ -204,8 +204,8 @@ const DestroyButton = <T,>({
     disabled={disabled}
     tabIndex={-1}
     aria-labelledby={`${labelId} ${suffixTextId}`}
-    onClick={functions.handleClick}
-    onKeyDown={functions.handleKeyDown}
+    onClick={functions.handleDestroyClick}
+    onKeyDown={functions.handleDestroyKeyDown}
     className={classNames.deleteButton}
   >
     <VisuallyHiddenText id={suffixTextId}>

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -53,6 +53,27 @@ const classNameGenerator = tv({
   },
 })
 
+const CLASS_NAMES = (() => {
+  const { wrapper, itemLabel, deleteButton, deleteButtonIcon } = classNameGenerator()
+
+  const common = {
+    wrapper: wrapper(),
+    deleteButton: deleteButton(),
+    deleteButtonIcon: deleteButtonIcon(),
+  }
+
+  return {
+    enableEllipsis: {
+      ...common,
+      itemLabel: itemLabel({ enableEllipsis: true }),
+    },
+    noEllipsis: {
+      ...common,
+      itemLabel: itemLabel({ enableEllipsis: false }),
+    },
+  }
+})()
+
 const EXEC_DESTROY_KEY = /^(Enter|Backspace| )$/
 
 export function MultiSelectedItem<T>({
@@ -89,17 +110,6 @@ export function MultiSelectedItem<T>({
     [itemDeletable, latest],
   )
 
-  const classNames = useMemo(() => {
-    const { wrapper, itemLabel, deleteButton, deleteButtonIcon } = classNameGenerator()
-
-    return {
-      wrapper: wrapper(),
-      itemLabel: itemLabel({ enableEllipsis }),
-      deleteButton: deleteButton(),
-      deleteButtonIcon: deleteButtonIcon(),
-    }
-  }, [enableEllipsis])
-
   const Component = enableEllipsis ? EllipsisMultiSelectedItem : ActualMultiSelectedItem
 
   return (
@@ -109,7 +119,7 @@ export function MultiSelectedItem<T>({
       itemDeletable={itemDeletable}
       disabled={disabled}
       functions={functions}
-      classNames={classNames}
+      classNames={CLASS_NAMES[enableEllipsis ? 'enableEllipsis' : 'noEllipsis']}
     />
   )
 }

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useLatest } from '../../../hooks/useLatest'
 import { Localizer } from '../../../intl'
 import { UnstyledButton } from '../../Button'
 import { Chip } from '../../Chip'
@@ -64,15 +65,12 @@ export function MultiSelectedItem<T>({
   onDelete,
   ...rest
 }: Props<T>) {
-  const onDeleteRef = useRef(onDelete)
-  onDeleteRef.current = onDelete
-  const itemRef = useRef(item)
-  itemRef.current = item
+  const latest = useLatest({ onDelete, item })
 
   const functions = useMemo(
     () => ({
       handleClick: () => {
-        onDeleteRef.current(itemRef.current)
+        latest.onDelete(latest.item)
       },
       handleKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
         if (EXEC_DESTROY_KEY.test(e.key)) {
@@ -80,11 +78,11 @@ export function MultiSelectedItem<T>({
 
           // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
           // このタイミングで明示的に削除処理を実行する
-          onDeleteRef.current(itemRef.current)
+          latest.onDelete(latest.item)
         }
       },
     }),
-    [],
+    [latest],
   )
 
   const classNames = useMemo(() => {

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -98,18 +98,17 @@ export function MultiSelectedItem<T>({
     }
   }, [disabled, enableEllipsis])
 
-  const commonAttrs = {
-    itemLabel: item.label,
-    itemDeletable: item.deletable ?? true,
-    disabled,
-    functions,
-    classNames,
-  }
+  const Component = enableEllipsis ? EllipsisMultiSelectedItem : ActualMultiSelectedItem
 
-  return enableEllipsis ? (
-    <EllipsisMultiSelectedItem {...rest} {...commonAttrs} />
-  ) : (
-    <ActualMultiSelectedItem {...rest} {...commonAttrs} />
+  return (
+    <Component
+      {...rest}
+      itemLabel={item.label}
+      itemDeletable={item.deletable ?? true}
+      disabled={disabled}
+      functions={functions}
+      classNames={classNames}
+    />
   )
 }
 

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -67,24 +67,31 @@ export function MultiSelectedItem<T>({
   onDelete,
   ...rest
 }: Props<T>) {
+  const itemDeletable = item.deletable ?? true
   const latest = useLatest({ onDelete, item })
 
   const functions = useMemo(
-    () => ({
-      handleDestroyClick: () => {
-        latest.onDelete(latest.item)
-      },
-      handleDestroyKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
-        if (EXEC_DESTROY_KEY.test(e.key)) {
-          e.stopPropagation()
+    () =>
+      itemDeletable
+        ? {
+            handleDestroyClick: () => {
+              latest.onDelete(latest.item)
+            },
+            handleDestroyKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
+              if (EXEC_DESTROY_KEY.test(e.key)) {
+                e.stopPropagation()
 
-          // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
-          // このタイミングで明示的に削除処理を実行する
-          latest.onDelete(latest.item)
-        }
-      },
-    }),
-    [latest],
+                // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
+                // このタイミングで明示的に削除処理を実行する
+                latest.onDelete(latest.item)
+              }
+            },
+          }
+        : {
+            handleDestroyClick: undefined,
+            handleDestroyKeyDown: undefined,
+          },
+    [itemDeletable, latest],
   )
 
   const classNames = useMemo(() => {
@@ -104,7 +111,7 @@ export function MultiSelectedItem<T>({
     <Component
       {...rest}
       itemLabel={item.label}
-      itemDeletable={item.deletable ?? true}
+      itemDeletable={itemDeletable}
       disabled={disabled}
       functions={functions}
       classNames={classNames}
@@ -117,8 +124,8 @@ type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' |
   itemLabel: ComboboxItem<T>['label']
   itemDeletable: boolean
   functions: {
-    handleDestroyClick: () => void
-    handleDestroyKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
+    handleDestroyClick?: () => void
+    handleDestroyKeyDown?: (e: KeyboardEvent<HTMLButtonElement>) => void
   }
   classNames: {
     wrapper: string

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -23,7 +23,7 @@ import type { ComboboxItem } from '../types'
 export type Props<T> = {
   item: ComboboxItem<T> & { deletable?: boolean }
   disabled: boolean
-  onDelete: (item: ComboboxItem<T>) => void
+  handleDelete: (item: ComboboxItem<T>) => void
   enableEllipsis?: boolean
   buttonRef: RefObject<HTMLButtonElement>
 }
@@ -59,26 +59,26 @@ export function MultiSelectedItem<T>({
   item,
   enableEllipsis,
   disabled,
-  onDelete,
+  handleDelete,
   ...rest
 }: Props<T>) {
   const itemDeletable = item.deletable ?? true
-  const latest = useLatest({ onDelete, item })
+  const latest = useLatest({ handleDelete, item })
 
   const functions = useMemo(
     () =>
       itemDeletable
         ? {
             handleDestroyClick: () => {
-              latest.onDelete(latest.item)
+              latest.handleDelete(latest.item)
             },
             handleDestroyKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => {
               if (EXEC_DESTROY_KEY.test(e.key)) {
                 e.stopPropagation()
 
-                // HINT: イベントの伝播が止まる関係でonClickに設定したonDeleteは実行されない
+                // HINT: イベントの伝播が止まる関係でonClickに設定したhandleDeleteは実行されない
                 // このタイミングで明示的に削除処理を実行する
-                latest.onDelete(latest.item)
+                latest.handleDelete(latest.item)
               }
             },
           }
@@ -114,7 +114,7 @@ export function MultiSelectedItem<T>({
   )
 }
 
-type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' | 'onDelete'> & {
+type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' | 'handleDelete'> & {
   labelRef?: RefObject<HTMLSpanElement>
   itemLabel: ComboboxItem<T>['label']
   itemDeletable: boolean

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -39,6 +39,7 @@ const classNameGenerator = tv({
       'shr-group/deleteButton',
       'shr-shrink shr-rounded-full shr-leading-[0] shr-text-black',
       'focus-visible:shr-outline-none',
+      'disabled:shr-cursor-not-allowed',
     ],
     deleteButtonIcon:
       'group-focus-visible/deleteButton:shr-focus-indicator--outer group-focus-visible/deleteButton:shr-rounded-full',
@@ -48,12 +49,6 @@ const classNameGenerator = tv({
       true: {
         itemLabel: 'shr-overflow-hidden shr-overflow-ellipsis shr-whitespace-nowrap',
       },
-    },
-    disabled: {
-      true: {
-        deleteButton: 'shr-cursor-not-allowed',
-      },
-      false: {},
     },
   },
 })
@@ -100,10 +95,10 @@ export function MultiSelectedItem<T>({
     return {
       wrapper: wrapper(),
       itemLabel: itemLabel({ enableEllipsis }),
-      deleteButton: deleteButton({ disabled }),
+      deleteButton: deleteButton(),
       deleteButtonIcon: deleteButtonIcon(),
     }
-  }, [disabled, enableEllipsis])
+  }, [enableEllipsis])
 
   const Component = enableEllipsis ? EllipsisMultiSelectedItem : ActualMultiSelectedItem
 

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -58,21 +58,7 @@ const classNameGenerator = tv({
   },
 })
 
-export function MultiSelectedItem<T>({
-  item,
-  disabled,
-  onDelete,
-  enableEllipsis,
-  buttonRef,
-}: Props<T>) {
-  const [needsTooltip, setNeedsTooltip] = useState(false)
-  const labelRef = useRef<HTMLDivElement>(null)
-  const idPrefix = useId()
-  const labelId = `${idPrefix}-item-label`
-  const destroySuffixTextId = `${idPrefix}-item-destroy-button-suffix`
-
-  const { deletable = true } = item
-
+export function MultiSelectedItem<T>({ enableEllipsis, disabled, ...rest }: Props<T>) {
   const classNames = useMemo(() => {
     const { wrapper, itemLabel, deleteButton, deleteButtonIcon } = classNameGenerator()
 
@@ -84,15 +70,64 @@ export function MultiSelectedItem<T>({
     }
   }, [disabled, enableEllipsis])
 
-  useEffect(() => {
-    if (enableEllipsis && labelRef.current) {
-      const elem = labelRef.current
+  const commonAttrs = {
+    disabled,
+    classNames,
+  }
 
+  return enableEllipsis ? (
+    <EllipsisMultiSelectedItem {...rest} {...commonAttrs} />
+  ) : (
+    <ActualMultiSelectedItem {...rest} {...commonAttrs} />
+  )
+}
+
+type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'enableEllipsis'> & {
+  labelRef?: RefObject<HTMLSpanElement>
+  classNames: {
+    wrapper: string
+    itemLabel: string
+    deleteButton: string
+    deleteButtonIcon: string
+  }
+}
+
+const EllipsisMultiSelectedItem = <T,>({ item, ...rest }: LowerMultiSelectedItemProps<T>) => {
+  const [needsTooltip, setNeedsTooltip] = useState(false)
+  const labelRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    const elem = labelRef.current
+
+    if (elem) {
       setNeedsTooltip(elem.offsetWidth < elem.scrollWidth)
     }
-  }, [enableEllipsis])
+  }, [])
 
-  const body = (
+  const body = <ActualMultiSelectedItem {...rest} labelRef={labelRef} item={item} />
+
+  if (needsTooltip) {
+    return <Tooltip message={item.label}>{body}</Tooltip>
+  }
+
+  return body
+}
+
+const ActualMultiSelectedItem = <T,>({
+  buttonRef,
+  labelRef,
+  item,
+  disabled,
+  onDelete,
+  classNames,
+}: LowerMultiSelectedItemProps<T>) => {
+  const idPrefix = useId()
+  const labelId = `${idPrefix}-item-label`
+  const destroySuffixTextId = `${idPrefix}-item-destroy-button-suffix`
+
+  const { deletable = true } = item
+
+  return (
     <Chip disabled={disabled} className={classNames.wrapper}>
       <span ref={labelRef} id={labelId} className={classNames.itemLabel}>
         {item.label}
@@ -112,12 +147,6 @@ export function MultiSelectedItem<T>({
       )}
     </Chip>
   )
-
-  if (needsTooltip) {
-    return <Tooltip message={item.label}>{body}</Tooltip>
-  }
-
-  return body
 }
 
 const typedMemo: <T>(c: T) => T = memo


### PR DESCRIPTION
## 関連URL

## 概要

`MultiSelectedItem` に `useLatest + functions` パターンを適用し、コンポーネント構造を整理するリファクタリングです。

## 変更内容

### MultiSelectedItem
- `ItemLabel` をインライン化して `needsTooltip` 分岐の下準備
- `enableEllipsis` によるコンポーネント分岐を実装（`EllipsisMultiSelectedItem` / `ActualMultiSelectedItem`）
- `useCallback` を `functions` パターンに統合
- `DestroyButton` の props を `classNames` オブジェクトに統合
- `item` オブジェクトを `itemLabel` / `itemDeletable` に分解して渡す
- `commonAttrs` を Component パターンに置き換える
- `Ellipsis` と `Actual` を memo 化、`DestroyButton` の memo 解除
- `onDeleteRef` / `itemRef` を `useLatest` に置き換える
- `handleClick` / `handleKeyDown` を `handleDestroy*` にrename
- `itemDeletable` を `functions` の生成条件に使用
- `deleteButton` の `disabled` 依存を CSS 擬似クラスに置き換え
- `onDelete` を `handleDelete` にrename
- `classNames` を `CLASS_NAMES` 定数に変換

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic でのVRT確認