### PR TITLE
feat(charts)!: ProgressDoughnutChartの進捗帯の端の既定を角端にする

### DIFF
--- a/packages/charts/src/components/DoughnutChart/DoughnutChart.tsx
+++ b/packages/charts/src/components/DoughnutChart/DoughnutChart.tsx
@@ -103,6 +103,9 @@ export const DoughnutChart: React.FC<Props> = ({
       <VisuallyHiddenText aria-live="polite" id={chartId}></VisuallyHiddenText>
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex */}
       <Doughnut
+        // tooltip は canvas の中に描かれるため、position 指定された中央コンテンツより
+        // 後ろに隠れてしまう。canvas 自体を前面に上げて中央コンテンツを背面に回す
+        className="shr-relative shr-z-1"
         tabIndex={0}
         role="application"
         ref={chartRef}

--- a/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.stories.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.stories.tsx
@@ -31,6 +31,7 @@ export const Playground: Story = {
     },
     thickness: 'S',
     tone: 1,
+    rounded: false,
     children: (
       <>
         <Text size="XXL" weight="bold">
@@ -46,6 +47,7 @@ export const Playground: Story = {
     data: { control: 'object' },
     thickness: { control: 'radio', options: ['S', 'M', 'L'] },
     tone: { control: { type: 'range', min: 1, max: 5, step: 1 } },
+    rounded: { control: 'boolean' },
   },
 }
 
@@ -75,5 +77,39 @@ export const WithCenterContent: Story = {
         </Text>
       </>
     ),
+  },
+}
+
+export const Rounded: Story = {
+  name: 'rounded',
+  args: {
+    data: {
+      labels: ['インストール済', '未インストール'],
+      datasets: [{ data: [780, 420] }],
+    },
+    rounded: true,
+  },
+}
+
+export const TinyValue: Story = {
+  name: 'with tiny value',
+  args: {
+    data: {
+      labels: ['インストール済', '未インストール'],
+      datasets: [{ data: [30, 9970] }],
+    },
+    children: (
+      <Text size="XXL" weight="bold">
+        0%
+      </Text>
+    ),
+  },
+}
+
+export const RoundedTinyValue: Story = {
+  name: 'rounded with tiny value',
+  args: {
+    ...TinyValue.args,
+    rounded: true,
   },
 }

--- a/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.tsx
@@ -35,6 +35,12 @@ type Props = {
   children?: React.ReactNode
   /** ドーナツの太さ。既定 'S' */
   thickness?: 'S' | 'M' | 'L'
+  /**
+   * 進捗の帯の端を丸くするか。既定 false。
+   * 丸端は進捗が極小のときに帯の長さより大きな塊として描かれ、実際の値より
+   * 多く見えてしまうため、既定は角端にしている。
+   */
+  rounded?: boolean
   /** 進捗色の濃淡。既定は基準色 tone=1 */
   tone?: 1 | 2 | 3 | 4 | 5
   className?: string
@@ -46,6 +52,7 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
   children,
   thickness = 'S',
   tone = 1,
+  rounded = false,
   className,
   options: externalOptions,
 }) => {
@@ -73,22 +80,23 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
       datasets: [
         {
           data: data.datasets[0].data,
-          // 進捗（index 0）の塗りは透明にし、見た目は roundedProgressPlugin が
+          // 丸端のときは進捗（index 0）の塗りを透明にし、見た目は roundedProgressPlugin が
           // 丸端付きの円弧ストロークで描く（hit 判定・キーボードナビ・tooltip は
-          // 透明でも arc として残る）。トラック（index 1）は chart.js が描く。
+          // 透明でも arc として残る）。角端のときはプラグインを止めて chart.js に塗らせる。
+          // トラック（index 1）は常に chart.js が描く。
           backgroundColor: [
-            'transparent',
+            rounded ? 'transparent' : colors.progress,
             colors.track,
           ] as ChartDataset<'doughnut'>['backgroundColor'],
           hoverBackgroundColor: [
-            'transparent',
+            rounded ? 'transparent' : colors.progressHover,
             colors.track,
           ] as ChartDataset<'doughnut'>['hoverBackgroundColor'],
-          // hover 時の枠はセグメント別に指定する。進捗（index 0）は透明にして
-          // プラグインが丸端付きの枠を描く（二重描画を避ける）。トラック（index 1）は
-          // 角端なので chart.js 標準の枠で強調する。
+          // hover 時の枠はセグメント別に指定する。丸端の進捗（index 0）は透明にして
+          // プラグインが丸端付きの枠を描く（二重描画を避ける）。角端の進捗と
+          // トラック（index 1）は chart.js 標準の枠で強調する。
           hoverBorderColor: [
-            'transparent',
+            rounded ? 'transparent' : SMARTHR_DEFAULT_COLORS.OUTLINE,
             SMARTHR_DEFAULT_COLORS.OUTLINE,
           ] as ChartDataset<'doughnut'>['hoverBorderColor'],
           hoverBorderWidth: 4,
@@ -99,7 +107,7 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
         },
       ],
     }),
