### PR TITLE
fix(DatePicker): Portal の useImperativeHandle に [] を追加して毎レンダリングの不要な再実行を防止

### DIFF
--- a/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
@@ -18,7 +18,11 @@ export const Portal = forwardRef<HTMLDivElement, Props>(({ inputRect, ...rest },
   const { portalRoot, createPortal } = usePortal()
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(ref, () => containerRef.current)
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+    ref,
+    () => containerRef.current,
+    [],
+  )
 
   const [style, setStyle] = useState(initialPosition)
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useImperativeHandle` に依存配列を指定しないと、毎レンダリングでcleanup（`ref(null)`）と再実行（`ref(node)`）が走り、不要なcallback refの呼び出しが発生する。

factory は `containerRef.current` を返すだけで外部の値に依存しないため、`[]` を指定して初回のみ実行されるよう修正する。

## 変更内容

`DatePicker/Portal.tsx` の `useImperativeHandle` に `[]` を追加。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテストが通ることを確認。