### PR TITLE
refactor(Textarea): 変数名をnode/innerRefに統一しuseMergeRefs適用予定のTODOを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -74,17 +74,17 @@ const classNameGenerator = tv({
 })
 
 const calculateIdealRows = (
-  element: HTMLTextAreaElement | null | undefined,
+  node: HTMLTextAreaElement | null | undefined,
   maxRows: number,
   lineHeightNormal: number,
 ): number => {
-  if (!element) {
+  if (!node) {
     return 0
   }
 
   // 現在の入力値に応じた行数
   const currentInputValueRows = Math.floor(
-    element.scrollHeight / (defaultHtmlFontSize * lineHeightNormal),
+    node.scrollHeight / (defaultHtmlFontSize * lineHeightNormal),
   )
 
   return currentInputValueRows < maxRows ? currentInputValueRows : maxRows
@@ -174,9 +174,9 @@ const MaxLettersTextarea: FC<
         id={textareaId}
         value={value}
         defaultValue={defaultValue}
-        onChange={functions.handleChange}
         aria-describedby={`${maxLettersNoticeId} ${maxLettersId}`}
         error={error || countError}
+        onChange={functions.handleChange}
       />
       <VisuallyHiddenText id={maxLettersNoticeId}>
         <Localizer
@@ -227,7 +227,7 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
 }) => {
   const theme = useTheme()
 
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const innerRef = useRef<HTMLTextAreaElement | null>(null)
   const [interimRows, setInterimRows] = useState(rows)
 
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
@@ -243,16 +243,18 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
 
   const functions = useMemo(
     () => ({
-      callbackRef: (element: HTMLTextAreaElement | null) => {
-        textareaRef.current = element
-        if (element) {
+      callbackRef: (node: HTMLTextAreaElement | null) => {
+        // TODO: useMergeRefs, useOnceCallbackが実装されたら適用する
+        innerRef.current = node
+
+        if (node) {
           // autoFocus時に、フォーカスを当てる
           if (latest.autoFocus) {
-            element.focus()
+            node.focus()
           }
           // autoResize時に、初期値での高さを指定
           if (latest.autoResize) {
-            setInterimRows(calculateIdealRows(element, latest.maxRows, latest.theme.leading.NORMAL))
+            setInterimRows(calculateIdealRows(node, latest.maxRows, latest.theme.leading.NORMAL))
           }
         }
       },
@@ -279,18 +281,18 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
 
   useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
     externalRef,
-    () => textareaRef.current,
+    () => innerRef.current,
     [],
   )
 
   return (
     <textarea
       {...rest}
-      data-smarthr-ui-input="true"
-      onChange={functions.handleChange}
       ref={functions.callbackRef}
       aria-invalid={error || undefined}
+      data-smarthr-ui-input="true"
       rows={interimRows}
+      onChange={functions.handleChange}
       className={actualClassName}
       style={{ width: typeof width === 'number' ? `${width}px` : width }}
     />


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Textarea` コンポーネントに `useMergeRefs`/`useOnceCallback` を適用する準備として、他コンポーネント（`Input`/`CurrencyInput`/`FocusTrap`）と命名規則を揃えるリファクタリング。

## 変更内容

- `calculateIdealRows` の引数名 `element` → `node` に変更
- `textareaRef` → `innerRef` に変更（`CurrencyInput` 等との命名統一）
- `callbackRef` に `useMergeRefs`/`useOnceCallback` 適用予定のTODOコメントを追加
- JSXの属性順序を整理（`ref` を先頭、`onChange` を末尾に移動）。機能的な差分なし

## プロダクト側で対応が必要な事項

なし（内部実装のリファクタリングのみで公開APIへの変更はなし）

## 確認方法

`pnpm ui test -- --run src/components/Textarea` が通ることを確認済み。lint・tscも通過済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * テキストエリア内部の参照処理を整理しました。
  * 表示や操作方法など、エンドユーザー向けの機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->