### PR TITLE
fix(MultiCombobox, SingleCombobox): 選択ダイアログのフォーカス状態は色覚異常の方々には分かりづらい

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/ItemButton.tsx
@@ -14,11 +14,22 @@ type Props = Omit<ComboboxOption<unknown>, 'item'> &
 
 const classNameGenerator = tv({
   base: [
-    'shr-block shr-min-w-full shr-cursor-pointer shr-border-none shr-px-1 shr-py-0.5 shr-text-left shr-text-base shr-leading-tight',
+    'shr-relative shr-block shr-min-w-full shr-cursor-pointer shr-border-none shr-px-1 shr-py-0.5 shr-text-left shr-text-base shr-leading-tight',
     'aria-selected:shr-text-white',
     'disabled:shr-cursor-not-allowed disabled:shr-text-disabled',
-    'data-[active=true]:shr-bg-white-darken data-[active=true]:aria-selected:shr-bg-main-darken',
+    'data-[active=true]:shr-focus-indicator data-[active=true]:aria-selected:shr-bg-main',
     'data-[active=false]:shr-bg-white data-[active=false]:aria-selected:shr-bg-main',
+    '[&[data-active=true]]:shr-z-1', // pseudoエレメントがliの::afterと衝突しないために子要素に適用しますが、次のエレメントに被られるからz-indexを一時的に変更します
+
+    // ::before: フォーカスリングと上のアイテムの下端の間の隙間を埋めるために、上端から1px外側に1pxの横線を描画する。
+    // 非選択かつ先頭以外のボタンにフォーカスが当たったときのみ表示する
+    'before:shr-absolute before:-shr-top-[1px] before:shr-left-0 before:shr-hidden before:shr-h-px before:shr-w-full before:shr-bg-border before:shr-content-[""]',
+    '[&[data-active=true]:not(:first-child):not([aria-selected=true])]:before:shr-block',
+
+    // ::after: フォーカスリングと下のアイテムの上端の間の隙間を埋めるために、下端から1px外側に1pxの横線を描画する。
+    // 非選択かつ末尾以外のボタンにフォーカスが当たったときのみ表示する
+    'after:shr-absolute after:-shr-bottom-[1px] after:shr-left-0 after:shr-hidden after:shr-h-px after:shr-w-full after:shr-bg-border after:shr-content-[""]',
+    '[&[data-active=true]:not(:last-child):not([aria-selected=true])]:after:shr-block',
   ],
   variants: {
     new: {


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

[WCAG 1.4.1](https://waic.jp/translations/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html)によって、色だけを活かして意味を表現するのが色覚異常の方々には問題となりますのでNGです。

MultiCombobox/SingleComboboxのDialogに色の若干の違いを活かして、「選択中・フォカス中」を表示するになっているから分かりづらいために変更します


＊ Combobox自体のリデザインする予定がありますが、どれぐらいの時間を分からいませんので、一旦これで対応します。

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- 「選択中・フォーカス中」の状況をもっと分かりやすく判別できるようにフォーカス状態（ホバー、フォーカス）のエレメントに`shr-focus-indicator`に変更しました。
- SideNavや他のエレメントのフォーカス状態と統一しました
- ForcedColorsの状態だと、現在のComboboxではフォーカス中な物を判別出来ませんので、この修正はそれを直します


#### Before
https://github.com/user-attachments/assets/2d0ea830-703c-4cfe-8b27-64dfe620e4d9 

#### After
https://github.com/user-attachments/assets/b2d8de02-d929-441f-a040-daf709c0ff2d 

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

- 特にありません

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

https://63d0ccabb5d2dd29825524ab-neovgnxjfp.chromatic.com/?path=/docs/components-combobox-multicombobox--docs
