### PR TITLE
refactor(Chip): defaultVariants削除・disabledをdata属性セレクタに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Chip/Chip.tsx
+++ b/packages/smarthr-ui/src/components/Chip/Chip.tsx
@@ -2,7 +2,8 @@ import { type ComponentPropsWithoutRef, type FC, type PropsWithChildren, useMemo
 import { type VariantProps, tv } from 'tailwind-variants'
 
 type Props = PropsWithChildren<
-  VariantProps<typeof classNameGenerator> & ComponentPropsWithoutRef<'span'>
+  VariantProps<typeof classNameGenerator> &
+    ComponentPropsWithoutRef<'span'> & { disabled?: boolean }
 >
 
 const classNameGenerator = tv({
@@ -10,6 +11,7 @@ const classNameGenerator = tv({
     'smarthr-ui-Chip',
     'shr-border-shorthand shr-rounded-full shr-bg-white shr-leading-none shr-text-black',
     'contrast-more:shr-border-high-contrast',
+    'data-[disabled]:shr-bg-white/50 data-[disabled]:shr-text-disabled',
   ],
   variants: {
     color: {
@@ -22,17 +24,14 @@ const classNameGenerator = tv({
     size: {
       S: 'shr-px-0.5 shr-py-0.25 shr-text-sm',
     },
-    disabled: {
-      true: 'shr-bg-white/50 shr-text-disabled',
-    },
   },
 })
 
 export const Chip: FC<Props> = ({ size, color, disabled, className, ...rest }) => {
   const actualClassName = useMemo(
-    () => classNameGenerator({ size: size || 'S', color: color || 'grey', disabled, className }),
-    [size, color, disabled, className],
+    () => classNameGenerator({ size: size || 'S', color: color || 'grey', className }),
+    [size, color, className],
   )
 
-  return <span {...rest} className={actualClassName} />
+  return <span {...rest} data-disabled={disabled || undefined} className={actualClassName} />
 }

--- a/packages/smarthr-ui/src/components/Chip/Chip.tsx
+++ b/packages/smarthr-ui/src/components/Chip/Chip.tsx
@@ -26,16 +26,13 @@ const classNameGenerator = tv({
       true: 'shr-bg-white/50 shr-text-disabled',
     },
   },
-  defaultVariants: {
-    size: 'S',
-    color: 'grey',
-  },
 })
 
 export const Chip: FC<Props> = ({ size, color, disabled, className, ...rest }) => {
   const actualClassName = useMemo(
-    () => classNameGenerator({ size, color, disabled, className }),
+    () => classNameGenerator({ size: size || 'S', color: color || 'grey', disabled, className }),
     [size, color, disabled, className],
   )
+
   return <span {...rest} className={actualClassName} />
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Chip` コンポーネントの小規模なリファクタリング。`tv()` の `defaultVariants` と `disabled` variant を整理する。

## 変更内容

- `defaultVariants: { size: 'S', color: 'grey' }` を削除し、呼び出し側で `size || 'S'`、`color || 'grey'` として明示的にフォールバック
- `disabled` variant（`shr-bg-white/50 shr-text-disabled`）を削除し、`data-[disabled]:` Tailwindセレクタに変更
- `<span>` に `data-disabled={disabled || undefined}` を渡すことでCSSで制御
- `actualClassName` の `useMemo` 依存配列から `disabled` を除去

いずれも振る舞いの変化はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook での動作確認、または既存テストの通過で確認。