### PR TITLE
refactor(SegmentedControl): useMergeRefs適用に向けたリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -111,7 +111,7 @@ export const SegmentedControl: FC<Props> = ({
       buttonGroup: buttonGroup(),
       button: button({ size }),
     }
-  }, [className, size])
+  }, [size, className])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -175,11 +175,11 @@ export const SegmentedControl: FC<Props> = ({
   return (
     <div
       {...rest}
-      className={classNames.container}
-      onFocus={functions.handleDelegateFocus}
-      onBlur={functions.handleDelegateBlur}
       ref={containerRef}
       role="toolbar"
+      onFocus={functions.handleDelegateFocus}
+      onBlur={functions.handleDelegateBlur}
+      className={classNames.container}
     >
       <div role="radiogroup" className={classNames.buttonGroup}>
         {options.map((option, index) => {
@@ -190,12 +190,12 @@ export const SegmentedControl: FC<Props> = ({
             <SegmentedControlButton
               {...optionRest}
               key={option.value}
-              aria-label={ariaLabel}
-              handleClick={functions.handleClickOption}
-              size={size}
               checked={checked}
               tabIndex={!isFocused && (excludesSelected ? index === 0 : checked) ? 0 : -1}
+              aria-label={ariaLabel}
               aria-checked={checked && !!value}
+              size={size}
+              handleClick={functions.handleClickOption}
               className={classNames.button}
             />
           )

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -119,13 +119,15 @@ export const SegmentedControl: FC<Props> = ({
         return
       }
 
-      const radios = Array.from(
-        containerRef.current.querySelectorAll('[role="radio"]:not(:disabled)'),
+      let radios: NodeListOf<Element> | Element[] = containerRef.current.querySelectorAll(
+        '[role="radio"]:not(:disabled)',
       )
 
       if (radios.length < 2) {
         return
       }
+
+      radios = Array.from(radios)
 
       const focusedIndex = radios.indexOf(document.activeElement)
 

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -6,7 +6,6 @@ import {
   type MouseEvent,
   type ReactNode,
   memo,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -84,7 +83,7 @@ export const SegmentedControl: FC<Props> = ({
   ...rest
 }) => {
   const [isFocused, setIsFocused] = useState(false)
-  const innerRef = useRef<HTMLDivElement>(null)
+  const innerRef = useRef<HTMLDivElement | null>(null)
 
   const classNames = useMemo(() => {
     const { container, buttonGroup, button } = classNameGenerator()
@@ -100,20 +99,7 @@ export const SegmentedControl: FC<Props> = ({
 
   const hasOnClickOption = !!onClickOption
 
-  const functions = useMemo(
-    () => ({
-      handleClickOption: hasOnClickOption
-        ? (e: MouseEvent<HTMLButtonElement>) => {
-            latest.onClickOption?.(e.currentTarget.value)
-          }
-        : undefined,
-      handleDelegateFocus: () => setIsFocused(true),
-      handleDelegateBlur: () => setIsFocused(false),
-    }),
-    [hasOnClickOption, latest],
-  )
-
-  useEffect(() => {
+  const functions = useMemo(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!latest.isFocused || !innerRef.current || !document.activeElement) {
         return
@@ -165,19 +151,33 @@ export const SegmentedControl: FC<Props> = ({
       }
     }
 
-    document.addEventListener('keydown', handleKeyDown)
+    return {
+      // TODO: useMergeRefsが実装された修正する
+      callbackRef: (node: HTMLDivElement | null) => {
+        innerRef.current = node
 
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown)
+        if (node) {
+          document.addEventListener('keydown', handleKeyDown)
+        } else {
+          document.removeEventListener('keydown', handleKeyDown)
+        }
+      },
+      handleClickOption: hasOnClickOption
+        ? (e: MouseEvent<HTMLButtonElement>) => {
+            latest.onClickOption?.(e.currentTarget.value)
+          }
+        : undefined,
+      handleDelegateFocus: () => setIsFocused(true),
+      handleDelegateBlur: () => setIsFocused(false),
     }
-  }, [latest])
+  }, [hasOnClickOption, latest])
 
   const excludesSelected = !value || options.every((option) => option.value !== value)
 
   return (
     <div
       {...rest}
-      ref={innerRef}
+      ref={functions.callbackRef}
       role="toolbar"
       onFocus={functions.handleDelegateFocus}
       onBlur={functions.handleDelegateBlur}

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -84,7 +84,17 @@ export const SegmentedControl: FC<Props> = ({
   ...rest
 }) => {
   const [isFocused, setIsFocused] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
+  const innerRef = useRef<HTMLDivElement>(null)
+
+  const classNames = useMemo(() => {
+    const { container, buttonGroup, button } = classNameGenerator()
+
+    return {
+      container: container({ className }),
+      buttonGroup: buttonGroup(),
+      button: button({ size }),
+    }
+  }, [size, className])
 
   const latest = useLatest({ onClickOption, isFocused })
 
@@ -103,23 +113,13 @@ export const SegmentedControl: FC<Props> = ({
     [hasOnClickOption, latest],
   )
 
-  const classNames = useMemo(() => {
-    const { container, buttonGroup, button } = classNameGenerator()
-
-    return {
-      container: container({ className }),
-      buttonGroup: buttonGroup(),
-      button: button({ size }),
-    }
-  }, [size, className])
-
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!latest.isFocused || !containerRef.current || !document.activeElement) {
+      if (!latest.isFocused || !innerRef.current || !document.activeElement) {
         return
       }
 
-      let radios: NodeListOf<Element> | Element[] = containerRef.current.querySelectorAll(
+      let radios: NodeListOf<Element> | Element[] = innerRef.current.querySelectorAll(
         '[role="radio"]:not(:disabled)',
       )
 
@@ -177,7 +177,7 @@ export const SegmentedControl: FC<Props> = ({
   return (
     <div
       {...rest}
-      ref={containerRef}
+      ref={innerRef}
       role="toolbar"
       onFocus={functions.handleDelegateFocus}
       onBlur={functions.handleDelegateBlur}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useMergeRefs`（今後実装予定）の適用に向けて、`SegmentedControl` の内部実装を整理する。

## 変更内容

- JSXの属性順序を整理
- `radios.length < 2` の早期return時に不要な `Array.from` 変換を行わないよう修正
- `containerRef` を `innerRef` に改名し、`classNames` の定義位置を整理
- `document` への `keydown` リスナーの登録・解除を `useEffect` から、DOM要素のマウント・アンマウントに合わせて発火する `callbackRef` に移動
  - 今後の `useMergeRefs` 適用に備えてTODOコメントを追加

機能的な変更はなく、挙動は変わらない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで既存の動作（キーボード操作によるフォーカス移動、クリックでの選択）に変化がないことを確認する。