### PR TITLE
fix: nanoid の脆弱性対応 (nanoid@<3.3.18 を >=3.3.18 に強制)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   js-yaml@>=4.0.0 <=5.2.1: '>=5.2.2'
   '@babel/core@<=7.29.0': '>=8.0.1'
   sharp@<0.35.0: '>=0.35.3'
-  nanoid@<3.3.17: '>=3.3.17 <4'
+  nanoid@<3.3.18: '>=3.3.18 <4'
 
 importers:
 
@@ -4584,8 +4584,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10765,7 +10765,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -11213,13 +11213,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,8 @@ packages:
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
-  # Security update: nanoid@3.3.17 (2026-08-03 公開。minimumReleaseAge 経過後に削除可)
-  - nanoid@3.3.17
+  # Security update: nanoid@3.3.18 (minimumReleaseAge 経過後に削除可)
+  - nanoid@3.3.18
 allowBuilds:
   '@swc/core': true
   canvas: true
@@ -21,4 +21,4 @@ overrides:
   js-yaml@>=4.0.0 <=5.2.1: '>=5.2.2'
   '@babel/core@<=7.29.0': '>=8.0.1'
   sharp@<0.35.0: '>=0.35.3'
-  nanoid@<3.3.17: '>=3.3.17 <4'
+  nanoid@<3.3.18: '>=3.3.18 <4'


### PR DESCRIPTION
## 関連URL

https://github.com/advisories/GHSA-2v37-7h3g-55p8

## 概要

`nanoid@<3.3.18` に新たな脆弱性（high）が報告されたため、`pnpm-workspace.yaml` の override を更新して `>=3.3.18` を強制する。

## 変更内容

- `pnpm-workspace.yaml` の `overrides` を `nanoid@<3.3.17: '>=3.3.17 <4'` → `nanoid@<3.3.18: '>=3.3.18 <4'` に更新
- `minimumReleaseAgeExclude` を `nanoid@3.3.17` → `nanoid@3.3.18` に更新
- `pnpm install` による `pnpm-lock.yaml` の更新

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm audit --prod` でNo known vulnerabilities foundになることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - `nanoid`をセキュリティ更新版の3.3.18以降に更新しました。
  - 更新版の削除時期に関する管理情報を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->