-    [data, colors],
+    [data, rounded, colors],
   )
 
   const chartOptions: ChartOptions<'doughnut'> = useMemo(
@@ -113,24 +121,28 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
           legend: { display: false },
           tooltip: {
             callbacks: {
-              // 進捗（index 0）の塗りは透明にしてプラグインで描いているため、
+              // 丸端のときは進捗（index 0）の塗りを透明にしてプラグインで描いているため、
               // tooltip の色マーカーが透明になってしまう。実際の進捗色／トラック色を返す。
+              // 角端のときは chart.js が実色で塗るため本来は不要だが、返す色は同じなので
+              // モードでは分岐しない。
               labelColor: (context: TooltipItem<'doughnut'>) => {
                 const segmentColor = context.dataIndex === 0 ? colors.progress : colors.track
                 return { borderColor: segmentColor, backgroundColor: segmentColor }
               },
             },
           },
-          roundedProgress: {
-            segmentIndex: 0,
-            color: colors.progress,
-            hoverColor: colors.progressHover,
-            hoverBorderColor: SMARTHR_DEFAULT_COLORS.OUTLINE,
-            hoverBorderWidth: 4,
-          },
+          roundedProgress: rounded
+            ? {
+                segmentIndex: 0,
+                color: colors.progress,
+                hoverColor: colors.progressHover,
+                hoverBorderColor: SMARTHR_DEFAULT_COLORS.OUTLINE,
+                hoverBorderWidth: 4,
+              }
+            : false,
         },
       }) as ChartOptions<'doughnut'>,
-    [thickness, externalOptions, colors],
+    [thickness, rounded, externalOptions, colors],
   )
 
   // chartAreaPlugin は children の有無に関わらず常に渡す。react-chartjs-2 は plugins を

--- a/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.tsx
@@ -162,6 +162,9 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
         keyboardNavigation も持たない）。
       */}
       <Doughnut
+        // tooltip は canvas の中に描かれるため、position 指定された中央コンテンツより
+        // 後ろに隠れてしまう。canvas 自体を前面に上げて中央コンテンツを背面に回す
+        className="shr-relative shr-z-1"
         aria-hidden="true"
         ref={chartRef}
         data={chartData}

