### PR TITLE
refactor(Combobox): ListBoxのイベントハンドラーをイベント移譲で実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,52 @@ useEffect(() => {
   - 依存配列のチェックは前から順に行われるため、変更される可能性が高いものを前に配置すれば早期に変更を検出できる
   - 変更されにくいものを後ろに配置することで、無駄な比較処理を削減
 
+#### イベント移譲（Event Delegation）パターン
+
+大量の子要素に個別のイベントハンドラーを設定する代わりに、コンテナ1つにハンドラーを設定してイベントを受け取る手法です。
+
+**使用する判断基準:**
+- 子要素が多い（例: リスト、選択肢）かつ各要素のハンドラーが同種の処理をする場合
+
+**`findDelegateTarget` の使用（`src/libs/delegate.ts`）:**
+
+CSS selectorで対象要素を絞り込む汎用ユーティリティです。`e.target` ではなく `e.nativeEvent.composedPath()` を使うことで、イベントの実際の伝播パスのみを対象にし、発生元を正確に特定できます。
+
+```typescript
+import { findDelegateTarget } from '../../libs/delegate'
+
+// コンテナにdelegateハンドラーを設定
+<ul
+  onClick={functions.handleDelegateClick}
+  onMouseOver={functions.handleDelegateMouseOver}
+>
+  {items.map(({ id, label }) => (
+    <button key={id} id={id} role="option">{label}</button>
+  ))}
+</ul>
+
+// useLatest + functions パターンと組み合わせる
+const functions = useMemo(() => ({
+  handleDelegateClick: (e: MouseEvent) => {
+    const el = findDelegateTarget<HTMLButtonElement>(e, 'button[role="option"]')
+    if (!el || el.disabled) return
+    const item = latest.items.find((o) => o.id === el.id)
+    if (item) latest.onSelect(item)
+  },
+  handleDelegateMouseOver: (e: MouseEvent) => {
+    const el = findDelegateTarget<HTMLButtonElement>(e, 'button[role="option"]')
+    if (!el || el.disabled) return
+    latest.onHover(el.id)
+  },
+}), [latest])
+```
+
+**命名規則:** delegateハンドラーは `handleDelegateXxx` 形式
+
+**子要素の識別には `id` を使う:**
+- `id` は `useId()` ベースで一意性が保証される
+- `value` は重複の可能性があるため不適切
+
 ## スキル
 
 - **PR作成** (`.claude/skills/pr-creator/`): PR作成時にリポジトリのテンプレートに沿った本文を生成する

--- a/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, memo } from 'react'
+import { type FC, type ReactNode, type RefObject, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../intl'
@@ -41,14 +41,14 @@ export const ItemButton = memo<Props>(({ disabled, selected, isNew, ...rest }) =
   ),
 )
 
-const SelectButton = memo<{
+const SelectButton: FC<{
   id: string
   label: ReactNode
   value: string
   disabled?: boolean
   selected: boolean
   activeRef: RefObject<HTMLButtonElement> | undefined
-}>(({ label, selected, activeRef, ...rest }) => (
+}> = ({ label, selected, activeRef, ...rest }) => (
   <button
     {...rest}
     ref={activeRef}
@@ -60,14 +60,14 @@ const SelectButton = memo<{
   >
     {label}
   </button>
-))
+)
 
-const AddButton = memo<{
+const AddButton: FC<{
   id: string
   label: ReactNode
   value: string
   activeRef: RefObject<HTMLButtonElement> | undefined
-}>(({ label, activeRef, ...rest }) => (
+}> = ({ label, activeRef, ...rest }) => (
   <button
     {...rest}
     ref={activeRef}
@@ -77,16 +77,12 @@ const AddButton = memo<{
     data-active={!!activeRef}
     className={CLASS_NAMES.new}
   >
-    <MemoizedNewIconWithText label={label} />
+    <Text color="TEXT_LINK" icon={<FaCirclePlusIcon color="TEXT_LINK" />}>
+      <Localizer
+        id="smarthr-ui/Combobox/addItemButtonLabel"
+        defaultText="「{name}」を追加"
+        values={{ name: label }}
+      />
+    </Text>
   </button>
-))
-
-const MemoizedNewIconWithText = memo<{ label: ReactNode }>(({ label }) => (
-  <Text color="TEXT_LINK" icon={<FaCirclePlusIcon color="TEXT_LINK" />}>
-    <Localizer
-      id="smarthr-ui/Combobox/addItemButtonLabel"
-      defaultText="「{name}」を追加"
-      values={{ name: label }}
-    />
-  </Text>
-))
+)

--- a/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, type RefObject, memo } from 'react'
+import { type RefObject, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../intl'
@@ -33,54 +33,27 @@ const CLASS_NAMES = {
   select: classNameGenerator({ new: false }),
 }
 
-export const ItemButton = memo<Props>(({ disabled, selected, isNew, ...rest }) =>
-  isNew ? (
-    <AddButton {...rest} />
-  ) : (
-    <SelectButton {...rest} disabled={disabled} selected={selected} />
-  ),
-)
-
-const SelectButton: FC<{
-  id: string
-  label: ReactNode
-  disabled?: boolean
-  selected: boolean
-  activeRef: RefObject<HTMLButtonElement> | undefined
-}> = ({ label, selected, activeRef, ...rest }) => (
+export const ItemButton = memo<Props>(({ id, label, disabled, selected, isNew, activeRef }) => (
   <button
-    {...rest}
     ref={activeRef}
     type="button"
     role="option"
-    aria-selected={selected}
+    id={id}
     data-active={!!activeRef}
-    className={CLASS_NAMES.select}
+    aria-selected={isNew ? false : selected}
+    disabled={isNew ? undefined : disabled}
+    className={isNew ? CLASS_NAMES.new : CLASS_NAMES.select}
   >
-    {label}
+    {isNew ? (
+      <Text color="TEXT_LINK" icon={<FaCirclePlusIcon color="TEXT_LINK" />}>
+        <Localizer
+          id="smarthr-ui/Combobox/addItemButtonLabel"
+          defaultText="「{name}」を追加"
+          values={{ name: label }}
+        />
+      </Text>
+    ) : (
+      label
+    )}
   </button>
-)
-
-const AddButton: FC<{
-  id: string
-  label: ReactNode
-  activeRef: RefObject<HTMLButtonElement> | undefined
-}> = ({ label, activeRef, ...rest }) => (
-  <button
-    {...rest}
-    ref={activeRef}
-    type="button"
-    role="option"
-    aria-selected={false}
-    data-active={!!activeRef}
-    className={CLASS_NAMES.new}
-  >
-    <Text color="TEXT_LINK" icon={<FaCirclePlusIcon color="TEXT_LINK" />}>
-      <Localizer
-        id="smarthr-ui/Combobox/addItemButtonLabel"
-        defaultText="「{name}」を追加"
-        values={{ name: label }}
-      />
-    </Text>
-  </button>
-)
+))

--- a/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
@@ -8,7 +8,7 @@ import { Text } from '../Text'
 import type { ComboboxOption } from './types'
 
 type Props = Omit<ComboboxOption<unknown>, 'item'> &
-  Omit<ComboboxOption<unknown>['item'], 'data'> & {
+  Omit<ComboboxOption<unknown>['item'], 'data' | 'value'> & {
     activeRef: RefObject<HTMLButtonElement> | undefined
   }
 
@@ -44,7 +44,6 @@ export const ItemButton = memo<Props>(({ disabled, selected, isNew, ...rest }) =
 const SelectButton: FC<{
   id: string
   label: ReactNode
-  value: string
   disabled?: boolean
   selected: boolean
   activeRef: RefObject<HTMLButtonElement> | undefined
@@ -65,7 +64,6 @@ const SelectButton: FC<{
 const AddButton: FC<{
   id: string
   label: ReactNode
-  value: string
   activeRef: RefObject<HTMLButtonElement> | undefined
 }> = ({ label, activeRef, ...rest }) => (
   <button

--- a/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
@@ -7,10 +7,10 @@ import { Text } from '../Text'
 
 import type { ComboboxOption } from './types'
 
-type Props<T> = {
-  option: ComboboxOption<T>
-  activeRef: RefObject<HTMLButtonElement> | undefined
-}
+type Props = Omit<ComboboxOption<unknown>, 'item'> &
+  Omit<ComboboxOption<unknown>['item'], 'data'> & {
+    activeRef: RefObject<HTMLButtonElement> | undefined
+  }
 
 const classNameGenerator = tv({
   base: [
@@ -33,28 +33,13 @@ const CLASS_NAMES = {
   select: classNameGenerator({ new: false }),
 }
 
-const ItemButton = <T,>({ option, activeRef }: Props<T>) =>
-  option.isNew ? (
-    <AddButton
-      id={option.id}
-      label={option.item.label}
-      value={option.item.value}
-      activeRef={activeRef}
-    />
+export const ItemButton = memo<Props>(({ disabled, selected, isNew, ...rest }) =>
+  isNew ? (
+    <AddButton {...rest} />
   ) : (
-    <SelectButton
-      id={option.id}
-      label={option.item.label}
-      value={option.item.value}
-      disabled={option.item.disabled}
-      selected={option.selected}
-      activeRef={activeRef}
-    />
-  )
-
-const typedMemo: <T>(c: T) => T = memo
-const Memoized = typedMemo(ItemButton)
-export { Memoized as ItemButton }
+    <SelectButton {...rest} disabled={disabled} selected={selected} />
+  ),
+)
 
 const SelectButton = memo<{
   id: string
@@ -63,14 +48,12 @@ const SelectButton = memo<{
   disabled?: boolean
   selected: boolean
   activeRef: RefObject<HTMLButtonElement> | undefined
-}>(({ id, label, value, disabled, selected, activeRef }) => (
+}>(({ label, selected, activeRef, ...rest }) => (
   <button
+    {...rest}
     ref={activeRef}
     type="button"
     role="option"
-    id={id}
-    value={value}
-    disabled={disabled}
     aria-selected={selected}
     data-active={!!activeRef}
     className={CLASS_NAMES.select}
@@ -84,14 +67,13 @@ const AddButton = memo<{
   label: ReactNode
   value: string
   activeRef: RefObject<HTMLButtonElement> | undefined
-}>(({ id, label, value, activeRef }) => (
+}>(({ label, activeRef, ...rest }) => (
   <button
+    {...rest}
     ref={activeRef}
     type="button"
     role="option"
     aria-selected={false}
-    id={id}
-    value={value}
     data-active={!!activeRef}
     className={CLASS_NAMES.new}
   >

--- a/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
@@ -1,7 +1,6 @@
-import { type ReactNode, type RefObject, memo, useMemo } from 'react'
+import { type ReactNode, type RefObject, memo } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { FaCirclePlusIcon } from '../Icon'
 import { Text } from '../Text'
@@ -10,9 +9,6 @@ import type { ComboboxOption } from './types'
 
 type Props<T> = {
   option: ComboboxOption<T>
-  handleAdd?: (option: ComboboxOption<T>) => void
-  handleSelect: (option: ComboboxOption<T>) => void
-  handleMouseOver: (option: ComboboxOption<T>) => void
   activeRef: RefObject<HTMLButtonElement> | undefined
 }
 
@@ -37,43 +33,25 @@ const CLASS_NAMES = {
   select: classNameGenerator({ new: false }),
 }
 
-const ItemButton = <T,>({
-  option,
-  handleAdd,
-  handleSelect,
-  handleMouseOver,
-  activeRef,
-}: Props<T>) => {
-  const latest = useLatest({ handleAdd, handleSelect, handleMouseOver, option })
-  const hasHandleAdd = !!handleAdd
-
-  const functions = useMemo(
-    () => ({
-      handleMouseOver: () => latest.handleMouseOver(latest.option),
-      handleAddClick: hasHandleAdd ? () => latest.handleAdd?.(latest.option) : undefined,
-      handleSelectClick: () => latest.handleSelect(latest.option),
-    }),
-    [hasHandleAdd, latest],
-  )
-
-  const commonAttrs = {
-    id: option.id,
-    label: option.item.label,
-    activeRef,
-    handleMouseOver: functions.handleMouseOver,
-  }
-
-  return option.isNew ? (
-    <AddButton {...commonAttrs} handleClick={functions.handleAddClick} />
+const ItemButton = <T,>({ option, activeRef }: Props<T>) =>
+  option.isNew ? (
+    <AddButton
+      id={option.id}
+      label={option.item.label}
+      value={option.item.value}
+      activeRef={activeRef}
+    />
   ) : (
     <SelectButton
-      {...commonAttrs}
+      id={option.id}
+      label={option.item.label}
+      value={option.item.value}
       disabled={option.item.disabled}
       selected={option.selected}
-      handleClick={functions.handleSelectClick}
+      activeRef={activeRef}
     />
   )
-}
+
 const typedMemo: <T>(c: T) => T = memo
 const Memoized = typedMemo(ItemButton)
 export { Memoized as ItemButton }
@@ -81,23 +59,20 @@ export { Memoized as ItemButton }
 const SelectButton = memo<{
   id: string
   label: ReactNode
+  value: string
   disabled?: boolean
   selected: boolean
   activeRef: RefObject<HTMLButtonElement> | undefined
-  handleClick: () => void
-  handleMouseOver: () => void
-}>(({ id, label, disabled, selected, activeRef, handleClick, handleMouseOver }) => (
+}>(({ id, label, value, disabled, selected, activeRef }) => (
   <button
     ref={activeRef}
     type="button"
     role="option"
     id={id}
+    value={value}
     disabled={disabled}
     aria-selected={selected}
     data-active={!!activeRef}
-    onClick={handleClick}
-    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-    onMouseOver={handleMouseOver}
     className={CLASS_NAMES.select}
   >
     {label}
@@ -107,20 +82,17 @@ const SelectButton = memo<{
 const AddButton = memo<{
   id: string
   label: ReactNode
+  value: string
   activeRef: RefObject<HTMLButtonElement> | undefined
-  handleClick?: () => void
-  handleMouseOver: () => void
-}>(({ id, label, activeRef, handleClick, handleMouseOver }) => (
+}>(({ id, label, value, activeRef }) => (
   <button
     ref={activeRef}
     type="button"
     role="option"
     aria-selected={false}
     id={id}
+    value={value}
     data-active={!!activeRef}
-    onClick={handleClick}
-    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-    onMouseOver={handleMouseOver}
     className={CLASS_NAMES.new}
   >
     <MemoizedNewIconWithText label={label} />

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -2,10 +2,10 @@
 
 import {
   type KeyboardEvent,
+  type MouseEvent,
   type ReactNode,
   type RefObject,
   memo,
-  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -369,12 +369,40 @@ export const ListBox = memo(
       }
     }, [listBoxRect, triggerWidth, dropdownWidth, theme])
 
-    const latest = useLatest({ minLength })
+    const latest = useLatest({ handleAdd, handleHoverOption, handleSelect, options, minLength })
 
-    const handleIntersect = useCallback(() => {
-      setCurrentItemLength((current) =>
-        Math.max(current + OPTION_INCREMENT_AMOUNT, latest.minLength),
-      )
+    const functions = useMemo(() => {
+      const resolveOption = (e: MouseEvent) => {
+        const button = (e.target as HTMLElement).closest('button[role="option"]')
+        if (!button || button.hasAttribute('disabled')) return null
+        return (
+          latest.options.find((o) => o.item.value === (button as HTMLButtonElement).value) ?? null
+        )
+      }
+
+      return {
+        handleDelegateClick: (e: MouseEvent) => {
+          const option = resolveOption(e)
+          if (option) {
+            if (option.isNew) {
+              latest.handleAdd?.(option)
+            } else {
+              latest.handleSelect(option)
+            }
+          }
+        },
+        handleDelegateMouseOver: (e: MouseEvent) => {
+          const option = resolveOption(e)
+          if (option) {
+            latest.handleHoverOption(option)
+          }
+        },
+        handleIntersect: () => {
+          setCurrentItemLength((current) =>
+            Math.max(current + OPTION_INCREMENT_AMOUNT, latest.minLength),
+          )
+        },
+      }
     }, [latest])
 
     useEffect(() => {
@@ -395,6 +423,9 @@ export const ListBox = memo(
           aria-hidden={!isExpanded}
           className={CLASS_NAMES.dropdownList}
           style={styles.dropdownList}
+
+          onMouseOver={functions.handleDelegateMouseOver}
+          onClick={functions.handleDelegateClick}
         >
           {dropdownHelpMessage && (
             <Text
@@ -424,15 +455,14 @@ export const ListBox = memo(
                 <ItemButton
                   key={option.id}
                   option={option}
-                  handleAdd={handleAdd}
-                  handleSelect={handleSelect}
-                  handleMouseOver={handleHoverOption}
                   activeRef={option.id === activeOptionId ? activeRef : undefined}
                 />
               ))
             )
           ) : null}
-          {currentItemLength < options.length && <Intersection handleIntersect={handleIntersect} />}
+          {currentItemLength < options.length && (
+            <Intersection handleIntersect={functions.handleIntersect} />
+          )}
         </Scroller>
       </div>,
     )

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -451,11 +451,13 @@ export const ListBox = memo(
                 )}
               </p>
             ) : (
-              items.map((option) => (
+              items.map(({ item, id, ...optionRest }) => (
                 <ItemButton
-                  key={option.id}
-                  option={option}
-                  activeRef={option.id === activeOptionId ? activeRef : undefined}
+                  {...optionRest}
+                  {...item}
+                  key={id}
+                  id={id}
+                  activeRef={id === activeOptionId ? activeRef : undefined}
                 />
               ))
             )

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -373,9 +373,13 @@ export const ListBox = memo(
 
     const functions = useMemo(() => {
       const resolveOption = (e: MouseEvent) => {
-        const button = (e.target as HTMLElement).closest<HTMLButtonElement>('button[role="option"]')
-        if (!button || button.disabled) return null
-        return latest.options.find((o) => o.id === button.id) ?? null
+        for (const el of e.nativeEvent.composedPath()) {
+          if (el instanceof HTMLButtonElement && el.getAttribute('role') === 'option') {
+            if (el.disabled) return null
+            return latest.options.find((o) => o.id === el.id) ?? null
+          }
+        }
+        return null
       }
 
       return {

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -375,8 +375,7 @@ export const ListBox = memo(
       const resolveOption = (e: MouseEvent) => {
         for (const el of e.nativeEvent.composedPath()) {
           if (el instanceof HTMLButtonElement && el.role === 'option') {
-            if (el.disabled) return null
-            return latest.options.find((o) => o.id === el.id) ?? null
+            return el.disabled ? null : (latest.options.find((o) => o.id === el.id) ?? null)
           }
         }
         return null

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -375,7 +375,7 @@ export const ListBox = memo(
       const resolveOption = (e: MouseEvent) => {
         const button = (e.target as HTMLElement).closest<HTMLButtonElement>('button[role="option"]')
         if (!button || button.disabled) return null
-        return latest.options.find((o) => o.item.value === button.value) ?? null
+        return latest.options.find((o) => o.id === button.id) ?? null
       }
 
       return {
@@ -448,11 +448,10 @@ export const ListBox = memo(
                 )}
               </p>
             ) : (
-              items.map(({ item: { label, value, disabled }, id, ...optionRest }) => (
+              items.map(({ item: { label, disabled }, id, ...optionRest }) => (
                 <ItemButton
                   {...optionRest}
                   label={label}
-                  value={value}
                   disabled={disabled}
                   key={id}
                   id={id}

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -423,7 +423,6 @@ export const ListBox = memo(
           aria-hidden={!isExpanded}
           className={CLASS_NAMES.dropdownList}
           style={styles.dropdownList}
-
           onMouseOver={functions.handleDelegateMouseOver}
           onClick={functions.handleDelegateClick}
         >
@@ -451,10 +450,12 @@ export const ListBox = memo(
                 )}
               </p>
             ) : (
-              items.map(({ item, id, ...optionRest }) => (
+              items.map(({ item: { label, value, disabled }, id, ...optionRest }) => (
                 <ItemButton
                   {...optionRest}
-                  {...item}
+                  label={label}
+                  value={value}
+                  disabled={disabled}
                   key={id}
                   id={id}
                   activeRef={id === activeOptionId ? activeRef : undefined}

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -374,7 +374,7 @@ export const ListBox = memo(
     const functions = useMemo(() => {
       const resolveOption = (e: MouseEvent) => {
         for (const el of e.nativeEvent.composedPath()) {
-          if (el instanceof HTMLButtonElement && el.getAttribute('role') === 'option') {
+          if (el instanceof HTMLButtonElement && el.role === 'option') {
             if (el.disabled) return null
             return latest.options.find((o) => o.id === el.id) ?? null
           }

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -19,6 +19,7 @@ import { useLatest } from '../../hooks/useLatest'
 import { usePortal } from '../../hooks/usePortal'
 import { useTheme } from '../../hooks/useTheme'
 import { Localizer } from '../../intl'
+import { findDelegateTarget } from '../../libs/delegate'
 import { FaCircleInfoIcon } from '../Icon'
 import { Loader } from '../Loader'
 import { Scroller } from '../Scroller'
@@ -373,12 +374,9 @@ export const ListBox = memo(
 
     const functions = useMemo(() => {
       const resolveOption = (e: MouseEvent) => {
-        for (const el of e.nativeEvent.composedPath()) {
-          if (el instanceof HTMLButtonElement && el.role === 'option') {
-            return el.disabled ? null : (latest.options.find((o) => o.id === el.id) ?? null)
-          }
-        }
-        return null
+        const el = findDelegateTarget<HTMLButtonElement>(e, 'button[role="option"]')
+        if (!el || el.disabled) return null
+        return latest.options.find((o) => o.id === el.id) ?? null
       }
 
       return {

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -373,11 +373,9 @@ export const ListBox = memo(
 
     const functions = useMemo(() => {
       const resolveOption = (e: MouseEvent) => {
-        const button = (e.target as HTMLElement).closest('button[role="option"]')
-        if (!button || button.hasAttribute('disabled')) return null
-        return (
-          latest.options.find((o) => o.item.value === (button as HTMLButtonElement).value) ?? null
-        )
+        const button = (e.target as HTMLElement).closest<HTMLButtonElement>('button[role="option"]')
+        if (!button || button.disabled) return null
+        return latest.options.find((o) => o.item.value === button.value) ?? null
       }
 
       return {

--- a/packages/smarthr-ui/src/libs/delegate.ts
+++ b/packages/smarthr-ui/src/libs/delegate.ts
@@ -1,0 +1,11 @@
+export const findDelegateTarget = <T extends Element>(
+  e: { nativeEvent: Event },
+  selector: string,
+): T | null => {
+  for (const el of e.nativeEvent.composedPath()) {
+    if (el instanceof Element && el.matches(selector)) {
+      return el as T
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## 関連URL

## 概要

ComboboxのListBoxで、各ItemButtonに個別のonClick/onMouseOverを設定する代わりに、コンテナへのイベント移譲（event delegation）で実装する。

## 変更内容

- `ItemButton`: `handleAdd`/`handleSelect`/`handleMouseOver` propsを削除し、シンプルなコンポーネントに整理
  - button要素に `value` 属性を追加し、イベント移譲でオプションを識別できるようにした
  - `onClick`/`onMouseOver` を各ボタンから削除
- `useListbox.tsx` の `ListBox`:
  - `useLatest + functions` パターンを統合し、`handleDelegateClick`/`handleDelegateMouseOver`/`handleIntersect` を1つの `functions` オブジェクトにまとめた
  - `Scroller` にイベント移譲用の `onClick`/`onMouseOver` を設定
  - `resolveOption` ヘルパーで `e.target.closest('button[role="option"]')` を使ってクリックされたオプションを特定

## プロダクト側で対応が必要な事項

なし（内部リファクタリング）

## 確認方法

Chromatic / Storybookで動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * コンボボックスの項目選択やマウス操作の応答性を改善しました。
  * 無効な項目が誤って選択・追加されないようになりました。
  * 項目数が多い場合のスクロールによる追加読み込みを安定化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->