### PR TITLE
chore(Panel): smarthr-ui-BaseをclassNameのaliasとして追加

### DIFF
--- a/packages/smarthr-ui/src/components/Panel/Panel.tsx
+++ b/packages/smarthr-ui/src/components/Panel/Panel.tsx
@@ -15,7 +15,8 @@ import { useSectionWrapper } from '../SectioningContent'
 import type { Gap } from '../../types'
 
 export const panelClassNameGenerator = tv({
-  base: 'smarthr-ui-Panel shr-bg-white forced-colors:shr-border-shorthand contrast-more:shr-border-high-contrast',
+  // TODO: smarthr-ui-Base はBaseコンポーネントのaliasが削除されてから消す
+  base: 'smarthr-ui-Panel smarthr-ui-Base shr-bg-white forced-colors:shr-border-shorthand contrast-more:shr-border-high-contrast',
   variants: {
     paddingBlock,
     paddingInline,


### PR DESCRIPTION
## 関連URL

## 概要

`Base` コンポーネントが `Panel` に rename された後も、既存のプロダクトコードが `smarthr-ui-Base` クラス名でスタイルを当てている可能性があるため、後方互換性のために `smarthr-ui-Base` を `Panel` の className に追加します。

## 変更内容

- `Panel` の `base` クラスに `smarthr-ui-Base` を追加
- TODO コメントで `Base` コンポーネントの alias が削除された後に消す旨を記載

## プロダクト側で対応が必要な事項

なし

## 確認方法

Chromatic でのVRT確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * パネルのスタイル適用を調整し、表示の一貫性を向上しました。
  * 今後のコンポーネント整理に向けた互換性を確保しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->