### PR TITLE
feat(FileViewer): searchable prop を追加して検索ボックスの表示/非表示を制御できるようにする

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -50,6 +50,8 @@ type Props = {
   scaleStep?: number
   onPassword?: ComponentProps<typeof PDFViewer>['handlePassword']
   onLoadError?: (error: unknown) => void
+  /** PDF表示時に検索ボックスを表示するかどうか */
+  searchable?: boolean
 }
 
 // 共通のprops（ImageとPDFで共有）
@@ -79,6 +81,7 @@ export const FileViewer: FC<Props> = ({
   width: fixedWidth,
   onPassword,
   onLoadError,
+  searchable = true,
 }) => {
   const [scale, setScale] = useState(1)
   const [loaded, setLoaded] = useState(false)
@@ -137,6 +140,7 @@ export const FileViewer: FC<Props> = ({
       {...commonAttrs}
       setRotation={setRotation}
       handlePassword={functions.handlePassword}
+      searchable={searchable}
     />
   ) : (
     <ImageFileViewer {...commonAttrs} />
@@ -147,6 +151,7 @@ const PDFFileViewer: FC<
   CommonViewerProps & {
     setRotation: (value: number | undefined) => void
     handlePassword?: ComponentProps<typeof PDFViewer>['handlePassword']
+    searchable?: boolean
   }
 > = ({
   file,
@@ -161,6 +166,7 @@ const PDFFileViewer: FC<
   setRotation,
   handlePassword,
   handleLoadError,
+  searchable = true,
 }) => {
   const search = usePDFSearch(file.url)
 
@@ -172,7 +178,7 @@ const PDFFileViewer: FC<
       setWidth={setWidth}
       scaleSteps={scaleSteps}
       functions={functions}
-      searchController={<SearchController search={search} />}
+      searchController={searchable ? <SearchController search={search} /> : undefined}
     >
       <PDFViewer
         scale={scale}
@@ -183,7 +189,7 @@ const PDFFileViewer: FC<
         handlePDFLoaded={setRotation}
         handlePassword={handlePassword}
         handleLoadError={handleLoadError}
-        search={search}
+        search={searchable ? search : undefined}
       />
     </ActualFileViewer>
   )

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -166,7 +166,7 @@ const PDFFileViewer: FC<
   setRotation,
   handlePassword,
   handleLoadError,
-  searchable = true,
+  searchable,
 }) => {
   const search = usePDFSearch(file.url)
 

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -151,7 +151,7 @@ const PDFFileViewer: FC<
   CommonViewerProps & {
     setRotation: (value: number | undefined) => void
     handlePassword?: ComponentProps<typeof PDFViewer>['handlePassword']
-    searchable?: boolean
+    searchable: boolean
   }
 > = ({
   file,

--- a/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
@@ -74,3 +74,10 @@ export const ScaleStep: Story = {
     scaleStep: 1,
   },
 }
+
+export const Searchable: Story = {
+  name: 'searchable',
+  args: {
+    searchable: false,
+  },
+}

--- a/packages/smarthr-ui/src/components/FileViewer/stories/VRTFileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/VRTFileViewer.stories.tsx
@@ -91,3 +91,34 @@ export const VRTForcedColors: StoryObj = {
     chromatic: { forcedColors: 'active' },
   },
 }
+
+export const VRTSearchable: StoryObj = {
+  render: () => (
+    <Stack className="shr-h-[50vh]">
+      <div className="shr-h-[50%]">
+        <FileViewer
+          file={{
+            url: '/fixtures/sample-japanese-pdf.pdf',
+            contentType: 'application/pdf',
+          }}
+        />
+      </div>
+      <div className="shr-h-[50%]">
+        <FileViewer
+          file={{
+            url: '/fixtures/sample-japanese-pdf.pdf',
+            contentType: 'application/pdf',
+          }}
+          searchable={false}
+        />
+      </div>
+    </Stack>
+  ),
+}
+
+export const VRTSearchableForcedColors: StoryObj = {
+  ...VRTSearchable,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -16,105 +16,109 @@ type Props = {
   file: File | null
   handleClose: () => void
   handleDownload: () => void
+  searchable?: boolean
 }
 
-export const FilePreviewDialog: FC<Props> = memo(({ file, handleClose, handleDownload }) => {
-  const [blobUrl, setBlobUrl] = useState<string>()
-  const isOpen = !!file
-  const { mobile } = useEnvironment()
+export const FilePreviewDialog: FC<Props> = memo(
+  ({ file, handleClose, handleDownload, searchable }) => {
+    const [blobUrl, setBlobUrl] = useState<string>()
+    const isOpen = !!file
+    const { mobile } = useEnvironment()
 
-  useEffect(() => {
-    if (!file) {
-      setBlobUrl((current) => {
-        if (current) {
-          URL.revokeObjectURL(current)
-          return undefined
-        }
+    useEffect(() => {
+      if (!file) {
+        setBlobUrl((current) => {
+          if (current) {
+            URL.revokeObjectURL(current)
+            return undefined
+          }
 
-        return current
-      })
+          return current
+        })
 
-      return
+        return
+      }
+
+      const url = URL.createObjectURL(file)
+      setBlobUrl(url)
+
+      return () => {
+        URL.revokeObjectURL(url)
+      }
+    }, [file])
+
+    const fileViewer =
+      isOpen && blobUrl ? (
+        <FileViewer
+          file={{
+            url: blobUrl,
+            contentType: file.type,
+            alt: file.name,
+          }}
+          searchable={searchable}
+        />
+      ) : (
+        <Center className="shr-h-full">
+          <Loader size="M" />
+        </Center>
+      )
+
+    if (mobile) {
+      return (
+        <Dialog
+          isOpen={isOpen}
+          onClickOverlay={handleClose}
+          onPressEscape={handleClose}
+          size="M"
+          ariaLabel={file?.name ?? ''}
+        >
+          <div className="shr-flex shr-h-[calc(100svh-1rem)] shr-flex-col">
+            <Cluster
+              align="center"
+              className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"
+            >
+              {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
+              <Heading className="shr-min-w-0 shr-grow shr-truncate shr-text-base">
+                {file?.name}
+              </Heading>
+              <Button size="S" onClick={handleClose}>
+                <FaXmarkIcon
+                  alt={<Localizer id="smarthr-ui/InputFile/closePreview" defaultText="閉じる" />}
+                />
+              </Button>
+            </Cluster>
+            <div className="shr-min-h-0 shr-grow">{fileViewer}</div>
+            <Cluster
+              justify="end"
+              className="shr-border-t-shorthand shr-shrink-0 shr-px-1.5 shr-py-1"
+            >
+              <Button onClick={handleDownload}>
+                <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
+              </Button>
+            </Cluster>
+          </div>
+        </Dialog>
+      )
     }
 
-    const url = URL.createObjectURL(file)
-    setBlobUrl(url)
-
-    return () => {
-      URL.revokeObjectURL(url)
-    }
-  }, [file])
-
-  const fileViewer =
-    isOpen && blobUrl ? (
-      <FileViewer
-        file={{
-          url: blobUrl,
-          contentType: file.type,
-          alt: file.name,
-        }}
-      />
-    ) : (
-      <Center className="shr-h-full">
-        <Loader size="M" />
-      </Center>
-    )
-
-  if (mobile) {
     return (
-      <Dialog
+      <ModelessDialog
         isOpen={isOpen}
-        onClickOverlay={handleClose}
-        onPressEscape={handleClose}
+        onClickClose={handleClose}
+        heading={file?.name ?? ''}
+        height="75svh"
         size="M"
-        ariaLabel={file?.name ?? ''}
-      >
-        <div className="shr-flex shr-h-[calc(100svh-1rem)] shr-flex-col">
-          <Cluster
-            align="center"
-            className="shr-border-b-shorthand shr-shrink-0 shr-px-1 shr-py-0.5"
-          >
-            {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
-            <Heading className="shr-min-w-0 shr-grow shr-truncate shr-text-base">
-              {file?.name}
-            </Heading>
-            <Button size="S" onClick={handleClose}>
-              <FaXmarkIcon
-                alt={<Localizer id="smarthr-ui/InputFile/closePreview" defaultText="閉じる" />}
-              />
-            </Button>
-          </Cluster>
-          <div className="shr-min-h-0 shr-grow">{fileViewer}</div>
-          <Cluster
-            justify="end"
-            className="shr-border-t-shorthand shr-shrink-0 shr-px-1.5 shr-py-1"
-          >
+        resizable
+        footer={
+          <Cluster justify="end" className="shr-px-1.5 shr-py-1">
             <Button onClick={handleDownload}>
               <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
             </Button>
           </Cluster>
-        </div>
-      </Dialog>
+        }
+      >
+        {fileViewer}
+      </ModelessDialog>
     )
-  }
-
-  return (
-    <ModelessDialog
-      isOpen={isOpen}
-      onClickClose={handleClose}
-      heading={file?.name ?? ''}
-      height="75svh"
-      size="M"
-      resizable
-      footer={
-        <Cluster justify="end" className="shr-px-1.5 shr-py-1">
-          <Button onClick={handleDownload}>
-            <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
-          </Button>
-        </Cluster>
-      }
-    >
-      {fileViewer}
-    </ModelessDialog>
-  )
-})
+  },
+)

--- a/packages/smarthr-ui/src/components/InputFile/InputFile.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFile.tsx
@@ -2,15 +2,33 @@
 
 import { forwardRef } from 'react'
 
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
+
 import { InputFileMultiplyAppendable } from './InputFileMultiplyAppendable'
 import { InputFileNative } from './InputFileNative'
 
-import type { Props } from './types'
+import type { PreviewableObjectType, Props } from './types'
 
-export const InputFile = forwardRef<HTMLInputElement, Props>(({ multiple, ...rest }, ref) => {
-  if (typeof multiple === 'object' && multiple.appendable) {
-    return <InputFileMultiplyAppendable {...rest} ref={ref} />
-  }
+const previewableObjectConverter = (org: boolean) => (org ? { searchable: true } : undefined)
 
-  return <InputFileNative {...rest} multiple={multiple as boolean | undefined} ref={ref} />
-})
+export const InputFile = forwardRef<HTMLInputElement, Props>(
+  ({ multiple, previewable: orgPreviewable, ...rest }, ref) => {
+    const previewable = useObjectAttributes<
+      typeof orgPreviewable,
+      PreviewableObjectType | undefined
+    >(orgPreviewable, previewableObjectConverter)
+
+    if (typeof multiple === 'object' && multiple.appendable) {
+      return <InputFileMultiplyAppendable {...rest} ref={ref} previewable={previewable} />
+    }
+
+    return (
+      <InputFileNative
+        {...rest}
+        ref={ref}
+        previewable={previewable}
+        multiple={multiple as boolean | undefined}
+      />
+    )
+  },
+)

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Stack } from '../Layout'
 import { Groupbox } from '../Panel'
 
@@ -38,6 +39,13 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
     },
     ref,
   ) => {
+    const isPreviewable = !!previewable
+    const previewableAttrs = useObjectAttributes<
+      typeof previewable,
+      { searchable?: boolean } | undefined
+    >(previewable, () => undefined)
+    const fileViewerSearchable = previewableAttrs?.searchable
+
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)
     const labelId = useId()
@@ -136,7 +144,7 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
                 key={index}
                 file={file}
                 index={index}
-                previewable={previewable}
+                previewable={isPreviewable}
                 handleDeleteClick={functions.handleDelete}
                 handlePreviewClick={setPreviewFile}
                 className={classNames.fileItem}
@@ -160,11 +168,12 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
           <StyledFaFolderOpenIcon className={classNames.prefix} />
           <LabelRender id={labelId} label={label} />
         </span>
-        {previewable && (
+        {isPreviewable && (
           <FilePreviewDialog
             file={previewFile}
             handleClose={functions.handleClosePreview}
             handleDownload={functions.handleDownload}
+            searchable={fileViewerSearchable}
           />
         )}
       </Stack>

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -44,7 +44,6 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
       typeof previewable,
       { searchable?: boolean } | undefined
     >(previewable, () => undefined)
-    const fileViewerSearchable = previewableAttrs?.searchable
 
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)
@@ -173,7 +172,7 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
             file={previewFile}
             handleClose={functions.handleClosePreview}
             handleDownload={functions.handleDownload}
-            searchable={fileViewerSearchable}
+            searchable={previewableAttrs?.searchable}
           />
         )}
       </Stack>

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -39,11 +39,11 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
     },
     ref,
   ) => {
-    const isPreviewable = !!previewable
     const previewableAttrs = useObjectAttributes<
       typeof previewable,
       { searchable?: boolean } | undefined
     >(previewable, () => undefined)
+    const isPreviewable = !!previewableAttrs
 
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
-import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Stack } from '../Layout'
 import { Groupbox } from '../Panel'
 
