### PR TITLE
refactor(TimelineItem): 不要なラッパーコンポーネントを条件分岐で省略

### DIFF
--- a/packages/smarthr-ui/src/components/Timeline/TimelineItem.tsx
+++ b/packages/smarthr-ui/src/components/Timeline/TimelineItem.tsx
@@ -86,27 +86,33 @@ export const TimelineItem: React.FC<Props> = ({
   }, [datetime, timeFormat])
 
   const id = useId()
+  const timeContent = (
+    <Cluster align="center" as="time" dateTime={isoString} id={id} className={classNames.title}>
+      <Text styleType="blockTitle" leading="NONE">
+        {dateLabel || date}
+      </Text>
+      {time && <Text leading="NONE">{time}</Text>}
+    </Cluster>
+  )
+  const dateContent = dateSuffixArea ? (
+    <Sidebar align="center" gap={0.5} className={classNames.dateArea}>
+      {timeContent}
+      <div>{dateSuffixArea}</div>
+    </Sidebar>
+  ) : (
+    timeContent
+  )
 
   return (
     <Stack {...rest} as="li" gap={0.5} aria-current={current} className={classNames.wrapper}>
-      <Cluster align="center" justify="space-between">
-        <Sidebar align="center" gap={0.5} className={classNames.dateArea}>
-          <Cluster
-            align="center"
-            as="time"
-            dateTime={isoString}
-            id={id}
-            className={classNames.title}
-          >
-            <Text styleType="blockTitle" leading="NONE">
-              {dateLabel || date}
-            </Text>
-            {time && <Text leading="NONE">{time}</Text>}
-          </Cluster>
-          {dateSuffixArea && <div>{dateSuffixArea}</div>}
-        </Sidebar>
-        {sideActionArea}
-      </Cluster>
+      {sideActionArea ? (
+        <Cluster align="center" justify="space-between">
+          {dateContent}
+          {sideActionArea}
+        </Cluster>
+      ) : (
+        dateContent
+      )}
       {children && (
         // eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content
         <Section aria-labelledby={id}>{children}</Section>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`TimelineItem` で props が存在しない場合に不要なラッパーコンポーネントが生成されていたため、条件分岐で省略する。

## 変更内容

- `dateSuffixArea` がない場合は `<Sidebar>` を省略
- `sideActionArea` がない場合は `<Cluster>` を省略
- `timeContent` を変数に切り出して JSX の重複を排除

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で TimelineItem の各 props の組み合わせ（dateSuffixArea あり/なし、sideActionArea あり/なし）を確認。