### PR TITLE
refactor(Scroller): useMergeRefs適用に向けたリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -126,7 +126,7 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
         setTabIndex(nextTabIndex)
       }
 
-      const resizeObserver = new ResizeObserver(autoTabIndex)
+      let resizeObserver: ResizeObserver
 
       return {
         callbackRef: (node: HTMLDivElement | null) => {
@@ -136,9 +136,10 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
           autoTabIndex()
 
           if (node) {
+            resizeObserver ??= new ResizeObserver(autoTabIndex)
             resizeObserver.observe(node)
           } else {
-            resizeObserver.disconnect()
+            resizeObserver?.disconnect()
           }
         },
       }

--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -5,7 +5,6 @@ import {
   type ComponentType,
   type PropsWithChildren,
   forwardRef,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -81,11 +80,12 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
     },
     ref,
   ) => {
-    const wrapperRef = useRef<HTMLDivElement>(null)
+    const innerRef = useRef<HTMLDivElement | null>(null)
 
     // as が切り替わると DOM 要素が変わるため、Component を依存配列に含める
+    // TODO: useMergeRefsが実装されたら修正する
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    useImperativeHandle(ref, () => wrapperRef.current!, [Component])
+    useImperativeHandle(ref, () => innerRef.current!, [Component])
 
     const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
 
@@ -99,11 +99,12 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
       [direction, styleType, className],
     )
 
-    useEffect(() => {
-      const refCurrent = wrapperRef.current
-      if (!refCurrent) return
-
+    const functions = useMemo(() => {
       const autoTabIndex = () => {
+        const refCurrent = innerRef.current
+
+        if (!refCurrent) return
+
         let nextTabIndex: 0 | undefined = undefined
 
         switch (direction) {
@@ -125,19 +126,32 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
         setTabIndex(nextTabIndex)
       }
 
-      autoTabIndex()
-
       const resizeObserver = new ResizeObserver(autoTabIndex)
-      resizeObserver.observe(refCurrent)
 
-      return () => {
-        resizeObserver.unobserve(refCurrent)
+      return {
+        callbackRef: (node: HTMLDivElement | null) => {
+          // TODO: useMergeRefsが実装されたら修正する
+          innerRef.current = node
+
+          autoTabIndex()
+
+          if (node) {
+            resizeObserver.observe(node)
+          } else {
+            resizeObserver.disconnect()
+          }
+        },
       }
     }, [direction])
 
     const Wrapper = useSectionWrapper(Component)
     const body = (
-      <Component {...rest} ref={wrapperRef} className={actualClassName} tabIndex={tabIndex}>
+      <Component
+        {...rest}
+        ref={functions.callbackRef}
+        tabIndex={tabIndex}
+        className={actualClassName}
+      >
         {children}
       </Component>
     )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useMergeRefs`（今後実装予定）の適用に向けて、`Scroller` の内部実装を整理する。

## 変更内容

- `wrapperRef` を `innerRef` に改名
- `ResizeObserver` の `observe`/`unobserve`（`disconnect`）を `useEffect` から、DOM要素のマウント・アンマウントに合わせて発火する `callbackRef` に移動
  - 今後の `useMergeRefs` 適用に備えてTODOコメントを追加

機能的な変更はなく、挙動は変わらない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで既存の動作（スクロール可能状態に応じた `tabIndex` の自動切り替え）に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Scroller の要素サイズ監視とキーボード操作対応を安定化しました。
  * コンポーネント切り替え時の参照更新を改善し、スクロール操作の一貫性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->