### PR TITLE
refactor(Select): wrapperStyleのuseMemoを削除しrefの位置を統一

### DIFF
--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -112,20 +112,27 @@ const ActualSelect = <T extends string>(
       iconWrap: iconWrap(sizeProps),
       blankOptGroup: blankOptgroup(),
     }
-  }, [className, size])
-  const wrapperStyle = useMemo(
-    () => ({
-      width: typeof width === 'number' ? `${width}px` : width,
-    }),
-    [width],
-  )
-
-  const actualBlankLabel = blankLabel ?? ''
+  }, [size, className])
 
   return (
-    <span className={classNames.wrapper} style={wrapperStyle}>
+    <span
+      className={classNames.wrapper}
+      style={{
+        width: typeof width === 'number' ? `${width}px` : width,
+      }}
+    >
       <select
         {...rest}
+        ref={ref}
+        disabled={disabled}
+        // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
+        //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
+        //    - エラーメッセージが表示されない
+        //    - 問題のある入力フィールドまでスクロールしない
+        // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
+        // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
+        required={isIOS ? undefined : required}
+        aria-invalid={error || undefined}
         data-smarthr-ui-input="true"
         onChange={(e: ChangeEvent<HTMLSelectElement>) => {
           onChange?.(e)
@@ -140,19 +147,9 @@ const ActualSelect = <T extends string>(
             }
           }
         }}
-        aria-invalid={error || undefined}
-        disabled={disabled}
-        // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
-        //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
-        //    - エラーメッセージが表示されない
-        //    - 問題のある入力フィールドまでスクロールしない
-        // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
-        // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
-        required={isIOS ? undefined : required}
-        ref={ref}
         className={classNames.select}
       >
-        <BlankOption hasBlank={hasBlank}>{actualBlankLabel}</BlankOption>
+        <BlankOption hasBlank={hasBlank}>{blankLabel ?? ''}</BlankOption>
         {options.map((option, index) => (
           <Option {...option} key={index} />
         ))}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Select` コンポーネントの内部実装を整理し、他コンポーネント（`Input`/`CurrencyInput`/`Textarea`/`Table`）と命名・記述スタイルを揃えるリファクタリング。

## 変更内容

- `wrapperStyle` の `useMemo` を削除し、`style` をインラインで指定するよう変更（`span` はネイティブ要素でありmemo化不要なため）
- `actualBlankLabel` 変数を削除し、`blankLabel ?? ''` を直接JSX内で使用するよう変更
- `select` 要素の属性順序を整理（`ref` を `{...rest}` の直後に配置）。機能的な差分なし

## プロダクト側で対応が必要な事項

なし（内部実装のリファクタリングのみで公開APIへの変更はなし）

## 確認方法

lint・tscが通過することを確認済み。`Select` には元々専用のテストファイルが存在しない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * セレクトコンポーネントのラッパー幅が、指定した幅に正しく反映されるようになりました。
  * 空の選択肢で設定したラベルが、より安定して表示されるようになりました。
  * 無効・必須・入力エラー状態などの属性が、正しく適用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->