### PR TITLE
refactor(UnstyledButton): disabled属性をaria-disabledに変更しイベントをキャンセル

### DIFF
--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -5,9 +5,9 @@ import {
   useButtonWrapper,
 } from './useButtonWrapper'
 
-import type { FC, MouseEvent } from 'react'
+import type { FC, SyntheticEvent } from 'react'
 
-export const EVENT_CANCELLER = (e: MouseEvent<HTMLButtonElement>) => {
+export const EVENT_CANCELLER = (e: SyntheticEvent) => {
   e.preventDefault()
   e.stopPropagation()
 }

--- a/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
+++ b/packages/smarthr-ui/src/components/Button/ButtonWrapper.tsx
@@ -7,7 +7,7 @@ import {
 
 import type { FC, MouseEvent } from 'react'
 
-const EVENT_CANCELLER = (e: MouseEvent<HTMLButtonElement>) => {
+export const EVENT_CANCELLER = (e: MouseEvent<HTMLButtonElement>) => {
   e.preventDefault()
   e.stopPropagation()
 }

--- a/packages/smarthr-ui/src/components/Button/UnstyledButton.tsx
+++ b/packages/smarthr-ui/src/components/Button/UnstyledButton.tsx
@@ -1,6 +1,8 @@
 import { type ComponentProps, type PropsWithChildren, forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { EVENT_CANCELLER } from './ButtonWrapper'
+
 const classNameGenerator = tv({
   base: [
     'shr-box-content shr-inline shr-cursor-pointer shr-select-auto shr-appearance-none shr-items-stretch shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit shr-text-color-inherit',
@@ -11,8 +13,18 @@ const classNameGenerator = tv({
 export const UnstyledButton = forwardRef<
   HTMLButtonElement,
   PropsWithChildren<ComponentProps<'button'>>
->(({ className, type = 'button', ...rest }, ref) => {
+>(({ type = 'button', disabled, onClick, onKeyDown, className, ...rest }, ref) => {
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
-  return <button {...rest} type={type} ref={ref} className={actualClassName} />
+  return (
+    <button
+      {...rest}
+      ref={ref}
+      type={type}
+      aria-disabled={disabled}
+      onClick={disabled ? EVENT_CANCELLER : onClick}
+      onKeyDown={disabled ? EVENT_CANCELLER : onKeyDown}
+      className={actualClassName}
+    />
+  )
 })

--- a/packages/smarthr-ui/src/components/Button/UnstyledButton.tsx
+++ b/packages/smarthr-ui/src/components/Button/UnstyledButton.tsx
@@ -1,12 +1,22 @@
-import { type ComponentProps, type PropsWithChildren, forwardRef, useMemo } from 'react'
+import {
+  type ComponentProps,
+  type PropsWithChildren,
+  type SyntheticEvent,
+  forwardRef,
+  useMemo,
+} from 'react'
 import { tv } from 'tailwind-variants'
 
-import { EVENT_CANCELLER } from './ButtonWrapper'
+const DISABLED_HANDLER = (e: SyntheticEvent) => {
+  e.preventDefault()
+  e.stopPropagation()
+}
 
 const classNameGenerator = tv({
   base: [
     'shr-box-content shr-inline shr-cursor-pointer shr-select-auto shr-appearance-none shr-items-stretch shr-overflow-visible shr-border-none shr-border-current shr-bg-transparent shr-bg-none shr-bg-origin-padding shr-p-0 shr-text-left shr-font-inherit shr-text-inherit shr-text-color-inherit',
     'focus-visible:shr-focus-indicator',
+    'aria-disabled:forced-colors:shr-text-[GrayText]',
   ],
 })
 
@@ -22,8 +32,8 @@ export const UnstyledButton = forwardRef<
       ref={ref}
       type={type}
       aria-disabled={disabled}
-      onClick={disabled ? EVENT_CANCELLER : onClick}
-      onKeyDown={disabled ? EVENT_CANCELLER : onKeyDown}
+      onClick={disabled ? DISABLED_HANDLER : onClick}
+      onKeyDown={disabled ? DISABLED_HANDLER : onKeyDown}
       className={actualClassName}
     />
   )

--- a/packages/smarthr-ui/src/components/Button/UnstyledButton.tsx
+++ b/packages/smarthr-ui/src/components/Button/UnstyledButton.tsx
@@ -1,16 +1,7 @@
-import {
-  type ComponentProps,
-  type PropsWithChildren,
-  type SyntheticEvent,
-  forwardRef,
-  useMemo,
-} from 'react'
+import { type ComponentProps, type PropsWithChildren, forwardRef, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
-const DISABLED_HANDLER = (e: SyntheticEvent) => {
-  e.preventDefault()
-  e.stopPropagation()
-}
+import { EVENT_CANCELLER } from './ButtonWrapper'
 
 const classNameGenerator = tv({
   base: [
@@ -32,8 +23,8 @@ export const UnstyledButton = forwardRef<
       ref={ref}
       type={type}
       aria-disabled={disabled}
-      onClick={disabled ? DISABLED_HANDLER : onClick}
-      onKeyDown={disabled ? DISABLED_HANDLER : onKeyDown}
+      onClick={disabled ? EVENT_CANCELLER : onClick}
+      onKeyDown={disabled ? EVENT_CANCELLER : onKeyDown}
       className={actualClassName}
     />
   )

--- a/packages/smarthr-ui/src/components/Calendar/CalendarTable.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/CalendarTable.tsx
@@ -44,9 +44,9 @@ const classNameGenerator = tv({
     th: 'smarthr-ui-CalendarTable-headCell shr-px-0 shr-py-0.5 shr-text-center shr-align-middle shr-font-normal shr-text-grey',
     td: 'smarthr-ui-CalendarTable-dataCell shr-p-0 shr-align-middle',
     cellButton:
-      'shr-group shr-flex shr-items-center shr-justify-center shr-px-0.5 shr-py-0.25 disabled:shr-cursor-not-allowed disabled:shr-text-disabled',
+      'shr-group shr-flex shr-items-center shr-justify-center shr-px-0.5 shr-py-0.25 aria-disabled:shr-cursor-not-allowed aria-disabled:shr-text-disabled',
     dateCell: [
-      'shr-box-border shr-flex shr-h-[1.75rem] shr-w-[1.75rem] shr-items-center shr-justify-center shr-rounded-[50%] shr-leading-[0] group-[:not(:disabled)]:group-hover:shr-bg-base-grey group-[:not(:disabled)]:group-hover:shr-text-black',
+      'shr-box-border shr-flex shr-h-[1.75rem] shr-w-[1.75rem] shr-items-center shr-justify-center shr-rounded-[50%] shr-leading-[0] group-[:not([aria-disabled])]:group-hover:shr-bg-base-grey group-[:not([aria-disabled])]:group-hover:shr-text-black',
       '[[aria-pressed="true"]>&&&]:shr-bg-main [[aria-pressed="true"]>&&&]:shr-text-white',
       '[[data-is-today="true"]>&&&]:shr-border-shorthand [[aria-pressed="true"]>&&&]:contrast-more:shr-border-high-contrast',
     ],

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -39,7 +39,7 @@ const classNameGenerator = tv({
       'shr-group/deleteButton',
       'shr-shrink shr-rounded-full shr-leading-[0] shr-text-black',
       'focus-visible:shr-outline-none',
-      'disabled:shr-cursor-not-allowed',
+      'aria-disabled:shr-cursor-not-allowed',
     ],
     deleteButtonIcon:
       'group-focus-visible/deleteButton:shr-focus-indicator--outer group-focus-visible/deleteButton:shr-rounded-full',

--- a/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/TabItem.tsx
@@ -22,14 +22,14 @@ const classNameGenerator = tv({
       'shr-relative shr-inline-flex shr-items-center shr-gap-0.5 shr-px-1 shr-py-0.75',
       'hover:shr-bg-white-darken',
       'focus-visible:shr-focus-indicator focus-visible:shr-z-1',
-      'disabled:shr-cursor-not-allowed disabled:shr-bg-transparent',
+      'aria-disabled:shr-cursor-not-allowed aria-disabled:shr-bg-transparent',
       'aria-selected:before:shr-absolute aria-selected:before:shr-inset-x-0 aria-selected:before:shr-bottom-0 aria-selected:before:shr-z-1 aria-selected:before:shr-block aria-selected:before:shr-h-0.25 aria-selected:before:shr-bg-main aria-selected:before:shr-content-[""]',
       'forced-colors:aria-selected:before:shr-bg-[Highlight]',
     ],
     label: [
       'shr-font-bold shr-leading-none shr-text-grey',
       'group-hover/tabitem:shr-text-black',
-      'group-disabled/tabitem:shr-text-grey/50',
+      'group-aria-disabled/tabitem:shr-text-grey/50',
       'group-aria-selected/tabitem:shr-text-black',
     ],
     suffixWrapper: [


### PR DESCRIPTION
## 関連URL

なし

## 概要

`UnstyledButton` の `disabled` prop をネイティブの `disabled` 属性ではなく `aria-disabled` に変更する。これにより、disabled 状態でもフォーカス可能な状態を保ちつつ、click / keydown イベントをキャンセルする。

## 変更内容

### UnstyledButton

- `disabled` prop を受け取り `aria-disabled` として設定
- `disabled` 時に click / keydown を `EVENT_CANCELLER` でキャンセル
- `ButtonWrapper` の `EVENT_CANCELLER` を export に変更して再利用

### 影響コンポーネントの修正

`disabled:` Tailwind 疑似クラスが機能しなくなるため、`aria-disabled:` 属性セレクタに更新:

| コンポーネント | 変更内容 |
|---|---|
| `MultiSelectedItem` | `disabled:shr-cursor-not-allowed` → `aria-disabled:shr-cursor-not-allowed` |
| `TabItem` | `disabled:shr-cursor-not-allowed/bg-transparent` → `aria-disabled:` 、`group-disabled/tabitem:` → `group-aria-disabled/tabitem:` |
| `CalendarTable` | `disabled:` → `aria-disabled:` 、`group-[:not(:disabled)]:` → `group-[:not([aria-disabled])]:` |

### 別PRで対応予定

- `DropZone`: `has-[.smarthr-ui-DropZone-Button:disabled]` → `Button` コンポーネントが既に `aria-disabled` を使用しているため既存の問題として別途対応

## プロダクト側で対応が必要な事項

`UnstyledButton` に `disabled` prop を渡しつつ `disabled:` Tailwind クラスをカスタムで指定している場合は `aria-disabled:` に変更が必要。

## 確認方法

Storybook で各コンポーネントの disabled 状態を確認。