### PR TITLE
feat: useMergeRefsフックを追加

### DIFF
--- a/packages/smarthr-ui/src/hooks/useLatest.ts
+++ b/packages/smarthr-ui/src/hooks/useLatest.ts
@@ -22,13 +22,11 @@ export function useLatest<T extends object>(values: T): Readonly<T> {
   const ref = useRef<T>(values)
   ref.current = values
 
-  const proxy = useMemo(
+  return useMemo(
     () =>
       new Proxy({} as T, {
         get: (_target, prop) => ref.current[prop as keyof T],
       }) as Readonly<T>,
     [],
   )
-
-  return proxy
 }

--- a/packages/smarthr-ui/src/hooks/useMergeRefs.ts
+++ b/packages/smarthr-ui/src/hooks/useMergeRefs.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react'
+
+import type { MutableRefObject, Ref } from 'react'
+
+/**
+ * 複数の ref を1つの callback ref にマージするフック。
+ * useImperativeHandle を使わずに外部 ref と内部 ref を同時に設定できる。
+ *
+ * @example
+ * const mergedRef = useMergeRefs(externalRef, internalRef)
+ * return <input ref={mergedRef} />
+ */
+export const useMergeRefs = <T>(...rest: Array<Ref<T> | undefined>) =>
+  useCallback(
+    (node: T | null) => {
+      // eslint-disable-next-line smarthr/best-practice-for-rest-parameters
+      rest.forEach((ref) => {
+        if (typeof ref === 'function') {
+          ref(node)
+        } else if (ref) {
+          ;(ref as MutableRefObject<T | null>).current = node
+        }
+      })
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    rest,
+  )

--- a/packages/smarthr-ui/src/hooks/useMergeRefs.ts
+++ b/packages/smarthr-ui/src/hooks/useMergeRefs.ts
@@ -2,26 +2,29 @@ import { useCallback } from 'react'
 
 import type { MutableRefObject, Ref } from 'react'
 
+type MergeableRefType<T> = Ref<T> | undefined
+
 /**
- * 複数の ref を1つの callback ref にマージするフック。
+ * ref を1つの callback ref にマージするフック。
  * useImperativeHandle を使わずに外部 ref と内部 ref を同時に設定できる。
  *
  * @example
  * const mergedRef = useMergeRefs(externalRef, internalRef)
  * return <input ref={mergedRef} />
  */
-export const useMergeRefs = <T>(...rest: Array<Ref<T> | undefined>) =>
+export const useMergeRefs = <T>(ref1: MergeableRefType<T>, ref2: MergeableRefType<T>) =>
   useCallback(
     (node: T | null) => {
-      // eslint-disable-next-line smarthr/best-practice-for-rest-parameters
-      rest.forEach((ref) => {
-        if (typeof ref === 'function') {
-          ref(node)
-        } else if (ref) {
-          ;(ref as MutableRefObject<T | null>).current = node
-        }
-      })
+      setRef(ref1, node)
+      setRef(ref2, node)
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    rest,
+    [ref1, ref2],
   )
+
+const setRef = <T>(ref: Ref<T> | undefined, value: T | null) => {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref) {
+    ;(ref as MutableRefObject<T | null>).current = value
+  }
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useImperativeHandle` を使わずに複数の ref をマージできる `useMergeRefs` フックを追加する。
`forwardRef` コンポーネントで外部 ref と内部 ref を同時に設定するユースケースに対応。

## 変更内容

`src/hooks/useMergeRefs.ts` を新規作成。

```tsx
// Before: useImperativeHandle でref転送
const innerRef = useRef<HTMLInputElement | null>(null)
useImperativeHandle(ref, () => innerRef.current, [])
<input ref={innerRef} />

// After: useMergeRefs でref転送
const innerRef = useRef<HTMLInputElement | null>(null)
const mergedRef = useMergeRefs(ref, innerRef)
<input ref={mergedRef} />
```

- `ref1`・`ref2` が変化した際に callback ref を再生成し、React が古い ref を null クリア → 新しい ref にノードを設定する挙動が正しく動作する
- `[ref1, ref2]` のリテラル依存配列で ESLint `react-hooks/exhaustive-deps` を満たす

## プロダクト側で対応が必要な事項

なし

## 確認方法

後続の PR（Input / CurrencyInput への適用）で動作確認する。