### PR TITLE
fix(PageHeading): React 18でページタイトルが自動設定されない問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
@@ -18,6 +18,7 @@ describe('Heading', () => {
     const ref = createRef<HTMLHeadingElement>()
     render(<Heading ref={ref}>見出し</Heading>)
 
+    expect(ref.current?.tagName).toBe('H1')
     expect(ref.current?.textContent).toBe('見出し')
   })
 
@@ -29,6 +30,7 @@ describe('Heading', () => {
       </Heading>,
     )
 
+    expect(ref.current?.tagName).toBe('H1')
     expect(ref.current?.textContent).toBe('見出し')
   })
 })

--- a/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable smarthr/a11y-heading-in-sectioning-content */
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+
+import { Heading } from './Heading'
+
+describe('Heading', () => {
+  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
+  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
+  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+    const memoized = Heading as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
+
+    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
+    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
+  })
+
+  test('ref を転送する', () => {
+    const ref = createRef<HTMLHeadingElement>()
+    render(<Heading ref={ref}>見出し</Heading>)
+
+    expect(ref.current?.textContent).toBe('見出し')
+  })
+
+  test('visuallyHidden でも ref を転送する', () => {
+    const ref = createRef<HTMLHeadingElement>()
+    render(
+      <Heading ref={ref} visuallyHidden>
+        見出し
+      </Heading>,
+    )
+
+    expect(ref.current?.textContent).toBe('見出し')
+  })
+})

--- a/packages/smarthr-ui/src/components/Heading/Heading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { type ComponentProps, type PropsWithChildren, memo, useContext, useMemo } from 'react'
+import {
+  type ComponentProps,
+  type PropsWithChildren,
+  forwardRef,
+  memo,
+  useContext,
+  useMemo,
+} from 'react'
 import { tv } from 'tailwind-variants'
 
 import { LevelContext } from '../SectioningContent'
@@ -62,37 +69,43 @@ const classNameGenerator = tv({
   },
 })
 
