### PR TITLE
feat(IndexNav): IndexNavコンポーネントを追加

### DIFF
--- a/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
+++ b/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
@@ -6,7 +6,7 @@ import { tv } from 'tailwind-variants'
 import { Stack } from '../Layout'
 import { TextLink } from '../TextLink'
 
-const _classNameGenerator = tv({
+const classNameGenerator = tv({
   base: [
     'shr-block',
     'shr-px-1 shr-py-0.5',
@@ -30,6 +30,7 @@ type Props = {
 }
 
 export const IndexNav = ({ items }: Props) => {
+  const actualClassName = useMemo(() => classNameGenerator(), [])
   const [activeId, setActiveId] = useState<string | null>(null)
   const { formatMessage } = useIntl()
 
@@ -70,7 +71,7 @@ export const IndexNav = ({ items }: Props) => {
           key={item.id}
           href={`#${item.id}`}
           // TODO: shr-border で対応している active時の表示を before 擬似要素を使って調整する
-          className={`${LINK_CLASSNAME} ${activeId === item.id ? 'shr-font-bold before:shr-border-link' : ''}`}
+          className={`${actualClassName} ${activeId === item.id ? 'shr-font-bold before:shr-border-link' : ''}`}
         >
           {item.label}
         </TextLink>

--- a/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
+++ b/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ReactNode, useEffect, useMemo, useState } from 'react'
+import { type ComponentPropsWithoutRef, type ReactNode, useEffect, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useIntl } from '../../intl'
@@ -24,20 +24,22 @@ const classNameGenerator = tv({
   },
 })
 
+type BaseProps = {
+  /** ページ内リンクのアイテム */
+  items: IndexNavItem[]
+}
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'nav'>, keyof BaseProps>
+
 type IndexNavItem = {
   id: string
   label: ReactNode
 }
 
-type Props = {
-  items: IndexNavItem[]
-}
-
-export const IndexNav = ({ items }: Props) => {
+export const IndexNav = ({ items, className, ...rest }: Props) => {
   const classNames = useMemo(() => {
     const { wrapper, textLink } = classNameGenerator()
-    return { wrapper: wrapper(), textLink: textLink() }
-  }, [])
+    return { wrapper: wrapper({ className }), textLink: textLink() }
+  }, [className])
   const [activeId, setActiveId] = useState<string | null>(null)
   const { localize } = useIntl()
 
@@ -66,11 +68,12 @@ export const IndexNav = ({ items }: Props) => {
 
   return (
     <Stack
+      {...rest}
       as="nav"
       className={classNames.wrapper}
       aria-label={localize({
         id: 'smarthr-ui/IndexNav/ariaLabel',
-        defaultMessage: 'ページ内リンク',
+        defaultText: 'ページ内リンク',
       })}
     >
       {items.map((item) => (

--- a/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
+++ b/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { type ReactNode, useEffect, useState } from 'react'
+
+import { Stack } from '../Layout'
+import { TextLink } from '../TextLink'
+
+type IndexNavItem = {
+  id: string
+  label: ReactNode
+}
+
+type Props = {
+  items: IndexNavItem[]
+}
+
+export const IndexNav = ({ items }: Props) => {
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const { formatMessage } = useIntl()
+
+  useEffect(() => {
+    const handleScroll = () => {
+      // 各セクションの位置を確認して、現在表示されているセクションを特定
+      const scrollPosition = window.scrollY + 100 // ヘッダー分のオフセット
+
+      for (const item of items) {
+        const element = document.getElementById(item.id)
+        if (element) {
+          const { offsetTop, offsetHeight } = element
+          if (scrollPosition >= offsetTop && scrollPosition < offsetTop + offsetHeight) {
+            setActiveId(item.id)
+            break
+          }
+        }
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    handleScroll() // 初期状態を設定
+
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [items])
+
+  return (
+    <Stack
+      as="nav"
+      className="shr-sticky shr-top-4"
+      aria-label={formatMessage({
+        id: 'requests/new/IndexNav/navLabel',
+        defaultMessage: 'ページ内リンク',
+      })}
+    >
+      {items.map((item) => (
+        <TextLink
+          key={item.id}
+          href={`#${item.id}`}
+          // TODO: shr-border で対応している active時の表示を before 擬似要素を使って調整する
+          className={`${LINK_CLASSNAME} ${activeId === item.id ? 'shr-font-bold before:shr-border-link' : ''}`}
+        >
+          {item.label}
+        </TextLink>
+      ))}
+    </Stack>
+  )
+}

--- a/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
+++ b/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
@@ -1,23 +1,27 @@
 'use client'
 
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useIntl } from '../../intl'
 import { Stack } from '../Layout'
 import { TextLink } from '../TextLink'
 
 const classNameGenerator = tv({
-  base: [
-    'shr-block',
-    'shr-px-1 shr-py-0.5',
-    'shr-rounded',
-    'shr-text-black',
-    'shr-no-underline',
-    '!shr-shadow-none',
-    'shr-leading-[0px]',
-    'hover:shr-font-bold',
-    `before:shr-border-l-shorthand before:shr-border-l-[4px] before:shr-border-transparent before:shr-pl-0.5 before:shr-content-['']`,
-  ],
+  slots: {
+    wrapper: 'shr-sticky shr-top-4',
+    textLink: [
+      'shr-block',
+      'shr-px-1 shr-py-0.5',
+      'shr-rounded',
+      'shr-text-black',
+      'shr-no-underline',
+      '!shr-shadow-none',
+      'shr-leading-[0px]',
+      'hover:shr-font-bold',
+      `before:shr-border-l-shorthand before:shr-border-l-[4px] before:shr-border-transparent before:shr-pl-0.5 before:shr-content-['']`,
+    ],
+  },
 })
 
 type IndexNavItem = {
@@ -30,9 +34,12 @@ type Props = {
 }
 
 export const IndexNav = ({ items }: Props) => {
-  const actualClassName = useMemo(() => classNameGenerator(), [])
+  const classNames = useMemo(() => {
+    const { wrapper, textLink } = classNameGenerator()
+    return { wrapper: wrapper(), textLink: textLink() }
+  }, [])
   const [activeId, setActiveId] = useState<string | null>(null)
-  const { formatMessage } = useIntl()
+  const { localize } = useIntl()
 
   useEffect(() => {
     const handleScroll = () => {
@@ -60,9 +67,9 @@ export const IndexNav = ({ items }: Props) => {
   return (
     <Stack
       as="nav"
-      className="shr-sticky shr-top-4"
-      aria-label={formatMessage({
-        id: 'requests/new/IndexNav/navLabel',
+      className={classNames.wrapper}
+      aria-label={localize({
+        id: 'smarthr-ui/IndexNav/ariaLabel',
         defaultMessage: 'ページ内リンク',
       })}
     >
@@ -71,7 +78,7 @@ export const IndexNav = ({ items }: Props) => {
           key={item.id}
           href={`#${item.id}`}
           // TODO: shr-border で対応している active時の表示を before 擬似要素を使って調整する
-          className={`${actualClassName} ${activeId === item.id ? 'shr-font-bold before:shr-border-link' : ''}`}
+          className={`${classNames.textLink} ${activeId === item.id ? 'shr-font-bold before:shr-border-link' : ''}`}
         >
           {item.label}
         </TextLink>

--- a/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
+++ b/packages/smarthr-ui/src/components/IndexNav/IndexNav.tsx
@@ -1,9 +1,24 @@
 'use client'
 
 import { type ReactNode, useEffect, useState } from 'react'
+import { tv } from 'tailwind-variants'
 
 import { Stack } from '../Layout'
 import { TextLink } from '../TextLink'
+
+const _classNameGenerator = tv({
+  base: [
+    'shr-block',
+    'shr-px-1 shr-py-0.5',
+    'shr-rounded',
+    'shr-text-black',
+    'shr-no-underline',
+    '!shr-shadow-none',
+    'shr-leading-[0px]',
+    'hover:shr-font-bold',
+    `before:shr-border-l-shorthand before:shr-border-l-[4px] before:shr-border-transparent before:shr-pl-0.5 before:shr-content-['']`,
+  ],
+})
 
 type IndexNavItem = {
   id: string

--- a/packages/smarthr-ui/src/components/IndexNav/index.ts
+++ b/packages/smarthr-ui/src/components/IndexNav/index.ts
@@ -1,0 +1,1 @@
+export { IndexNav } from './IndexNav'

--- a/packages/smarthr-ui/src/intl/locales/ja.json
+++ b/packages/smarthr-ui/src/intl/locales/ja.json
@@ -58,6 +58,7 @@
   "smarthr-ui/FilterDropdown/status": "適用中",
   "smarthr-ui/FilterDropdown/triggerText": "絞り込み",
   "smarthr-ui/FormDialog/closeButtonLabel": "キャンセル",
+  "smarthr-ui/IndexNav/ariaLabel": "ページ内リンク",
   "smarthr-ui/InformationPanel/closeButtonLabel": "閉じる",
   "smarthr-ui/InformationPanel/openButtonLabel": "開く",
   "smarthr-ui/InputFile/destroy": "削除",

--- a/packages/smarthr-ui/src/intl/locales/ja.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja.ts
@@ -60,6 +60,7 @@ export const locale = {
   'smarthr-ui/FilterDropdown/status': '適用中',
   'smarthr-ui/FilterDropdown/triggerText': '絞り込み',
   'smarthr-ui/FormDialog/closeButtonLabel': 'キャンセル',
+  'smarthr-ui/IndexNav/ariaLabel': 'ページ内リンク',
   'smarthr-ui/InformationPanel/closeButtonLabel': '閉じる',
   'smarthr-ui/InformationPanel/openButtonLabel': '開く',
   'smarthr-ui/InputFile/destroy': '削除',


### PR DESCRIPTION
## 関連URL

なし

## 概要

ページ内リンクナビゲーションを提供する `IndexNav` コンポーネントを追加する。スクロール位置に応じてアクティブなセクションをハイライトする機能を持つ。

## 変更内容

- `IndexNav` コンポーネントを新規追加（作業中）
  - `items` prop（`{ id: string; label: ReactNode }[]`）を受け取り、ページ内リンクを一覧表示
  - スクロールイベントを監視し、現在表示中のセクションに対応するリンクをアクティブ表示

## プロダクト側で対応が必要な事項

なし

## 確認方法

作業中のため未定。