### PR TITLE
fix(FileViewer): レイアウトを調整し親の幅で折り返すよう修正

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -13,9 +13,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { tv } from 'tailwind-variants'
 
-import { useEnvironment } from '../../hooks/useEnvironment'
 import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
@@ -183,77 +181,74 @@ type ControllerProps = {
   searchController?: ReactNode
 }
 
-const controllerClassNameGenerator = tv({
-  base: 'shr-sticky shr-grid shr-w-full shr-items-center shr-bg-scrim shr-py-0.5 shr-shadow-layer-1',
-  variants: {
-    mobile: {
-      true: 'shr-gap-0.5 shr-px-1',
-      false: 'shr-grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] shr-gap-1.5 shr-px-2',
-    },
-  },
-})
-
 const Controller: FC<ControllerProps> = memo(
-  ({ scale, scaleSteps, functions, searchController }) => {
-    const { mobile } = useEnvironment()
-    const className = useMemo(() => controllerClassNameGenerator({ mobile }), [mobile])
-
-    return (
-      <div className={className}>
-        {/* PC 表示時のときに中央の操作ボタンたちを中央へ寄せるための空のスペーサー */}
-        {!mobile && <div role="presentation" aria-hidden="true" />}
-        <Cluster gap={0.5} className="shr-justify-self-center">
-          <div className="shr-border-shorthand shr-flex shr-divide-x shr-divide-solid shr-overflow-hidden shr-rounded-m">
-            <Button
-              onClick={functions.scaleDown}
-              disabled={scale <= scaleSteps[0]}
-              className="shr-rounded-r-none shr-border-none"
-            >
-              <FaMagnifyingGlassMinusIcon
-                alt={<Localizer id="smarthr-ui/FileViewer/scaleDownAlt" defaultText="縮小" />}
-              />
-            </Button>
-            <DropdownMenuButton
-              trigger={
-                <>
-                  <VisuallyHiddenText>
-                    <Localizer id="smarthr-ui/FileViewer/scaleRateLabel" defaultText="拡大率" />
-                  </VisuallyHiddenText>
-                  {`${(scale * 100).toFixed(0)}%`}
-                </>
-              }
-              className="shr-border-y-0 shr-border-[theme(borderColor.default)] [&_.smarthr-ui-Button]:shr-rounded-none [&_.smarthr-ui-Button]:shr-border-[transparent]"
-            >
-              {scaleSteps.map((step) => (
-                <Button
-                  key={step.toString()}
-                  value={step}
-                  onClick={functions.handleClickScaleStep}
-                  className="shr-rounded-none shr-border-0"
-                >
-                  {`${(step * 100).toFixed(0)}%`}
-                </Button>
-              ))}
-            </DropdownMenuButton>
-            <Button onClick={functions.scaleUp} className="shr-rounded-l-none shr-border-0">
-              <FaMagnifyingGlassPlusIcon
-                alt={<Localizer id="smarthr-ui/FileViewer/scaleUpAlt" defaultText="拡大" />}
-              />
-            </Button>
-          </div>
-          <Button onClick={functions.rotate} className="shr-p-0.75">
-            <FaArrowRotateLeftIcon
-              alt={<Localizer id="smarthr-ui/FileViewer/rotateAlt" defaultText="左回転" />}
+  ({ scale, scaleSteps, functions, searchController }) => (
+    <Cluster
+      gap={0}
+      align="end"
+      className="shr-sticky shr-box-border shr-w-full shr-justify-center shr-bg-scrim shr-px-0.5 shr-shadow-layer-1"
+    >
+      {/* 操作ボタンを中央へ寄せるための空のスペーサー */}
+      <div
+        role="presentation"
+        aria-hidden="true"
+        className="shr-grow shr-basis-[calc((45em_-_100%)*999)]"
+      />
+      <Cluster
+        gap={0.5}
+        className="shr-grow shr-basis-[calc((45em_-_100%)*999)] shr-items-center shr-justify-center shr-justify-self-center shr-py-0.5"
+      >
+        <Cluster gap={0}>
+          <Button
+            onClick={functions.scaleDown}
+            disabled={scale <= scaleSteps[0]}
+            className="shr-rounded-r-none"
+          >
+            <FaMagnifyingGlassMinusIcon
+              alt={<Localizer id="smarthr-ui/FileViewer/scaleDownAlt" defaultText="縮小" />}
+            />
+          </Button>
+          <DropdownMenuButton
+            trigger={
+              <>
+                <VisuallyHiddenText>
+                  <Localizer id="smarthr-ui/FileViewer/scaleRateLabel" defaultText="拡大率" />
+                </VisuallyHiddenText>
+                {`${(scale * 100).toFixed(0)}%`}
+              </>
+            }
+            className="[&_.smarthr-ui-Button]:shr-rounded-none [&_.smarthr-ui-Button]:shr-border-x-[0]"
+          >
+            {scaleSteps.map((step) => (
+              <Button key={step.toString()} value={step} onClick={functions.handleClickScaleStep}>
+                {`${(step * 100).toFixed(0)}%`}
+              </Button>
+            ))}
+          </DropdownMenuButton>
+          <Button onClick={functions.scaleUp} className="shr-rounded-l-none">
+            <FaMagnifyingGlassPlusIcon
+              alt={<Localizer id="smarthr-ui/FileViewer/scaleUpAlt" defaultText="拡大" />}
             />
           </Button>
         </Cluster>
-        {searchController ? (
-          <div className="shr-min-w-0 shr-justify-self-stretch">{searchController}</div>
-        ) : (
-          /* PC 表示時のときに中央の操作ボタンたちを中央へ寄せるための空のスペーサー */
-          !mobile && <div role="presentation" aria-hidden="true" />
-        )}
-      </div>
-    )
-  },
+        <Button onClick={functions.rotate} className="shr-p-0.75">
+          <FaArrowRotateLeftIcon
+            alt={<Localizer id="smarthr-ui/FileViewer/rotateAlt" defaultText="左回転" />}
+          />
+        </Button>
+      </Cluster>
+      {searchController ? (
+        <div className="shr-min-w-0 shr-grow shr-basis-[calc((45em_-_100%)*999)] shr-justify-end shr-justify-self-stretch shr-px-0.5 shr-pb-0.5">
+          {searchController}
+        </div>
+      ) : (
+        // 操作ボタンを中央へ寄せるための空のスペーサー
+        <div
+          role="presentation"
+          aria-hidden="true"
+          className="shr-grow shr-basis-[calc((45em_-_100%)*999)]"
+        />
+      )}
+    </Cluster>
+  ),
 )

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -238,7 +238,7 @@ const Controller: FC<ControllerProps> = memo(
         </Button>
       </Cluster>
       {searchController ? (
-        <div className="shr-min-w-0 shr-grow shr-basis-[calc((45em_-_100%)*999)] shr-justify-end shr-justify-self-stretch shr-px-0.5 shr-pb-0.5">
+        <div className="shr-min-w-0 shr-grow shr-basis-[calc((45em_-_100%)*999)] shr-justify-self-stretch shr-px-0.5 shr-pb-0.5">
           {searchController}
         </div>
       ) : (

--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -26,7 +26,6 @@ const classNameGenerator = tv({
       true: {},
       false: {
         wrapper: 'shr-justify-end',
-        inputArea: 'shr-max-w-[15em]',
       },
     },
   },

--- a/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
@@ -6,7 +6,8 @@ export default {
   title: 'Components/FileViewer',
   component: FileViewer,
   render: (args) => (
-    <div className="shr-h-[90vh]">
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    <div className="shr-h-[90vh] shr-w-full shr-resize shr-overflow-auto" tabIndex={0}>
       <FileViewer {...args} />
     </div>
   ),


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

https://kufuinc.slack.com/archives/C06KVP5PL23/p1786328602568579

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

検索欄の折り返しの判定がmobileになっていたため、広いviewport内の狭い領域で使っている場合に検索欄がうまく表示されない不具合を修正

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

## 変更内容

折り返しの判定をmobileかどうかではなく、15em以上の幅を確保できるかどうかに変更した。

before:

<img width="1173" height="823" alt="image" src="https://github.com/user-attachments/assets/2325aac9-add5-42d3-bb50-96d1f89f1421" />

after:

<img width="1169" height="820" alt="image" src="https://github.com/user-attachments/assets/566a2265-c9e9-4149-84d1-305072d86ab6" />

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

## プロダクト側で対応が必要な事項

なし

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

https://63d0ccabb5d2dd29825524ab-vrfrmansht.chromatic.com/?path=/story/components-fileviewer--playground

でresizeしてみる（Storybookにresizeをつけました）

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改善

* ファイルビューアーのズーム・回転・検索コントロールを、より見やすく中央配置しました。
* 操作ボタンの境界線、角丸、余白を調整し、操作性を向上しました。
* 検索入力欄の表示幅を広げ、長い検索語を入力しやすくしました。
* ビューアーのサイズ変更やスクロールに対応し、さまざまな表示環境で利用しやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->