### PR TITLE
refactor(FileViewer): aria-live="polite"をoutput要素に置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/SearchController.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FC, memo, useMemo } from 'react'
+import { type FC, memo, useId, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
@@ -42,6 +42,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
     goPrev,
   } = search
   const { mobile } = useEnvironment()
+  const searchInputId = useId()
   const classNames = useMemo(() => {
     const { wrapper, inputArea } = classNameGenerator({ mobile })
     return { wrapper: wrapper(), inputArea: inputArea() }
@@ -53,6 +54,7 @@ export const SearchController: FC<Props> = memo(({ search }) => {
     <div className={classNames.wrapper}>
       <div className={classNames.inputArea}>
         <SearchInput
+          id={searchInputId}
           name="file_viewer_search"
           tooltipMessage={
             <Localizer
@@ -66,7 +68,13 @@ export const SearchController: FC<Props> = memo(({ search }) => {
           width="100%"
           suffix={
             query !== '' ? (
-              <Text size="S" aria-live="polite" className="shr-tabular-nums">
+              <Text
+                as="output"
+                role="status"
+                htmlFor={searchInputId}
+                size="S"
+                className="shr-tabular-nums"
+              >
                 {`${noMatches ? 0 : currentMatchIndex + 1}/${matchCount}`}
               </Text>
             ) : undefined


### PR DESCRIPTION
## 関連URL

## 概要

`FileViewer/SearchController` で使用していた `aria-live="polite"` を、より意味的に適切な `<output>` 要素に置き換えた。

## 変更内容

- `<Text aria-live="polite">` → `<Text as="output" role="status" htmlFor={searchInputId}>`
- `useId()` で `searchInputId` を生成し、`SearchInput` に `id` として渡すことで `<output>` と入力欄を `htmlFor` で紐づけた

`<output>` 要素は暗黙的に `aria-live="polite"` と `role="status"` を持つが、クロスブラウザ互換性のため `role="status"` を明示的に付与している。

## プロダクト側で対応が必要な事項

なし（内部実装の変更のみ）

## 確認方法

Storybook で FileViewer を表示し、検索機能が正常に動作することを確認。