### PR TITLE
refactor(SingleCombobox): useLatest + functionsパターンを適用

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
@@ -128,8 +128,8 @@ describe('SingleCombobox', () => {
     await userEvent.click(combobox())
     expect(listbox()).not.toBeInTheDocument()
 
-    // 選択解除ボタンが表示されていない(非表示用のクラスが付与されている)
-    expect(clearButton()).toHaveClass('shr-hidden')
+    // 選択解除ボタンが表示されていない(data-clear-button-hidden属性がtrueになっている)
+    expect(screen.getByRole('group')).toHaveAttribute('data-clear-button-hidden', 'true')
   })
 
   it('readOnly なコンボボックスではアイテムの選択・解除ができないこと', async () => {
@@ -140,8 +140,8 @@ describe('SingleCombobox', () => {
     await userEvent.click(combobox())
     expect(listbox()).not.toBeInTheDocument()
 
-    // 選択解除ボタンが表示されていない(非表示用のクラスが付与されている)
-    expect(clearButton()).toHaveClass('shr-hidden')
+    // 選択解除ボタンが表示されていない(data-clear-button-hidden属性がtrueになっている)
+    expect(screen.getByRole('group')).toHaveAttribute('data-clear-button-hidden', 'true')
   })
 
   it('キーボードで操作できること', async () => {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -119,10 +119,10 @@ const classNameGenerator = tv({
 })
 
 type SuffixButtonsProps = {
-  handleClickClear: (e: MouseEvent) => void
   clearButtonRef: RefObject<HTMLButtonElement>
-  onClickIcon: (e: MouseEvent) => void
   caretIconColor: string
+  handleClickClear: (e: MouseEvent) => void
+  handleClickIcon: (e: MouseEvent) => void
   classNames: {
     clearButton: string
     clearButtonIcon: string
@@ -133,10 +133,10 @@ type SuffixButtonsProps = {
 
 const SuffixButtons = memo<SuffixButtonsProps>(
   ({
-    handleClickClear,
     clearButtonRef,
-    onClickIcon: onDelegateClickIcon,
     caretIconColor,
+    handleClickClear,
+    handleClickIcon: handleDelegateClickIcon,
     classNames,
   }) => (
     <>
@@ -155,7 +155,7 @@ const SuffixButtons = memo<SuffixButtonsProps>(
       </UnstyledButton>
       <span
         role="presentation"
-        onClick={onDelegateClickIcon}
+        onClick={handleDelegateClickIcon}
         className={classNames.caretDownLayout}
       >
         <FaCaretDownIcon color={caretIconColor} className={classNames.caretDownIcon} />
@@ -329,25 +329,22 @@ const ActualSingleCombobox = <T,>(
           setIsExpanded(true)
         }
       },
+      handleClickInput: (e: MouseEvent) => {
+        if (latest.disabled || latest.readOnly) {
+          e.stopPropagation()
+
+          return
+        }
+
+        inputRef.current?.focus()
+
+        if (!latest.isExpanded) {
+          setIsExpanded(true)
+        }
+      },
     }
   }, [latest])
 
-  const onClickInput = useCallback(
-    (e: MouseEvent) => {
-      if (latest.disabled || latest.readOnly) {
-        e.stopPropagation()
-
-        return
-      }
-
-      inputRef.current?.focus()
-
-      if (!latest.isExpanded) {
-        setIsExpanded(true)
-      }
-    },
-    [latest],
-  )
   const actualOnChangeInput = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       latest.onChange?.(e)
@@ -474,7 +471,7 @@ const ActualSingleCombobox = <T,>(
         aria-autocomplete="list"
         /* eslint-disable-next-line smarthr/a11y-prohibit-input-placeholder */
         placeholder={placeholder}
-        onClick={onClickInput}
+        onClick={functions.handleClickInput}
         onChange={actualOnChangeInput}
         onFocus={isFocused ? undefined : functions.handleFocus}
         onCompositionStart={onCompositionStart}
@@ -488,7 +485,7 @@ const ActualSingleCombobox = <T,>(
             clearButtonRef={clearButtonRef}
             caretIconColor={caretIconColor}
             handleClickClear={functions.handleClickClear}
-            onClickIcon={onClickInput}
+            handleClickIcon={functions.handleClickInput}
             classNames={classNames}
           />
         }

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -342,27 +342,24 @@ const ActualSingleCombobox = <T,>(
           setIsExpanded(true)
         }
       },
+      handleChangeInput: (e: ChangeEvent<HTMLInputElement>) => {
+        latest.onChange?.(e)
+        latest.onChangeInput?.(e)
+
+        if (!latest.isEditing) setIsEditing(true)
+
+        const { value } = e.currentTarget
+
+        setInputValue(value)
+
+        if (value === '') {
+          latest.onClear?.()
+          latest.onChangeSelected?.(null)
+        }
+      },
     }
   }, [latest])
 
-  const actualOnChangeInput = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      latest.onChange?.(e)
-      latest.onChangeInput?.(e)
-
-      if (!latest.isEditing) setIsEditing(true)
-
-      const { value } = e.currentTarget
-
-      setInputValue(value)
-
-      if (value === '') {
-        latest.onClear?.()
-        latest.onChangeSelected?.(null)
-      }
-    },
-    [latest],
-  )
   const onCompositionStart = useCallback(() => setIsComposing(true), [])
   const onCompositionEnd = useCallback(() => setIsComposing(false), [])
   const onKeyDownInput = useCallback(
@@ -472,7 +469,7 @@ const ActualSingleCombobox = <T,>(
         /* eslint-disable-next-line smarthr/a11y-prohibit-input-placeholder */
         placeholder={placeholder}
         onClick={functions.handleClickInput}
-        onChange={actualOnChangeInput}
+        onChange={functions.handleChangeInput}
         onFocus={isFocused ? undefined : functions.handleFocus}
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -357,11 +357,11 @@ const ActualSingleCombobox = <T,>(
           latest.onChangeSelected?.(null)
         }
       },
+      handleCompositionStart: () => setIsComposing(true),
+      handleCompositionEnd: () => setIsComposing(false),
     }
   }, [latest])
 
