### PR TITLE
feat(InputFile): モバイル環境でFilePreviewDialogをフルスクリーンDialogで表示する

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -7,6 +7,7 @@ import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { Dialog, ModelessDialog } from '../Dialog'
 import { FileViewer } from '../FileViewer'
+import { Heading } from '../Heading'
 import { FaXmarkIcon } from '../Icon'
 import { Center, Cluster } from '../Layout'
 import { Loader } from '../Loader'
@@ -73,9 +74,10 @@ export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDow
             align="center"
             className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"
           >
-            <span className="shr-min-w-0 shr-grow shr-truncate shr-text-base shr-font-bold">
+            {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
+            <Heading className="shr-min-w-0 shr-grow shr-truncate shr-text-base">
               {file?.name}
-            </span>
+            </Heading>
             <Button size="S" onClick={handleClose}>
               <FaXmarkIcon
                 alt={<Localizer id="smarthr-ui/InputFile/closePreview" defaultText="閉じる" />}

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -66,10 +66,10 @@ export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDow
         isOpen={isOpen}
         onClickOverlay={handleClose}
         onPressEscape={handleClose}
-        size="FULL"
+        size="M"
         ariaLabel={file?.name ?? ''}
       >
-        <div className="shr-flex shr-h-[100dvh] shr-flex-col">
+        <div className="shr-flex shr-h-full shr-flex-col">
           <Cluster
             align="center"
             className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -69,7 +69,7 @@ export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDow
         size="M"
         ariaLabel={file?.name ?? ''}
       >
-        <div className="shr-flex shr-h-svh shr-flex-col">
+        <div className="shr-flex shr-h-[calc(100svh-1rem)] shr-flex-col">
           <Cluster
             align="center"
             className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -69,7 +69,7 @@ export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDow
         size="M"
         ariaLabel={file?.name ?? ''}
       >
-        <div className="shr-flex shr-h-full shr-flex-col">
+        <div className="shr-flex shr-h-svh shr-flex-col">
           <Cluster
             align="center"
             className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -2,10 +2,12 @@
 
 import { type FC, memo, useEffect, useState } from 'react'
 
+import { useEnvironment } from '../../hooks/useEnvironment'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
-import { ModelessDialog } from '../Dialog'
+import { Dialog, ModelessDialog } from '../Dialog'
 import { FileViewer } from '../FileViewer'
+import { FaXmarkIcon } from '../Icon'
 import { Center, Cluster } from '../Layout'
 import { Loader } from '../Loader'
 
@@ -18,6 +20,7 @@ type Props = {
 export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDownload }) => {
   const [blobUrl, setBlobUrl] = useState<string>()
   const isOpen = !!file
+  const { mobile } = useEnvironment()
 
   useEffect(() => {
     if (!file) {
@@ -41,6 +44,58 @@ export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDow
     }
   }, [file])
 
+  const fileViewer =
+    isOpen && blobUrl ? (
+      <FileViewer
+        file={{
+          url: blobUrl,
+          contentType: file.type,
+          alt: file.name,
+        }}
+      />
+    ) : (
+      <Center className="shr-h-full">
+        <Loader size="M" />
+      </Center>
+    )
+
+  if (mobile) {
+    return (
+      <Dialog
+        isOpen={isOpen}
+        onClickOverlay={handleClose}
+        onPressEscape={handleClose}
+        size="FULL"
+        ariaLabel={file?.name ?? ''}
+      >
+        <div className="shr-flex shr-h-[100dvh] shr-flex-col">
+          <Cluster
+            align="center"
+            className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"
+          >
+            <span className="shr-min-w-0 shr-grow shr-truncate shr-text-base shr-font-bold">
+              {file?.name}
+            </span>
+            <Button size="S" onClick={handleClose}>
+              <FaXmarkIcon
+                alt={<Localizer id="smarthr-ui/InputFile/closePreview" defaultText="閉じる" />}
+              />
+            </Button>
+          </Cluster>
+          <div className="shr-min-h-0 shr-grow">{fileViewer}</div>
+          <Cluster
+            justify="end"
+            className="shr-border-t-shorthand shr-shrink-0 shr-px-1.5 shr-py-1"
+          >
+            <Button onClick={handleDownload}>
+              <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
+            </Button>
+          </Cluster>
+        </div>
+      </Dialog>
+    )
+  }
+
   return (
     <ModelessDialog
       isOpen={isOpen}
@@ -57,19 +112,7 @@ export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDow
         </Cluster>
       }
     >
-      {isOpen && blobUrl ? (
-        <FileViewer
-          file={{
-            url: blobUrl,
-            contentType: file.type,
-            alt: file.name,
-          }}
-        />
-      ) : (
-        <Center className="shr-h-full">
-          <Loader size="M" />
-        </Center>
-      )}
+      {fileViewer}
     </ModelessDialog>
   )
 })

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-grow shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{
@@ -29,7 +29,11 @@ const PreviewButton: FC<{
 }> = ({ file, handlePreviewClick }) => (
   <Button
     variant="tertiary"
-    prefix={<FaFileLinesIcon />}
+    prefix={
+      <span className="shr-inline-flex shr-shrink-0">
+        <FaFileLinesIcon />
+      </span>
+    }
     onClick={() => handlePreviewClick(file)}
     className={PREVIEW_BUTTON_CLASSNAME}
   >
@@ -60,7 +64,11 @@ const DownloadAnchorButton: FC<{ file: File }> = ({ file }) => {
     <AnchorButton
       href={href}
       download={file.name}
-      prefix={<FaFileArrowDownIcon />}
+      prefix={
+        <span className="shr-inline-flex shr-shrink-0">
+          <FaFileArrowDownIcon />
+        </span>
+      }
       variant="text"
       className={PREVIEW_BUTTON_CLASSNAME}
     >
@@ -102,7 +110,7 @@ export const FileListItem = memo<FileListItemProps>(
         prefix={<FaTrashCanIcon />}
         value={index}
         onClick={handleDeleteClick}
-        className="smarthr-ui-InputFile-deleteButton"
+        className="smarthr-ui-InputFile-deleteButton shr-shrink-0"
       >
         <Localizer id="smarthr-ui/InputFile/destroy" defaultText="削除" />
       </Button>

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-grow shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-all shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-justify-start shr-min-w-0 shr-break-all shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -20,7 +20,7 @@ export const LabelRender = memo<{ id: string; label: ReactNode }>(({ id, label }
 ))
 
 const FILE_NAME_BUTTON_CLASSNAME =
-  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-words shr-whitespace-normal shr-text-left'
+  'smarthr-ui-InputFile-fileName shr-grow shr-justify-start shr-min-w-0 shr-break-all shr-whitespace-normal shr-text-left'
 const PREVIEW_BUTTON_CLASSNAME = `${FILE_NAME_BUTTON_CLASSNAME} shr-p-0 shr-font-normal shr-text-link`
 
 const PreviewButton: FC<{

--- a/packages/smarthr-ui/src/components/InputFile/parts.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/parts.tsx
@@ -29,11 +29,7 @@ const PreviewButton: FC<{
 }> = ({ file, handlePreviewClick }) => (
   <Button
     variant="tertiary"
-    prefix={
-      <span className="shr-inline-flex shr-shrink-0">
-        <FaFileLinesIcon />
-      </span>
-    }
+    prefix={<FaFileLinesIcon className="shr-shrink-0" />}
     onClick={() => handlePreviewClick(file)}
     className={PREVIEW_BUTTON_CLASSNAME}
   >
@@ -64,11 +60,7 @@ const DownloadAnchorButton: FC<{ file: File }> = ({ file }) => {
     <AnchorButton
       href={href}
       download={file.name}
-      prefix={
-        <span className="shr-inline-flex shr-shrink-0">
-          <FaFileArrowDownIcon />
-        </span>
-      }
+      prefix={<FaFileArrowDownIcon className="shr-shrink-0" />}
       variant="text"
       className={PREVIEW_BUTTON_CLASSNAME}
     >

--- a/packages/smarthr-ui/src/intl/locales/ja.json
+++ b/packages/smarthr-ui/src/intl/locales/ja.json
@@ -64,6 +64,7 @@
   "smarthr-ui/InputFile/download": "ダウンロード",
   "smarthr-ui/InputFile/previewLabel": "{fileName}のプレビューを開く",
   "smarthr-ui/InputFile/downloadLabel": "{fileName}をダウンロード",
+  "smarthr-ui/InputFile/closePreview": "閉じる",
   "smarthr-ui/LanguageSwitcher/checkIconAlt": "選択中",
   "smarthr-ui/Loader/alt": "処理中",
   "smarthr-ui/MessageDialog/closeButtonLabel": "閉じる",

--- a/packages/smarthr-ui/src/intl/locales/ja.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja.ts
@@ -66,6 +66,7 @@ export const locale = {
   'smarthr-ui/InputFile/download': 'ダウンロード',
   'smarthr-ui/InputFile/previewLabel': '{fileName}のプレビューを開く',
   'smarthr-ui/InputFile/downloadLabel': '{fileName}をダウンロード',
+  'smarthr-ui/InputFile/closePreview': '閉じる',
   'smarthr-ui/LanguageSwitcher/checkIconAlt': '選択中',
   'smarthr-ui/Loader/alt': '処理中',
   'smarthr-ui/MessageDialog/closeButtonLabel': '閉じる',


### PR DESCRIPTION
## 関連URL

なし

## 概要

モバイル環境では `ModelessDialog`（ドラッグ・リサイズ可能）がタッチ操作に適していないため、`useEnvironment().mobile` を参照して環境に応じたダイアログに切り替えるようにした。

## 変更内容

- **モバイル**: `Dialog`（`size="M"`）でモーダル表示。ヘッダーにファイル名（`Heading`）と閉じるボタン、フッターにダウンロードボタンを配置
- **デスクトップ**: `ModelessDialog`（現状維持。ドラッグ・リサイズ可能）
- 閉じるボタンのアクセシブルテキスト用に `smarthr-ui/InputFile/closePreview`（"閉じる"）をjaロケールに追加

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookの `InputFile` ストーリーでモバイルビューポート時にプレビューボタンを押し、`Dialog` でプレビューが開くことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイル環境でファイルプレビューをフルスクリーン相当で表示できるようになりました。
  * モバイル表示に閉じるボタン、ファイル名、ダウンロードボタンを追加しました。
  * デスクトップでは従来どおりのモードレスダイアログで表示します。
* **改善**
  * ファイル表示と読み込み中の表示を統一し、環境に応じて最適なプレビュー画面を提供します。
* **多言語対応**
  * モバイル用の閉じるボタンに日本語ラベル「閉じる」を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->