### PR TITLE
fix(Dropdown): Dropdownコンテンツ内のスクロールが動作しない問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -125,15 +125,13 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   useEffect(() => {
     if (!active) return
 
-    const scrollOption = { capture: true, passive: true }
-
     document.body.addEventListener('click', functions.handleClickBody, false)
-    window.addEventListener('scroll', functions.updateTriggerRect, scrollOption)
+    window.addEventListener('scroll', functions.updateTriggerRect, { passive: true })
     window.addEventListener('resize', functions.updateTriggerRect, { passive: true })
 
     return () => {
       document.body.removeEventListener('click', functions.handleClickBody, false)
-      window.removeEventListener('scroll', functions.updateTriggerRect, scrollOption)
+      window.removeEventListener('scroll', functions.updateTriggerRect)
       window.removeEventListener('resize', functions.updateTriggerRect)
     }
   }, [active, functions])


### PR DESCRIPTION
## 関連URL

- #6769 の修正による副作用
- #6774（Revert PR）

## 概要

#6769 でDropdownのスクロール追従を実装した際に `scroll` リスナーに `capture: true` を指定したことにより、Dropdownコンテンツパネル内のスクロールが正常に動作しなくなる問題が発生しました。

## 変更内容

`scroll` リスナーの `capture: true` を除去します。

```ts
// Before
window.addEventListener('scroll', functions.updateTriggerRect, { capture: true, passive: true })

// After
window.addEventListener('scroll', functions.updateTriggerRect, { passive: true })
```

### 原因

`capture: true` を指定すると、Dropdownコンテンツパネル（`shr-overflow-y-auto`）内のスクロールも捕捉してしまいます。その結果:

1. パネル内をスクロール → `scroll` イベントをキャプチャ → `updateTriggerRect()` 実行
2. `setTriggerRect(新しいオブジェクト)` → Reactがstate変化と判定（値同一でも参照が異なる）
3. `DropdownContentInner.useEffect([triggerRect])` が実行される
4. `setContentBox()` でパネルが再配置 / `focusTargetRef.current?.focus()` でフォーカスが移動
5. スクロールが中断される

Dropdownのトリガーは通常のページフロー上にあるため、ページスクロール（`capture` なし）の検知のみで十分です。

なお、ComboboxのスクロールリスナーはDropdown内部にあるトリガーを追従させるため `capture: true` が引き続き必要です。

## プロダクト側で対応が必要な事項

なし

## 確認方法

StorybookでDropdownMenuButtonなどを開き、コンテンツが多い場合にパネル内をスクロールできることを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * ドロップダウン表示中のスクロール監視を最適化し、スクロール時の処理負荷を軽減しました。
  * クリックおよび画面サイズ変更時の動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->