-  const onCompositionStart = useCallback(() => setIsComposing(true), [])
-  const onCompositionEnd = useCallback(() => setIsComposing(false), [])
   const onKeyDownInput = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       if (latest.isComposing) {
@@ -471,8 +471,8 @@ const ActualSingleCombobox = <T,>(
         onClick={functions.handleClickInput}
         onChange={functions.handleChangeInput}
         onFocus={isFocused ? undefined : functions.handleFocus}
-        onCompositionStart={onCompositionStart}
-        onCompositionEnd={onCompositionEnd}
+        onCompositionStart={functions.handleCompositionStart}
+        onCompositionEnd={functions.handleCompositionEnd}
         onKeyDown={onKeyDownInput}
         onKeyPress={handleKeyPress}
         error={error}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -279,9 +279,25 @@ const ActualSingleCombobox = <T,>(
         latest.onSelect(latest.defaultItem)
       }
     }
+    const unfocus = () => {
+      if (!latest.isFocused) return
+
+      latest.onBlur?.()
+
+      setIsFocused(false)
+      setIsExpanded(false)
+      setIsEditing(false)
+
+      if (latest.selectedItem) {
+        setInputValue(innerText(latest.selectedItem.label))
+      } else {
+        selectDefaultItem()
+      }
+    }
 
     return {
       selectDefaultItem,
+      unfocus,
       handleFocus: () => {
         latest.onFocus?.()
         inputRef.current?.focus()
@@ -289,21 +305,6 @@ const ActualSingleCombobox = <T,>(
 
         if (!latest.isFocused) {
           setIsExpanded(true)
-        }
-      },
-      unfocus: () => {
-        if (!latest.isFocused) return
-
-        latest.onBlur?.()
-
-        setIsFocused(false)
-        setIsExpanded(false)
-        setIsEditing(false)
-
-        if (latest.selectedItem) {
-          setInputValue(innerText(latest.selectedItem.label))
-        } else {
-          selectDefaultItem()
         }
       },
       handleClickClear: (e: MouseEvent) => {
@@ -359,38 +360,34 @@ const ActualSingleCombobox = <T,>(
       },
       handleCompositionStart: () => setIsComposing(true),
       handleCompositionEnd: () => setIsComposing(false),
+      handleKeyDownInput: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (latest.isComposing) {
+          return
+        }
+
+        if (ESCAPE_KEY_REGEX.test(e.key)) {
+          if (latest.isExpanded) {
+            e.stopPropagation()
+            setIsExpanded(false)
+          }
+        } else if (e.key === 'Tab') {
+          unfocus()
+        } else {
+          if (ARROW_UP_DOWN_REGEX.test(e.key)) {
+            e.preventDefault()
+          }
+
+          inputRef.current?.focus()
+
+          if (!latest.isExpanded) {
+            setIsExpanded(true)
+          }
+        }
+
+        latest.handleKeyDownListBox(e)
+      },
     }
   }, [latest])