@@ -20,31 +19,18 @@ import { FilePreviewDialog } from './FilePreviewDialog'
 import { FileListItem, LabelRender, StyledFaFolderOpenIcon } from './parts'
 import { classNameGenerator } from './style'
 
-import type { Props } from './types'
+import type { LowerProps } from './types'
 
 const BASE_COLUMN_PADDING = { block: 0.5, inline: 1 } as const
 
-export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Props, 'multiple'>>(
+export const InputFileMultiplyAppendable = forwardRef<
+  HTMLInputElement,
+  Omit<LowerProps, 'multiple'>
+>(
   (
-    {
-      className,
-      size,
-      label,
-      hasFileList = true,
-      previewable = false,
-      onChange,
-      disabled,
-      error,
-      ...rest
-    },
+    { className, size, label, hasFileList = true, previewable, onChange, disabled, error, ...rest },
     ref,
   ) => {
-    const previewableAttrs = useObjectAttributes<
-      typeof previewable,
-      { searchable?: boolean } | undefined
-    >(previewable, (original) => (original ? { searchable: true } : undefined))
-    const isPreviewable = !!previewableAttrs
-
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)
     const labelId = useId()
@@ -143,7 +129,7 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
                 key={index}
                 file={file}
                 index={index}
-                previewable={isPreviewable}
+                previewable={!!previewable}
                 handleDeleteClick={functions.handleDelete}
                 handlePreviewClick={setPreviewFile}
                 className={classNames.fileItem}
@@ -167,12 +153,12 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
           <StyledFaFolderOpenIcon className={classNames.prefix} />
           <LabelRender id={labelId} label={label} />
         </span>
-        {isPreviewable && (
+        {previewable && (
           <FilePreviewDialog
             file={previewFile}
             handleClose={functions.handleClosePreview}
             handleDownload={functions.handleDownload}
-            searchable={previewableAttrs?.searchable}
+            searchable={previewable?.searchable}
           />
         )}
       </Stack>

--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -42,7 +42,7 @@ export const InputFileMultiplyAppendable = forwardRef<HTMLInputElement, Omit<Pro
     const previewableAttrs = useObjectAttributes<
       typeof previewable,
       { searchable?: boolean } | undefined
-    >(previewable, () => undefined)
+    >(previewable, (original) => (original ? { searchable: true } : undefined))
     const isPreviewable = !!previewableAttrs
 
     const [files, setFiles] = useState<File[]>([])

--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Stack } from '../Layout'
 import { Groupbox } from '../Panel'
 
@@ -42,6 +43,13 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
     },
     ref,
   ) => {
+    const isPreviewable = !!previewable
+    const previewableAttrs = useObjectAttributes<
+      typeof previewable,
+      { searchable?: boolean } | undefined
+    >(previewable, () => undefined)
+    const fileViewerSearchable = previewableAttrs?.searchable
+
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)
     const labelId = useId()
@@ -128,7 +136,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
                 key={index}
                 file={file}
                 index={index}
-                previewable={previewable}
+                previewable={isPreviewable}
                 handleDeleteClick={functions.handleDelete}
                 handlePreviewClick={setPreviewFile}
                 className={classNames.fileItem}
@@ -151,11 +159,12 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
           <StyledFaFolderOpenIcon className={classNames.prefix} />
           <LabelRender id={labelId} label={label} />
         </span>
-        {previewable && (
+        {isPreviewable && (
           <FilePreviewDialog
             file={previewFile}
             handleClose={functions.handleClosePreview}
             handleDownload={functions.handleDownload}
+            searchable={fileViewerSearchable}
           />
         )}
       </Stack>

--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -43,11 +43,11 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
     },
     ref,
   ) => {
-    const isPreviewable = !!previewable
     const previewableAttrs = useObjectAttributes<
       typeof previewable,
       { searchable?: boolean } | undefined
     >(previewable, () => undefined)
+    const isPreviewable = !!previewableAttrs
 
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)

--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
-import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Stack } from '../Layout'
 import { Groupbox } from '../Panel'
 
