### PR TITLE
refactor(Tooltip): イベントハンドラをuseLatest + functionsパターンに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/Tooltip.tsx
@@ -5,8 +5,10 @@ import {
   type ComponentProps,
   type FC,
   type PropsWithChildren,
+  type FocusEvent as ReactFocusEvent,
   type ReactNode,
-  useCallback,
+  type PointerEvent as ReactPointerEvent,
+  type TouchEvent as ReactTouchEvent,
   useId,
   useMemo,
   useRef,
@@ -17,6 +19,7 @@ import { createPortal } from 'react-dom'
 import { tv } from 'tailwind-variants'
 
 import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'
+import { useLatest } from '../../hooks/useLatest'
 
 import { TooltipPortal } from './TooltipPortal'
 
@@ -104,14 +107,24 @@ export const Tooltip: FC<Props> = ({
     [isIcon, className],
   )
 
-  const toShowAction = useCallback(
-    (e: BaseSyntheticEvent) => {
+  const latest = useLatest({
+    onPointerEnter,
+    onPointerLeave,
+    onTouchStart,
+    onTouchEnd,
+    onFocus,
+    onBlur,
+    ellipsisOnly,
+  })
+
+  const functions = useMemo(() => {
+    const toShowAction = (e: BaseSyntheticEvent) => {
       // Tooltipのtriggerの他の要素(Dropwdown menu buttonで開いたmenu contentとか)に移動されたらtooltipを表示しない
       if (!ref.current?.contains(e.target)) {
         return
       }
 
-      if (ellipsisOnly) {
+      if (latest.ellipsisOnly) {
         const outerWidth = parseInt(
           window
             .getComputedStyle(ref.current.parentNode! as HTMLElement, null)
@@ -126,13 +139,39 @@ export const Tooltip: FC<Props> = ({
 
       setRect(ref.current.getBoundingClientRect())
       setIsVisible(true)
-    },
-    [ellipsisOnly],
-  )
-  const toCloseAction = useCallback(() => {
-    setRect(null)
-    setIsVisible(false)
-  }, [])
+    }
+    const toCloseAction = () => {
+      setRect(null)
+      setIsVisible(false)
+    }
+
+    return {
+      handlePointerEnter: (e: ReactPointerEvent<HTMLSpanElement>) => {
+        latest.onPointerEnter?.(e)
+        toShowAction(e)
+      },
+      handleTouchStart: (e: ReactTouchEvent<HTMLSpanElement>) => {
+        latest.onTouchStart?.(e)
+        toShowAction(e)
+      },
+      handleFocus: (e: ReactFocusEvent<HTMLSpanElement>) => {
+        latest.onFocus?.(e)
+        toShowAction(e)
+      },
+      handlePointerLeave: (e: ReactPointerEvent<HTMLSpanElement>) => {
+        latest.onPointerLeave?.(e)
+        toCloseAction()
+      },
+      handleTouchEnd: (e: ReactTouchEvent<HTMLSpanElement>) => {
+        latest.onTouchEnd?.(e)
+        toCloseAction()
+      },
+      handleBlur: (e: ReactFocusEvent<HTMLSpanElement>) => {
+        latest.onBlur?.(e)
+        toCloseAction()
+      },
+    }
+  }, [latest])
 
   useEnhancedEffect(() => {
     setPortalRoot(fullscreenElement ?? document.body)
@@ -153,7 +192,7 @@ export const Tooltip: FC<Props> = ({
   }, [tabIndex, isLabel, messageId])
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, smarthr/best-practice-for-interactive-element
     <span
       {...rest}
       ref={ref}
@@ -161,30 +200,12 @@ export const Tooltip: FC<Props> = ({
       aria-describedby={
         isLabel || isFocusableChild || ariaDescribedbyTarget === 'inner' ? undefined : messageId
       }
-      onPointerEnter={(delegateEvent) => {
-        onPointerEnter?.(delegateEvent)
-        toShowAction(delegateEvent)
-      }}
-      onTouchStart={(delegateEvent) => {
-        onTouchStart?.(delegateEvent)
-        toShowAction(delegateEvent)
-      }}
-      onFocus={(delegateEvent) => {
-        onFocus?.(delegateEvent)
-        toShowAction(delegateEvent)
-      }}
-      onPointerLeave={(delegateEvent) => {
-        onPointerLeave?.(delegateEvent)
-        toCloseAction()
-      }}
-      onTouchEnd={(delegateEvent) => {
-        onTouchEnd?.(delegateEvent)
-        toCloseAction()
-      }}
-      onBlur={(delegateEvent) => {
-        onBlur?.(delegateEvent)
-        toCloseAction()
-      }}
+      onPointerEnter={functions.handlePointerEnter}
+      onTouchStart={functions.handleTouchStart}
+      onFocus={functions.handleFocus}
+      onPointerLeave={functions.handlePointerLeave}
+      onTouchEnd={functions.handleTouchEnd}
+      onBlur={functions.handleBlur}
       className={actualClassName}
     >
       {portalRoot &&


### PR DESCRIPTION
## 関連URL

## 概要

`Tooltip.tsx` のイベントハンドラを `useLatest + functions` パターンにリファクタリングする。

## 変更内容

- `useCallback` による `toShowAction` / `toCloseAction` の個別メモ化を廃止
- `useLatest` で外部から受け取るコールバックをまとめて安定化
- `useMemo` で `functions` オブジェクトを生成し、すべてのイベントハンドラをまとめて管理
- JSX のインラインハンドラーを `functions.*` への参照に置き換え

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic での VRT 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ツールチップのイベント処理を改善し、表示・非表示や操作時の動作がより安定しました。
  * `ellipsisOnly` 設定やコールバックの変更が、最新の状態に正しく反映されるようになりました。
  * 静的な要素上でのツールチップ操作に関するアクセシビリティと互換性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->