### PR TITLE
GitHub Actions workflow の全 job 先頭で safe-chain を実行する

### DIFF
--- a/.github/workflows/closeReleaseCandidate.yml
+++ b/.github/workflows/closeReleaseCandidate.yml
@@ -10,6 +10,7 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'release candidate')
     runs-on: ubuntu-latest
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@v4
       - name: delete branch
         run: git push origin :release-candidate

--- a/.github/workflows/previewRelease.yml
+++ b/.github/workflows/previewRelease.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -13,6 +13,7 @@ jobs:
       CHANGELOG_PATH: /tmp/CHANGELOG.md
       IS_PRERELEASE: ${{ contains(github.event.issue.labels.*.name, 'prerelease') }}
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@v4
         with:
           ref: release-candidate

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -20,6 +20,7 @@ jobs:
       IS_PRERELEASE: ${{ github.event.inputs.prerelease == 'true' }}
       NO_BRANCH_PREPARATION: ${{ github.event.inputs.manual_preparation == 'true' }}
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -11,6 +11,7 @@ jobs:
     if: ${{ (((github.event_name != 'pull_request_review') && !(startsWith(github.event.pull_request.head.ref, 'merge-release-'))) || (github.event_name == 'pull_request_review') && (startsWith(github.event.pull_request.head.ref, 'merge-release-'))) }}
     runs-on: ubuntu-latest
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - name: check title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/typoChecker.yml
+++ b/.github/workflows/typoChecker.yml
@@ -6,6 +6,7 @@ jobs:
     name: Typo Checker
     runs-on: ubuntu-latest
     steps:
+    - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
     - uses: actions/checkout@v4
     - name: Use custom config file
       uses: crate-ci/typos@master


### PR DESCRIPTION
## Summary
- npm/pnpm のサプライチェーン攻撃対策として、`kufu/safe-chain-orb` を全 job の `steps:` 先頭に追加
- `typoChecker.yml` は既存の step が 4 スペースインデントだったため、それに揃えて挿入（他ファイルは標準の 6 スペース）

## Test plan
- [x] `devguardian` の `check-github-workflows` を実行し、エラー0・終了コード0であることを確認
- [x] 全 workflow ファイルの YAML 構文チェックを実行し、パースエラーがないことを確認
- [x] `git diff` で safe-chain 挿入1行のみの最小差分であることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * リリース関連の各種自動処理で、実行内容を固定したチェックを導入しました。
  * プレビュー、公開、開始、終了のリリースフローにおける処理の安定性を向上しました。
  * プルリクエストのタイトル確認および誤字チェックでも、同じ検証を適用しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->