### PR TITLE
fix(FormControl): aria-describedbyのid重複バグを修正

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -160,10 +160,11 @@ export const ActualFormControl: FC<Props> = ({
   const managedLabelId = label.id || defaultLabelId
   const inputWrapperRef = useRef<HTMLDivElement>(null)
   const labelTextRef = useRef<HTMLElement>(null)
+  const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
   const describedbyIds = useMemo(() => {
-    const temp = []
+    const temp: string[] = []
 
     if (helpMessage) {
       temp.push(`${managedHtmlFor}_helpMessage`)
@@ -245,24 +246,35 @@ export const ActualFormControl: FC<Props> = ({
   }, [managedHtmlFor, isFieldset, managedLabelId])
 
   useEffect(() => {
-    if (!describedbyIds || !inputWrapperRef?.current) {
+    if (!inputWrapperRef?.current) {
       return
     }
 
-    const inputWrapper = inputWrapperRef.current
+    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+
+    if (!input) {
+      return
+    }
+
     const attrName = 'aria-describedby'
+    const ariaDescribedBy = input.getAttribute(attrName) || ''
+    const currentTokens = ariaDescribedBy ? ariaDescribedBy.split(' ') : []
+    // HINT: 自分が過去に付与したid以外（=外部由来のid）だけを残す
+    const externalTokens = currentTokens.filter(
+      (token) => !managedDescribedbyIdsRef.current.includes(token),
+    )
+    const describedbyIdTokens = describedbyIds ? describedbyIds.split(' ') : []
+    const nextValue = [...externalTokens, ...describedbyIdTokens].join(' ')
 
-    if (inputWrapper.querySelector(`[${attrName}="${describedbyIds}"]`)) {
-      return
+    if (nextValue !== ariaDescribedBy) {
+      if (nextValue) {
+        input.setAttribute(attrName, nextValue)
+      } else {
+        input.removeAttribute(attrName)
+      }
     }
 
-    const input = inputWrapper.querySelector(SMARTHR_UI_INPUT_SELECTOR)
-
-    if (input) {
-      const attribute = input.getAttribute(attrName)
-
-      input.setAttribute(attrName, attribute ? `${attribute} ${describedbyIds}` : describedbyIds)
-    }
+    managedDescribedbyIdsRef.current = describedbyIdTokens
   }, [describedbyIds])
 
   useEffect(() => {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormControl`/`Fieldset`配下のinputが自前で`aria-describedby`を設定するケース（例: `Textarea`の文字数カウンター）で、`helpMessage`/`exampleMessage`/`supplementaryMessage`/`errorMessages`の有無が変化して`describedbyIds`が更新されると、FormControlが過去に付与したidが重複して蓄積し続ける不具合を修正しました。

原因は、既に付与済みかどうかの判定に`querySelector([aria-describedby="${describedbyIds}"])`という完全一致チェックを使っており、`describedbyIds`が過去の値と異なる文字列に変化すると必ず不一致になり、既存のid文字列に新しいid文字列をそのまま連結してしまうためです。

## 変更内容

- `FormControl`が前回付与したidのトークン集合を`useRef`で保持するようにした
- `aria-describedby`更新時、現在の属性値から「FormControlが過去に付与した分」を除去し、外部由来のid（他コンポーネントが独自に設定したid）は温存した上で、新しい`describedbyIds`を付け直す方式に変更
- `describedbyIds`が空になった場合（メッセージが全て消えた場合）も、FormControl管理分のidを正しく除去できるようになった（従来は一度付与されたidが残り続けていた）

## プロダクト側で対応が必要な事項

なし（内部实装のみの修正で、公開インターフェースに変更はありません）

## 確認方法

- `FormControl`/`Fieldset`、および依存コンポーネント（`DatePicker`, `AccordionPanel`, `Combobox`, `Dialog`, `WarekiPicker`, `Textarea`, `InputFile`）の既存Unit testがすべてパスすることを確認済みです
- `Textarea`（文字数カウンターでaria-describedbyを自前設定するコンポーネント）に`errorMessages`を後から追加するなど、`describedbyIds`が動的に変化するケースで、DOM上の`aria-describedby`属性値にidの重複が発生しないことをご確認ください