### PR TITLE
refactor(TableScroller): tv()を削除しSCROLLER_PROPSとして定数化

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TableScroller.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableScroller.tsx
@@ -9,7 +9,6 @@ import {
   useLayoutEffect,
   useRef,
 } from 'react'
-import { tv } from 'tailwind-variants'
 
 import { defaultHtmlFontSize } from '../../themes'
 import { Scroller } from '../Scroller'
@@ -19,37 +18,23 @@ type Props = PropsWithChildren &
     fixedHead?: boolean
   }
 
-const classNameGenerator = tv({
-  slots: {
-    // fixedHead のとき、スクロールインスタンスがTableからWrapperに変わるため、Wrapperに対して高さとoverflowを指定する
-    wrapper: 'shr-h-[inherit] shr-max-h-[inherit] shr-scroll-pb-0.5',
-  },
-})
-
-const classNames = (() => {
-  const { wrapper } = classNameGenerator()
-  return {
-    wrapper: wrapper(),
-  }
-})()
+const SCROLLER_PROPS = {
+  direction: 'both' as const,
+  // fixedHead のとき、スクロールインスタンスがTableからWrapperに変わるため、Wrapperに対して高さとoverflowを指定する
+  className: 'shr-h-[inherit] shr-max-h-[inherit] shr-scroll-pb-0.5',
+}
 
 export const TableScroller = forwardRef<HTMLDivElement, Props>(
-  ({ children, fixedHead, ...rest }, forwardedRef: ForwardedRef<HTMLDivElement>) => {
-    const commonProps = {
-      direction: 'both' as const,
-      className: classNames.wrapper,
-    }
-
-    return fixedHead ? (
-      <FixedHeadTableScroller {...rest} {...commonProps} forwardedRef={forwardedRef}>
+  ({ children, fixedHead, ...rest }, forwardedRef: ForwardedRef<HTMLDivElement>) =>
+    fixedHead ? (
+      <FixedHeadTableScroller {...rest} {...SCROLLER_PROPS} forwardedRef={forwardedRef}>
         {children}
       </FixedHeadTableScroller>
     ) : (
-      <Scroller {...rest} {...commonProps} ref={forwardedRef}>
+      <Scroller {...rest} {...SCROLLER_PROPS} ref={forwardedRef}>
         {children}
       </Scroller>
-    )
-  },
+    ),
 )
 
 type FixedHeadTableScrollerProps = PropsWithChildren &


### PR DESCRIPTION
## 関連URL

なし

## 概要

`TableScroller` の静的クラス名生成に `tv()` を使っていたが、バリアントも合成も不要な単一の静的文字列に対して `tv()` を使うのは過剰なため削除する。

## 変更内容

- `tv()` による `classNameGenerator` と IIFE による `classNames` を削除
- クラス文字列をコンポーネント外の `SCROLLER_PROPS` 定数に直接記述
- `commonProps` をコンポーネント関数外の定数 `SCROLLER_PROPS` に昇格させ、レンダリングごとのオブジェクト生成を排除
- コメントを `SCROLLER_PROPS` 定義の直上に移動

## プロダクト側で対応が必要な事項

なし

## 確認方法

動作変更なし。Storybookで `TableScroller` を含む `Table` コンポーネントの表示を確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * テーブルのスクロール領域に共通のスタイルを適用する構造を整理しました。
  * 通常表示と固定ヘッダー表示で、スクロール方向やラッパーの見た目が統一されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->