-export const Heading = memo<Props>(
-  ({ unrecommendedTag, type = 'sectionTitle', size, className, visuallyHidden, icon, ...rest }) => {
-    const level = useContext(LevelContext)
+export const Heading = memo(
+  forwardRef<HTMLHeadingElement, Props>(
+    (
+      { unrecommendedTag, type = 'sectionTitle', size, className, visuallyHidden, icon, ...rest },
+      ref,
+    ) => {
+      const level = useContext(LevelContext)
 
-    let role = undefined
-    let ariaLevel = undefined
+      let role = undefined
+      let ariaLevel = undefined
 
-    // TODO: h1はPageHeadingで設定するため、自動計算では必ずh2以下になるようにする
-    if (!unrecommendedTag && level > 6) {
-      role = 'heading'
-      ariaLevel = level
-    }
+      // TODO: h1はPageHeadingで設定するため、自動計算では必ずh2以下になるようにする
+      if (!unrecommendedTag && level > 6) {
+        role = 'heading'
+        ariaLevel = level
+      }
 
-    const actualClassName = useMemo(
-      () => classNameGenerator({ visuallyHidden, className }),
-      [className, visuallyHidden],
-    )
-    const typography = STYLE_TYPE_MAP[type]
+      const actualClassName = useMemo(
+        () => classNameGenerator({ visuallyHidden, className }),
+        [className, visuallyHidden],
+      )
+      const typography = STYLE_TYPE_MAP[type]
 
-    const commonProps = {
-      as: unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span'),
-      role,
-      'aria-level': ariaLevel,
-      className: actualClassName,
-      size: type === 'sectionTitle' && size ? size : typography.size,
-    }
+      const commonProps = {
+        as: unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span'),
+        role,
+        'aria-level': ariaLevel,
+        className: actualClassName,
+        size: type === 'sectionTitle' && size ? size : typography.size,
+        ref,
+      }
 
-    if (visuallyHidden) {
-      return <VisuallyHiddenText {...rest} {...typography} {...commonProps} />
-    }
+      if (visuallyHidden) {
+        return <VisuallyHiddenText {...rest} {...typography} {...commonProps} />
+      }
 
-    return <Text {...rest} {...typography} {...commonProps} icon={icon} />
-  },
+      return <Text {...rest} {...typography} {...commonProps} icon={icon} />
+    },
+  ),
 )

--- a/packages/smarthr-ui/src/components/Heading/Heading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.tsx
@@ -92,6 +92,8 @@ export const Heading = memo(
       )
       const typography = STYLE_TYPE_MAP[type]
 
+      // HINT: unrecommendedTag未指定かつlevel>6の場合はspan要素になるが、
+      // refの型はHTMLHeadingElementのままにしている（呼び出し側は基本的にh1〜h6を期待するため）
       const commonProps = {
         as: unrecommendedTag || ((level <= 6 ? `h${level}` : 'span') as HeadingTagTypes | 'span'),
         role,

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable smarthr/a11y-heading-in-sectioning-content */
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import { createRef } from 'react'
 
 import { PageHeading } from './PageHeading'
 
@@ -10,6 +11,15 @@ describe('PageHeading', () => {
     document.title = ''
   })
 
+  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
+  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
+  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+    const memoized = PageHeading as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
+
+    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
+    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
+  })
+
   test('ページのタイトルを自動で設定する', async () => {
     render(<PageHeading>これはタイトルです</PageHeading>)
 
@@ -18,6 +28,53 @@ describe('PageHeading', () => {
     expect(document.querySelector(`*[aria-live="polite"]`)).toHaveTextContent(
       'これはタイトルです｜SmartHR（スマートHR）',
     )
+  })
+
+  test('visuallyHiddenでもページのタイトルを自動で設定する', async () => {
+    render(<PageHeading visuallyHidden>これはタイトルです</PageHeading>)
+
+    await waitForAnimationFrame()
+    expect(document.title).toBe('これはタイトルです｜SmartHR（スマートHR）')
+  })
+
+  test('childrenの変更にページのタイトルが追従する', async () => {
+    const { rerender } = render(<PageHeading>これはタイトルです</PageHeading>)
+
+    await waitForAnimationFrame()
+    expect(document.title).toBe('これはタイトルです｜SmartHR（スマートHR）')
+
+    rerender(<PageHeading>タイトルが変わりました</PageHeading>)
+
+    await waitFor(() => {
+      expect(document.title).toBe('タイトルが変わりました｜SmartHR（スマートHR）')
+    })
+  })
+
+  test('pageTitleSuffixに空文字を渡すとsuffixを空にできる', async () => {
+    render(<PageHeading pageTitleSuffix="">これはタイトルです</PageHeading>)
+
+    await waitForAnimationFrame()
+    expect(document.title).toBe('これはタイトルです｜')
+  })
+
+  test('利用者が渡したrefにh1要素を設定する', async () => {
+    const ref = createRef<HTMLHeadingElement>()
+    render(<PageHeading ref={ref}>これはタイトルです</PageHeading>)
+
+    await waitForAnimationFrame()
+    expect(ref.current?.tagName).toBe('H1')
+    expect(document.title).toBe('これはタイトルです｜SmartHR（スマートHR）')
+  })
+
+  test('autoPageTitle=falseでも利用者が渡したrefにh1要素を設定する', () => {
+    const ref = createRef<HTMLHeadingElement>()
+    render(
+      <PageHeading ref={ref} autoPageTitle={false}>
+        これはタイトルです
+      </PageHeading>,
+    )
+
+    expect(ref.current?.tagName).toBe('H1')
   })
 
   test('autoPageTitle=falseではページのタイトルを設定しない', async () => {

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
@@ -50,11 +50,11 @@ describe('PageHeading', () => {
     })
   })
 
-  test('pageTitleSuffixに空文字を渡すとsuffixを空にできる', async () => {
+  test('pageTitleSuffixに空文字を渡すと区切り文字を含めずsuffixを空にできる', async () => {
     render(<PageHeading pageTitleSuffix="">これはタイトルです</PageHeading>)
 
     await waitForAnimationFrame()
-    expect(document.title).toBe('これはタイトルです｜')
+    expect(document.title).toBe('これはタイトルです')
   })
 
   test('利用者が渡したrefにh1要素を設定する', async () => {

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -108,7 +108,8 @@ const AutoPageTitleHeading: FC<
     if (!h1) return
 
     const updateTitle = () => {
-      document.title = `${pageTitle || h1.textContent || ''}｜${pageTitleSuffix}`
+      const title = pageTitle || h1.textContent || ''
+      document.title = pageTitleSuffix ? `${title}｜${pageTitleSuffix}` : title
 
       // HINT: SPAで遷移する場合などの対策としてbody直下にaria-liveを仕込む
       // head内はスクリーンリーダーの変更検知のチェック対象外のため、title要素にaria-liveは設定しない

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -2,12 +2,15 @@
 
 import {
   type FC,
+  type ForwardedRef,
   type PropsWithChildren,
   type ReactNode,
   type Ref,
+  forwardRef,
   memo,
   useEffect,
   useId,
+  useImperativeHandle,
   useMemo,
   useRef,
 } from 'react'
@@ -53,38 +56,59 @@ const classNameGenerator = tv({
   },
 })
 
-export const PageHeading = memo<Props>(
-  ({ autoPageTitle = true, pageTitleSuffix, pageTitle, size = 'XL', children, ...rest }) =>
-    !IS_NEXT_JS && autoPageTitle ? (
-      <AutoPageTitleHeading
-        {...rest}
-        size={size}
-        pageTitleSuffix={pageTitleSuffix}
-        pageTitle={pageTitle}
-      >
-        {children}
-      </AutoPageTitleHeading>
-    ) : (
-      <ActualHeading {...rest} size={size}>
-        {children}
-      </ActualHeading>
-    ),
+export const PageHeading = memo(
+  forwardRef<HTMLHeadingElement, Props>(
+    (
+      {
+        autoPageTitle = true,
+        pageTitleSuffix = 'SmartHR（スマートHR）',
+        pageTitle,
+        size = 'XL',
+        children,
+        ...rest
+      },
+      ref,
+    ) =>
+      !IS_NEXT_JS && autoPageTitle ? (
+        <AutoPageTitleHeading
+          {...rest}
+          size={size}
+          pageTitleSuffix={pageTitleSuffix}
+          pageTitle={pageTitle}
+          outerRef={ref}
+        >
+          {children}
+        </AutoPageTitleHeading>
+      ) : (
+        <ActualHeading {...rest} size={size} headingRef={ref}>
+          {children}
+        </ActualHeading>
+      ),
+  ),
 )
 
 const AutoPageTitleHeading: FC<
-  Omit<Props, 'size' | 'autoPageTitle'> & {
+  Omit<Props, 'size' | 'autoPageTitle' | 'pageTitleSuffix' | 'ref'> & {
     size: TextProps['size']
+    pageTitleSuffix: string
+    outerRef?: ForwardedRef<HTMLHeadingElement>
   }
-> = ({ pageTitleSuffix, pageTitle, children, ...rest }) => {
+> = ({ pageTitleSuffix, pageTitle, outerRef, children, ...rest }) => {
   const pseudoTitleId = useId()
-  const ref = useRef<HTMLHeadingElement>(null)
+  // HINT: h1のテキストをMutationObserverで監視するために内部でrefを保持しつつ、利用者のrefにも要素を渡す
+  const innerRef = useRef<HTMLHeadingElement | null>(null)
+
+  useImperativeHandle<HTMLHeadingElement | null, HTMLHeadingElement | null>(
+    outerRef,
+    () => innerRef.current,
+  )
 
   useEffect(() => {
-    const h1 = ref.current
+    const h1 = innerRef.current
     if (!h1) return
 
     const updateTitle = () => {
-      document.title = `${pageTitle || h1.textContent || ''}｜${pageTitleSuffix || 'SmartHR（スマートHR）'}`
+      document.title = `${pageTitle || h1.textContent || ''}｜${pageTitleSuffix}`
 
       // HINT: SPAで遷移する場合などの対策としてbody直下にaria-liveを仕込む
       // head内はスクリーンリーダーの変更検知のチェック対象外のため、title要素にaria-liveは設定しない
@@ -120,7 +144,7 @@ const AutoPageTitleHeading: FC<
   }, [pageTitle, pageTitleSuffix, pseudoTitleId])
 
   return (
-    <ActualHeading {...rest} headingRef={ref}>
+    <ActualHeading {...rest} headingRef={innerRef}>
       {children}
     </ActualHeading>
   )
@@ -132,7 +156,7 @@ type ActualHeadingProps = {
   className?: string
   children: ReactNode
   headingRef?: Ref<HTMLHeadingElement>
-} & Omit<ElementProps, 'size' | 'className' | 'visuallyHidden' | 'children'>
+} & Omit<ElementProps, 'size' | 'className' | 'visuallyHidden' | 'children' | 'ref'>
 
 const ActualHeading: FC<ActualHeadingProps> = ({
   visuallyHidden,

--- a/packages/smarthr-ui/src/components/Text/Text.test.tsx
+++ b/packages/smarthr-ui/src/components/Text/Text.test.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable smarthr/best-practice-for-text-component */
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+
+import { Text } from './Text'
+
+describe('Text', () => {
+  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
+  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
+  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+    const memoized = Text as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
+
+    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
+    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
+  })
+
+  test('ref を転送する', () => {
+    const ref = createRef<HTMLSpanElement>()
+    render(<Text ref={ref}>テキスト</Text>)
+
+    expect(ref.current?.tagName).toBe('SPAN')
+  })
+})

--- a/packages/smarthr-ui/src/components/Text/Text.tsx
+++ b/packages/smarthr-ui/src/components/Text/Text.tsx
@@ -1,8 +1,11 @@
 import {
   type ComponentProps,
   type ElementType,
+  type FC,
   type PropsWithChildren,
   type ReactNode,
+  type Ref,
+  forwardRef,
   memo,
   useMemo,
 } from 'react'
@@ -11,7 +14,7 @@ import { type VariantProps, tv } from 'tailwind-variants'
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 
 import type { AbstractSize, CharRelativeSize } from '../../themes'
-import type { Gap } from '../../types'
+import type { ElementRef, Gap } from '../../types'
 
 type StyleType =
   'screenTitle' | 'sectionTitle' | 'blockTitle' | 'subBlockTitle' | 'subSubBlockTitle'
@@ -170,66 +173,76 @@ export type TextProps<T extends ElementType = 'span'> = VariantProps<typeof clas
   icon?: IconType
 }
 
+// HINT: ComponentProps<T> が ref を含むため、TextLink などのように ElementRefProps<T> は付与しない
+type ActualTextProps<T extends ElementType> = PropsWithChildren<TextProps<T> & ComponentProps<T>>
+
+type TextComponent = <T extends ElementType = 'span'>(props: ActualTextProps<T>) => ReturnType<FC>
+
 const iconObjectConverter = (icon: ReactNode) => (icon ? { prefix: icon } : undefined)
 
-const ActualText = <T extends ElementType = 'span'>({
-  emphasis,
-  styleType,
-  icon: orgIcon,
-  weight = emphasis ? 'bold' : undefined,
-  as: Component = emphasis ? 'em' : 'span',
-  size,
-  italic,
-  color,
-  leading,
-  whiteSpace,
-  maxLines,
-  className,
-  children,
-  ...rest
-}: PropsWithChildren<TextProps<T> & ComponentProps<T>>) => {
-  if (maxLines !== undefined && (maxLines < 1 || maxLines > 6)) {
-    throw new Error('"maxLines" は 1 ~ 6 の範囲で指定してください')
-  }
-
-  const icon = useObjectAttributes<IconType, ActualIconType>(orgIcon, iconObjectConverter)
-  const actualClassName = useMemo(() => {
-    const styleTypeValues = styleType
-      ? STYLE_TYPE_MAP[styleType as StyleType]
-      : UNDEFINED_STYLE_VALUES
-
-    return classNameGenerator({
-      size: size || styleTypeValues.size,
-      weight: weight || styleTypeValues.weight,
-      color: color || styleTypeValues.color,
-      leading: leading || styleTypeValues.leading,
+const ActualText: TextComponent = forwardRef(
+  <T extends ElementType = 'span'>(
+    {
+      emphasis,
+      styleType,
+      icon: orgIcon,
+      weight = emphasis ? 'bold' : undefined,
+      as: Component = emphasis ? 'em' : 'span',
+      size,
       italic,
+      color,
+      leading,
       whiteSpace,
       maxLines,
       className,
-    })
-  }, [size, weight, italic, color, leading, whiteSpace, maxLines, className, styleType])
-  const hasIcon = !!icon
-  const iconGap = icon?.gap
+      children,
+      ...rest
+    }: ActualTextProps<T>,
+    ref: Ref<ElementRef<T>>,
+  ) => {
+    if (maxLines !== undefined && (maxLines < 1 || maxLines > 6)) {
+      throw new Error('"maxLines" は 1 ~ 6 の範囲で指定してください')
+    }
 
-  const wrapperClassName = useMemo(
-    () => (hasIcon ? wrapperClassNameGenerator({ gap: iconGap || 0.25 }) : ''),
-    [hasIcon, iconGap],
-  )
+    const icon = useObjectAttributes<IconType, ActualIconType>(orgIcon, iconObjectConverter)
+    const actualClassName = useMemo(() => {
+      const styleTypeValues = styleType
+        ? STYLE_TYPE_MAP[styleType as StyleType]
+        : UNDEFINED_STYLE_VALUES
 
-  return (
-    <Component {...rest} className={actualClassName}>
-      {icon ? (
-        <span className={wrapperClassName}>
-          {icon.prefix}
-          {children}
-          {icon.suffix}
-        </span>
-      ) : (
-        children
-      )}
-    </Component>
-  )
-}
+      return classNameGenerator({
+        size: size || styleTypeValues.size,
+        weight: weight || styleTypeValues.weight,
+        color: color || styleTypeValues.color,
+        leading: leading || styleTypeValues.leading,
+        italic,
+        whiteSpace,
+        maxLines,
+        className,
+      })
+    }, [size, weight, italic, color, leading, whiteSpace, maxLines, className, styleType])
+    const hasIcon = !!icon
+    const iconGap = icon?.gap
+
+    const wrapperClassName = useMemo(
+      () => (hasIcon ? wrapperClassNameGenerator({ gap: iconGap || 0.25 }) : ''),
+      [hasIcon, iconGap],
+    )
+
+    return (
+      <Component {...rest} ref={ref} className={actualClassName}>
+        {icon ? (
+          <span className={wrapperClassName}>
+            {icon.prefix}
+            {children}
+            {icon.suffix}
+          </span>
+        ) : (
+          children
+        )}
+      </Component>
+    )
+  },
+)
 
 export const Text = memo(ActualText) as typeof ActualText

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.test.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+
+import { VisuallyHiddenText } from './VisuallyHiddenText'
+
+describe('VisuallyHiddenText', () => {
+  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
+  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
+  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+    const memoized = VisuallyHiddenText as unknown as {
+      $$typeof: symbol
+      type: { $$typeof: symbol }
+    }
+
+    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
+    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
+  })
+
+  test('ref を転送する', () => {
+    const ref = createRef<HTMLSpanElement>()
+    render(<VisuallyHiddenText ref={ref}>テキスト</VisuallyHiddenText>)
+
+    expect(ref.current?.tagName).toBe('SPAN')
+  })
+})

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
@@ -1,5 +1,16 @@
-import { type ComponentProps, type ElementType, type PropsWithChildren, memo, useMemo } from 'react'
+import {
+  type ComponentProps,
+  type ElementType,
+  type FC,
+  type PropsWithChildren,
+  type Ref,
+  forwardRef,
+  memo,
+  useMemo,
+} from 'react'
 import { tv } from 'tailwind-variants'
+
+import type { ElementRef } from '../../types'
 
 const visuallyHiddenTextClassNameGenerator = tv({
   base: 'shr-absolute shr-h-px shr-w-px shr-overflow-hidden shr-whitespace-nowrap shr-border-0 shr-p-0 [clip-path:inset(100%)] [clip:rect(0_0_0_0)]',
@@ -7,22 +18,34 @@ const visuallyHiddenTextClassNameGenerator = tv({
 
 export const visuallyHiddenTextClassName = visuallyHiddenTextClassNameGenerator()
 
+// HINT: ComponentProps<T> が ref を含むため、TextLink などのように ElementRefProps<T> は付与しない
 type Props<T extends ElementType> = PropsWithChildren<{
   as?: T
 }> &
   ComponentProps<T>
 
-const ActualVisuallyHiddenText = <T extends ElementType = 'span'>({
-  as: Component = 'span',
-  className,
-  ...rest
-}: Props<T>) => {
-  const actualClassName = useMemo(
-    () => visuallyHiddenTextClassNameGenerator({ className }),
-    [className],
-  )
+type VisuallyHiddenTextComponent = <T extends ElementType = 'span'>(
+  props: Props<T>,
+) => ReturnType<FC>
 
-  return <Component {...rest} className={`smarthr-ui-VisuallyHiddenText ${actualClassName}`} />
-}
+const ActualVisuallyHiddenText: VisuallyHiddenTextComponent = forwardRef(
+  <T extends ElementType = 'span'>(
+    { as: Component = 'span', className, ...rest }: Props<T>,
+    ref: Ref<ElementRef<T>>,
+  ) => {
+    const actualClassName = useMemo(
+      () => visuallyHiddenTextClassNameGenerator({ className }),
+      [className],
+    )
+
+    return (
+      <Component
+        {...rest}
+        ref={ref}
+        className={`smarthr-ui-VisuallyHiddenText ${actualClassName}`}
+      />
+    )
+  },
+)
 
 export const VisuallyHiddenText = memo(ActualVisuallyHiddenText) as typeof ActualVisuallyHiddenText


### PR DESCRIPTION
## 関連URL

なし

## 概要

v99.1.0 で `PageHeading` の `document.title` 自動設定が **React 18 環境では一切動作しなくなっていた** ため、これを修正します。

v99.1.0 のコミット 35e860e8 で、title の算出方法が `react-innertext` の `innerText(children)` から「実 DOM の `h1.textContent` を読み、`MutationObserver` で追従する」方式に変わりました。この変更により `Text` / `VisuallyHiddenText` へ `ref` を渡すようになりましたが、両コンポーネントは `memo()` した関数コンポーネントのままで `forwardRef` していませんでした。

React 19 は `ref` を通常の props として扱うため動作しますが、React 18 は `ref` を props から取り除くため関数コンポーネントには届かず、`ref.current` が `null` のまま `useEffect` が early return し、`document.title` が設定されません。React 18 では以下の警告も出ます。

```
Warning: Function components cannot be given refs. ... Check the render method of `ActualHeading`.
```

`peerDependencies` は `react: ^18.0.0 || ^19.0.0` を宣言しているため、peer の契約違反になっている状態でした。CI・ローカルのテストが React 19 のみで動いているため検知できていませんでした。

## 変更内容

### 1. `Text` / `VisuallyHiddenText` を forwardRef 化（本体の修正）

既存の `TextLink` と同じ `memo(forwardRef())` の形に揃えています。ポリモーフィックなため ref の型には `src/types/ComponentTypes.ts` の `ElementRef<T>` を使用しました。

**公開する props の型は変わりません。** `ComponentProps<T>` が元々 `ref` を含んでいるため、`ref` を渡すコードは今までどおり型チェックを通り、React 18 でも実際に転送されるようになります。

### 2. `Heading` / `PageHeading` を forwardRef 化

どちらも型の上では `ref` を受け取れるのに、React 18 では黙って捨てていたため同じ穴を塞いでいます。

### 3. 利用者が渡した `ref` を尊重するよう修正

`ActualHeading` が `{...rest}` の後に `ref={headingRef}` を書いていたため、利用者が `PageHeading` に渡した `ref` が内部の ref に上書きされて捨てられていました（React 19 では v99.0.0 まで届いていました）。`Input` と同じ `useImperativeHandle` パターンで、内部の ref と利用者の ref を両立させています。

### 4. `pageTitleSuffix` に空文字を渡せるよう修正

同じコミットで `pageTitleSuffix` のデフォルト値がデフォルト引数から `||` フォールバックへ変わっており、空文字を渡しても suffix を空にできなくなっていました。v99.0.0 の挙動に戻しています。

```tsx
// v99.1.0（suffix が空にならない）
<PageHeading pageTitleSuffix="">タイトル</PageHeading>
// → document.title = "タイトル｜SmartHR（スマートHR）"

// このPR適用後（v99.0.0 と同じ）
<PageHeading pageTitleSuffix="">タイトル</PageHeading>
// → document.title = "タイトル｜"
```

-> 末尾に `|` が残らないように修正済み https://github.com/kufu/smarthr-ui/commit/0a432b47

### 5. テストを追加

React 19 上でしか CI が回らないため、挙動のテストだけでは同種のデグレを検知できません。そこで `memo(forwardRef())` でラップされているという構造そのものを検証するテストを、対象 4 コンポーネントに追加しています。あわせて `visuallyHidden` 経路、`MutationObserver` による children 追従、`pageTitleSuffix=""`、ref の転送についてもテストを追加しました。

## プロダクト側で対応が必要な事項

なし。

React 18 を利用している場合、これまで `PageHeading` の `document.title` 自動設定が動作していませんでしたが、このバージョンから動作するようになります。

## 確認方法

### テスト

```sh
pnpm ui test -- --run
```

### React 18 での動作確認

このリポジトリの devDependencies は React 19 のみのため、一時的に React 18 へ差し替えて確認しました。

```sh
pnpm -F smarthr-ui add -D react@18.3.1 react-dom@18.3.1
pnpm ui test -- --run
```

| | React 19.2.8 | React 18.3.1 |
| --- | --- | --- |
| 修正前 | 全 pass | `document.title` が空で fail + `Function components cannot be given refs` 警告 |
| 修正後 | 全 pass | 全 pass・警告なし |

### Storybook

`PageHeading` のストーリーを開き、ブラウザタブのタイトルが `<h1>` の内容 + `｜SmartHR（スマートHR）` になることを確認できます。見た目の変更はないため Chromatic に差分は出ない想定です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 見出し、ページ見出し、テキスト、視覚的に非表示のテキストで、描画要素への `ref` 転送に対応しました。
  * ページ見出しでは、タイトル自動更新機能を利用する場合も見出し要素を参照できます。
  * 表示する要素に応じた `ref` 型を利用できるようになりました。

* **テスト**
  * 各コンポーネントの `ref` 転送や主要な表示パターンを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->