### PR TITLE
fix(Combobox): 画面の右端に寄せて配置した場合にドロップダウンが指定した幅で表示されない問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/MultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/MultiCombobox.stories.tsx
@@ -154,6 +154,20 @@ export const DropdownWidth: StoryObj<typeof MultiCombobox> = {
   },
 }
 
+export const DropdownWidthOnRightEdge: StoryObj<typeof MultiCombobox> = {
+  name: 'dropdownWidth（画面の右端に寄せた場合）',
+  decorators: [
+    (Story) => (
+      <div className="shr-flex shr-justify-end">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    dropdownWidth: '30rem',
+  },
+}
+
 export const NoResultText: StoryObj<typeof MultiCombobox> = {
   name: 'noResultText',
   args: {

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/VRTMultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/VRTMultiCombobox.stories.tsx
@@ -107,3 +107,31 @@ export const VRTForcedColors: StoryObj<typeof MultiCombobox> = {
     chromatic: { forcedColors: 'active' },
   },
 }
+
+const playOnRightEdge = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const combobox = await canvas.findByRole('combobox')
+
+  combobox.focus()
+
+  const body = canvasElement.ownerDocument.body
+  const helpMessage = await within(body).findByText('入力でフィルタリングできます。')
+  await userEvent.click(helpMessage) // カーソルの点滅によるVRTのフレーキーを避けるためにフォーカスを移動する
+}
+
+// 画面の右端に寄せた場合に、ドロップダウンが指定された幅を保ったまま左方向に表示されることを確認する
+export const VRTOnRightEdge: StoryObj<typeof MultiCombobox> = {
+  render: (args) => (
+    <div className="shr-flex shr-h-screen shr-justify-end">
+      <MultiCombobox
+        {...args}
+        name="onRightEdge"
+        items={Object.values(defaultItems)}
+        dropdownHelpMessage="入力でフィルタリングできます。"
+        dropdownWidth="30rem"
+        selectedItems={[]}
+      />
+    </div>
+  ),
+  play: playOnRightEdge,
+}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/SingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/SingleCombobox.stories.tsx
@@ -217,6 +217,20 @@ export const DropdownWidth: StoryObj<typeof SingleCombobox> = {
   },
 }
 
+export const DropdownWidthOnRightEdge: StoryObj<typeof SingleCombobox> = {
+  name: 'dropdownWidth（画面の右端に寄せた場合）',
+  decorators: [
+    (Story) => (
+      <div className="shr-flex shr-justify-end">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    dropdownWidth: '30rem',
+  },
+}
+
 export const NoResultText: StoryObj<typeof SingleCombobox> = {
   name: 'noResultText',
   args: {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/VRTSingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/VRTSingleCombobox.stories.tsx
@@ -159,3 +159,36 @@ export const VRTForcedColors: StoryObj<typeof SingleCombobox> = {
     backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
   },
 }
+
+const playOnRightEdge = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const textbox = await canvas.findByRole('combobox')
+
+  textbox.click()
+
+  const body = canvasElement.ownerDocument.body
+  const option = await within(body).findByText('option 1')
+  await userEvent.hover(option)
+  const helpMessage = await within(body).findByText('入力でフィルタリングできます。')
+  await userEvent.click(helpMessage) // カーソルの点滅によるVRTのフレーキーを避けるためにフォーカスを移動する
+}
+
+// 画面の右端に寄せた場合に、ドロップダウンが指定された幅を保ったまま左方向に表示されることを確認する
+export const VRTOnRightEdge: StoryObj<typeof SingleCombobox> = {
+  render: (args) => (
+    <div className="shr-flex shr-h-screen shr-justify-end">
+      <SingleCombobox
+        {...args}
+        name="onRightEdge"
+        items={Object.values(defaultItems)}
+        dropdownHelpMessage="入力でフィルタリングできます。"
+        dropdownWidth="30rem"
+        selectedItem={null}
+      />
+    </div>
+  ),
+  play: playOnRightEdge,
+  parameters: {
+    backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
+  },
+}

--- a/packages/smarthr-ui/src/components/Combobox/__tests__/useListbox.test.ts
+++ b/packages/smarthr-ui/src/components/Combobox/__tests__/useListbox.test.ts
@@ -103,4 +103,108 @@ describe('useListbox', () => {
       expect(result.current.activeOption).toEqual(options[3])
     })
   })
