### PR TITLE
fix(ModelessDialog): 画面サイズを超えてはみ出す問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -95,7 +95,8 @@ type Props = BaseProps &
 const classNameGenerator = tv({
   slots: {
     overlap: 'shr-inset-[unset]',
-    wrapper: 'smarthr-ui-ModelessDialog shr-fixed shr-flex shr-flex-col',
+    wrapper:
+      'smarthr-ui-ModelessDialog shr-fixed shr-flex shr-max-h-[calc(100svh-theme(spacing[0.5]))] shr-max-w-[calc(100vw-theme(spacing[0.5]))] shr-flex-col',
     headerEl: [
       'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5',
       'hover:shr-bg-white-darken',
@@ -302,8 +303,8 @@ export const ModelessDialog: FC<Props> = ({
       const rect = wrapperRef.current.getBoundingClientRect()
 
       setCentering({
-        top: isYCenter ? window.innerHeight / 2 - rect.height / 2 : undefined,
-        left: isXCenter ? window.innerWidth / 2 - rect.width / 2 : undefined,
+        top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
+        left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
       })
     }
   }, [bottom, isOpen, left, right, top])


### PR DESCRIPTION
## 関連URL

なし

## 概要

`ModelessDialog` のサイズが画面（ビューポート）の縦・横サイズを超えた場合にダイアログがはみ出す問題を修正しました。

`InputFile` の `previewable` を使ったファイルプレビュー機能（`FilePreviewDialog`）などで、狭い画面サイズのときにダイアログが画面外にはみ出すケースがありました。

## 変更内容

`ModelessDialog` に対して以下の修正を行いました。

**1. wrapperにmax-width/max-heightを追加**

```
shr-max-w-[calc(100vw-theme(spacing[0.5]))]
shr-max-h-[calc(100svh-theme(spacing[0.5]))]
```

ビューポートサイズを超えるダイアログサイズが指定された場合でも、画面内に収まるよう制約を追加しました。

**2. センタリング計算のクランプ**

```ts
// Before
top: window.innerHeight / 2 - rect.height / 2
left: window.innerWidth / 2 - rect.width / 2

// After
top: Math.max(0, window.innerHeight / 2 - rect.height / 2)
left: Math.max(0, window.innerWidth / 2 - rect.width / 2)
```

ダイアログ幅/高さがビューポートを超えた際に `top`/`left` が負値になり、左端・上端がはみ出す問題を防ぎます。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで `ModelessDialog` または `InputFile`（previewable）を開き、ブラウザウィンドウを小さくした状態でもダイアログが画面内に収まることを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * モードレスダイアログがビューポートを超えないよう、最大幅・最大高さを設定しました。
  * 初期表示時の位置を調整し、画面外にはみ出さないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->