### PR TITLE
feat(Chart): disablePatterns propsを追加

### DIFF
--- a/packages/charts/src/components/Chart/Chart.stories.tsx
+++ b/packages/charts/src/components/Chart/Chart.stories.tsx
@@ -42,6 +42,9 @@ export const Playground: Story = {
     options: {
       control: 'object',
     },
+    disablePatterns: {
+      control: 'boolean',
+    },
   },
 }
 
@@ -70,6 +73,15 @@ export const Title: Story = {
     title: {
       control: 'text',
     },
+  },
+}
+
+export const DisablePatterns: Story = {
+  name: 'disablePatterns',
+  args: {
+    type: 'bar',
+    data: multiSmall,
+    disablePatterns: true,
   },
 }
 

--- a/packages/charts/src/components/Chart/Chart.tsx
+++ b/packages/charts/src/components/Chart/Chart.tsx
@@ -21,6 +21,10 @@ type Props = {
     title?: string
     className?: string
     options?: Partial<ChartOptions<K>>
+    /**
+     * 棒グラフの柄を無効化するか（type="bar" のときのみ有効）
+     */
+    disablePatterns?: boolean
   }
 }[ChartType]
 
@@ -40,7 +44,14 @@ export const Chart: React.FC<Props> = ({ className, ...rest }) => {
 const InnerChart: React.FC<Props> = (props) => {
   switch (props.type) {
     case 'bar':
-      return <BarChart data={props.data} title={props.title} options={props.options} />
+      return (
+        <BarChart
+          data={props.data}
+          title={props.title}
+          options={props.options}
+          disablePatterns={props.disablePatterns}
+        />
+      )
     case 'line':
       return <LineChart data={props.data} title={props.title} options={props.options} />
     case 'radar':


### PR DESCRIPTION
## 関連URL

なし

## 概要

`BarChart` には棒グラフの柄（パターン）を無効化する `disablePatterns` props がありますが、`BarChart` をラップしている `Chart` には生えていないため、`Chart` 経由では柄を無効化できませんでした。

`Chart` からも同じ指定ができるようにします。

## 変更内容

- `Chart` に `disablePatterns?: boolean` を追加し、`type="bar"` のときに `BarChart` へ透過的に渡すようにしました
  - `type="line"` / `type="radar"` では LineChart / RadarChart が柄を使わない実装のため、指定しても無視されます
- Storybook に `disablePatterns` ストーリーと、Playground の Controls（boolean）を追加しました

### 使用例

```tsx
// 柄あり（デフォルト）
<Chart type="bar" data={data} />

// 柄なし
<Chart type="bar" data={data} disablePatterns />
```

## プロダクト側で対応が必要な事項

なし（props の追加のみで、既存の挙動は変わりません）

## 確認方法

Storybook の `Charts/Chart` で確認できます。

- `disablePatterns` ストーリー: 複数データセットの棒グラフで柄が付いていないこと
- `Playground`: `disablePatterns` のトグルで柄の有無が切り替わること。`type` を `line` / `radar` に変えると影響しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 棒グラフで柄（パターン）表示を無効化できるオプションを追加しました。
  * 柄表示の有効・無効を確認できるサンプルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->