### PR TITLE
fix(charts): ProgressDoughnutChartで進捗と残りが両方0のとき何も描画されない

### DIFF
--- a/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.stories.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.stories.tsx
@@ -113,3 +113,26 @@ export const RoundedTinyValue: Story = {
     rounded: true,
   },
 }
+
+export const Empty: Story = {
+  name: 'with empty data',
+  args: {
+    data: {
+      labels: ['インストール済', '未インストール'],
+      datasets: [{ data: [0, 0] }],
+    },
+    children: (
+      <Text size="XXL" weight="bold">
+        0%
+      </Text>
+    ),
+  },
+}
+
+export const RoundedEmpty: Story = {
+  name: 'rounded with empty data',
+  args: {
+    ...Empty.args,
+    rounded: true,
+  },
+}

--- a/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/ProgressDoughnutChart.tsx
@@ -60,17 +60,25 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
   const colors = useMemo(() => getProgressDoughnutColors(tone), [tone])
   const { chartArea, chartAreaPlugin } = useChartAreaTracker()
 
-  // 支援技術には円弧ではなく <progress> として見せるため、その属性を data から算出する。
-  const progress = useMemo(() => {
+  // 進捗と残りが両方 0 のときの扱いをここに集約する。<progress> は max=0 が不正になり、
+  // canvas は chart.js が全セグメントの角度を 0 と計算して進捗もトラックも描かず
+  // 空白になる。同じ「合計 0」への対処なので、利用側に [0, 1] を渡させず両方をここで吸収する。
+  const { isEmpty, segments, progress } = useMemo(() => {
     const [progressValue, remainingValue] = data.datasets[0].data
     const total = progressValue + remainingValue
+    const empty = total <= 0
 
     return {
-      // 進捗セグメントのラベルが「何の進捗か」を表す（例: インストール済）
-      label: data.labels[0],
-      // 進捗と残りが両方 0 だと max=0 で <progress> が不正になるため 1 に置き換える
-      max: total > 0 ? total : 1,
-      value: progressValue,
+      isEmpty: empty,
+      // 合計 0 でもトラックだけは見せたいので、残りを 1 とみなして満円のトラックを描かせる
+      segments: (empty ? [0, 1] : [progressValue, remainingValue]) as [number, number],
+      // 支援技術には円弧ではなく <progress> として見せるため、その属性を data から算出する。
+      progress: {
+        // 進捗セグメントのラベルが「何の進捗か」を表す（例: インストール済）
+        label: data.labels[0],
+        max: empty ? 1 : total,
+        value: progressValue,
+      },
     }
   }, [data])
 
@@ -79,7 +87,7 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
       labels: data.labels,
       datasets: [
         {
-          data: data.datasets[0].data,
+          data: segments,
           // 丸端のときは進捗（index 0）の塗りを透明にし、見た目は roundedProgressPlugin が
           // 丸端付きの円弧ストロークで描く（hit 判定・キーボードナビ・tooltip は
           // 透明でも arc として残る）。角端のときはプラグインを止めて chart.js に塗らせる。
@@ -99,7 +107,9 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
             rounded ? 'transparent' : SMARTHR_DEFAULT_COLORS.OUTLINE,
             SMARTHR_DEFAULT_COLORS.OUTLINE,
           ] as ChartDataset<'doughnut'>['hoverBorderColor'],
-          hoverBorderWidth: 4,
+          // 合計 0 のときはトラックしか描かれておらず選べるものがない。tooltip も出さないため、
+          // hover の枠だけ出て操作できるように見えるのを避ける。
+          hoverBorderWidth: isEmpty ? 0 : 4,
           borderWidth: 0,
           // 枠を arc の内側に描く。既定（center）だと外周の外側にはみ出し、canvas 端
           // ぎりぎりのリングでは hover 枠が見切れるため、inner で内側に寄せて防ぐ。
@@ -107,7 +117,7 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
         },
       ],
     }),
