### PR TITLE
test(hooks): useMediaQueriesの動作を保証するテストを追加

### DIFF
--- a/packages/smarthr-ui/src/hooks/useMediaQueries/useMediaQueries.test.ts
+++ b/packages/smarthr-ui/src/hooks/useMediaQueries/useMediaQueries.test.ts
@@ -1,0 +1,137 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useMediaQueries } from './useMediaQueries'
+
+class MockMediaQueryList {
+  matches: boolean
+  readonly media: string
+  private listeners = new Set<(event: MediaQueryListEvent) => void>()
+
+  constructor(media: string, matches: boolean) {
+    this.media = media
+    this.matches = matches
+  }
+
+  addEventListener(type: string, listener: (event: MediaQueryListEvent) => void) {
+    if (type === 'change') {
+      this.listeners.add(listener)
+    }
+  }
+
+  removeEventListener(type: string, listener: (event: MediaQueryListEvent) => void) {
+    if (type === 'change') {
+      this.listeners.delete(listener)
+    }
+  }
+
+  dispatch(matches: boolean) {
+    this.matches = matches
+    this.listeners.forEach((listener) =>
+      listener({ matches, media: this.media } as MediaQueryListEvent),
+    )
+  }
+
+  get listenerCount() {
+    return this.listeners.size
+  }
+}
+
+describe('useMediaQueries', () => {
+  let mediaQueryLists: Map<string, MockMediaQueryList>
+  let originalMatchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    mediaQueryLists = new Map()
+    originalMatchMedia = window.matchMedia
+
+    window.matchMedia = vi.fn((query: string) => {
+      const mql = mediaQueryLists.get(query) ?? new MockMediaQueryList(query, false)
+      mediaQueryLists.set(query, mql)
+      return mql as unknown as MediaQueryList
+    })
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  test('各クエリの現在のmatches状態を返す', () => {
+    mediaQueryLists.set('(min-width: 600px)', new MockMediaQueryList('(min-width: 600px)', true))
+    mediaQueryLists.set('(min-width: 900px)', new MockMediaQueryList('(min-width: 900px)', false))
+
+    const { result } = renderHook(() =>
+      useMediaQueries({ isTablet: '(min-width: 600px)', isDesktop: '(min-width: 900px)' }),
+    )
+
+    expect(result.current).toEqual({ isTablet: true, isDesktop: false })
+  })
+
+  test('メディアクエリのchangeイベントで最新の状態に更新される', () => {
+    const mql = new MockMediaQueryList('(min-width: 600px)', false)
+    mediaQueryLists.set('(min-width: 600px)', mql)
+
+    const { result } = renderHook(() => useMediaQueries({ isTablet: '(min-width: 600px)' }))
+
+    expect(result.current).toEqual({ isTablet: false })
+
+    act(() => {
+      mql.dispatch(true)
+    })
+
+    expect(result.current).toEqual({ isTablet: true })
+  })
+
+  test('queriesが変わると新しいクエリを購読し直し、古いクエリの購読は解除される', () => {
+    const narrow = new MockMediaQueryList('(min-width: 600px)', true)
+    const wide = new MockMediaQueryList('(min-width: 900px)', false)
+    mediaQueryLists.set('(min-width: 600px)', narrow)
+    mediaQueryLists.set('(min-width: 900px)', wide)
+
+    const { result, rerender } = renderHook(({ query }) => useMediaQueries({ matched: query }), {
+      initialProps: { query: '(min-width: 600px)' },
+    })
+
+    expect(result.current).toEqual({ matched: true })
+
+    rerender({ query: '(min-width: 900px)' })
+
+    expect(result.current).toEqual({ matched: false })
+
+    act(() => {
+      wide.dispatch(true)
+    })
+
+    expect(result.current).toEqual({ matched: true })
+
+    act(() => {
+      narrow.dispatch(false)
+    })
+
+    // 古いクエリの購読は解除済みのため、結果に影響しない
+    expect(result.current).toEqual({ matched: true })
+  })
+
+  test('unmount時にすべてのメディアクエリの購読を解除する', () => {
+    const mql = new MockMediaQueryList('(min-width: 600px)', false)
+    mediaQueryLists.set('(min-width: 600px)', mql)
+
+    const { unmount } = renderHook(() => useMediaQueries({ isTablet: '(min-width: 600px)' }))
+
+    expect(mql.listenerCount).toBe(1)
+
+    unmount()
+
+    expect(mql.listenerCount).toBe(0)
+  })
+
+  test('window.matchMediaが存在しない場合はすべてfalseを返す', () => {
+    // @ts-expect-error SSR環境を模倣するため意図的にundefinedにする
+    window.matchMedia = undefined
+
+    const { result } = renderHook(() =>
+      useMediaQueries({ isTablet: '(min-width: 600px)', isDesktop: '(min-width: 900px)' }),
+    )
+
+    expect(result.current).toEqual({ isTablet: false, isDesktop: false })
+  })
+})


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useMediaQueries` には専用のテストファイルが存在せず、`refactor/hooks-media-queries` (#6816) のPR本文に記載されていた「既存テストが全てパスする」という確認方法は誤りだった（テスト自体が存在しないため）。リファクタリングの前提として動作を保証するテストが必要なため追加する。

## 変更内容

`window.matchMedia` をモックしたテストを追加し、以下を検証する:

- 各クエリの現在の `matches` 状態を返すこと
- メディアクエリの `change` イベントで最新の状態に更新されること
- `queries` が変わると新しいクエリを購読し直し、古いクエリの購読が解除されること
- unmount時にすべてのメディアクエリの購読が解除されること
- `window.matchMedia` が存在しない環境（SSR相当）ではすべて `false` を返すこと

## プロダクト側で対応が必要な事項

なし（テスト追加のみ）

## 確認方法

`pnpm ui test -- --run src/hooks/useMediaQueries` で追加した5件のテストがすべてパスすることを確認済み。lint・tscも通過済み。