-
-  const onKeyDownInput = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (latest.isComposing) {
-        return
-      }
-
-      if (ESCAPE_KEY_REGEX.test(e.key)) {
-        if (latest.isExpanded) {
-          e.stopPropagation()
-          setIsExpanded(false)
-        }
-      } else if (e.key === 'Tab') {
-        functions.unfocus()
-      } else {
-        if (ARROW_UP_DOWN_REGEX.test(e.key)) {
-          e.preventDefault()
-        }
-
-        inputRef.current?.focus()
-
-        if (!latest.isExpanded) {
-          setIsExpanded(true)
-        }
-      }
-
-      latest.handleKeyDownListBox(e)
-    },
-    [functions, latest],
-  )
 
   // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で
   // アイテムをキーボードで選択し、Enterを押すとinput上でEnterを押したことになるため、
@@ -473,7 +470,7 @@ const ActualSingleCombobox = <T,>(
         onFocus={isFocused ? undefined : functions.handleFocus}
         onCompositionStart={functions.handleCompositionStart}
         onCompositionEnd={functions.handleCompositionEnd}
-        onKeyDown={onKeyDownInput}
+        onKeyDown={functions.handleKeyDownInput}
         onKeyPress={handleKeyPress}
         error={error}
         prefix={prefix}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -84,7 +84,8 @@ const EMPTY_INPUT_CHANGE_EVENT = {
 
 const classNameGenerator = tv({
   slots: {
-    wrapper: 'smarthr-ui-SingleCombobox shr-inline-block',
+    wrapper:
+      'smarthr-ui-SingleCombobox shr-inline-block [&:has(.smarthr-ui-Input-input:disabled)]:shr-cursor-not-allowed',
     input: 'smarthr-ui-SingleCombobox-input shr-w-full',
     caretDownLayout: [
       'shr-relative -shr-me-0.5 shr-p-0.5',
@@ -104,13 +105,7 @@ const classNameGenerator = tv({
       'group-focus-visible/clearButton:shr-focus-indicator group-focus-visible/clearButton:shr-rounded-full',
     ],
   },
-  variants: {
-    disabled: {
-      true: {
-        wrapper: 'shr-cursor-not-allowed',
-      },
-    },
-  },
+  variants: {},
 })
 
 type SuffixButtonsProps = {
@@ -415,25 +410,25 @@ const ActualSingleCombobox = <T,>(
       classNameGenerator()
 
     return {
-      wrapper: wrapper({ disabled, className }),
+      wrapper: wrapper({ className }),
       input: input(),
       caretDownLayout: caretDownLayout(),
       caretDownIcon: caretDownIcon(),
       clearButton: clearButton(),
       clearButtonIcon: clearButtonIcon(),
     }
-  }, [disabled, className])
+  }, [className])
 
   return (
     <div
+      ref={triggerRef}
       role="group"
       className={classNames.wrapper}
       style={{
         ...style,
         width: typeof width === 'number' ? `${width}px` : width,
       }}
-      data-clear-button-hidden={(selectedItem === null || disabled || readOnly).toString()}
-      ref={triggerRef}
+      data-clear-button-hidden={(selectedItem === null || disabled || readOnly || false).toString()}
     >
       <Input
         {...rest}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -9,7 +9,6 @@ import {
   type Ref,
   type RefObject,
   memo,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -360,6 +359,14 @@ const ActualSingleCombobox = <T,>(
       },
       handleCompositionStart: () => setIsComposing(true),
       handleCompositionEnd: () => setIsComposing(false),
+      // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で
+      // アイテムをキーボードで選択し、Enterを押すとinput上でEnterを押したことになるため、
+      // submitイベントが発生し、formが送信される場合がある
+      handleKeyPress: (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') e.preventDefault()
+
+        latest.onKeyPress?.(e)
+      },
       handleKeyDownInput: (e: KeyboardEvent<HTMLInputElement>) => {
         if (latest.isComposing) {
           return
@@ -388,18 +395,6 @@ const ActualSingleCombobox = <T,>(
       },
     }
   }, [latest])
-
-  // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で
-  // アイテムをキーボードで選択し、Enterを押すとinput上でEnterを押したことになるため、
-  // submitイベントが発生し、formが送信される場合がある
-  const handleKeyPress = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') e.preventDefault()
-
-      latest.onKeyPress?.(e)
-    },
-    [latest],
-  )
 
   const caretIconColor = isFocused
     ? theme.textColor.black
@@ -471,7 +466,7 @@ const ActualSingleCombobox = <T,>(
         onCompositionStart={functions.handleCompositionStart}
         onCompositionEnd={functions.handleCompositionEnd}
         onKeyDown={functions.handleKeyDownInput}
-        onKeyPress={handleKeyPress}
+        onKeyPress={functions.handleKeyPress}
         error={error}
         prefix={prefix}
         suffix={

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -105,7 +105,6 @@ const classNameGenerator = tv({
       'group-focus-visible/clearButton:shr-focus-indicator group-focus-visible/clearButton:shr-rounded-full',
     ],
   },
-  variants: {},
 })
 
 type SuffixButtonsProps = {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -119,7 +119,7 @@ const classNameGenerator = tv({
 })
 
 type SuffixButtonsProps = {
-  onClickClear: (e: MouseEvent) => void
+  handleClickClear: (e: MouseEvent) => void
   clearButtonRef: RefObject<HTMLButtonElement>
   onClickIcon: (e: MouseEvent) => void
   caretIconColor: string
@@ -133,7 +133,7 @@ type SuffixButtonsProps = {
 
 const SuffixButtons = memo<SuffixButtonsProps>(
   ({
-    onClickClear,
+    handleClickClear,
     clearButtonRef,
     onClickIcon: onDelegateClickIcon,
     caretIconColor,
@@ -141,7 +141,7 @@ const SuffixButtons = memo<SuffixButtonsProps>(
   }) => (
     <>
       <UnstyledButton
-        onClick={onClickClear}
+        onClick={handleClickClear}
         ref={clearButtonRef}
         className={classNames.clearButton}
       >
@@ -306,35 +306,32 @@ const ActualSingleCombobox = <T,>(
           selectDefaultItem()
         }
       },
+      handleClickClear: (e: MouseEvent) => {
+        e.stopPropagation()
+
+        let isExecutedPreventDefault = false
+
+        latest.onClearClick?.({
+          ...e,
+          preventDefault: () => {
+            e.preventDefault()
+            isExecutedPreventDefault = true
+          },
+        })
+
+        if (!isExecutedPreventDefault) {
+          latest.onClear?.()
+          latest.onChangeSelected?.(null)
+
+          inputRef.current?.focus()
+
+          setIsFocused(true)
+          setIsExpanded(true)
+        }
+      },
     }
   }, [latest])
 
-  const onClickClear = useCallback(
-    (e: MouseEvent) => {
-      e.stopPropagation()
-
-      let isExecutedPreventDefault = false
-
-      latest.onClearClick?.({
-        ...e,
-        preventDefault: () => {
-          e.preventDefault()
-          isExecutedPreventDefault = true
-        },
-      })
-
-      if (!isExecutedPreventDefault) {
-        latest.onClear?.()
-        latest.onChangeSelected?.(null)
-
-        inputRef.current?.focus()
-
-        setIsFocused(true)
-        setIsExpanded(true)
-      }
-    },
-    [latest],
-  )
   const onClickInput = useCallback(
     (e: MouseEvent) => {
       if (latest.disabled || latest.readOnly) {
@@ -488,16 +485,11 @@ const ActualSingleCombobox = <T,>(
         prefix={prefix}
         suffix={
           <SuffixButtons
-            onClickClear={onClickClear}
             clearButtonRef={clearButtonRef}
-            onClickIcon={onClickInput}
             caretIconColor={caretIconColor}
-            classNames={{
-              clearButton: classNames.clearButton,
-              clearButtonIcon: classNames.clearButtonIcon,
-              caretDownLayout: classNames.caretDownLayout,
-              caretDownIcon: classNames.caretDownIcon,
-            }}
+            handleClickClear={functions.handleClickClear}
+            onClickIcon={onClickInput}
+            classNames={classNames}
           />
         }
         className={classNames.input}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -199,7 +199,7 @@ const ActualSingleCombobox = <T,>(
   ref: Ref<HTMLInputElement>,
 ) => {
   const theme = useTheme()
-  const outerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const clearButtonRef = useRef<HTMLButtonElement>(null)
   const [isFocused, setIsFocused] = useState(false)
@@ -246,7 +246,7 @@ const ActualSingleCombobox = <T,>(
       },
       isExpanded,
       isLoading,
-      triggerRef: outerRef,
+      triggerRef,
       noResultText,
     },
   )
@@ -403,7 +403,7 @@ const ActualSingleCombobox = <T,>(
       : theme.textColor.grey
 
   useClick(
-    useMemo(() => [outerRef, listBoxRef, clearButtonRef], [listBoxRef]),
+    useMemo(() => [triggerRef, listBoxRef, clearButtonRef], [listBoxRef]),
     isFocused || selectedItem ? NOOP : functions.selectDefaultItem,
     functions.unfocus,
   )
@@ -441,7 +441,7 @@ const ActualSingleCombobox = <T,>(
   }, [hasSelectedItem, disabled, readOnly, className])
 
   return (
-    <div role="group" className={classNames.wrapper} style={wrapperStyle} ref={outerRef}>
+    <div role="group" className={classNames.wrapper} style={wrapperStyle} ref={triggerRef}>
       <Input
         {...rest}
         ref={inputRef}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -97,6 +97,7 @@ const classNameGenerator = tv({
       'shr-group/clearButton',
       'shr-me-0.5',
       'focus-visible:shr-shadow-none',
+      '[[data-clear-button-hidden=true]_&]:shr-hidden',
     ],
     clearButtonIcon: [
       'shr-block',
@@ -107,11 +108,6 @@ const classNameGenerator = tv({
     disabled: {
       true: {
         wrapper: 'shr-cursor-not-allowed',
-      },
-    },
-    hidden: {
-      true: {
-        clearButton: 'shr-hidden',
       },
     },
   },
@@ -414,8 +410,6 @@ const ActualSingleCombobox = <T,>(
     setInputValue(selectedItemLabelText)
   }, [selectedItemLabelText])
 
-  const hasSelectedItem = selectedItem !== null
-
   const classNames = useMemo(() => {
     const { wrapper, input, caretDownLayout, caretDownIcon, clearButton, clearButtonIcon } =
       classNameGenerator()
@@ -425,12 +419,10 @@ const ActualSingleCombobox = <T,>(
       input: input(),
       caretDownLayout: caretDownLayout(),
       caretDownIcon: caretDownIcon(),
-      clearButton: clearButton({
-        hidden: !hasSelectedItem || disabled || readOnly,
-      }),
+      clearButton: clearButton(),
       clearButtonIcon: clearButtonIcon(),
     }
-  }, [hasSelectedItem, disabled, readOnly, className])
+  }, [disabled, className])
 
   return (
     <div
@@ -440,6 +432,7 @@ const ActualSingleCombobox = <T,>(
         ...style,
         width: typeof width === 'number' ? `${width}px` : width,
       }}
+      data-clear-button-hidden={(selectedItem === null || disabled || readOnly).toString()}
       ref={triggerRef}
     >
       <Input

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -244,28 +244,25 @@ const ActualSingleCombobox = <T,>(
       dropdownHelpMessage,
       dropdownWidth,
       onAdd,
-      onSelect: useCallback(
-        (selected: ComboboxItem<T>) => {
-          latest.onSelect?.(selected)
-          latest.onChangeSelected?.(selected)
+      onSelect: (selected: ComboboxItem<T>) => {
+        onSelect?.(selected)
+        onChangeSelected?.(selected)
 
-          // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-          // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-          requestAnimationFrame(() => {
-            setIsExpanded(false)
-            // HINT:
-            // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
-            // - 対応するdropdownを閉じて以降にonChangeInputを発火する必要がある
-            //   - 先にclearしてしまうと意図せずこの要素のドロップダウンを閉じる前に他要素の再レンダリングを引き起こす可能性がある
-            //   - 例えばFilterDropdownなどで当comboboxを使っている場合、レイアウト上comboboxのdropdown以下の要素がクリックされた扱いになってしまい
-            //     FilterDropdownを意図せず閉じてしまうなどの挙動のバグを引き起こす可能性がある
-            latest.onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
-          })
+        // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
+        // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        requestAnimationFrame(() => {
+          setIsExpanded(false)
+          // HINT:
+          // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
+          // - 対応するdropdownを閉じて以降にonChangeInputを発火する必要がある
+          //   - 先にclearしてしまうと意図せずこの要素のドロップダウンを閉じる前に他要素の再レンダリングを引き起こす可能性がある
+          //   - 例えばFilterDropdownなどで当comboboxを使っている場合、レイアウト上comboboxのdropdown以下の要素がクリックされた扱いになってしまい
+          //     FilterDropdownを意図せず閉じてしまうなどの挙動のバグを引き起こす可能性がある
+          onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
+        })
 
-          setIsEditing(false)
-        },
-        [latest],
-      ),
+        setIsEditing(false)
+      },
       isExpanded,
       isLoading,
       triggerRef: outerRef,

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -414,14 +414,6 @@ const ActualSingleCombobox = <T,>(
     setInputValue(selectedItemLabelText)
   }, [selectedItemLabelText])
 
-  const wrapperStyle = useMemo(
-    () => ({
-      ...style,
-      width: typeof width === 'number' ? `${width}px` : width,
-    }),
-    [style, width],
-  )
-
   const hasSelectedItem = selectedItem !== null
 
   const classNames = useMemo(() => {
@@ -441,7 +433,15 @@ const ActualSingleCombobox = <T,>(
   }, [hasSelectedItem, disabled, readOnly, className])
 
   return (
-    <div role="group" className={classNames.wrapper} style={wrapperStyle} ref={triggerRef}>
+    <div
+      role="group"
+      className={classNames.wrapper}
+      style={{
+        ...style,
+        width: typeof width === 'number' ? `${width}px` : width,
+      }}
+      ref={triggerRef}
+    >
       <Input
         {...rest}
         ref={inputRef}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -225,6 +225,7 @@ const ActualSingleCombobox = <T,>(
       dropdownHelpMessage,
       dropdownWidth,
       onAdd,
+      // HINT: memo化していないが、内部でuseLatestでstableにしているため最適化としてそのまま渡している
       onSelect: (selected: ComboboxItem<T>) => {
         onSelect?.(selected)
         onChangeSelected?.(selected)
@@ -272,36 +273,42 @@ const ActualSingleCombobox = <T,>(
     readOnly,
   })
 
-  const selectDefaultItem = useCallback(() => {
-    if (latest.onSelect && latest.defaultItem) {
-      latest.onSelect(latest.defaultItem)
+  const functions = useMemo(() => {
+    const selectDefaultItem = () => {
+      if (latest.onSelect && latest.defaultItem) {
+        latest.onSelect(latest.defaultItem)
+      }
+    }
+
+    return {
+      selectDefaultItem,
+      handleFocus: () => {
+        latest.onFocus?.()
+        inputRef.current?.focus()
+        setIsFocused(true)
+
+        if (!latest.isFocused) {
+          setIsExpanded(true)
+        }
+      },
+      unfocus: () => {
+        if (!latest.isFocused) return
+
+        latest.onBlur?.()
+
+        setIsFocused(false)
+        setIsExpanded(false)
+        setIsEditing(false)
+
+        if (latest.selectedItem) {
+          setInputValue(innerText(latest.selectedItem.label))
+        } else {
+          selectDefaultItem()
+        }
+      },
     }
   }, [latest])
 
-  const focus = useCallback(() => {
-    latest.onFocus?.()
-    inputRef.current?.focus()
-    setIsFocused(true)
-
-    if (!latest.isFocused) {
-      setIsExpanded(true)
-    }
-  }, [latest])
-  const unfocus = useCallback(() => {
-    if (!latest.isFocused) return
-
-    latest.onBlur?.()
-
-    setIsFocused(false)
-    setIsExpanded(false)
-    setIsEditing(false)
-
-    if (latest.selectedItem) {
-      setInputValue(innerText(latest.selectedItem.label))
-    } else {
-      selectDefaultItem()
-    }
-  }, [selectDefaultItem, latest])
   const onClickClear = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
@@ -376,7 +383,7 @@ const ActualSingleCombobox = <T,>(
           setIsExpanded(false)
         }
       } else if (e.key === 'Tab') {
-        unfocus()
+        functions.unfocus()
       } else {
         if (ARROW_UP_DOWN_REGEX.test(e.key)) {
           e.preventDefault()
@@ -391,7 +398,7 @@ const ActualSingleCombobox = <T,>(
 
       latest.handleKeyDownListBox(e)
     },
-    [unfocus, latest],
+    [functions, latest],
   )
 
   // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で
@@ -414,8 +421,8 @@ const ActualSingleCombobox = <T,>(
 
   useClick(
     useMemo(() => [outerRef, listBoxRef, clearButtonRef], [listBoxRef]),
-    isFocused || selectedItem ? NOOP : selectDefaultItem,
-    unfocus,
+    isFocused || selectedItem ? NOOP : functions.selectDefaultItem,
+    functions.unfocus,
   )
 
   // selectedItem.label はプリミティブ値でないデータ型の可能性があり、そのまま useEffect の依存配列に入れると意図せぬエフェクトの実行を引き起こしてしまう可能性があるので、プリミティブ値である string 型に変換したものを依存配列に入れています。
@@ -472,7 +479,7 @@ const ActualSingleCombobox = <T,>(
         placeholder={placeholder}
         onClick={onClickInput}
         onChange={actualOnChangeInput}
-        onFocus={isFocused ? undefined : focus}
+        onFocus={isFocused ? undefined : functions.handleFocus}
         onCompositionStart={onCompositionStart}
         onCompositionEnd={onCompositionEnd}
         onKeyDown={onKeyDownInput}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -219,25 +219,6 @@ const ActualSingleCombobox = <T,>(
     isFilteringDisabled: !isEditing,
   })
 
-  const latest = useLatest({
-    onChange,
-    onChangeInput,
-    onAdd,
-    onSelect,
-    onClear,
-    onClearClick,
-    onChangeSelected,
-    onFocus,
-    onBlur,
-    onKeyPress,
-    defaultItem,
-    selectedItem,
-    isFocused,
-    isExpanded,
-    isComposing,
-    isEditing,
-  })
-
   const { listBoxProps, activeOption, handleKeyDownListBox, listBoxId, listBoxRef } = useListbox<T>(
     {
       options,
@@ -269,6 +250,27 @@ const ActualSingleCombobox = <T,>(
       noResultText,
     },
   )
+
+  const latest = useLatest({
+    onChange,
+    onChangeInput,
+    onSelect,
+    onClear,
+    onClearClick,
+    onChangeSelected,
+    onFocus,
+    onBlur,
+    onKeyPress,
+    handleKeyDownListBox,
+    defaultItem,
+    selectedItem,
+    isFocused,
+    isExpanded,
+    isComposing,
+    isEditing,
+    disabled,
+    readOnly,
+  })
 
   const selectDefaultItem = useCallback(() => {
     if (latest.onSelect && latest.defaultItem) {
@@ -328,7 +330,7 @@ const ActualSingleCombobox = <T,>(
   )
   const onClickInput = useCallback(
     (e: MouseEvent) => {
-      if (disabled || readOnly) {
+      if (latest.disabled || latest.readOnly) {
         e.stopPropagation()
 
         return
@@ -340,7 +342,7 @@ const ActualSingleCombobox = <T,>(
         setIsExpanded(true)
       }
     },
-    [disabled, readOnly, latest],
+    [latest],
   )
   const actualOnChangeInput = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -386,9 +388,10 @@ const ActualSingleCombobox = <T,>(
           setIsExpanded(true)
         }
       }
-      handleKeyDownListBox(e)
+
+      latest.handleKeyDownListBox(e)
     },
-    [unfocus, handleKeyDownListBox, latest],
+    [unfocus, latest],
   )
 
   // HINT: form内にcomboboxを設置 & 検索inputにfocusした状態で


### PR DESCRIPTION
## 関連URL

## 概要

`SingleCombobox` に `useLatest + functions` パターンを適用するリファクタリングです。

## 変更内容

- `useListbox` に渡す `onSelect` をインライン化（`useCallback` 除去）
- `handleKeyDownListBox` を `useLatest` 経由で呼び出し
- `selectDefaultItem` / `focus` / `unfocus` を `functions` パターンに統合
- `onClickClear` を `functions` に統合
- `onClickInput` を `functions` に統合
- `actualOnChangeInput` を `functions` に統合
- `onCompositionStart` / `onCompositionEnd` を `functions` の `useMemo` に統合
- `onKeyDownInput` を `functions` に統合
- `handleKeyPress` を `functions` に統合し `useCallback` を削除
- `outerRef` を `triggerRef` にrename
- `wrapperStyle` の `useMemo` を削除してインライン化
- `data-clear-button-hidden` 属性でクリアボタンの表示制御をCSS化
- `:has(.smarthr-ui-Input-input:disabled)` で `cursor` 制御をCSS化

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic でのVRT確認