-    [data, rounded, colors],
+    [data, segments, isEmpty, rounded, colors],
   )
 
   const chartOptions: ChartOptions<'doughnut'> = useMemo(
@@ -120,6 +130,10 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
           title: { display: false },
           legend: { display: false },
           tooltip: {
+            // 合計 0 のときは残りを 1 とみなして描いているため、tooltip を出すと実在しない
+            // 「残り: 1」を見せてしまう。events を空にする手もあるが、createDoughnutChartOptions
+            // の deepmerge が配列を連結するので既定の events が残り、効かない。
+            enabled: !isEmpty,
             callbacks: {
               // 丸端のときは進捗（index 0）の塗りを透明にしてプラグインで描いているため、
               // tooltip の色マーカーが透明になってしまう。実際の進捗色／トラック色を返す。
@@ -142,7 +156,7 @@ export const ProgressDoughnutChart: React.FC<Props> = ({
             : false,
         },
       }) as ChartOptions<'doughnut'>,
-    [thickness, rounded, externalOptions, colors],
+    [thickness, rounded, isEmpty, externalOptions, colors],
   )
 
   // chartAreaPlugin は children の有無に関わらず常に渡す。react-chartjs-2 は plugins を

--- a/packages/charts/src/components/ProgressDoughnutChart/VRTProgressDoughnutChart.stories.tsx
+++ b/packages/charts/src/components/ProgressDoughnutChart/VRTProgressDoughnutChart.stories.tsx
@@ -103,6 +103,30 @@ export default {
           </Text>
         </ProgressDoughnutChart>
       </div>
+      {/* パターン9: 母集団 0。トラックだけが満円で描かれる */}
+      <div className="shr-h-[300px] shr-w-[300px]">
+        <ProgressDoughnutChart
+          data={{ labels: ['インストール済', '未インストール'], datasets: [{ data: [0, 0] }] }}
+          thickness="S"
+        >
+          <Text size="XXL" weight="bold">
+            0%
+          </Text>
+        </ProgressDoughnutChart>
+      </div>
+
+      {/* パターン10: 丸端かつ母集団 0。角端と同じくトラックだけが描かれる */}
+      <div className="shr-h-[300px] shr-w-[300px]">
+        <ProgressDoughnutChart
+          data={{ labels: ['インストール済', '未インストール'], datasets: [{ data: [0, 0] }] }}
+          thickness="S"
+          rounded
+        >
+          <Text size="XXL" weight="bold">
+            0%
+          </Text>
+        </ProgressDoughnutChart>
+      </div>
     </Stack>
   ),
   parameters: {

--- a/packages/charts/src/config/chartConfig.test.ts
+++ b/packages/charts/src/config/chartConfig.test.ts
@@ -333,6 +333,20 @@ describe('createDoughnutChartOptions', () => {
     expect(result.cutout).toBe('85%')
   })
 
+  it('tooltipのenabledは保護対象外で、外部から無効化できること', () => {
+    const result = createDoughnutChartOptions({
+      plugins: {
+        tooltip: {
+          enabled: false,
+        } as ChartOptions<'doughnut'>['plugins']['tooltip'],
+      },
+    })
+
+    expect(result.plugins?.tooltip?.enabled).toBe(false)
+    // 装飾の内部設定は保護されたまま
+    expect(result.plugins?.tooltip?.backgroundColor).toBe(SMARTHR_DEFAULT_COLORS.BACKGROUND)
+  })
+
   it('その他のplugin設定は外部から追加できること', () => {
     const result = createDoughnutChartOptions({
       plugins: {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`ProgressDoughnutChart` は進捗と残りが両方 0 のとき、`<progress>` 側にしかガードがなく canvas 側には無かった。chart.js は合計 0 のとき全セグメントの角度を 0 と計算するため、進捗もトラックも描かれず指定サイズの空白になる。

そのため利用側が `[0, 1]` に差し替えて回避する必要があり、副作用として tooltip が実在しない残り「1」を表示していた。同じ「合計 0」への対処がライブラリと利用側に分かれている状態だったので、ライブラリに集約する。

## 変更内容

- 合計 0 のとき、canvas でも残りを 1 とみなして満円のトラックを描く
- その状態では tooltip と hover 枠を出さない（実在しない値を見せないため）
- `<progress>` は従来どおり `max=1 / value=0`。`[0, 100]` や `[100, 0]` の挙動も変わらない
- Story と VRT に `[0, 0]` のケースを追加（角端・丸端の両方）
- tooltip の `enabled` が `createDoughnutChartOptions` の保護対象外である契約をテストで固定

## プロダクト側で対応が必要な事項

破壊的変更はなし。

合計 0 のときに `[0, 1]` へ差し替える回避策を入れている場合は、このバージョン以降は不要なので削除してよい。削除すると tooltip に実在しない値が出る問題も解消する。

## 確認方法

Storybook の `Charts/ProgressDoughnutChart` の `with empty data` / `rounded with empty data`。トラックが満円で描かれ、ホバーしても tooltip が出ないこと。

VRT はパターン 9 / 10 を追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 進捗と残りがない場合でも、進捗ドーナツチャートを空状態として正しく表示できるようになりました。
  * 空状態ではトラックのみを表示し、中央に「0%」を表示します。
  * 空状態のチャートで不要なホバー枠やツールチップが表示されないようにしました。
  * 丸み付きデザインでも空状態を正しく表示できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->