### PR TITLE
refactor(PageHeading): useMergeRefs適用に向けたリファクタリング

### DIFF
--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -8,7 +8,6 @@ import {
   type Ref,
   forwardRef,
   memo,
-  useEffect,
   useId,
   useImperativeHandle,
   useMemo,
@@ -16,6 +15,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useLatest } from '../../../hooks/useLatest'
 import { IS_NEXT_JS } from '../../../libs/nextjs'
 import { STYLE_TYPE_MAP, Text, type TextProps } from '../../Text'
 import { VisuallyHiddenText, visuallyHiddenTextClassName } from '../../VisuallyHiddenText'
@@ -98,26 +98,25 @@ const AutoPageTitleHeading: FC<
   // HINT: h1のテキストをMutationObserverで監視するために内部でrefを保持しつつ、利用者のrefにも要素を渡す
   const innerRef = useRef<HTMLHeadingElement | null>(null)
 
-  useImperativeHandle<HTMLHeadingElement | null, HTMLHeadingElement | null>(
-    outerRef,
-    () => innerRef.current,
-    [],
-  )
+  const latest = useLatest({ pageTitle, pageTitleSuffix, pseudoTitleId })
 
-  useEffect(() => {
-    const h1 = innerRef.current
-    if (!h1) return
-
+  const functions = useMemo(() => {
     const updateTitle = () => {
-      const title = pageTitle || h1.textContent || ''
-      document.title = pageTitleSuffix ? `${title}｜${pageTitleSuffix}` : title
+      const node = innerRef.current
+
+      if (!node) {
+        return
+      }
+
+      const title = latest.pageTitle || node.textContent || ''
+      document.title = latest.pageTitleSuffix ? `${title}｜${latest.pageTitleSuffix}` : title
 
       // HINT: SPAで遷移する場合などの対策としてbody直下にaria-liveを仕込む
       // head内はスクリーンリーダーの変更検知のチェック対象外のため、title要素にaria-liveは設定しない
-      const pseudoTitle: HTMLDivElement = (document.getElementById(pseudoTitleId) ||
+      const pseudoTitle: HTMLDivElement = (document.getElementById(latest.pseudoTitleId) ||
         document.createElement('div')) as HTMLDivElement
 
-      pseudoTitle.setAttribute('id', pseudoTitleId)
+      pseudoTitle.setAttribute('id', latest.pseudoTitleId)
       pseudoTitle.setAttribute('class', visuallyHiddenTextClassName)
       pseudoTitle.setAttribute('aria-live', 'polite')
       document.body.prepend(pseudoTitle)
@@ -126,27 +125,42 @@ const AutoPageTitleHeading: FC<
         pseudoTitle.textContent = document.title
       })
     }
-
-    updateTitle()
-
     const observer = new MutationObserver(updateTitle)
-    observer.observe(h1, {
-      characterData: true,
-      childList: true,
-      subtree: true,
-    })
 
-    return () => {
-      observer.disconnect()
-      const pseudoTitle = document.getElementById(pseudoTitleId)
-      if (pseudoTitle) {
-        pseudoTitle.remove()
-      }
+    return {
+      callbackRef: (node: HTMLHeadingElement | null) => {
+        // TODO: useMergeRefsが実装された修正
+        innerRef.current = node
+        updateTitle()
+
+        if (node) {
+          observer.observe(node, {
+            characterData: true,
+            childList: true,
+            subtree: true,
+          })
+        } else {
+          observer.disconnect()
+
+          const pseudoTitle = document.getElementById(latest.pseudoTitleId)
+
+          if (pseudoTitle) {
+            pseudoTitle.remove()
+          }
+        }
+      },
     }
-  }, [pageTitle, pageTitleSuffix, pseudoTitleId])
+  }, [latest])
+
+  // TODO: useMergeRefsが実装された修正
+  useImperativeHandle<HTMLHeadingElement | null, HTMLHeadingElement | null>(
+    outerRef,
+    () => innerRef.current,
+    [],
+  )
 
   return (
-    <ActualHeading {...rest} headingRef={innerRef}>
+    <ActualHeading {...rest} headingRef={functions.callbackRef}>
       {children}
     </ActualHeading>
   )
@@ -178,10 +192,10 @@ const ActualHeading: FC<ActualHeadingProps> = ({
     <Component
       {...rest}
       {...STYLE_TYPE_MAP.screenTitle}
-      size={size || STYLE_TYPE_MAP.screenTitle.size}
-      as="h1"
-      className={actualClassName}
       ref={headingRef}
+      size={size || STYLE_TYPE_MAP.screenTitle.size}
+      className={actualClassName}
+      as="h1"
     >
       {children}
     </Component>

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -125,7 +125,7 @@ const AutoPageTitleHeading: FC<
         pseudoTitle.textContent = document.title
       })
     }
-    const observer = new MutationObserver(updateTitle)
+    let observer: MutationObserver
 
     return {
       callbackRef: (node: HTMLHeadingElement | null) => {
@@ -134,13 +134,14 @@ const AutoPageTitleHeading: FC<
         updateTitle()
 
         if (node) {
+          observer ??= new MutationObserver(updateTitle)
           observer.observe(node, {
             characterData: true,
             childList: true,
             subtree: true,
           })
         } else {
-          observer.disconnect()
+          observer?.disconnect()
 
           const pseudoTitle = document.getElementById(latest.pseudoTitleId)
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useMergeRefs`（今後実装予定）の適用に向けて、`PageHeading` の内部実装を整理する。

## 変更内容

- `document.title` の自動更新に使う `MutationObserver` の登録・解除を `useEffect` から、DOM要素のマウント・アンマウントに合わせて発火する `callbackRef` に移動
  - 今後の `useMergeRefs` 適用に備えてTODOコメントを追加
- JSXの属性順序を整理

機能的な変更はなく、挙動は変わらない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで既存の動作（`document.title` の自動更新）に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ページ見出しの変更がページタイトルに正しく反映されるよう、更新処理の安定性を改善しました。
  * 見出しの監視状態を適切に管理し、不要なタイトル要素が残らないよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->