+
+  describe('calculateRect による横方向の位置の算出', () => {
+    const VIEWPORT_WIDTH = 1000
+    // theme.spacingByChar(0.5) 相当の、ビューポート右端に残す余白
+    const VIEWPORT_MARGIN = 8
+
+    const originalInnerWidth = window.innerWidth
+
+    const setInnerWidth = (value: number) => {
+      Object.defineProperty(window, 'innerWidth', {
+        value,
+        configurable: true,
+        writable: true,
+      })
+    }
+
+    afterEach(() => setInnerWidth(originalInnerWidth))
+
+    const EMPTY_RECT = {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => '',
+    }
+
+    const createRect = (rect: Partial<DOMRect>) => ({ ...EMPTY_RECT, ...rect }) as DOMRect
+
+    // 入力欄とリストボックスの実測値を固定した状態で calculateRect を実行し、算出された left を返す
+    const getCalculatedLeft = ({
+      triggerLeft,
+      triggerRight,
+      listBoxWidth,
+    }: {
+      triggerLeft: number
+      triggerRight: number
+      listBoxWidth: number
+    }) => {
+      setInnerWidth(VIEWPORT_WIDTH)
+
+      const trigger = document.createElement('div')
+      trigger.getBoundingClientRect = () =>
+        createRect({
+          left: triggerLeft,
+          right: triggerRight,
+          width: triggerRight - triggerLeft,
+          bottom: 30,
+          height: 30,
+        })
+
+      const listBox = document.createElement('div')
+      listBox.style.maxHeight = '300px'
+      listBox.getBoundingClientRect = () => createRect({ width: listBoxWidth })
+
+      const props = { ...initialProps, triggerRef: { current: trigger } }
+      const renderHookResult = renderHook((p) => useListbox(p), { initialProps: props })
+
+      // ListBox がレンダリングされた状態を再現し、実測値が得られる状態で再計算させる
+      renderHookResult.result.current.listBoxRef.current = listBox
+      renderHookResult.rerender({ ...props, options: [...options] })
+
+      return renderHookResult.result.current.listBoxProps.listBoxRect.left
+    }
+
+    it('右側に十分なスペースがある場合、入力欄の左端に揃うこと', () => {
+      expect(getCalculatedLeft({ triggerLeft: 100, triggerRight: 300, listBoxWidth: 200 })).toBe(
+        100,
+      )
+    })
+
+    it('右側にちょうど収まる場合、入力欄の左端に揃うこと', () => {
+      // 右側に使える幅 = 1000 - 500 - 8 = 492
+      expect(getCalculatedLeft({ triggerLeft: 500, triggerRight: 700, listBoxWidth: 492 })).toBe(
+        500,
+      )
+    })
+
+    it('右側に収まらず左側に収まる場合、入力欄の右端に揃うこと', () => {
+      // 右側に使える幅を 1px 超えるため、入力欄の右端 700 に揃えて左方向に表示する
+      expect(getCalculatedLeft({ triggerLeft: 500, triggerRight: 700, listBoxWidth: 493 })).toBe(
+        700 - 493,
+      )
+    })
+
+    it('画面右端に寄った入力欄でも、ドロップダウンの幅が保たれる位置に揃うこと', () => {
+      expect(getCalculatedLeft({ triggerLeft: 900, triggerRight: 1000, listBoxWidth: 480 })).toBe(
+        1000 - 480,
+      )
+    })
+
+    it('左右いずれにも収まらない場合、ビューポートの左端に揃うこと', () => {
+      expect(
+        getCalculatedLeft({
+          triggerLeft: 300,
+          triggerRight: 500,
+          listBoxWidth: VIEWPORT_WIDTH - VIEWPORT_MARGIN,
+        }),
+      ).toBe(0)
+    })
+  })
 })

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -108,7 +108,9 @@ export const useListbox = <T,>({
   const listBoxRef = useRef<HTMLDivElement>(null)
   const activeRef = useRef<HTMLButtonElement>(null)
 
-  const latest = useLatest({ onAdd, onSelect, activeOption, options, triggerRef })
+  const theme = useTheme()
+
+  const latest = useLatest({ onAdd, onSelect, activeOption, options, triggerRef, theme })
   const hasOnAdd = !!onAdd
 
   const functions = useMemo(() => {
@@ -173,9 +175,31 @@ export const useListbox = <T,>({
           height = bottomSpace
         }
 
+        // HINT: dropdownWidth は 'auto' や '%' などの CSS 値を取りうるため、算出済みの幅を実測して判定する
+        const listBoxWidth = listBoxRef.current.getBoundingClientRect().width
+        // ドロップダウンの幅は maxWidth でビューポート右端から余白分を残すよう制限しているため、位置の判定にも同じ余白を使う
+        const viewportMargin = parseInt(latest.theme.spacingByChar(0.5), 10)
+        // 入力欄の左端を起点に右方向へ表示する場合に使える幅
+        const rightSpace = window.innerWidth - rect.left - viewportMargin
+        // 入力欄の右端を起点に左方向へ表示する場合に使える幅
+        const leftSpace = rect.right
+
+        let left = 0
+
+        if (listBoxWidth <= rightSpace) {
+          // 右側に十分なスペースがある場合は入力欄の左端に揃えて通常表示
+          left = rect.left + window.pageXOffset
+        } else if (listBoxWidth <= leftSpace) {
+          // 右側に十分なスペースがなく左側に収まる場合は入力欄の右端に揃えて表示
+          left = rect.right - listBoxWidth + window.pageXOffset
+        } else {
+          // 左右いずれにも収まらない場合はビューポートの左端に揃えて表示
+          left = window.pageXOffset
+        }
+
         setListBoxRect({
           top,
-          left: rect.left + window.pageXOffset,
+          left,
           height,
         })
         setTriggerWidth(rect.width)
@@ -363,7 +387,9 @@ export const ListBox = memo(
         dropdownList: {
           width:
             typeof dropdownListWidth === 'string' ? dropdownListWidth : `${dropdownListWidth}px`,
-          maxWidth: `calc(100vw - ${left}px - ${theme.spacingByChar(0.5)})`,
+          /* HINT: left に依存させると、算出した幅がさらに maxWidth を縮めて再計算の度に幅が縮んでいくため、
+          ビューポート幅のみから算出する */
+          maxWidth: `calc(100vw - ${theme.spacingByChar(0.5)})`,
           height: height ? `${height}px` : undefined,
         },
       }

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -184,17 +184,15 @@ export const useListbox = <T,>({
         // 入力欄の右端を起点に左方向へ表示する場合に使える幅
         const leftSpace = rect.right
 
-        let left = 0
+        // ビューポートの左端を基準に計算
+        let left = window.pageXOffset
 
         if (listBoxWidth <= rightSpace) {
           // 右側に十分なスペースがある場合は入力欄の左端に揃えて通常表示
-          left = rect.left + window.pageXOffset
+          left += rect.left
         } else if (listBoxWidth <= leftSpace) {
-          // 右側に十分なスペースがなく左側に収まる場合は入力欄の右端に揃えて表示
-          left = rect.right - listBoxWidth + window.pageXOffset
-        } else {
-          // 左右いずれにも収まらない場合はビューポートの左端に揃えて表示
-          left = window.pageXOffset
+          // 左側に収まる場合は入力欄の右端に揃えて表示
+          left += rect.right - listBoxWidth
         }
 
         setListBoxRect({


### PR DESCRIPTION
## 関連URL

なし

## 概要

`SingleCombobox` / `MultiCombobox` のドロップダウン（候補一覧）は、縦方向には表示領域の広さに応じて位置を調整していますが、横方向には調整していません。常に入力欄の左端を起点に右方向へ展開し、`max-width` でビューポートの右端に合わせて切り詰められます。

そのため、画面の右端に寄せたコンテナ（右寄せの Drawer やサイドペインなど）の中に配置すると、ドロップダウンに使える幅が「入力欄の左端からビューポート右端まで」に限られ、`dropdownWidth` に指定した幅が反映されません。`dropdownWidth` のデフォルトは `'auto'` なので、幅を明示していない場合もアイテムのラベルが不要に折り返されます。

なお `Dropdown` は `getContentBoxStyle` で横方向の位置調整を行っているため、横方向の衝突回避は Combobox のみ未対応の状態でした。

## 変更内容

`useListbox` の `calculateRect` に、縦方向と対称な横方向の分岐を追加しました。`SingleCombobox` と `MultiCombobox` は `useListbox` を共有しているため、どちらにも反映されます。

1. 右側に十分なスペースがある場合は、入力欄の左端に揃えて通常表示（従来と同じ）
2. 右側に収まらず左側に収まる場合は、入力欄の右端に揃えて左方向へ表示
3. 左右いずれにも収まらない場合は、ビューポートの左端に揃えて表示

`dropdownWidth` は `'auto'` や `%` などの CSS 値を取りうるため、値を解釈せず `getBoundingClientRect()` の実測値で判定しています（縦方向が `getComputedStyle().maxHeight` を実測しているのと同じ考え方です）。

あわせて、ドロップダウンの `max-width` を `calc(100vw - {left}px - {余白})` から `calc(100vw - {余白})` に変更しました。算出した位置に `max-width` が依存していると、位置の再計算ごとに「算出した幅が `max-width` をさらに縮める」ことになり、幅が段階的に縮み続けてしまうためです。この変更により `max-width` は「ビューポート幅を超えない」という本来の役割のみを担い、位置の判定に必要な幅を正しく実測できます。

**既存の表示は変わりません。** 1つ目の分岐の式は従来の実装と同一で、ドロップダウンが収まっているケースでは座標も幅も変化しません。位置が変わるのは、これまで表示しきれていなかったケースのみです。


| | Before | After |
| --- | --- | --- |
| `SingleCombobox` | <img width="480" alt="single-before" src="https://github.com/user-attachments/assets/32f408d0-acdb-4c2e-b24c-47856360c5d8" /> | <img width="480" alt="single-after" src="https://github.com/user-attachments/assets/905bff3b-a4d0-40de-b352-193536fd7548" /> |
| `MultiCombobox` | <img width="480" alt="multi-before" src="https://github.com/user-attachments/assets/82bb784c-df98-494d-98fc-e065bd5b22b2" /> | <img width="480" alt="multi-after" src="https://github.com/user-attachments/assets/30488487-2025-442e-b2c1-c9c9022719bb" /> |

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook に確認用のストーリーを追加しています。ドロップダウンを開くと、指定した幅（`30rem`）を保ったまま入力欄の右端に揃って表示されます。

- `Components/Combobox/SingleCombobox` → `dropdownWidth（画面の右端に寄せた場合）`
- `Components/Combobox/MultiCombobox` → `dropdownWidth（画面の右端に寄せた場合）`

VRT 用のストーリーも追加しています。既存の VRT ストーリーには手を入れていないため、既存のスナップショットには影響しません。

- `Components/Combobox/SingleCombobox/VRT` → `VRTOnRightEdge`
- `Components/Combobox/MultiCombobox/VRT` → `VRTOnRightEdge`

`useListbox` のユニットテストに、横方向の位置算出のテストを追加しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - コンボボックスのドロップダウンが、画面幅や入力欄の位置に応じて右側・左側へ適切に表示されるようになりました。
  - 画面右端に配置した場合も、ドロップダウンがビューポート内に収まるよう調整されます。
  - ドロップダウンの幅と左右の余白が適切に保たれ、表示内容を確認しやすくなりました。

- **テスト**
  - 画面端や表示領域が限られる場合のレイアウト検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->