### PR TITLE
fix(Dropdown): メニュー開放中のスクロール/リサイズでメニュー位置を追従させる

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -132,14 +132,13 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     }
 
     const scrollOption = { capture: true, passive: true }
-    const resizeOption = { passive: true }
 
     window.addEventListener('scroll', updateTriggerRect, scrollOption)
-    window.addEventListener('resize', updateTriggerRect, resizeOption)
+    window.addEventListener('resize', updateTriggerRect, { passive: true })
 
     return () => {
       window.removeEventListener('scroll', updateTriggerRect, scrollOption)
-      window.removeEventListener('resize', updateTriggerRect, resizeOption)
+      window.removeEventListener('resize', updateTriggerRect)
     }
   }, [active, latest])
 

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -122,6 +122,22 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     if (latest.portalRoot) {
       latest[active ? 'onOpen' : 'onClose']?.()
     }
+
+    if (!active) return
+
+    const updateTriggerRect = () => {
+      if (triggerElementRef.current) {
+        setTriggerRect(triggerElementRef.current.getBoundingClientRect())
+      }
+    }
+
+    window.addEventListener('scroll', updateTriggerRect, { capture: true, passive: true })
+    window.addEventListener('resize', updateTriggerRect, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', updateTriggerRect, { capture: true })
+      window.removeEventListener('resize', updateTriggerRect)
+    }
   }, [active, latest])
 
   return (

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -131,12 +131,15 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
       }
     }
 
-    window.addEventListener('scroll', updateTriggerRect, { capture: true, passive: true })
-    window.addEventListener('resize', updateTriggerRect, { passive: true })
+    const scrollOption = { capture: true, passive: true }
+    const resizeOption = { passive: true }
+
+    window.addEventListener('scroll', updateTriggerRect, scrollOption)
+    window.addEventListener('resize', updateTriggerRect, resizeOption)
 
     return () => {
-      window.removeEventListener('scroll', updateTriggerRect, { capture: true })
-      window.removeEventListener('resize', updateTriggerRect)
+      window.removeEventListener('scroll', updateTriggerRect, scrollOption)
+      window.removeEventListener('resize', updateTriggerRect, resizeOption)
     }
   }, [active, latest])
 

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -100,40 +100,43 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
         // return focus to the Trigger
         getFirstTabbable(triggerElementRef)?.focus()
       },
