### PR TITLE
refactor(Table): TableScrollerの変数名をref/callbackRefに統一しuseMergeRefs適用予定のTODOを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Table/TableScroller.tsx
+++ b/packages/smarthr-ui/src/components/Table/TableScroller.tsx
@@ -23,13 +23,13 @@ const SCROLLER_PROPS = {
 }
 
 export const TableScroller = forwardRef<HTMLDivElement, Props>(
-  ({ children, fixedHead, ...rest }, forwardedRef: ForwardedRef<HTMLDivElement>) =>
+  ({ children, fixedHead, ...rest }, ref: ForwardedRef<HTMLDivElement>) =>
     fixedHead ? (
-      <FixedHeadTableScroller {...rest} {...SCROLLER_PROPS} forwardedRef={forwardedRef}>
+      <FixedHeadTableScroller {...rest} {...SCROLLER_PROPS} forwardedRef={ref}>
         {children}
       </FixedHeadTableScroller>
     ) : (
-      <Scroller {...rest} {...SCROLLER_PROPS} ref={forwardedRef}>
+      <Scroller {...rest} {...SCROLLER_PROPS} ref={ref}>
         {children}
       </Scroller>
     ),
@@ -47,13 +47,16 @@ const FixedHeadTableScroller = ({
   direction,
   ...rest
 }: FixedHeadTableScrollerProps) => {
-  const setRefs = useCallback(
+  // TODO: useMergeRefsが作成されたら修正する
+  const callbackRef = useCallback(
     (node: HTMLDivElement | null) => {
       // thead の高さ分だけ scroll-padding-top を設定
       if (node) {
         const thead = node.querySelector('thead')
+
         if (thead) {
           const { height } = thead.getBoundingClientRect()
+
           node.style.scrollPaddingTop = `${height + defaultHtmlFontSize}px`
         }
       }
@@ -71,7 +74,7 @@ const FixedHeadTableScroller = ({
   )
 
   return (
-    <Scroller {...rest} ref={setRefs} direction={direction}>
+    <Scroller {...rest} ref={callbackRef} direction={direction}>
       {children}
     </Scroller>
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`TableScroller`/`FixedHeadTableScroller` に `useMergeRefs` を適用する準備として、他コンポーネント（`Input`/`CurrencyInput`/`Textarea`/`FocusTrap`）と命名規則を揃えるリファクタリング。

## 変更内容

- `TableScroller` の `forwardedRef` → `ref` に変更（外部から渡されたforwarded refの命名統一）
- `FixedHeadTableScroller` 内の `setRefs` → `callbackRef` に変更
- `callbackRef` に `useMergeRefs` 適用予定のTODOコメントを追加
- 空行の整理。機能的な差分なし

## プロダクト側で対応が必要な事項

なし（内部実装のリファクタリングのみで公開APIへの変更はなし）

## 確認方法

`pnpm ui test -- --run src/components/Table` が通ることを確認済み。lint・tscも通過済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * テーブルのスクロール領域における参照処理を見直し、安定性を向上しました。
  * テーブルヘッダーの高さ設定と転送参照の動作を維持し、既存の表示・スクロール体験への影響を抑えています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->