### PR TITLE
refactor(TextLink): classNames生成パターンをsmarthr-uiの規約に合わせて整理

### DIFF
--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -62,10 +62,6 @@ const classNameGenerator = tv({
     },
   },
 })
-const { anchor, prefixWrapper, suffixWrapper } = classNameGenerator()
-const prefixWrapperClassName = prefixWrapper()
-const suffixWrapperClassName = suffixWrapper()
-
 const ActualTextLink: TextLinkComponent = forwardRef(
   <T extends ElementType = 'a'>(
     {
@@ -87,7 +83,14 @@ const ActualTextLink: TextLinkComponent = forwardRef(
     // target="_blank" だが OpenInNewTabIcon を表示したくない場合 suffix に null を指定すれば表示しないようにしている
     const actualSuffix =
       target === '_blank' && !prefix && suffix === undefined ? <OpenInNewTabIcon /> : suffix
-    const anchorClassName = useMemo(() => anchor({ size, className }), [size, className])
+    const classNames = useMemo(() => {
+      const { anchor, prefixWrapper, suffixWrapper } = classNameGenerator()
+      return {
+        anchor: anchor({ size, className }),
+        prefixWrapper: prefixWrapper(),
+        suffixWrapper: suffixWrapper(),
+      }
+    }, [size, className])
 
     const latest = useLatest({ onClick, href })
 
@@ -115,11 +118,11 @@ const ActualTextLink: TextLinkComponent = forwardRef(
         target={target}
         rel={rel === undefined && target === '_blank' ? 'noopener noreferrer' : rel}
         onClick={functions.handleClick}
-        className={anchorClassName}
+        className={classNames.anchor}
       >
-        {prefix && <span className={prefixWrapperClassName}>{prefix}</span>}
+        {prefix && <span className={classNames.prefixWrapper}>{prefix}</span>}
         {children}
-        {actualSuffix && <span className={suffixWrapperClassName}>{actualSuffix}</span>}
+        {actualSuffix && <span className={classNames.suffixWrapper}>{actualSuffix}</span>}
       </Anchor>
     )
   },

--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -87,8 +87,6 @@ const ActualTextLink: TextLinkComponent = forwardRef(
     // target="_blank" だが OpenInNewTabIcon を表示したくない場合 suffix に null を指定すれば表示しないようにしている
     const actualSuffix =
       target === '_blank' && !prefix && suffix === undefined ? <OpenInNewTabIcon /> : suffix
-    const actualHref = href ? href : onClick ? '' : undefined
-    const actualRel = rel === undefined && target === '_blank' ? 'noopener noreferrer' : rel
     const anchorClassName = useMemo(() => anchor({ size, className }), [size, className])
 
     const latest = useLatest({ onClick, href })
@@ -113,9 +111,9 @@ const ActualTextLink: TextLinkComponent = forwardRef(
       <Anchor
         {...rest}
         ref={ref}
-        href={actualHref}
+        href={href ? href : onClick ? '' : undefined}
         target={target}
-        rel={actualRel}
+        rel={rel === undefined && target === '_blank' ? 'noopener noreferrer' : rel}
         onClick={functions.handleClick}
         className={anchorClassName}
       >


### PR DESCRIPTION
## 関連URL

## 概要

`TextLink.tsx` の classNames 生成パターンを smarthr-ui の規約に合わせて整理する。

## 変更内容

- 不要な中間変数（`actualHref`、`actualRel`）を削除し JSX にインライン化
- モジュールレベルの `classNameGenerator()` 呼び出しと個別変数（`prefixWrapperClassName`、`suffixWrapperClassName`）を削除
- すべての classNames 生成を1つの `useMemo` にまとめて統一

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic での VRT 確認