### PR TITLE
refactor(DropZone): disabled:疑似クラスをaria-disabled属性セレクタに変更

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -26,7 +26,7 @@ const classNameGenerator = tv({
       'smarthr-ui-DropZone',
       'shr-relative',
       'shr-border-shorthand shr-flex shr-flex-col shr-items-center shr-justify-center shr-bg-column shr-p-2.5',
-      'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed',
+      'has-[.smarthr-ui-DropZone-Button[aria-disabled]]:shr-cursor-not-allowed',
       '[&:not([data-files-dragged-over])]:shr-border-dashed',
       'data-[files-dragged-over]:shr-border-main',
     ],


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DropZone` の wrapper が `has-[.smarthr-ui-DropZone-Button:disabled]` セレクタで disabled 時のスタイルを制御していたが、`Button` コンポーネントはネイティブの `disabled` 属性ではなく `aria-disabled` を使用しているため、このセレクタが機能していなかった。

## 変更内容

```tsx
// Before
'has-[.smarthr-ui-DropZone-Button:disabled]:shr-cursor-not-allowed'

// After
'has-[.smarthr-ui-DropZone-Button[aria-disabled]]:shr-cursor-not-allowed'
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で `DropZone` の `disabled` 状態時に `cursor: not-allowed` が適用されることを確認。