### PR TITLE
fix(InputFile): previewableでファイル名が長い場合に折り返されない問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-min-w-0 shr-break-words shr-whitespace-normal'
+  'smarthr-ui-InputFile-fileName shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -19,7 +19,8 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
   </span>
 ))
 
-const FILE_NAME_BUTTON_CLASSNAME = 'smarthr-ui-InputFile-fileName'
+const FILE_NAME_BUTTON_CLASSNAME =
+  'smarthr-ui-InputFile-fileName shr-min-w-0 shr-break-words shr-whitespace-normal'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InputFile` でファイル名が長い場合に横にはみ出して折り返されない問題を修正する。

## 変更内容

`FILE_NAME_BUTTON_CLASSNAME` と `PREVIEW_BUTTON_CLASSNAME` に以下のクラスを追加。

```diff
- const FILE_NAME_BUTTON_CLASSNAME = 'smarthr-ui-InputFile-fileName'
+ const FILE_NAME_BUTTON_CLASSNAME =
+   'smarthr-ui-InputFile-fileName shr-min-w-0 shr-break-words shr-whitespace-normal'

- const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
+ const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
```

**各クラスの役割:**

- `shr-min-w-0`（`min-width: 0`）  
  `li` が `shr-flex` のフレックスコンテナで、フレックスアイテムのデフォルト `min-width` は `auto`（＝コンテンツの min-content サイズ）。スペースなしの長いファイル名は1単語として扱われるため、`min-width: auto` のままではフレックスアルゴリズムがアイテムを縮小せず `overflow-wrap` が機能しない。`min-width: 0` を明示することで縮小を許可する。

- `shr-break-words`（`overflow-wrap: break-word`）  
  縮小されたコンテナ内でスペースのない長いファイル名を折り返す。`word-break: break-all` より穏やかで、単語がコンテナをはみ出す場合のみ折り返す。

- `shr-whitespace-normal`（`white-space: normal`）  
  `Button` コンポーネントは内部に `shr-whitespace-nowrap` を持つ。`Button`（`tv()`）は外部 `className` を `tailwind-merge` で後勝ち適用するため、`shr-whitespace-normal` で上書きして折り返しを有効にする。`FILE_NAME_BUTTON_CLASSNAME` に含めることで previewable / non-previewable の全ケースに統一して適用する。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで長いファイル名のファイルを `InputFile`（previewable / non-previewable 両方）に添付し、ファイル名が正しく折り返されることを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ファイル名表示ボタンで、長いファイル名が適切に折り返されるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->