### PR TITLE
GitHub Actions workflow の全 job 先頭で safe-chain を実行する

### DIFF
--- a/.github/workflows/crowdinPullTranslations.yml
+++ b/.github/workflows/crowdinPullTranslations.yml
@@ -17,6 +17,7 @@ jobs:
     name: Download translations from Crowdin
     runs-on: ubuntu-latest
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - name: Checkout branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/crowdinPushSources.yml
+++ b/.github/workflows/crowdinPushSources.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       TARGET_BRANCH: ${{ inputs.github_branch || github.ref_name }}
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - name: Checkout branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/previewRelease.yml
+++ b/.github/workflows/previewRelease.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release_please.outputs.releases_created }}
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release_please
         with:
@@ -29,6 +30,7 @@ jobs:
     needs: release_please
     if: ${{ needs.release_please.outputs.releases_created }}
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:

--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -11,6 +11,7 @@ jobs:
     if: ${{ (((github.event_name != 'pull_request_review') && !(startsWith(github.event.pull_request.head.ref, 'merge-release-'))) || (github.event_name == 'pull_request_review') && (startsWith(github.event.pull_request.head.ref, 'merge-release-'))) }}
     runs-on: ubuntu-latest
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - name: check title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/typoChecker.yml
+++ b/.github/workflows/typoChecker.yml
@@ -6,6 +6,7 @@ jobs:
     name: Typo Checker
     runs-on: ubuntu-latest
     steps:
+    - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Use custom config file
       uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/updateLockfile.yml
+++ b/.github/workflows/updateLockfile.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: kufu/safe-chain-orb@90f4f6b5e801be1257a4e3ac1756f2136d023ef6 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:


### PR DESCRIPTION
related: https://github.com/kufu/devguardian/issues/1

## Summary
- npm/pnpm のサプライチェーン攻撃対策として、`kufu/safe-chain-orb` を全 job の `steps:` 先頭に追加
- `typoChecker.yml` は既存の step が 4 スペースインデントだったため、それに揃えて挿入（他ファイルは標準の 6 スペース）
- job レベルで reusable workflow を呼んでいる job は無し

## Test plan
- [x] `devguardian` の `check-github-workflows` を実行し、エラー0・終了コード0であることを確認
- [x] 全 workflow ファイルの YAML 構文チェックを実行し、パースエラーがないことを確認
- [x] `git diff` で safe-chain 挿入1行のみの最小差分であることを確認