### PR TITLE
fix(InputFile): previewable時のアイコン縮小と横方向オーバーフローを修正

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-grow shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{
@@ -29,7 +29,11 @@ const PreviewButton: FC<{
 }> = ({ file, handlePreviewClick }) => (
   <Button
     variant="tertiary"
-    prefix={<FaFileLinesIcon />}
+    prefix={
+      <span className="shr-inline-flex shr-shrink-0">
+        <FaFileLinesIcon />
+      </span>
+    }
     onClick={() => handlePreviewClick(file)}
     className={PREVIEW_BUTTON_CLASSNAME}
   >
@@ -60,7 +64,11 @@ const DownloadAnchorButton: FC<{ file: File }> = ({ file }) => {
     <AnchorButton
       href={href}
       download={file.name}
-      prefix={<FaFileArrowDownIcon />}
+      prefix={
+        <span className="shr-inline-flex shr-shrink-0">
+          <FaFileArrowDownIcon />
+        </span>
+      }
       variant="text"
       className={PREVIEW_BUTTON_CLASSNAME}
     >
@@ -102,7 +110,7 @@ export const FileListItem = memo<FileListItemProps>(
         prefix={<FaTrashCanIcon />}
         value={index}
         onClick={handleDeleteClick}
-        className="smarthr-ui-InputFile-deleteButton"
+        className="smarthr-ui-InputFile-deleteButton shr-shrink-0"
       >
         <Localizer id="smarthr-ui/InputFile/destroy" defaultText="削除" />
       </Button>

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-grow shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-all shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-justify-start shr-min-w-0 shr-break-all shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-all shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -29,11 +29,7 @@ const PreviewButton: FC<{
 }> = ({ file, handlePreviewClick }) => (
   <Button
     variant="tertiary"
-    prefix={
-      <span className="shr-inline-flex shr-shrink-0">
-        <FaFileLinesIcon />
-      </span>
-    }
+    prefix={<FaFileLinesIcon className="shr-shrink-0" />}
     onClick={() => handlePreviewClick(file)}
     className={PREVIEW_BUTTON_CLASSNAME}
   >
@@ -64,11 +60,7 @@ const DownloadAnchorButton: FC<{ file: File }> = ({ file }) => {
     <AnchorButton
       href={href}
       download={file.name}
-      prefix={
-        <span className="shr-inline-flex shr-shrink-0">
-          <FaFileArrowDownIcon />
-        </span>
-      }
+      prefix={<FaFileArrowDownIcon className="shr-shrink-0" />}
       variant="text"
       className={PREVIEW_BUTTON_CLASSNAME}
     >


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InputFile` の `previewable` 設定時に発生していた2つの表示問題を修正します。

1. ファイル名が長い場合に左側のアイコンが縮小して見える問題
2. スペースのない長いファイル名でリストアイテムが横方向に伸びてしまう問題

## 変更内容

`packages/smarthr-ui/src/components/InputFile/parts.tsx` を修正しました。

- `FILE_NAME_BUTTON_CLASSNAME` に `shr-grow` を追加
  - ファイル名ボタンが `li.fileItem`（flex コンテナ）の利用可能幅いっぱいに広がるようになり、横方向への伸びを防止
  - 削除ボタンが常に右端に配置されるようになる
- `PreviewButton` / `DownloadAnchorButton` の `prefix` アイコンを `shr-inline-flex shr-shrink-0` の span でラップ
  - アイコンが flex 縮小の影響を受けて小さくなる問題を修正
- 削除ボタンに `shr-shrink-0` を追加
  - 削除ボタンが縮まないよう固定

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook の InputFile ストーリーで `previewable` を有効にした状態で、長いファイル名（特にスペースのない文字列）のファイルを添付して表示を確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 長いファイル名が文字単位で折り返され、ファイル名ボタン内で見やすく表示されるよう改善しました。
  * プレビュー・ダウンロード・削除アイコンが縮小されず、安定して表示されるよう調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->