@@ -20,35 +19,19 @@ import { FilePreviewDialog } from './FilePreviewDialog'
 import { FileListItem, LabelRender, StyledFaFolderOpenIcon } from './parts'
 import { classNameGenerator } from './style'
 
-import type { Props as CommonProps } from './types'
+import type { LowerProps } from './types'
 
 const BASE_COLUMN_PADDING = { block: 0.5, inline: 1 } as const
 
-type Props = Omit<CommonProps, 'multiple'> & {
+type Props = Omit<LowerProps, 'multiple'> & {
   multiple?: boolean
 }
 
 export const InputFileNative = forwardRef<HTMLInputElement, Props>(
   (
-    {
-      className,
-      size,
-      label,
-      hasFileList = true,
-      previewable = false,
-      onChange,
-      disabled,
-      error,
-      ...rest
-    },
+    { className, size, label, hasFileList = true, previewable, onChange, disabled, error, ...rest },
     ref,
   ) => {
-    const previewableAttrs = useObjectAttributes<
-      typeof previewable,
-      { searchable?: boolean } | undefined
-    >(previewable, (original) => (original ? { searchable: true } : undefined))
-    const isPreviewable = !!previewableAttrs
-
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)
     const labelId = useId()
@@ -135,7 +118,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
                 key={index}
                 file={file}
                 index={index}
-                previewable={isPreviewable}
+                previewable={!!previewable}
                 handleDeleteClick={functions.handleDelete}
                 handlePreviewClick={setPreviewFile}
                 className={classNames.fileItem}
@@ -158,12 +141,12 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
           <StyledFaFolderOpenIcon className={classNames.prefix} />
           <LabelRender id={labelId} label={label} />
         </span>
-        {isPreviewable && (
+        {previewable && (
           <FilePreviewDialog
             file={previewFile}
             handleClose={functions.handleClosePreview}
             handleDownload={functions.handleDownload}
-            searchable={previewableAttrs?.searchable}
+            searchable={previewable?.searchable}
           />
         )}
       </Stack>

--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -48,7 +48,6 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
       typeof previewable,
       { searchable?: boolean } | undefined
     >(previewable, () => undefined)
-    const fileViewerSearchable = previewableAttrs?.searchable
 
     const [files, setFiles] = useState<File[]>([])
     const [previewFile, setPreviewFile] = useState<File | null>(null)
@@ -164,7 +163,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
             file={previewFile}
             handleClose={functions.handleClosePreview}
             handleDownload={functions.handleDownload}
-            searchable={fileViewerSearchable}
+            searchable={previewableAttrs?.searchable}
           />
         )}
       </Stack>

--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -46,7 +46,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
     const previewableAttrs = useObjectAttributes<
       typeof previewable,
       { searchable?: boolean } | undefined
-    >(previewable, () => undefined)
+    >(previewable, (original) => (original ? { searchable: true } : undefined))
     const isPreviewable = !!previewableAttrs
 
     const [files, setFiles] = useState<File[]>([])

--- a/packages/smarthr-ui/src/components/InputFile/stories/InputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/stories/InputFile.stories.tsx
@@ -82,6 +82,11 @@ export const Previewable: StoryObj<typeof InputFile> = {
   args: { previewable: true, multiple: { appendable: true } },
 }
 
+export const PreviewableSearchable: StoryObj<typeof InputFile> = {
+  name: 'previewable.searchable',
+  args: { previewable: { searchable: false }, multiple: { appendable: true } },
+}
+
 export const OnChange: StoryObj<typeof InputFile> = {
   name: 'onChange',
   args: { onChange: action('changed') },

--- a/packages/smarthr-ui/src/components/InputFile/stories/VRTInputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/stories/VRTInputFile.stories.tsx
@@ -81,3 +81,35 @@ export const VRTPreviewableForcedColors: StoryObj<typeof InputFile> = {
     chromatic: { forcedColors: 'active' },
   },
 }
+
+const previewableSearchablePlay = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const input = canvasElement.querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"]')
+  if (!input) return
+  const pdfFile = new File([''], 'document.pdf', { type: 'application/pdf' })
+  await userEvent.upload(input, [pdfFile])
+  const previewButton = canvasElement.querySelector<HTMLButtonElement>(
+    '.smarthr-ui-InputFile-fileName',
+  )
+  if (previewButton) {
+    await userEvent.click(previewButton)
+  }
+}
+
+export const VRTPreviewableSearchable: StoryObj<typeof InputFile> = {
+  render: () => (
+    <InputFile
+      label="previewable: { searchable: false }"
+      name="previewablesearchable"
+      previewable={{ searchable: false }}
+    />
+  ),
+  play: previewableSearchablePlay,
+}
+
+export const VRTPreviewableSearchableForcedColors: StoryObj<typeof InputFile> = {
+  render: VRTPreviewableSearchable.render,
+  play: previewableSearchablePlay,
+  parameters: {
+    chromatic: { forcedColors: 'active' },
+  },
+}

--- a/packages/smarthr-ui/src/components/InputFile/types.ts
+++ b/packages/smarthr-ui/src/components/InputFile/types.ts
@@ -2,6 +2,11 @@ import type { classNameGenerator } from './style'
 import type { ComponentPropsWithRef, ReactNode } from 'react'
 import type { VariantProps } from 'tailwind-variants'
 
+export type PreviewableObjectType = {
+  /** プレビューダイアログ内のFileViewerで検索機能を有効にするかどうか */
+  searchable?: boolean
+}
+
 type BaseProps = VariantProps<typeof classNameGenerator> & {
   /** フォームのラベル */
   label: ReactNode
@@ -10,12 +15,7 @@ type BaseProps = VariantProps<typeof classNameGenerator> & {
   /** ファイルリストを表示するかどうか */
   hasFileList?: boolean
   /** ファイルのプレビュー機能を有効にするかどうか */
-  previewable?:
-    | boolean
-    | {
-        /** プレビューダイアログ内のFileViewerで検索機能を有効にするかどうか */
-        searchable?: boolean
-      }
+  previewable?: boolean | PreviewableObjectType
   error?: boolean
   multiple?:
     | boolean
@@ -25,3 +25,6 @@ type BaseProps = VariantProps<typeof classNameGenerator> & {
       }
 }
 export type Props = BaseProps & Omit<ComponentPropsWithRef<'input'>, keyof BaseProps>
+export type LowerProps = Omit<Props, 'previewable'> & {
+  previewable: PreviewableObjectType | undefined
+}

--- a/packages/smarthr-ui/src/components/InputFile/types.ts
+++ b/packages/smarthr-ui/src/components/InputFile/types.ts
@@ -10,7 +10,12 @@ type BaseProps = VariantProps<typeof classNameGenerator> & {
   /** ファイルリストを表示するかどうか */
   hasFileList?: boolean
   /** ファイルのプレビュー機能を有効にするかどうか */
-  previewable?: boolean
+  previewable?:
+    | boolean
+    | {
+        /** プレビューダイアログ内のFileViewerで検索機能を有効にするかどうか */
+        searchable?: boolean
+      }
   error?: boolean
   multiple?:
     | boolean


### PR DESCRIPTION
## 関連URL

なし

## 概要

PDF表示時に検索ボックスが画面サイズを圧迫する場合（モバイルなど）に、開発者が明示的に検索ボックスを非表示にできるようにする。

## 変更内容

### `FileViewer` に `searchable` prop を追加

```tsx
// 検索ボックスあり（デフォルト、既存動作を維持）
<FileViewer file={...} />
<FileViewer file={...} searchable={true} />

// 検索ボックスなし
<FileViewer file={...} searchable={false} />
```

`searchable={false}` のとき:
- `SearchController`（検索ボックス）を非表示
- `PDFViewer` への `search` も渡さずテキスト抽出・ハイライト処理もスキップ
- `usePDFSearch` はフックのルール上常に呼ぶが結果を使用しない

### `InputFile` の `previewable` prop を拡張

`boolean` から `boolean | { searchable?: boolean }` に変更し、プレビューダイアログ内の `FileViewer` まで `searchable` を引き回せるようにする。

```tsx
// 既存 — 変更なし
<InputFile label="..." previewable />
<InputFile label="..." previewable={false} />

// 新規 — プレビューダイアログ内の検索ボックスを非表示
<InputFile label="..." previewable={{ searchable: false }} />
```

`previewable` の object/boolean 判定には `useObjectAttributes` を使用。

## プロダクト側で対応が必要な事項

なし（後方互換あり）

## 確認方法

Storybook の FileViewer / InputFile で以下を確認:
- `searchable` 未指定で検索ボックスが表示される（既存動作）
- `searchable={false}` で検索ボックスが非表示になる
- `previewable={{ searchable: false }}` でプレビューダイアログ内の検索ボックスが非表示になる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - PDFビューアーで検索機能の表示・非表示を設定できるようになりました。
  - ファイルプレビュー時も検索設定を指定でき、検索を無効化すると検索コントローラーとPDF検索機能が表示されません。
  - 検索機能はデフォルトで有効です。
- **テスト**
  - 検索の有効・無効状態や強制カラーモードでの表示確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->