+      handleClickBody: (e: any) => {
+        // ignore events from events within DropdownTrigger and DropdownContent
+        if (
+          latest.active &&
+          !isEventFromChild(e, triggerElementRef.current) &&
+          !latest.isChildPortal(e.target)
+        ) {
+          setActive(false)
+
+          if (latest.onClose) {
+            requestAnimationFrame(() => latest.onClose?.())
+          }
+        }
+      },
+      updateTriggerRect: () => {
+        if (triggerElementRef.current) {
+          setTriggerRect(triggerElementRef.current.getBoundingClientRect())
+        }
+      },
     }
   }, [latest])
 
   useEffect(() => {
     if (!active) return
 
-    const handleClickBody = (e: any) => {
-      // ignore events from events within DropdownTrigger and DropdownContent
-      if (!isEventFromChild(e, triggerElementRef.current) && !latest.isChildPortal(e.target)) {
-        setActive(false)
-
-        if (latest.onClose) {
-          requestAnimationFrame(() => latest.onClose?.())
-        }
-      }
-    }
-    const updateTriggerRect = () => {
-      if (triggerElementRef.current) {
-        setTriggerRect(triggerElementRef.current.getBoundingClientRect())
-      }
-    }
-
     const scrollOption = { capture: true, passive: true }
 
-    document.body.addEventListener('click', handleClickBody, false)
-    window.addEventListener('scroll', updateTriggerRect, scrollOption)
-    window.addEventListener('resize', updateTriggerRect, { passive: true })
+    document.body.addEventListener('click', functions.handleClickBody, false)
+    window.addEventListener('scroll', functions.updateTriggerRect, scrollOption)
+    window.addEventListener('resize', functions.updateTriggerRect, { passive: true })
 
     return () => {
-      document.body.removeEventListener('click', handleClickBody, false)
-      window.removeEventListener('scroll', updateTriggerRect, scrollOption)
-      window.removeEventListener('resize', updateTriggerRect)
+      document.body.removeEventListener('click', functions.handleClickBody, false)
+      window.removeEventListener('scroll', functions.updateTriggerRect, scrollOption)
+      window.removeEventListener('resize', functions.updateTriggerRect)
     }
-  }, [active, latest])
+  }, [active, functions])
 
   return (
     <PortalParentProvider>

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -104,26 +104,22 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   }, [latest])
 
   useEffect(() => {
-    const onClickBody = (e: any) => {
+    if (!active) return
+
+    let lastAnimationFrame: ReturnType<typeof requestAnimationFrame> | undefined = undefined
+
+    const handleClickBody = (e: any) => {
       // ignore events from events within DropdownTrigger and DropdownContent
       if (!isEventFromChild(e, triggerElementRef.current) && !latest.isChildPortal(e.target)) {
-        if (latest.active) {
-          setActive(false)
-          if (latest.onClose) requestAnimationFrame(() => latest.onClose?.())
+        setActive(false)
+        if (latest.onClose) {
+          lastAnimationFrame = requestAnimationFrame(() => {
+            latest.onClose?.()
+            lastAnimationFrame = undefined
+          })
         }
       }
     }
-
-    document.body.addEventListener('click', onClickBody, false)
-
-    return () => {
-      document.body.removeEventListener('click', onClickBody, false)
-    }
-  }, [contentId, latest])
-
-  useEffect(() => {
-    if (!active) return
-
     const updateTriggerRect = () => {
       if (triggerElementRef.current) {
         setTriggerRect(triggerElementRef.current.getBoundingClientRect())
@@ -132,10 +128,16 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
 
     const scrollOption = { capture: true, passive: true }
 
+    document.body.addEventListener('click', handleClickBody, false)
     window.addEventListener('scroll', updateTriggerRect, scrollOption)
     window.addEventListener('resize', updateTriggerRect, { passive: true })
 
     return () => {
+      if (lastAnimationFrame) {
+        cancelAnimationFrame(lastAnimationFrame)
+      }
+
+      document.body.removeEventListener('click', handleClickBody, false)
       window.removeEventListener('scroll', updateTriggerRect, scrollOption)
       window.removeEventListener('resize', updateTriggerRect)
     }

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -106,17 +106,13 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   useEffect(() => {
     if (!active) return
 
-    let lastAnimationFrame: ReturnType<typeof requestAnimationFrame> | undefined = undefined
-
     const handleClickBody = (e: any) => {
       // ignore events from events within DropdownTrigger and DropdownContent
       if (!isEventFromChild(e, triggerElementRef.current) && !latest.isChildPortal(e.target)) {
         setActive(false)
+
         if (latest.onClose) {
-          lastAnimationFrame = requestAnimationFrame(() => {
-            latest.onClose?.()
-            lastAnimationFrame = undefined
-          })
+          requestAnimationFrame(() => latest.onClose?.())
         }
       }
     }
@@ -133,10 +129,6 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     window.addEventListener('resize', updateTriggerRect, { passive: true })
 
     return () => {
-      if (lastAnimationFrame) {
-        cancelAnimationFrame(lastAnimationFrame)
-      }
-
       document.body.removeEventListener('click', handleClickBody, false)
       window.removeEventListener('scroll', updateTriggerRect, scrollOption)
       window.removeEventListener('resize', updateTriggerRect)


### PR DESCRIPTION
## 関連URL

なし

## 概要

Dropdownのメニューが開いた状態でページをスクロールしても、メニューがトリガー要素に追従しないバグを修正する。

## 変更内容

**バグの原因:**

- `DropdownTrigger` のクリック時に `getBoundingClientRect()` の結果（viewport相対座標）を `triggerRect` state に保存する
- `DropdownContentInner` はその `triggerRect` とクリック時点の `scrollY`/`scrollX` を使って絶対座標を計算する
- スクロールしても `triggerRect` も `scrollY` も更新されないため、メニューが開いた瞬間の絶対座標に固定されたまま動かない

**修正内容:**

`Dropdown.tsx` の `active` を監視する既存の `useEffect` に、スクロール・リサイズイベントのリスナーを追加した。`active` な間はスクロール/リサイズが発生するたびに `triggerElementRef.current.getBoundingClientRect()` で `triggerRect` を再計算・更新する。

- `capture: true` にすることで、ページ全体だけでなくスクロール可能な子要素内でのスクロールにも対応
- `passive: true` でスクロールパフォーマンスへの影響を最小化
- オプションオブジェクトを変数に切り出し、`addEventListener` と `removeEventListener` で同じ参照を使用することで、`capture: true` の解除が確実に行われるよう保証

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookの Dropdown ストーリーで、メニューを開いた状態でページをスクロールし、メニューがトリガー要素に追従することを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **不具合修正**
  * ドロップダウンの外側をクリックした際、より安定して閉じるよう改善しました。
  * スクロールや画面サイズ変更時に、ドロップダウンの表示位置が適切に更新されるようにしました。
  * 非表示時の不要な処理を抑制し、動作の安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->