### PR TITLE
fix(Dialog): closeButtonのtext型をオプショナルに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
@@ -34,7 +34,7 @@ type ObjectActionButtonType = {
 
 type ObjectCloseButtonType = {
   /** 閉じるボタンのラベル */
-  text: ReactNode
+  text?: ReactNode
   /** 閉じるボタンを無効にするかどうか */
   disabled?: boolean
 }

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
@@ -26,7 +26,7 @@ type ObjectActionButtonType = {
 
 type ObjectCloseButtonType = {
   /** 閉じるボタンのラベル */
-  text: ReactNode
+  text?: ReactNode
   /** 閉じるボタンを無効にするかどうか */
   disabled?: boolean
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`ActionDialog`・`FormDialog` の `closeButton` オブジェクト型で `text` が必須になっていたが、実装側では `text ?? <Localizer ...>` でデフォルト値（「キャンセル」）にフォールバックしている。型と実装が不一致だったため、型を `text?: ReactNode` に修正する。

## 変更内容

- `ActionDialogContentInner` の `ObjectCloseButtonType.text`: `ReactNode` → `ReactNode | undefined`（オプショナル化）
- `FormDialogContentInner` の `ObjectCloseButtonType.text`: `ReactNode` → `ReactNode | undefined`（オプショナル化）

## プロダクト側で対応が必要な事項

なし（型の緩和のみ。`text` を省略した場合はデフォルトで「キャンセル」が表示される）

## 確認方法

既存テストの通過で確認。