--- a/packages/charts/src/components/ProgressDoughnutChart/VRTProgressDoughnutChart.stories.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/VRTProgressDoughnutChart.stories.tsx
@@ -65,6 +65,44 @@ export default {
           thickness="L"
         />
       </div>
+
+      {/* パターン6: 極小値（0.3%）。角端では帯の長さどおりに描かれる */}
+      <div className="shr-h-[300px] shr-w-[300px]">
+        <ProgressDoughnutChart
+          data={{ labels: ['インストール済', '未インストール'], datasets: [{ data: [30, 9970] }] }}
+          thickness="S"
+        >
+          <Text size="XXL" weight="bold">
+            0%
+          </Text>
+        </ProgressDoughnutChart>
+      </div>
+
+      {/* パターン7: 丸端、65% */}
+      <div className="shr-h-[300px] shr-w-[300px]">
+        <ProgressDoughnutChart
+          data={{ labels: ['インストール済', '未インストール'], datasets: [{ data: [780, 420] }] }}
+          thickness="S"
+          rounded
+        >
+          <Text size="XXL" weight="bold">
+            65%
+          </Text>
+        </ProgressDoughnutChart>
+      </div>
+
+      {/* パターン8: 丸端かつ極小値。丸端が帯より大きな塊になる */}
+      <div className="shr-h-[300px] shr-w-[300px]">
+        <ProgressDoughnutChart
+          data={{ labels: ['インストール済', '未インストール'], datasets: [{ data: [30, 9970] }] }}
+          thickness="S"
+          rounded
+        >
+          <Text size="XXL" weight="bold">
+            0%
+          </Text>
+        </ProgressDoughnutChart>
+      </div>
     </Stack>
   ),
   parameters: {

--- a/packages/charts/src/plugins/types.d.ts
+++ b/packages/charts/src/plugins/types.d.ts
@@ -8,6 +8,8 @@ declare module 'chart.js' {
   interface PluginOptionsByType<_TType extends ChartType> {
     doughnutSegmentDivider?: DoughnutSegmentDividerOptions
     keyboardNavigation?: KeyboardNavigationOptions
-    roundedProgress?: RoundedProgressOptions
+    // chart.js はプラグインオプションが false のときそのプラグインを実行しないため、
+    // 丸端をやめる指定として false を受け取れるようにする。
+    roundedProgress?: RoundedProgressOptions | false
   }
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`ProgressDoughnutChart` の進捗帯は常に丸端で描かれていましたが、進捗が極小のとき（例: 30 / 9,970 = 0.3%）に丸端が帯の長さより大きな塊として描かれ、実際の値より多く進んでいるように見えてしまいます。

このケースで丸みを消せるよう、端の形を切り替えられるようにしました。既定は「実際の値どおりに描かれる」角端とし、丸端は opt-in とします。

あわせて、canvas 内に描かれる tooltip が中央コンテンツ（`children`）の下に隠れて読めなくなる問題も修正しています。

## 変更内容

### 1. `rounded` prop の追加（破壊的変更）

`ProgressDoughnutChart` に `rounded?: boolean`（既定 `false`）を追加しました。既定では進捗帯の端が角端になります。

```tsx
// Before（常に丸端）
<ProgressDoughnutChart data={data} />

// After（既定は角端。従来の見た目は rounded で復元）
<ProgressDoughnutChart data={data} />          {/* 角端 */}
<ProgressDoughnutChart data={data} rounded />  {/* 従来どおりの丸端 */}
```

実装上は、`rounded={false}` のとき `plugins.roundedProgress` に `false` を渡して `roundedProgressPlugin` を止め、進捗セグメントの塗り・hover 色・hover 枠を chart.js 標準の描画に任せています（`rounded` のときは従来どおり塗りを透明にしてプラグインが丸端の円弧を描く）。プラグインを `plugins` 配列から外していないのは、react-chartjs-2 が `plugins` を mount 時にしか読まず、後から切り替えられなくなるためです。

### 2. tooltip が中央コンテンツの下に隠れる問題の修正

tooltip は chart.js が canvas の中に描くピクセルなので z-index を持たず、`position: absolute` の中央コンテンツが常に前面に来ていました。canvas 側を `shr-relative shr-z-1` で前面に上げ、中央コンテンツを背面に回しています（ドーナツの穴は透明なので中央コンテンツはこれまでどおり見えます）。

`ProgressDoughnutChart` と `DoughnutChart` の両方に同じ問題があったため、どちらも修正しました。

## プロダクト側で対応が必要な事項

`ProgressDoughnutChart` の進捗帯の端が、既定で丸端から角端に変わります。API の破壊的変更ではないため、更新しても型エラーやビルドエラーにはなりませんが、**見た目が変わります**。

従来の丸端を維持したい場合は `rounded` を指定してください。

```tsx
<ProgressDoughnutChart data={data} rounded />
```

## 確認方法

Storybook（`pnpm charts dev`）の `Charts/ProgressDoughnutChart` で確認できます。

- `with tiny value` / `rounded with tiny value` — 0.3% のときの角端と丸端の差（今回の動機）
- `rounded` — 丸端の従来表示
- Playground の `rounded` コントロールで切り替え

tooltip の重なりは、いずれかのストーリーで帯にホバーし、tooltip が中央のテキストの上に表示されることで確認できます（ホバー状態は VRT では撮っていないため目視確認をお願いします）。

VRT には角端・丸端・極小値のパターンを追加しました。既定の変更により、既存の VRT パターンも角端になるため Chromatic に差分が出ますが、意図した変更です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 進捗ドーナツチャートに、進捗部分の端を丸く表示する設定を追加しました。
  * 丸端表示と極小値の組み合わせに対応しました。

* **改善**
  * ドーナツチャートの重なり順を調整し、中央コンテンツを適切に表示できるようにしました。

* **テスト**
  * 丸端表示、極小値表示、および両方を組み合わせた表示パターンを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->