### PR TITLE
fix(Scroller, DatePicker): useImperativeHandleに[]を追加して毎レンダリングの不要な再実行を防止

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,9 +497,15 @@ const functions = useMemo(() => ({
 **依存配列の決め方:**
 
 ```typescript
-// ✅ factory が ref.current を返すだけ → []
+// ✅ factory が ref.current を返すだけ、かつ
+//    その要素が初回コミットで無条件にマウントされる → []
 // DOM要素はコンポーネントのライフタイム中に変わらないため、初回のみ実行すれば十分
 useImperativeHandle(ref, () => innerRef.current, [])
+
+// ✅ 条件付きマウント（portal、遅延描画など）
+//    マウントを制御する値を依存配列に含める
+// eslint-disable-next-line react-hooks/exhaustive-deps
+useImperativeHandle(ref, () => containerRef.current, [portalRoot])
 
 // ✅ factory がオブジェクトを返し、中身が useCallback の値に依存する → [theCallback]
 // focus が変わったときのみ ref を再作成する
@@ -517,7 +523,8 @@ useImperativeHandle(ref, () => wrapperRef.current!, [Component])
 
 **依存配列に含めないもの:**
 
-- factory 内で参照していない値（`Component` など外部からの `as` prop を除く）
+- factory 内で参照していない値
+  - ただし「ref 対象の（再）マウントを引き起こす値」は例外（`as` の `Component`、portal の `portalRoot` など）
 - `ref` 自体（React が内部で管理するため不要）
 
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,43 @@ const functions = useMemo(() => ({
 - `id` は `useId()` ベースで一意性が保証される
 - `value` は重複の可能性があるため不適切
 
+#### useImperativeHandle の依存配列
+
+`useImperativeHandle` には**必ず依存配列を指定**します。
+
+**理由:** 依存配列を省略すると、毎レンダリングで React がcleanupとして `ref(null)` を呼んだあと `ref(node)` を再実行します。これによりcallback refを使う親コンポーネントで不要な処理（DOM操作、副作用など）が毎レンダリング走ります。
+
+**依存配列の決め方:**
+
+```typescript
+// ✅ factory が ref.current を返すだけ → []
+// DOM要素はコンポーネントのライフタイム中に変わらないため、初回のみ実行すれば十分
+useImperativeHandle(ref, () => innerRef.current, [])
+
+// ✅ factory がオブジェクトを返し、中身が useCallback の値に依存する → [theCallback]
+// focus が変わったときのみ ref を再作成する
+const focus = useCallback(() => {
+  firstFocusTarget?.current?.focus()
+}, [firstFocusTarget])
+
+useImperativeHandle(ref, () => ({ focus }), [focus])
+
+// ✅ as prop でレンダリングする DOM 要素が変わる場合 → [Component]
+// factory 内で Component を参照しないが、レンダリング要素が変わると ref が指す型も変わるため必要
+// eslint-disable-next-line react-hooks/exhaustive-deps
+useImperativeHandle(ref, () => wrapperRef.current!, [Component])
+```
+
+**依存配列に含めないもの:**
+
+- factory 内で参照していない値（`Component` など外部からの `as` prop を除く）
+- `ref` 自体（React が内部で管理するため不要）
+
+```typescript
+// ❌ 依存配列を省略してはいけない
+useImperativeHandle(ref, () => innerRef.current)
+```
+
 ## スキル
 
 - **PR作成** (`.claude/skills/pr-creator/`): PR作成時にリポジトリのテンプレートに沿った本文を生成する

--- a/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
@@ -18,7 +18,11 @@ export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, ...rest },
   const { portalRoot, createPortal } = usePortal()
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(ref, () => containerRef.current)
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+    ref,
+    () => containerRef.current,
+    [portalRoot], // eslint-disable-line react-hooks/exhaustive-deps
+  )
 
   const [style, setStyle] = useState(initialPosition)
 

--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -83,7 +83,9 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
   ) => {
     const wrapperRef = useRef<HTMLDivElement>(null)
 
-    useImperativeHandle(ref, () => wrapperRef.current!, [])
+    // as が切り替わると DOM 要素が変わるため、Component を依存配列に含める
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useImperativeHandle(ref, () => wrapperRef.current!, [Component])
 
     const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
 

--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -83,7 +83,7 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
   ) => {
     const wrapperRef = useRef<HTMLDivElement>(null)
 
-    useImperativeHandle(ref, () => wrapperRef.current!)
+    useImperativeHandle(ref, () => wrapperRef.current!, [])
 
     const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useImperativeHandle` に依存配列を指定しないと、毎レンダリングでcleanup（`ref(null)`）と再実行（`ref(node)`）が走り、不要なcallback refの呼び出しが発生する。

Scroller は `as` prop によってレンダリングする DOM 要素が変わるため、`wrapperRef.current` の型が変わる可能性がある。factory 内では `Component` を参照しないが、依存配列に `[Component]` を追加して `as` 切り替え時に ref を再作成するよう修正する。

DatePicker の Portal は `portalRoot` が `null` で初期化され `useEnhancedEffect` 後に設定されるため、`[]` では portal マウント後に ref が更新されない。依存配列に `[portalRoot]` を追加して portal マウント時に ref を再作成するよう修正する。

また、`useImperativeHandle` の依存配列の使い方を CLAUDE.md に追記した。

## 変更内容

- `Scroller/Scroller.tsx`: `useImperativeHandle` の依存配列を `[Component]` に変更
  - `as` が切り替わると DOM 要素が変わるため、`react-hooks/exhaustive-deps` を無効化しコメントで理由を明記
- `DatePicker/Portal.tsx`: `useImperativeHandle` の依存配列を `[portalRoot]` に変更
  - portal が条件付きマウントのため、`portalRoot` が設定された後に factory を再実行する必要がある
- `CLAUDE.md`: `useImperativeHandle` の依存配列パターン（`[]` / 条件付きマウント / `[callback]` / `[Component]`）を追記

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストが通ることを確認。