### PR TITLE
refactor(Dropdown): useCallbackをuseMemoのfunctionsパターンに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -10,6 +10,7 @@ import {
   useContext,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
 } from 'react'

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -30,7 +30,7 @@ type DropdownContextType = {
   triggerRect: Rect
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
-  memoizedOnClickTrigger: (rect: Rect) => void
+  handleClickTrigger: (rect: Rect) => void
   handleDelegateClickCloser: () => void
   DropdownContentRoot: FC<{ children: ReactNode }>
   contentId: string
@@ -43,7 +43,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   triggerRect: initialRect,
   triggerElementRef: createRef(),
   rootTriggerRef: null,
-  memoizedOnClickTrigger: () => {
+  handleClickTrigger: () => {
     /* noop */
   },
   handleDelegateClickCloser: () => {
@@ -82,7 +82,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
 
     return {
       DropdownContentRoot,
-      memoizedOnClickTrigger: (rect: Rect) => {
+      handleClickTrigger: (rect: Rect) => {
         setActive((current) => {
           const newActive = !current
 
@@ -135,7 +135,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerRect,
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
-          memoizedOnClickTrigger: functions.memoizedOnClickTrigger,
+          handleClickTrigger: functions.handleClickTrigger,
           handleDelegateClickCloser: functions.handleDelegateClickCloser,
           DropdownContentRoot: functions.DropdownContentRoot,
           contentId,

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,6 @@ import {
   type ReactNode,
   createContext,
   createRef,
-  useCallback,
   useContext,
   useEffect,
   useId,
@@ -74,31 +73,33 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     createPortal,
   })
 
-  // This is the root container of a dropdown content located in outside the DOM tree
-  const DropdownContentRoot = useCallback<FC<{ children: ReactNode }>>(
-    (props) => (latest.active ? latest.createPortal(props.children) : null),
-    [latest],
-  )
-  DropdownContentRoot.displayName = 'DropdownContentRoot'
+  const functions = useMemo(() => {
+    // This is the root container of a dropdown content located in outside the DOM tree
+    const DropdownContentRoot: FC<{ children: ReactNode }> = (props) =>
+      latest.active ? latest.createPortal(props.children) : null
+    DropdownContentRoot.displayName = 'DropdownContentRoot'
 
-  const memoizedOnClickTrigger = useCallback((rect: Rect) => {
-    setActive((current) => {
-      const newActive = !current
+    return {
+      DropdownContentRoot,
+      memoizedOnClickTrigger: (rect: Rect) => {
+        setActive((current) => {
+          const newActive = !current
 
-      if (newActive) {
-        setTriggerRect(rect)
-      }
+          if (newActive) {
+            setTriggerRect(rect)
+          }
 
-      return newActive
-    })
-  }, [])
+          return newActive
+        })
+      },
+      handleDelegateClickCloser: () => {
+        setActive(false)
 
-  const handleDelegateClickCloser = useCallback(() => {
-    setActive(false)
-
-    // return focus to the Trigger
-    getFirstTabbable(triggerElementRef)?.focus()
-  }, [])
+        // return focus to the Trigger
+        getFirstTabbable(triggerElementRef)?.focus()
+      },
+    }
+  }, [latest])
 
   useEffect(() => {
     if (latest.portalRoot) {
@@ -133,9 +134,9 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerRect,
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
-          memoizedOnClickTrigger,
-          handleDelegateClickCloser,
-          DropdownContentRoot,
+          memoizedOnClickTrigger: functions.memoizedOnClickTrigger,
+          handleDelegateClickCloser: functions.handleDelegateClickCloser,
+          DropdownContentRoot: functions.DropdownContentRoot,
           contentId,
         }}
       >

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -43,8 +43,7 @@ const classNameGenerator = tv({
 })
 
 export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => {
-  const { active, memoizedOnClickTrigger, contentId, triggerElementRef } =
-    useContext(DropdownContext)
+  const { active, handleClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
   useEffect(() => {
@@ -84,7 +83,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
       // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
       // そのためcaptureで開く処理を実行する
       const callback = (e: MouseEvent) => {
-        memoizedOnClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
+        handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
       }
 
       button.addEventListener('click', callback, CAPTURE_OPTION)
@@ -110,7 +109,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
       currentCleanup?.()
       observer.disconnect()
     }
-  }, [memoizedOnClickTrigger, triggerElementRef])
+  }, [handleClickTrigger, triggerElementRef])
 
   return (
     <div ref={triggerElementRef} className={actualClassName}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Dropdown` コンポーネントの複数の `useCallback` を `useLatest + functions` パターンに統合するリファクタリング。

## 変更内容

- `DropdownContentRoot`・`memoizedOnClickTrigger`・`handleDelegateClickCloser` の3つの `useCallback` を削除
- `useMemo([latest])` による `functions` オブジェクトにまとめて統合
- `useCallback` の import を削除

振る舞いの変化はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存テストの通過で確認。