### PR TITLE
docs(Table): useTableHeadCellCountにa11y対応の意図を示すコメントを追記

### DIFF
--- a/packages/smarthr-ui/src/components/Table/useTableHeadCellCount.ts
+++ b/packages/smarthr-ui/src/components/Table/useTableHeadCellCount.ts
@@ -3,6 +3,10 @@ import { useCallback, useState } from 'react'
 // HINT: 初期表示のタイミングでBulkActionRowも表示している場合、潰れてみえないよう初期値を大きめに設定しておく
 const INITIAL_COUNT = 999
 
+// HINT: colSpan=999 を固定値として使い続けることも視覚的には問題ない（ブラウザが実際のカラム数にクランプして描画するため）。
+// ただし、一部のスクリーンリーダーや支援技術（AT）はDOMのcolSpan属性値（999）を直接参照し、
+// 「999カラムにまたがる」と誤って告知する実装がある。
+// これを防ぐためにa11y対応として実際のheadセル数を取得し、正確なcolSpan値を設定するhookとして実装している。
 export const useTableHeadCellCount = <T extends HTMLElement>() => {
   const [count, setCount] = useState(INITIAL_COUNT)
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useTableHeadCellCount` は `colSpan` に大きな初期値（999）を設定したうえで、マウント後に実際の `thead` のセル数を取得して正確な値に更新するhookだが、なぜ 999 固定ではなく正確な値を取得する必要があるのかの意図がコードから読み取りにくかったため、コメントを追記する。

## 変更内容

`useTableHeadCellCount.ts` にコメントを追加。

**背景（調査結果）:**
- `colSpan=999` のまま固定しても、ブラウザは実際のカラム数にクランプして描画するため視覚的な問題はない
- ただし、一部のスクリーンリーダー・支援技術（AT）は DOM の `colSpan` 属性値（999）を直接参照し、「999カラムにまたがる」と誤って告知する実装がある
- これを防ぐためのa11y対応として、実際の `th` セル数を取得・設定するhookとして実装している

## プロダクト側で対応が必要な事項

なし

## 確認方法

コードコメントの確認のみ。動作変更なし。