### PR TITLE
refactor(Dialog): APIレスポンス成功メッセージのrole="status"をoutput要素に置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
   memo,
   useCallback,
+  useId,
 } from 'react'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
@@ -89,6 +90,7 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
   subActionArea,
 }) => {
   const calcedResponseStatus = useResponseStatus(responseStatus)
+  const actionButtonId = useId()
 
   return (
     <Section className={CLASS_NAMES.wrapper}>
@@ -105,12 +107,14 @@ export const ActionDialogContentInner: FC<ActionDialogContentInnerProps> = ({
             closeButton={closeButton}
             actionButton={actionButton}
             loading={calcedResponseStatus.isProcessing}
+            actionButtonId={actionButtonId}
             className={CLASS_NAMES.buttonArea}
           />
         </Cluster>
         <DialogContentResponseStatusMessage
           responseStatus={calcedResponseStatus}
           className={CLASS_NAMES.message}
+          actionButtonId={actionButtonId}
         />
       </div>
     </Section>
@@ -122,48 +126,62 @@ const ActionAreaCluster = memo<
     actionButton: ObjectActionButtonType
     closeButton: ObjectCloseButtonType
     loading: boolean
+    actionButtonId: string
     className: string
   }
->(({ handleClickClose, handleClickAction, closeButton, actionButton, loading, className }) => {
-  const handleClickActionWithHelpers = useCallback(
-    (e: MouseEvent<Element>) => {
-      handleClickAction(e, { close: handleClickClose })
-    },
-    [handleClickAction, handleClickClose],
-  )
+>(
+  ({
+    handleClickClose,
+    handleClickAction,
+    closeButton,
+    actionButton,
+    loading,
+    actionButtonId,
+    className,
+  }) => {
+    const handleClickActionWithHelpers = useCallback(
+      (e: MouseEvent<Element>) => {
+        handleClickAction(e, { close: handleClickClose })
+      },
+      [handleClickAction, handleClickClose],
+    )
 
-  return (
-    <Cluster gap={ACTION_AREA_CLUSTER_GAP} className={className}>
-      <CloseButton
-        handleClick={handleClickClose}
-        disabled={closeButton.disabled || loading}
-        text={closeButton.text}
-      />
-      <ActionButton
-        variant={actionButton.theme}
-        disabled={actionButton.disabled}
-        loading={loading}
-        handleClick={handleClickActionWithHelpers}
-      >
-        {actionButton.text}
-      </ActionButton>
-    </Cluster>
-  )
-})
+    return (
+      <Cluster gap={ACTION_AREA_CLUSTER_GAP} className={className}>
+        <CloseButton
+          handleClick={handleClickClose}
+          disabled={closeButton.disabled || loading}
+          text={closeButton.text}
+        />
+        <ActionButton
+          variant={actionButton.theme}
+          disabled={actionButton.disabled}
+          loading={loading}
+          id={actionButtonId}
+          handleClick={handleClickActionWithHelpers}
+        >
+          {actionButton.text}
+        </ActionButton>
+      </Cluster>
+    )
+  },
+)
 
 const ActionButton = memo<
   PropsWithChildren<{
     variant: ObjectActionButtonType['theme']
     disabled: ObjectActionButtonType['disabled']
     loading: boolean
+    id: string
     handleClick: (e: MouseEvent<HTMLButtonElement>) => void
   }>
->(({ variant = 'primary', disabled, loading, handleClick, children }) => (
+>(({ variant = 'primary', disabled, loading, id, handleClick, children }) => (
   <Button
     type="submit"
     variant={variant}
     disabled={disabled}
     loading={loading}
+    id={id}
     onClick={handleClick}
     className="smarthr-ui-Dialog-actionButton"
   >

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import { type FC, type FormEvent, type PropsWithChildren, type ReactNode, memo } from 'react'
+import { type FC, type FormEvent, type PropsWithChildren, type ReactNode, memo, useId } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
@@ -88,6 +88,7 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
   subActionArea,
 }) => {
   const calculatedResponseStatus = useResponseStatus(responseStatus)
+  const actionButtonId = useId()
 
   return (
     // eslint-disable-next-line smarthr/a11y-prohibit-sectioning-content-in-form
@@ -105,12 +106,14 @@ export const FormDialogContentInner: FC<FormDialogContentInnerProps> = ({
               closeButton={closeButton}
               actionButton={actionButton}
               loading={calculatedResponseStatus.isProcessing}
+              actionButtonId={actionButtonId}
               className={CLASS_NAMES.buttonArea}
             />
           </Cluster>
           <DialogContentResponseStatusMessage
             responseStatus={calculatedResponseStatus}
             className={CLASS_NAMES.message}
+            actionButtonId={actionButtonId}
           />
         </div>
       </form>
@@ -123,16 +126,22 @@ const ActionAreaCluster = memo<
     actionButton: ObjectActionButtonType
     closeButton: ObjectCloseButtonType
     loading: boolean
+    actionButtonId: string
     className: string
   }
->(({ handleClickClose, closeButton, actionButton, loading, className }) => (
+>(({ handleClickClose, closeButton, actionButton, loading, actionButtonId, className }) => (
   <Cluster gap={ACTION_AREA_CLUSTER_GAP} className={className}>
     <CloseButton
       handleClick={handleClickClose}
       disabled={closeButton.disabled || loading}
       text={closeButton.text}
     />
-    <ActionButton variant={actionButton.theme} disabled={actionButton.disabled} loading={loading}>
+    <ActionButton
+      variant={actionButton.theme}
+      disabled={actionButton.disabled}
+      loading={loading}
+      id={actionButtonId}
+    >
       {actionButton.text}
     </ActionButton>
   </Cluster>
@@ -143,13 +152,15 @@ const ActionButton = memo<
     variant: ObjectActionButtonType['theme']
     disabled: ObjectActionButtonType['disabled']
     loading: boolean
+    id: string
   }>
->(({ variant = 'primary', disabled, loading, children }) => (
+>(({ variant = 'primary', disabled, loading, id, children }) => (
   <Button
     type="submit"
     variant={variant}
     disabled={disabled}
     loading={loading}
+    id={id}
     className="smarthr-ui-Dialog-actionButton"
   >
     {children}

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
   memo,
   useContext,
+  useId,
   useMemo,
 } from 'react'
 
@@ -160,6 +161,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
   const stepText = stepLength > 1 ? `（${activeStep}/${stepLength}）` : ''
 
   const calcedResponseStatus = useResponseStatus(responseStatus)
+  const actionButtonId = useId()
 
   return (
     // eslint-disable-next-line smarthr/a11y-prohibit-sectioning-content-in-form
@@ -203,6 +205,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
                     disabled={submitButton.disabled}
                     loading={calcedResponseStatus.isProcessing}
                     text={submitButton.text}
+                    id={actionButtonId}
                   />
                 )}
               </Cluster>
@@ -210,6 +213,7 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
             <DialogContentResponseStatusMessage
               responseStatus={calcedResponseStatus}
               className={CLASS_NAMES.message}
+              actionButtonId={actionButtonId}
             />
           </div>
         </div>
@@ -255,12 +259,14 @@ const SubmitButton = memo<{
   disabled: boolean | undefined
   loading: boolean
   text: ReactNode
-}>(({ variant, disabled, loading, text }) => (
+  id: string
+}>(({ variant, disabled, loading, text, id }) => (
   <Button
     type="submit"
     variant={variant}
     disabled={disabled}
     loading={loading}
+    id={id}
     className="smarthr-ui-Dialog-actionButton"
   >
     {text}

--- a/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
@@ -6,7 +6,8 @@ import type { FC } from 'react'
 export const DialogContentResponseStatusMessage: FC<{
   responseStatus: ReturnType<typeof useResponseStatus>
   className?: string
-}> = ({ responseStatus, className }) => {
+  actionButtonId?: string
+}> = ({ responseStatus, className, actionButtonId }) => {
   const isError = responseStatus.message && responseStatus.status === 'error'
   const isSuccess = responseStatus.message && responseStatus.status === 'success'
 
@@ -22,7 +23,10 @@ export const DialogContentResponseStatusMessage: FC<{
         {isError && <ResponseMessage status="error">{responseStatus.message}</ResponseMessage>}
       </div>
       {/* APIレスポンスの成功結果を表示するoutput要素。output要素はaria-live="polite"相当のrole="status"を暗黙的に持つ */}
-      <output className={isSuccess ? `${className} shr-mt-0.5` : className}>
+      <output
+        className={isSuccess ? `${className} shr-mt-0.5` : className}
+        htmlFor={actionButtonId}
+      >
         {isSuccess && <ResponseMessage status="success">{responseStatus.message}</ResponseMessage>}
       </output>
     </>

--- a/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
@@ -17,12 +17,14 @@ export const DialogContentResponseStatusMessage: FC<{
      * @see https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/#make-sure-the-live-region-container-is-in-the-dom-as-early-as-possible
      */
     <>
+      {/* output要素はaria-live="polite"相当のため、即座に読み上げが必要なエラーにはrole="alert"のdivを使用する */}
       <div className={isError ? `${className} shr-mt-0.5` : className} role="alert">
         {isError && <ResponseMessage status="error">{responseStatus.message}</ResponseMessage>}
       </div>
-      <div className={isSuccess ? `${className} shr-mt-0.5` : className} role="status">
+      {/* APIレスポンスの成功結果を表示するoutput要素。output要素はaria-live="polite"相当のrole="status"を暗黙的に持つ */}
+      <output className={isSuccess ? `${className} shr-mt-0.5` : className}>
         {isSuccess && <ResponseMessage status="success">{responseStatus.message}</ResponseMessage>}
-      </div>
+      </output>
     </>
   )
 }


### PR DESCRIPTION
## 関連URL

## 概要

`DialogContentResponseStatusMessage` でAPIレスポンスの成功メッセージを表示していた `<div role="status">` を、より意味論的に適切な `<output>` 要素に置き換えた。また、action buttonとの関連を `htmlFor` で明示した。

## 変更内容

### `DialogContentResponseStatusMessage.tsx`
- `<div role="status">` → `<output>`
  - `<output>` 要素は暗黙的に `role="status"`（`aria-live="polite"` 相当）を持つため、フォーム送信結果の表示に意味論的に合致する
  - `role="status"` の明示的な付与は ESLint（`jsx-a11y/no-redundant-roles`）により冗長と判定されるため省略
- `<div role="alert">` はエラー表示のために `aria-live="assertive"` が必要であり変更しない
- `actionButtonId` prop を追加し、`htmlFor` でaction buttonと関連付け
- 各要素にコメントを追加し、変更意図と使い分けの理由を記録

### `ActionDialogContentInner.tsx` / `FormDialogContentInner.tsx` / `StepFormDialogContentInner.tsx`
- `useId()` で `actionButtonId` を生成
- action button（`ActionButton` / `SubmitButton`）に `id={actionButtonId}` を付与
- `DialogContentResponseStatusMessage` に `actionButtonId` を渡す

`<button>` は form-associated element のため、`<output>` の `for` 属性のターゲットとして HTML 仕様上有効。「このボタンを押した結果としてこのoutputが更新された」という関係を表現できる。

常にDOMに存在させる制約（ライブリージョンの通知の確実性）は `<output>` でも同様に維持される。

## プロダクト側で対応が必要な事項

なし（内部実装の変更のみ）

## 確認方法

Storybook で FormDialog / ActionDialog / StepFormDialog を表示し、送信後の成功・エラーメッセージが正常に表示されることを確認。