### PR TITLE
fix(Combobox): スクロール・リサイズ時に選択肢の位置が追従しない問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -260,10 +260,20 @@ export const useListbox = <T,>({
   useEnhancedEffect(() => {
     // 閉じたときに activeOption を初期化
     if (!isExpanded) {
-      setActiveOption(null)
-    } else {
-      functions.calculateRect()
+      return setActiveOption(null)
     }
+
+    functions.calculateRect()
+
+    const scrollOption = { capture: true, passive: true }
+    window.addEventListener('scroll', functions.calculateRect, scrollOption)
+    window.addEventListener('resize', functions.calculateRect, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', functions.calculateRect, scrollOption)
+      window.removeEventListener('resize', functions.calculateRect)
+    }
+    // HINT: optionsが変わる場合メニューのサイズが変わる可能性がある
   }, [isExpanded, options, functions])
 
   return {

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -237,19 +237,6 @@ export const useListbox = <T,>({
   }, [options])
 
   useEffect(() => {
-    // 閉じたときに activeOption を初期化
-    if (!isExpanded) {
-      setActiveOption(null)
-    }
-
-    const trigger = latest.triggerRef.current
-
-    if (trigger) {
-      setTriggerWidth(trigger.getBoundingClientRect().width)
-    }
-  }, [isExpanded, latest])
-
-  useEffect(() => {
     // actionOption の要素が表示される位置までリストボックス内をスクロールさせる
     if (
       !activeRef.current ||
@@ -271,8 +258,10 @@ export const useListbox = <T,>({
   }, [activeOption, navigationType])
 
   useEnhancedEffect(() => {
-    if (isExpanded) {
-      // options の更新毎に座標を再計算する
+    // 閉じたときに activeOption を初期化
+    if (!isExpanded) {
+      setActiveOption(null)
+    } else {
       functions.calculateRect()
     }
   }, [isExpanded, options, functions])

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
@@ -1,9 +1,13 @@
 import { userEvent, within } from 'storybook/test'
 
 import { AnchorButton, Button } from '../../../Button'
+import { SingleCombobox } from '../../../Combobox'
 import { RemoteDialogTrigger } from '../../../Dialog'
 import { FaGearIcon } from '../../../Icon'
-import { Cluster } from '../../../Layout'
+import { Cluster, Stack } from '../../../Layout'
+import { Dropdown } from '../../Dropdown'
+import { DropdownContent } from '../../DropdownContent'
+import { DropdownTrigger } from '../../DropdownTrigger'
 import { DropdownMenuButton } from '../DropdownMenuButton'
 import { DropdownMenuGroup } from '../DropdownMenuGroup'
 
@@ -72,4 +76,62 @@ export const VRTForcedColors: StoryObj<typeof DropdownMenuButton> = {
   parameters: {
     chromatic: { forcedColors: 'active' },
   },
+}
+
+const _comboboxItems = [
+  { label: 'option 1', value: 'value-1' },
+  { label: 'option 2', value: 'value-2' },
+  { label: 'option 3', value: 'value-3' },
+  { label: 'option 4', value: 'value-4' },
+  { label: 'option 5', value: 'value-5' },
+]
+
+export const VRTComboboxScrollTracking: StoryObj<typeof DropdownMenuButton> = {
+  render: () => (
+    <Dropdown>
+      <DropdownTrigger>
+        <Button>その他の操作</Button>
+      </DropdownTrigger>
+      <DropdownContent controllable>
+        <Stack>
+          <Button>操作1</Button>
+          <Button>操作2</Button>
+          <Button>操作3</Button>
+          <Button>操作4</Button>
+          <Button>操作5</Button>
+          <Button>操作6</Button>
+          <Button>操作7</Button>
+          <Button>操作8</Button>
+          <SingleCombobox
+            name="combobox"
+            items={_comboboxItems}
+            selectedItem={null}
+            onSelect={() => {}}
+            onClearClick={() => {}}
+          />
+        </Stack>
+      </DropdownContent>
+    </Dropdown>
+  ),
+  play: async ({ canvasElement }) => {
+    const body = canvasElement.ownerDocument.body
+
+    // Dropdown を開く
+    const trigger = await within(canvasElement).findByRole('button')
+    await userEvent.click(trigger)
+
+    // SingleCombobox のメニューを開く
+    const combobox = await within(body).findByRole('combobox')
+    await userEvent.click(combobox)
+
+    // Dropdown のコンテンツをスクロールし、Combobox メニューが追従するか確認する
+    const dropdownContent = body.querySelector('.smarthr-ui-Dropdown-content')
+    if (dropdownContent) {
+      dropdownContent.scrollTop += 80
+    }
+  },
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+  tags: ['!autodocs'],
 }

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
@@ -109,6 +109,14 @@ export const VRTComboboxScrollTracking: StoryObj<typeof DropdownMenuButton> = {
             onSelect={() => {}}
             onClearClick={() => {}}
           />
+          <Button>操作9</Button>
+          <Button>操作10</Button>
+          <Button>操作11</Button>
+          <Button>操作12</Button>
+          <Button>操作13</Button>
+          <Button>操作14</Button>
+          <Button>操作15</Button>
+          <Button>操作16</Button>
         </Stack>
       </DropdownContent>
     </Dropdown>


### PR DESCRIPTION
## 関連URL

なし

## 概要

Comboboxの選択肢（ドロップダウン）が表示された状態でページをスクロールまたはウィンドウをリサイズした際に、選択肢の表示位置がトリガー要素に追従しない問題を修正しました。

Dropdownコンポーネント（#6769）と同じ根本原因によるものです。

## 変更内容

`useListbox.tsx` の `useEnhancedEffect` 内で、`isExpanded` が `true` のとき scroll/resize イベントリスナーを登録し、`calculateRect()` を再実行することで選択肢の位置をトリガー要素に追従させます。

- `isExpanded` 中に `window` の `scroll`（`capture: true`）および `resize` イベントで `calculateRect()` を呼び出すリスナーを登録
- `isExpanded` が `false` になった時点でクリーンアップ
- あわせて `useEnhancedEffect` 内のコードを整理（`useLatest` 依存の除去、`triggerWidth` の個別 set を `calculateRect` 内に一本化）

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで Combobox の選択肢を開いた状態でページをスクロール・ウィンドウをリサイズし、選択肢がトリガー要素に追従することを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コンボボックスのメニュー位置が、画面のスクロールやウィンドウサイズ変更に合わせて正しく追従するようになりました。
  * メニューを閉じた際に、選択状態が適切に初期化されるようになりました。
* **テスト**
  * ドロップダウン内でコンボボックスをスクロールした際の表示を確認するビジュアルテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->