### PR TITLE
refactor(InputFile): useMergeRefs適用に向けたリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -51,10 +51,12 @@ export const InputFileMultiplyAppendable = forwardRef<
     // Safari において、input.files への直接代入時に onChange が発火することを防ぐためのフラグ
     const isUpdatingFilesRef = useRef(false)
 
-    const inputRef = useRef<HTMLInputElement>(null)
+    const innerRef = useRef<HTMLInputElement>(null)
+
+    // TODO: useMergeRefsが実装されたら修正
     useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
       ref,
-      () => inputRef.current,
+      () => innerRef.current,
       [],
     )
 
@@ -62,7 +64,7 @@ export const InputFileMultiplyAppendable = forwardRef<
 
     const functions = useMemo(() => {
       const updateFiles = (newFiles: File[]) => {
-        if (!inputRef.current) {
+        if (!innerRef.current) {
           return
         }
 
@@ -74,7 +76,7 @@ export const InputFileMultiplyAppendable = forwardRef<
         })
 
         isUpdatingFilesRef.current = true
-        inputRef.current.files = buff.files
+        innerRef.current.files = buff.files
         isUpdatingFilesRef.current = false
 
         setFiles(newFiles)
@@ -92,7 +94,7 @@ export const InputFileMultiplyAppendable = forwardRef<
           updateFiles([...latest.files, ...newFiles])
         },
         handleDelete: (e: MouseEvent<HTMLButtonElement>) => {
-          if (!inputRef.current) {
+          if (!innerRef.current) {
             return
           }
 
@@ -100,7 +102,7 @@ export const InputFileMultiplyAppendable = forwardRef<
           const newFiles = latest.files.filter((_, i) => index !== i)
 
           // 削除後、同一ファイルを再選択可能にするためinput.valueをリセット
-          inputRef.current.value = ''
+          innerRef.current.value = ''
 
           updateFiles(newFiles)
         },
@@ -141,14 +143,14 @@ export const InputFileMultiplyAppendable = forwardRef<
         <span className={classNames.inputWrapper}>
           <input
             {...rest}
-            multiple
-            data-smarthr-ui-input="true"
+            ref={innerRef}
             type="file"
-            onChange={functions.handleChange}
             disabled={disabled}
-            ref={inputRef}
+            multiple
             aria-invalid={error || undefined}
             aria-labelledby={labelId}
+            data-smarthr-ui-input="true"
+            onChange={functions.handleChange}
             className={classNames.input}
           />
           <StyledFaFolderOpenIcon className={classNames.prefix} />

--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -52,10 +52,12 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
     // Safari において、input.files への直接代入時に onChange が発火することを防ぐためのフラグ
     const isUpdatingFilesRef = useRef(false)
 
-    const inputRef = useRef<HTMLInputElement>(null)
+    const innerRef = useRef<HTMLInputElement>(null)
+
+    // TODO: useMergeRefsが実装されたら修正
     useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
       ref,
-      () => inputRef.current,
+      () => innerRef.current,
       [],
     )
 
@@ -74,7 +76,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
           }
         },
         handleDelete: (e: MouseEvent<HTMLButtonElement>) => {
-          if (!inputRef.current) {
+          if (!innerRef.current) {
             return
           }
 
@@ -90,7 +92,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
           })
 
           isUpdatingFilesRef.current = true
-          inputRef.current.files = buff.files
+          innerRef.current.files = buff.files
           isUpdatingFilesRef.current = false
         },
         handleClosePreview: () => {
@@ -130,13 +132,13 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
         <span className={classNames.inputWrapper}>
           <input
             {...rest}
-            data-smarthr-ui-input="true"
+            ref={innerRef}
             type="file"
-            onChange={functions.handleChange}
             disabled={disabled}
-            ref={inputRef}
             aria-invalid={error || undefined}
             aria-labelledby={labelId}
+            data-smarthr-ui-input="true"
+            onChange={functions.handleChange}
             className={classNames.input}
           />
           <StyledFaFolderOpenIcon className={classNames.prefix} />

--- a/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
@@ -114,5 +114,6 @@ export const Container: FC<Props> = ({
       className,
     })
   }, [size, className, padding, mobile])
+
   return <div {...rest} className={actualClassName} />
 }

--- a/packages/smarthr-ui/src/components/Panel/Groupbox/Groupbox.tsx
+++ b/packages/smarthr-ui/src/components/Panel/Groupbox/Groupbox.tsx
@@ -21,6 +21,7 @@ const classNameGenerator = tv({
       left: 'shr-rounded-l-l',
     },
   },
+  // TODO: tailwindの場合のみdefault値が設定される挙動はバグの原因になりかねないので整理する
   defaultVariants: {
     bgColor: 'COLUMN',
     rounded: false,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useMergeRefs`（今後実装予定）の適用に向けて、`InputFile` 関連コンポーネントの内部実装を整理する。

## 変更内容

- `InputFileNative` / `InputFileMultiplyAppendable` の `inputRef` を `innerRef` に改名
  - 今後の `useMergeRefs` 適用に備えてTODOコメントを追加
- `Container` の末尾に空行を追加
- `Groupbox` の `tailwind-variants` の `defaultVariants` に、tailwindの場合のみdefault値が設定される挙動についてのTODOコメントを追加

機能的な変更はなく、挙動は変わらない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで既存の動作（ファイル選択・削除）に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ファイル入力コンポーネントの参照処理を改善し、ファイルの追加・削除操作がより安定して動作するようになりました。
  - 複数ファイル選択、無効状態、アクセシビリティ属性など、既存の設定や動作は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->