### PR TITLE
refactor(MultiCombobox): 小規模なリファクタリング（rename・インライン化・useLocalize統合）

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -459,13 +459,6 @@ const ActualMultiCombobox = <T,>(
 
   const selectedListId = useId()
 
-  const wrapperStyle = useMemo(
-    () => ({
-      ...style,
-      width: typeof width === 'number' ? `${width}px` : width,
-    }),
-    [style, width],
-  )
   const classNames = useMemo(() => {
     const {
       wrapper,
@@ -506,7 +499,10 @@ const ActualMultiCombobox = <T,>(
       onKeyDown={onDelegateKeyDown}
       onKeyPress={onDelegateKeyPress}
       className={classNames.wrapper}
-      style={wrapperStyle}
+      style={{
+        ...style,
+        width: typeof width === 'number' ? `${width}px` : width,
+      }}
     >
       <Scroller className={classNames.inputArea}>
         <ul

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -490,7 +490,7 @@ const ActualMultiCombobox = <T,>(
     }
   }, [isExpanded, disabled, className])
 
-  const { selectedListAriaLabel } = useLocalize({
+  const localized = useLocalize({
     selectedListAriaLabel: {
       id: 'smarthr-ui/MultiCombobox/selectedListAriaLabel',
       defaultText: '選択済みアイテム',
@@ -511,7 +511,7 @@ const ActualMultiCombobox = <T,>(
       <Scroller className={classNames.inputArea}>
         <ul
           id={selectedListId}
-          aria-label={selectedListAriaLabel}
+          aria-label={localized.selectedListAriaLabel}
           className={classNames.selectedList}
         >
           {selectedItems.map((selectedItem, i) => (

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -183,13 +183,15 @@ const ActualMultiCombobox = <T,>(
   }: Props<T>,
   ref: Ref<HTMLInputElement>,
 ) => {
-  const outerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLDivElement>(null)
   const [isExpanded, setIsExpanded] = useState(false)
   const [highlighted, setHighlighted] = useState(false)
   const isInputControlled = controlledInputValue !== undefined
   const [uncontrolledInputValue, setUncontrolledInputValue] = useState('')
   const inputValue = isInputControlled ? controlledInputValue : uncontrolledInputValue
   const [isComposing, setIsComposing] = useState(false)
+
+  const selectedListId = useId()
 
   const { options } = useMultiOptions({
     items,
@@ -198,7 +200,20 @@ const ActualMultiCombobox = <T,>(
     inputValue,
     isItemSelected,
   })
-  const setInputValueIfUncontrolled = isInputControlled ? NOOP : setUncontrolledInputValue
+  const selectedItemLength = selectedItems.length
+
+  const deletionButtonRefs = useMemo(() => {
+    const refs: Array<ReturnType<typeof createRef<HTMLButtonElement>>> = []
+
+    for (let i = 0; i < selectedItemLength; i++) {
+      refs[i] = createRef<HTMLButtonElement>()
+    }
+
+    return refs
+  }, [selectedItemLength])
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
 
   const latest = useLatest({
     onChange,
@@ -273,24 +288,9 @@ const ActualMultiCombobox = <T,>(
     onSelect: actualOnSelect,
     isExpanded,
     isLoading,
-    triggerRef: outerRef,
+    triggerRef,
     noResultText,
   })
-
-  const selectedItemLength = selectedItems.length
-
-  const deletionButtonRefs = useMemo(() => {
-    const refs: Array<ReturnType<typeof createRef<HTMLButtonElement>>> = []
-
-    for (let i = 0; i < selectedItemLength; i++) {
-      refs[i] = createRef<HTMLButtonElement>()
-    }
-
-    return refs
-  }, [selectedItemLength])
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
 
   const focusPrevDeletionButton = useCallback(() => {
     if (selectedItemLength === 0) {
@@ -348,24 +348,10 @@ const ActualMultiCombobox = <T,>(
     }
   }, [resetDeletionButtonFocus, latest])
 
-  const outerClickRef = useMemo(() => [outerRef, listBoxRef], [listBoxRef])
+  const outerClickRef = useMemo(() => [triggerRef, listBoxRef], [listBoxRef])
   useOuterClick(outerClickRef, blur)
 
-  useEffect(() => {
-    if (latest.highlighted) {
-      setHighlighted(false)
-      inputRef.current?.select()
-    } else {
-      setInputValueIfUncontrolled('')
-    }
-  }, [selectedItems, setInputValueIfUncontrolled, inputRef, latest])
-
-  useEffect(() => {
-    if (isExpanded) {
-      inputRef.current?.focus()
-    }
-  }, [isExpanded, setInputValueIfUncontrolled, selectedItems, inputRef])
-
+  const setInputValueIfUncontrolled = isInputControlled ? NOOP : setUncontrolledInputValue
   const isInputEmpty = !inputValue
 
   const onDelegateKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -457,7 +443,20 @@ const ActualMultiCombobox = <T,>(
     [latest],
   )
 
-  const selectedListId = useId()
+  useEffect(() => {
+    if (latest.highlighted) {
+      setHighlighted(false)
+      inputRef.current?.select()
+    } else {
+      setInputValueIfUncontrolled('')
+    }
+  }, [selectedItems, setInputValueIfUncontrolled, inputRef, latest])
+
+  useEffect(() => {
+    if (isExpanded) {
+      inputRef.current?.focus()
+    }
+  }, [isExpanded, setInputValueIfUncontrolled, selectedItems, inputRef])
 
   const classNames = useMemo(() => {
     const {
@@ -493,7 +492,7 @@ const ActualMultiCombobox = <T,>(
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <div
-      ref={outerRef}
+      ref={triggerRef}
       role="group"
       onClick={onDelegateClick}
       onKeyDown={onDelegateKeyDown}

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -217,7 +217,7 @@ const ActualMultiCombobox = <T,>(
     isComposing,
   })
 
-  const actualOnDelete = useCallback(
+  const handleDelete = useCallback(
     (item: ComboboxItem<T>) => {
       const handlers: Array<(deletingItem: ComboboxItem<T>) => void> = []
 
@@ -258,11 +258,11 @@ const ActualMultiCombobox = <T,>(
           // 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
           latest.onChangeInput?.(EMPTY_INPUT_CHANGE_EVENT)
         } else if (matchedSelectedItem.deletable !== false) {
-          actualOnDelete(selected)
+          handleDelete(selected)
         }
       })
     },
-    [actualOnDelete, latest],
+    [handleDelete, latest],
   )
 
   const { listBoxProps, activeOption, handleKeyDownListBox, listBoxId, listBoxRef } = useListbox({
@@ -398,7 +398,7 @@ const ActualMultiCombobox = <T,>(
 
       const lastItem = selectedItems[selectedItems.length - 1]
 
-      actualOnDelete(lastItem)
+      handleDelete(lastItem)
       setHighlighted(true)
       setInputValueIfUncontrolled(innerText(lastItem.label))
     } else {
@@ -519,7 +519,7 @@ const ActualMultiCombobox = <T,>(
               <MultiSelectedItem
                 item={selectedItem}
                 disabled={disabled}
-                handleDelete={actualOnDelete}
+                handleDelete={handleDelete}
                 enableEllipsis={selectedItemEllipsis}
                 buttonRef={deletionButtonRefs[i]}
               />
@@ -561,12 +561,7 @@ const ActualMultiCombobox = <T,>(
         )}
       </Scroller>
 
-      <MemoizedCaretDown
-        disabled={disabled}
-        isExpanded={isExpanded}
-        className={classNames.suffixWrapper}
-        iconStyle={classNames.suffixIcon}
-      />
+      <MemoizedCaretDown disabled={disabled} isExpanded={isExpanded} classNames={classNames} />
 
       <ListBox {...listBoxProps} />
     </div>
@@ -576,11 +571,13 @@ const ActualMultiCombobox = <T,>(
 export const MultiCombobox = genericsForwardRef(ActualMultiCombobox)
 
 const MemoizedCaretDown = memo<{
-  className: string
-  iconStyle: string
   disabled: boolean
   isExpanded: boolean
-}>(({ className, iconStyle, disabled, isExpanded }) => {
+  className: {
+    suffixWrapper: string
+    suffixIcon: string
+  }
+}>(({ disabled, isExpanded, classNames }) => {
   const theme = useTheme()
   const caretIconColor = isExpanded
     ? theme.textColor.black
@@ -589,8 +586,8 @@ const MemoizedCaretDown = memo<{
       : theme.textColor.grey
 
   return (
-    <div className={className}>
-      <FaCaretDownIcon color={caretIconColor} className={iconStyle} />
+    <div className={classNames.suffixWrapper}>
+      <FaCaretDownIcon color={caretIconColor} className={classNames.suffixIcon} />
     </div>
   )
 })

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -568,7 +568,7 @@ export const MultiCombobox = genericsForwardRef(ActualMultiCombobox)
 const MemoizedCaretDown = memo<{
   disabled: boolean
   isExpanded: boolean
-  className: {
+  classNames: {
     suffixWrapper: string
     suffixIcon: string
   }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`MultiCombobox` に残っていた小規模なリファクタリングをまとめて適用する。

## 変更内容

- `actualOnDelete` を `handleDelete` にrename、`MemoizedCaretDown` のpropsを `classNames` オブジェクトに統合
- `useLocalize` の戻り値を `localized` オブジェクトに変更（一貫性向上）
- `wrapperStyle` の `useMemo` を削除してインラインスタイルに変更
- `outerRef` を `triggerRef` にrename、宣言順を整理

いずれも振る舞いの変化はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存テストの通過で確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 複数選択コンボボックスで、項目の選択解除やキーボードによる削除をより一貫して処理できるよう改善しました。
  * 選択項目の削除後も、入力欄のリセットとフォーカス移動が適切に行われるようになりました。
  * ドロップダウンの開閉やフォーカス時の表示が安定しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->