### PR TITLE
refactor(Textarea): MaxLettersTextareaのclassNames生成とアクセシビリティを改善

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -183,7 +183,9 @@ const MaxLettersTextarea: FC<
           values={{ maxLetters }}
         />
       </VisuallyHiddenText>
-      <VisuallyHiddenText aria-live="polite">{srCounterMessage}</VisuallyHiddenText>
+      <VisuallyHiddenText as="output" role="status">
+        {srCounterMessage}
+      </VisuallyHiddenText>
       <span
         ref={counterSpanRef}
         id={maxLettersId}

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -106,8 +106,9 @@ const MaxLettersTextarea: FC<
   Omit<LocalTextareaProps, 'maxLetters'> & {
     maxLetters: number
   }
-> = ({ maxLetters, error, value, defaultValue, onChange, ...rest }) => {
+> = ({ maxLetters, error, value, defaultValue, onChange, id, ...rest }) => {
   const maxLettersId = useId()
+  const textareaId = id || `${maxLettersId}-textarea`
   const maxLettersNoticeId = `${maxLettersId}-notice`
 
   const counterSpanRef = useRef<HTMLSpanElement>(null)
@@ -170,6 +171,7 @@ const MaxLettersTextarea: FC<
     <span className="shr-relative">
       <ActualTextarea
         {...rest}
+        id={textareaId}
         value={value}
         defaultValue={defaultValue}
         onChange={functions.handleChange}
@@ -183,7 +185,7 @@ const MaxLettersTextarea: FC<
           values={{ maxLetters }}
         />
       </VisuallyHiddenText>
-      <VisuallyHiddenText as="output" role="status">
+      <VisuallyHiddenText as="output" role="status" htmlFor={textareaId}>
         {srCounterMessage}
       </VisuallyHiddenText>
       <span

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -62,28 +62,15 @@ const getStringLength = (value: TextareaValue) => {
 }
 
 const classNameGenerator = tv({
-  slots: {
-    textareaEl: [
-      'smarthr-ui-Textarea-textarea',
-      'shr-border-shorthand shr-my-[unset] shr-box-border shr-rounded-m shr-bg-white shr-p-0.5 shr-text-base shr-leading-normal shr-text-black shr-opacity-100',
-      'contrast-more:shr-border-high-contrast',
-      'placeholder:shr-text-grey',
-      'focus-visible:shr-focus-indicator',
-      'disabled:shr-pointer-events-none disabled:shr-bg-column disabled:shr-text-disabled disabled:placeholder:shr-text-disabled',
-      'aria-[invalid]:shr-border-danger',
-    ],
-    counter: 'smarthr-ui-Textarea-counter shr-block shr-text-sm shr-text-black',
-  },
-  variants: {
-    error: {
-      true: {
-        counter: 'shr-text-danger',
-      },
-    },
-  },
-  defaultVariants: {
-    error: false,
-  },
+  base: [
+    'smarthr-ui-Textarea-textarea',
+    'shr-border-shorthand shr-my-[unset] shr-box-border shr-rounded-m shr-bg-white shr-p-0.5 shr-text-base shr-leading-normal shr-text-black shr-opacity-100',
+    'contrast-more:shr-border-high-contrast',
+    'placeholder:shr-text-grey',
+    'focus-visible:shr-focus-indicator',
+    'disabled:shr-pointer-events-none disabled:shr-bg-column disabled:shr-text-disabled disabled:placeholder:shr-text-disabled',
+    'aria-[invalid]:shr-border-danger',
+  ],
 })
 
 const calculateIdealRows = (
@@ -131,13 +118,6 @@ const MaxLettersTextarea: FC<
   const [srCounterMessage, setSrCounterMessage] = useState<ReactNode>('')
 
   const countError = count > maxLetters
-  const classNames = useMemo(() => {
-    const { counter } = classNameGenerator()
-
-    return {
-      counter: counter({ error: !!countError }),
-    }
-  }, [countError])
 
   const latest = useLatest({
     onChange,
@@ -208,7 +188,8 @@ const MaxLettersTextarea: FC<
         ref={counterSpanRef}
         id={maxLettersId}
         aria-hidden={true}
-        className={classNames.counter}
+        data-error={countError || undefined}
+        className="smarthr-ui-Textarea-counter shr-block shr-text-sm shr-text-black data-[error]:shr-text-danger"
       >
         {count > maxLetters ? (
           <Localizer
@@ -245,13 +226,7 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const [interimRows, setInterimRows] = useState(rows)
 
-  const classNames = useMemo(() => {
-    const { textareaEl } = classNameGenerator()
-
-    return {
-      textarea: textareaEl({ className }),
-    }
-  }, [className])
+  const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
   const latest = useLatest({
     onChange,
@@ -311,7 +286,7 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
       ref={functions.callbackRef}
       aria-invalid={error || undefined}
       rows={interimRows}
-      className={classNames.textarea}
+      className={actualClassName}
       style={{ width: typeof width === 'number' ? `${width}px` : width }}
     />
   )


### PR DESCRIPTION
## 関連URL

## 概要

`MaxLettersTextarea` の classNames 生成パターンの最適化と、スクリーンリーダー向けのライブリージョンの意味論的な改善を行う。

## 変更内容

- `countError` をトリガーとした `useMemo` の再計算を廃止し、`data-[error]:` CSS 属性セレクタで代替
- `counter` スロットを `tv()` から分離し、プレーンな文字列定数として定義
- `tv()` の slots 構造を廃止し、textarea のクラス生成を `base` に統一
- `aria-live="polite"` を `<VisuallyHiddenText as="output" role="status">` に変更し、`<output>` 要素の意味論を活用
- `<output>` に `htmlFor` を設定し、textarea と関連付け

## プロダクト側で対応が必要な事項

なし（内部リファクタリングのみ）

## 確認方法

Chromatic での VRT 確認