### PR TITLE
fix(AppHeader): プラットフォーム固有のpropsがDOM要素に渡る問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -7,7 +7,13 @@ import { mediaQuery, useMediaQuery } from './hooks/useMediaQuery'
 import type { HeaderProps } from './types'
 import type { FC } from 'react'
 
-export const AppHeader: FC<HeaderProps> = ({ children, ...rest }) => {
+export const AppHeader: FC<HeaderProps> = ({
+  children,
+  desktopAdditionalContent,
+  desktopNavigationAdditionalContent,
+  mobileAdditionalContent,
+  ...rest
+}) => {
   // NOTE: ヘッダーの出し分けは CSS によって行われているので、useMediaQuery による children の出し分けは本来不要ですが、
   //  wovn の言語切替カスタム UI の挿入対象となる DOM ("wovn-embedded-widget-anchor" クラスを持った div) が複数描画されていると、
   //  wovn のスクリプトの仕様上1つ目の DOM にしか UI が挿入されないため、やむを得ず children のみ React のレンダリングレベルでの出し分けをしています。
@@ -17,8 +23,16 @@ export const AppHeader: FC<HeaderProps> = ({ children, ...rest }) => {
   // 表示切替は画面幅によって決まり、SSR環境では判定出来ないためです
   return (
     <>
-      <DesktopHeader {...rest}>{isDesktop ? children : undefined}</DesktopHeader>
-      <MobileHeader {...rest}>{isDesktop ? undefined : children}</MobileHeader>
+      <DesktopHeader
+        {...rest}
+        desktopAdditionalContent={desktopAdditionalContent}
+        desktopNavigationAdditionalContent={desktopNavigationAdditionalContent}
+      >
+        {isDesktop ? children : undefined}
+      </DesktopHeader>
+      <MobileHeader {...rest} mobileAdditionalContent={mobileAdditionalContent}>
+        {isDesktop ? undefined : children}
+      </MobileHeader>
     </>
   )
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`AppHeader` にプラットフォーム固有の props を渡すと、**ブラウザのコンソールに React の unknown prop 警告（Warning）が出力され**、`<header>` 要素に不要な属性が出力される問題を修正します。

`AppHeader` は `children` 以外のすべての props を `DesktopHeader` と `MobileHeader` の両方へ渡していますが、各ヘッダーは自分向けの props しか分割代入していません。そのため受け取らなかった側では rest props として残り、`Header` を経由して DOM 要素まで伝播していました。

対象の props は以下の3つです。

| props | 消費するヘッダー | 漏れていた経路 |
| --- | --- | --- |
| `desktopAdditionalContent` | `DesktopHeader` | `MobileHeader` の rest props |
| `desktopNavigationAdditionalContent` | `DesktopHeader` | `MobileHeader` の rest props |
| `mobileAdditionalContent` | `MobileHeader` | `DesktopHeader` の rest props |

再現例として、以下のように `mobileAdditionalContent` を渡すと、ブラウザのコンソールに警告が出力され、デスクトップ側の `<header>` に `mobileadditionalcontent` 属性が付与されます。

```tsx
<AppHeader
  desktopAdditionalContent={<LogoutButton />}
  mobileAdditionalContent={<LogoutButton />}
/>
```

ブラウザのコンソールに出力される警告:

```
Warning: React does not recognize the `mobileAdditionalContent` prop on a DOM element.
If you intentionally want it to appear in the DOM as a custom attribute,
spell it as lowercase `mobileadditionalcontent` instead.
If you accidentally passed it from a parent component, remove it from the DOM element.
```

なお、この警告は開発時のみ出力されますが、DOM 要素への不要な属性の出力は本番ビルドでも発生します。

## 変更内容

`AppHeader` で上記3つの props を分割代入し、該当するヘッダーにのみ明示的に渡すようにしました。

これにより両ヘッダーの rest props からプラットフォーム固有の props が除かれ、DOM 要素へ伝播しなくなります。

## プロダクト側で対応が必要な事項

なし（インタフェースの変更はありません）。これまでブラウザのコンソールに出力されていた警告と、DOM 要素の不要な属性が消えるのみです。

## 確認方法

`AppHeader` に `desktopAdditionalContent` / `mobileAdditionalContent` を渡した状態で描画し、以下を確認してください。

- ブラウザのコンソールに unknown prop の警告（Warning）が出力されないこと
- 2つの `<header>` 要素のいずれにも `desktopadditionalcontent` / `desktopnavigationadditionalcontent` / `mobileadditionalcontent` 属性が付与されていないこと
- デスクトップ幅ではユーザー情報のドロップダウン内、モバイル幅ではメニュー内に、それぞれ従来どおり追加コンテンツが表示されること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ヘッダーに、デスクトップ表示専用・モバイル表示専用の追加コンテンツを設定できるようになりました。
  * デスクトップではナビゲーション向けの追加コンテンツも表示できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->