### PR TITLE
refactor(libs): libs・intlの軽微なリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/intl/useDateFormat.ts
+++ b/packages/smarthr-ui/src/intl/useDateFormat.ts
@@ -306,7 +306,7 @@ const applyCapitalization = (text: string, shouldCapitalize: boolean) =>
 export const useDateFormat = (): UseDateFormatReturn => {
   const intl = useReactIntl()
 
-  const functions = useMemo(() => {
+  return useMemo(() => {
     const locale = isValidLocale(intl.locale) ? intl.locale : 'ja'
 
     const formatDate = ({
@@ -405,6 +405,4 @@ export const useDateFormat = (): UseDateFormatReturn => {
       getWeekStartDay: (): number => DATE_FORMATS[locale].weekStartDay,
     }
   }, [intl])
-
-  return functions
 }

--- a/packages/smarthr-ui/src/intl/useIntl.ts
+++ b/packages/smarthr-ui/src/intl/useIntl.ts
@@ -58,7 +58,7 @@ const isValidLocale = (locale: string): locale is keyof typeof locales => locale
 export const useIntl = (): UseIntlReturn => {
   const intl = useReactIntl()
 
-  const result = useMemo(
+  return useMemo(
     () => ({
       localize: <T extends keyof Messages>(
         descriptor: MessageDescriptor<T>,
@@ -70,8 +70,6 @@ export const useIntl = (): UseIntlReturn => {
     }),
     [intl],
   )
-
-  return result
 }
 
 export const useLocalize = <T extends { [key: string]: LocalizeProps }>(
@@ -79,7 +77,7 @@ export const useLocalize = <T extends { [key: string]: LocalizeProps }>(
 ): { [K in keyof T]: string } => {
   const { localize } = useIntl()
 
-  const localized = useMemo(() => {
+  return useMemo(() => {
     const result = {} as { [K in keyof T]: string }
 
     for (const i in props) {
@@ -91,6 +89,4 @@ export const useLocalize = <T extends { [key: string]: LocalizeProps }>(
     // 依存配列からは意図的に排除している
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [localize])
-
-  return localized
 }

--- a/packages/smarthr-ui/src/libs/lodash.ts
+++ b/packages/smarthr-ui/src/libs/lodash.ts
@@ -1,5 +1,2 @@
-import _merge from 'lodash.merge'
-import _range from 'lodash.range'
-
-export const merge = _merge
-export const range = _range
+export { default as merge } from 'lodash.merge'
+export { default as range } from 'lodash.range'

--- a/packages/smarthr-ui/src/libs/map.ts
+++ b/packages/smarthr-ui/src/libs/map.ts
@@ -2,8 +2,4 @@ export const getIsInclude = <K, V>(map: Map<K, V>, key: K) => !!map.get(key)
 
 export const mapToKeyArray = <K, V>(map: Map<K, V>) => Array.from(map.keys())
 
-export const flatArrayToMap = <T>(array: T[]) => {
-  const map = new Map<T, T>()
-  array.forEach((item) => map.set(item, item))
-  return map
-}
+export const flatArrayToMap = <T>(array: T[]) => new Map(array.map((item): [T, T] => [item, item]))


### PR DESCRIPTION
## 関連URL

なし

## 概要

`src/libs` と `src/intl` の軽微なリファクタリング。動作に変更はない。

## 変更内容

### `libs/map.ts` — `flatArrayToMap` の簡略化
`forEach` + `Map.set` のループを `Map` コンストラクタのエントリ配列形式に置き換え。

```ts
// Before
export const flatArrayToMap = <T>(array: T[]) => {
  const map = new Map<T, T>()
  array.forEach((item) => map.set(item, item))
  return map
}

// After
export const flatArrayToMap = <T>(array: T[]) =>
  new Map(array.map((item): [T, T] => [item, item]))
```

### `libs/lodash.ts` — 再エクスポート構文の簡略化
中間変数を介した再エクスポートを `export { default as }` 構文に変更。

```ts
// Before
import _merge from 'lodash.merge'
import _range from 'lodash.range'

export const merge = _merge
export const range = _range

// After
export { default as merge } from 'lodash.merge'
export { default as range } from 'lodash.range'
```

### `intl/useIntl.ts` — 中間変数の削除
`useIntl` / `useLocalize` の中間変数 `result` / `localized` を削除し、`useMemo` の結果を直接 `return` するよう変更。

## プロダクト側で対応が必要な事項

なし

## 確認方法

TypeScript のビルドエラーがないことを確認済み。動作変更はないため、Storybook での目視確認は不要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 日付・時刻のフォーマット処理とローカライズ処理を簡略化しました。
  * 配列からマップへの変換処理を整理しました。
  * ユーティリティの公開方法を見直しました。
  * 既存のフォーマット、ローカライズ、変換処理の動作と公開APIに変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->