### PR TITLE
fix(Fieldset): legend変更時にaria-labelへ古いlegend文言が蓄積する不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import { FormControl } from '../FormControl'
 import { Input } from '../Input'
@@ -80,5 +80,29 @@ describe('Fieldset', () => {
       screen.getByRole('textbox', { name: '追加されないラベル1の子ラベル' }),
     ).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: '追加されないラベル2' })).toBeInTheDocument()
+  })
+
+  it('legendが変更されても、アクセシブルネームに古いlegend文言が蓄積されない', async () => {
+    const { rerender } = render(
+      <form>
+        <Fieldset legend="旧legend">
+          <Input name="test" aria-label="input-accessible-name" />
+        </Fieldset>
+      </form>,
+    )
+
+    rerender(
+      <form>
+        <Fieldset legend="新legend">
+          <Input name="test" aria-label="input-accessible-name" />
+        </Fieldset>
+      </form>,
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('textbox', { name: 'input-accessible-name 新legend' }),
+      ).toBeInTheDocument(),
+    )
   })
 })

--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
@@ -3,6 +3,7 @@ import { useEffect, useId, useRef } from 'react'
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import {
   ActualFormControl,
+  type FormControl,
   type ObjectLabelType,
   SMARTHR_UI_INPUT_SELECTOR,
   SMARTHR_UI_LABEL_TEXT_SELECTOR,
@@ -11,10 +12,12 @@ import {
 
 import type { ComponentProps, FC, ReactNode } from 'react'
 
-type FormControlType = ComponentProps<typeof ActualFormControl>
+type FormControlType = ComponentProps<typeof FormControl>
 
 export const Fieldset: FC<
-  Omit<FormControlType, 'as' | 'label' | 'inputWrapperRef'> & {
+  Omit<FormControlType, 'label'> & {
+    /** `true` のとき、文字色を `TEXT_DISABLED` にする */
+    disabled?: boolean
     legend: Omit<Exclude<FormControlType['label'], ReactNode>, 'htmlFor'> | ReactNode
   }
 > = ({ legend: orgLegend, ...rest }) => {

--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
@@ -47,6 +47,10 @@ export const Fieldset: FC<
     )
     if (!labelTextEl) return
 
+    // HINT: legend変更のたびにaria-labelへ古いlegend文言が蓄積しないよう、
+    // 初回に確定したアクセシブルネームをinput要素ごとに保持しておく
+    const baseAccessibleNames = new WeakMap<HTMLInputElement, string>()
+
     const updateAriaLabels = () => {
       const labelText = labelTextEl.textContent || ''
       if (!labelText) return
@@ -56,11 +60,16 @@ export const Fieldset: FC<
       if (!inputs.length) return
 
       inputs.forEach((input: HTMLInputElement) => {
-        const accessibleName =
-          input.getAttribute('aria-label') ||
-          (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
-            ? input.labels[0].textContent
-            : '')
+        let accessibleName = baseAccessibleNames.get(input)
+
+        if (accessibleName === undefined) {
+          accessibleName =
+            input.getAttribute('aria-label') ||
+            (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
+              ? input.labels[0].textContent || ''
+              : '')
+          baseAccessibleNames.set(input, accessibleName)
+        }
 
         if (
           accessibleName &&

--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react'
+
 import { ActualFormControl } from '../FormControl'
 
 import type { ComponentProps, FC, ReactNode } from 'react'
@@ -5,7 +7,13 @@ import type { ComponentProps, FC, ReactNode } from 'react'
 type FormControlType = ComponentProps<typeof ActualFormControl>
 
 export const Fieldset: FC<
-  Omit<FormControlType, 'as' | 'label'> & {
+  Omit<FormControlType, 'as' | 'label' | 'inputWrapperRef'> & {
     legend: Omit<Exclude<FormControlType['label'], ReactNode>, 'htmlFor'> | ReactNode
   }
-> = ({ legend, ...rest }) => <ActualFormControl {...rest} label={legend} as="fieldset" />
+> = ({ legend, ...rest }) => {
+  const inputWrapperRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <ActualFormControl {...rest} label={legend} as="fieldset" inputWrapperRef={inputWrapperRef} />
+  )
+}

--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
@@ -1,7 +1,13 @@
-import { useId, useRef } from 'react'
+import { useEffect, useId, useRef } from 'react'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
-import { ActualFormControl, type ObjectLabelType, labelObjectConverter } from '../FormControl'
+import {
+  ActualFormControl,
+  type ObjectLabelType,
+  SMARTHR_UI_INPUT_SELECTOR,
+  SMARTHR_UI_LABEL_TEXT_SELECTOR,
+  labelObjectConverter,
+} from '../FormControl'
 
 import type { ComponentProps, FC, ReactNode } from 'react'
 
@@ -18,6 +24,57 @@ export const Fieldset: FC<
   )
   const baseId = useId()
   const inputWrapperRef = useRef<HTMLDivElement>(null)
+
+  // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
+  // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
+  useEffect(() => {
+    if (!inputWrapperRef.current) return
+
+    // HINT: unrecommendedHideLabelがfalseの場合、同じテキストを持つ要素が2つレンダリングされるが
+    // どちらも同一文字列のため、1つ目を取得すれば十分
+    const labelTextEl = inputWrapperRef.current.parentElement?.querySelector(
+      `.${SMARTHR_UI_LABEL_TEXT_SELECTOR}`,
+    )
+    if (!labelTextEl) return
+
+    const updateAriaLabels = () => {
+      const labelText = labelTextEl.textContent || ''
+      if (!labelText) return
+
+      const inputs =
+        inputWrapperRef.current!.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
+      if (!inputs.length) return
+
+      inputs.forEach((input: HTMLInputElement) => {
+        const accessibleName =
+          input.getAttribute('aria-label') ||
+          (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
+            ? input.labels[0].textContent
+            : '')
+
+        if (
+          accessibleName &&
+          !accessibleName.includes(labelText) &&
+          !labelText.includes(accessibleName)
+        ) {
+          input.setAttribute('aria-label', `${accessibleName} ${labelText}`)
+        }
+      })
+    }
+
+    // 初回実行
+    updateAriaLabels()
+
+    // label要素の変更を監視
+    const observer = new MutationObserver(updateAriaLabels)
+    observer.observe(labelTextEl, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    })
+
+    return () => observer.disconnect()
+  }, [])
 
   return (
     <ActualFormControl

--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
@@ -20,13 +20,20 @@ export const Fieldset: FC<
     disabled?: boolean
     legend: Omit<Exclude<FormControlType['label'], ReactNode>, 'htmlFor'> | ReactNode
   }
-> = ({ legend: orgLegend, ...rest }) => {
+> = ({ legend: orgLegend, innerMargin, ...rest }) => {
   const legend = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
     orgLegend,
     labelObjectConverter,
   )
   const baseId = useId()
   const inputWrapperRef = useRef<HTMLDivElement>(null)
+
+  // TODO: innerMarginが未指定、初期値の場合、childrenの上部の余白を広げることで
+  // FormControlとの差をわかりやすくしている
+  // 微妙な方法ではあるので、必要に応じてinnerMarginではない属性を用意する
+  // https://kufuinc.slack.com/archives/CGC58MW01/p1737944965871159?thread_ts=1737541173.404369&cid=CGC58MW01
+  const childrenWrapperClassName =
+    innerMargin === undefined ? '[:not([hidden])_~_&&&]:shr-mt-0.5' : undefined
 
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
@@ -82,6 +89,7 @@ export const Fieldset: FC<
   return (
     <ActualFormControl
       {...rest}
+      innerMargin={innerMargin}
       label={{
         ...legend,
         htmlFor: legend.htmlFor || `${baseId}-htmlFor`,
@@ -89,6 +97,7 @@ export const Fieldset: FC<
       }}
       as="fieldset"
       inputWrapperRef={inputWrapperRef}
+      childrenWrapperClassName={childrenWrapperClassName}
     />
   )
 }

--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.tsx
@@ -1,6 +1,7 @@
-import { useRef } from 'react'
+import { useId, useRef } from 'react'
 
-import { ActualFormControl } from '../FormControl'
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
+import { ActualFormControl, type ObjectLabelType, labelObjectConverter } from '../FormControl'
 
 import type { ComponentProps, FC, ReactNode } from 'react'
 
@@ -10,10 +11,24 @@ export const Fieldset: FC<
   Omit<FormControlType, 'as' | 'label' | 'inputWrapperRef'> & {
     legend: Omit<Exclude<FormControlType['label'], ReactNode>, 'htmlFor'> | ReactNode
   }
-> = ({ legend, ...rest }) => {
+> = ({ legend: orgLegend, ...rest }) => {
+  const legend = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
+    orgLegend,
+    labelObjectConverter,
+  )
+  const baseId = useId()
   const inputWrapperRef = useRef<HTMLDivElement>(null)
 
   return (
-    <ActualFormControl {...rest} label={legend} as="fieldset" inputWrapperRef={inputWrapperRef} />
+    <ActualFormControl
+      {...rest}
+      label={{
+        ...legend,
+        htmlFor: legend.htmlFor || `${baseId}-htmlFor`,
+        id: legend.id || `${baseId}-legend`,
+      }}
+      as="fieldset"
+      inputWrapperRef={inputWrapperRef}
+    />
   )
 }

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -365,6 +365,10 @@ export const ActualFormControl: FC<Props> = ({
   )
 }
 
+export const FormControl: FC<Omit<Props, 'as' | 'disabled'>> = (props) => (
+  <ActualFormControl {...props} />
+)
+
 const LabelCluster = memo<
   Pick<Props, 'subActionArea'> & {
     label: ReactNode
@@ -513,5 +517,3 @@ const SupplementaryMessageText = memo<
     </Text>
   ) : null,
 )
-
-export const FormControl: FC<Omit<Props, 'as' | 'disabled'>> = ActualFormControl

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -246,57 +246,6 @@ export const ActualFormControl: FC<
     }
   }, [actualErrorMessages.length, autoBindErrorInput, inputWrapperRef])
 
-  // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
-  // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
-  useEffect(() => {
-    if (!isFieldset || !inputWrapperRef.current) return
-
-    // HINT: unrecommendedHideLabelがfalseの場合、同じテキストを持つ要素が2つレンダリングされるが
-    // どちらも同一文字列のため、1つ目を取得すれば十分
-    const labelTextEl = inputWrapperRef.current.parentElement?.querySelector(
-      `.${SMARTHR_UI_LABEL_TEXT_SELECTOR}`,
-    )
-    if (!labelTextEl) return
-
-    const updateAriaLabels = () => {
-      const labelText = labelTextEl.textContent || ''
-      if (!labelText) return
-
-      const inputs =
-        inputWrapperRef.current!.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
-      if (!inputs.length) return
-
-      inputs.forEach((input: HTMLInputElement) => {
-        const accessibleName =
-          input.getAttribute('aria-label') ||
-          (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
-            ? input.labels[0].textContent
-            : '')
-
-        if (
-          accessibleName &&
-          !accessibleName.includes(labelText) &&
-          !labelText.includes(accessibleName)
-        ) {
-          input.setAttribute('aria-label', `${accessibleName} ${labelText}`)
-        }
-      })
-    }
-
-    // 初回実行
-    updateAriaLabels()
-
-    // label要素の変更を監視
-    const observer = new MutationObserver(updateAriaLabels)
-    observer.observe(labelTextEl, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    })
-
-    return () => observer.disconnect()
-  }, [isFieldset, inputWrapperRef])
-
   return (
     <Stack
       {...rest}

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -8,6 +8,7 @@ import {
   type FunctionComponentElement,
   type PropsWithChildren,
   type ReactNode,
+  type RefObject,
   memo,
   useEffect,
   useMemo,
@@ -64,6 +65,7 @@ type BaseProps = PropsWithChildren<{
   /** `true` のとき、文字色を `TEXT_DISABLED` にする */
   disabled?: boolean
   as?: string | ComponentType<any>
+  inputWrapperRef: RefObject<HTMLDivElement>
 }>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'aria-labelledby'>
 
@@ -147,6 +149,7 @@ export const ActualFormControl: FC<Props> = ({
   as = 'div',
   className,
   children,
+  inputWrapperRef,
   ...rest
 }) => {
   const label = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
@@ -157,7 +160,6 @@ export const ActualFormControl: FC<Props> = ({
   const [childInputId, setChildInputId] = useState<string>('')
   const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
   const managedLabelId = label.id || `${baseId}-label`
-  const inputWrapperRef = useRef<HTMLDivElement>(null)
   const labelTextRef = useRef<HTMLElement>(null)
   const isFieldset = as === 'fieldset'
 
@@ -211,7 +213,7 @@ export const ActualFormControl: FC<Props> = ({
   useEffect(() => {
     if (
       isFieldset ||
-      !inputWrapperRef?.current ||
+      !inputWrapperRef.current ||
       // HINT: 対象idを持つ要素が既に存在する場合、何もしない
       document.getElementById(managedHtmlFor)
     ) {
@@ -241,10 +243,10 @@ export const ActualFormControl: FC<Props> = ({
         input.setAttribute(attrName, `${inputLabelledByIds} ${managedLabelId}`)
       }
     }
-  }, [managedHtmlFor, isFieldset, managedLabelId])
+  }, [managedHtmlFor, isFieldset, managedLabelId, inputWrapperRef])
 
   useEffect(() => {
-    if (!describedbyIds || !inputWrapperRef?.current) {
+    if (!describedbyIds || !inputWrapperRef.current) {
       return
     }
 
@@ -262,10 +264,10 @@ export const ActualFormControl: FC<Props> = ({
 
       input.setAttribute(attrName, attribute ? `${attribute} ${describedbyIds}` : describedbyIds)
     }
-  }, [describedbyIds])
+  }, [describedbyIds, inputWrapperRef])
 
   useEffect(() => {
-    if (!autoBindErrorInput || !inputWrapperRef?.current) {
+    if (!autoBindErrorInput || !inputWrapperRef.current) {
       return
     }
 
@@ -280,7 +282,7 @@ export const ActualFormControl: FC<Props> = ({
         input.removeAttribute(attrName)
       }
     }
-  }, [actualErrorMessages.length, autoBindErrorInput])
+  }, [actualErrorMessages.length, autoBindErrorInput, inputWrapperRef])
 
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
@@ -324,7 +326,7 @@ export const ActualFormControl: FC<Props> = ({
     })
 
     return () => observer.disconnect()
-  }, [isFieldset])
+  }, [isFieldset, inputWrapperRef])
 
   return (
     <Stack
@@ -365,9 +367,11 @@ export const ActualFormControl: FC<Props> = ({
   )
 }
 
-export const FormControl: FC<Omit<Props, 'as' | 'disabled'>> = (props) => (
-  <ActualFormControl {...props} />
-)
+export const FormControl: FC<Omit<Props, 'as' | 'disabled' | 'inputWrapperRef'>> = (props) => {
+  const inputWrapperRef = useRef<HTMLDivElement>(null)
+
+  return <ActualFormControl {...props} inputWrapperRef={inputWrapperRef} />
+}
 
 const LabelCluster = memo<
   Pick<Props, 'subActionArea'> & {

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -153,11 +153,10 @@ export const ActualFormControl: FC<Props> = ({
     orgLabel,
     labelObjectConverter,
   )
-  const defaultHtmlFor = useId()
-  const defaultLabelId = useId()
+  const baseId = useId()
   const [childInputId, setChildInputId] = useState<string>('')
-  const managedHtmlFor = label.htmlFor || childInputId || defaultHtmlFor
-  const managedLabelId = label.id || defaultLabelId
+  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
+  const managedLabelId = label.id || `${baseId}-label`
   const inputWrapperRef = useRef<HTMLDivElement>(null)
   const labelTextRef = useRef<HTMLElement>(null)
   const isFieldset = as === 'fieldset'

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -247,7 +247,7 @@ export const ActualFormControl: FC<
   }, [errorMessages])
 
   const classNames = useMemo(() => {
-    const generators = classNameGenerator({ innerMargin, isFieldset })
+    const generators = classNameGenerator()
 
     return {
       wrapper: generators.wrapper({ className }),
@@ -257,7 +257,8 @@ export const ActualFormControl: FC<
       errorList: generators.errorList(),
       errorIcon: generators.errorIcon(),
       errorMessage: generators.errorMessage(),
-      childrenWrapper: generators.childrenWrapper(),
+      // NOTE: innerMargin・isFieldsetはchildrenWrapperのスタイルにのみ影響するため、ここでのみ指定する
+      childrenWrapper: generators.childrenWrapper({ innerMargin, isFieldset }),
     }
   }, [innerMargin, isFieldset, label.unrecommendedHide, className])
 

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -83,7 +83,6 @@ const classNameGenerator = tv({
     errorList: ['shr-list-none'],
     errorIcon: ['smarthr-ui-FormControl-errorMessage-Icon', 'shr-text-danger'],
     errorMessage: ['smarthr-ui-FormControl-errorMessage'],
-    childrenWrapper: [],
   },
 })
 
@@ -217,7 +216,7 @@ export const ActualFormControl: FC<
       errorList: generators.errorList(),
       errorIcon: generators.errorIcon(),
       errorMessage: generators.errorMessage(),
-      childrenWrapper: generators.childrenWrapper({ className: childrenWrapperClassName }),
+      childrenWrapper: childrenWrapperClassName,
     }
   }, [label.unrecommendedHide, className, childrenWrapperClassName])
 

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -85,49 +85,6 @@ const classNameGenerator = tv({
     errorMessage: ['smarthr-ui-FormControl-errorMessage'],
     childrenWrapper: [],
   },
-  variants: {
-    innerMargin: {
-      0: {},
-      0.25: {},
-      0.5: {},
-      0.75: {},
-      1: {},
-      1.25: {},
-      1.5: {},
-      2: {},
-      2.5: {},
-      3: {},
-      3.5: {},
-      4: {},
-      8: {},
-      X3S: {},
-      XXS: {},
-      XS: {},
-      S: {},
-      M: {},
-      L: {},
-      XL: {},
-      XXL: {},
-      X3L: {},
-    } as { [key in Gap]: string },
-    isFieldset: {
-      true: {},
-      false: {},
-    },
-  },
-  compoundVariants: [
-    // TODO: innerMarginが未指定、初期値の場合、かつFieldsetの場合、childrenの上部の余白を広げることで
-    // FormControltとの差をわかりやすくしている
-    // 微妙な方法ではあるので、必要に応じてinnerMarginではない属性を用意する
-    // https://kufuinc.slack.com/archives/CGC58MW01/p1737944965871159?thread_ts=1737541173.404369&cid=CGC58MW01
-    {
-      innerMargin: undefined,
-      isFieldset: true,
-      class: {
-        childrenWrapper: '[:not([hidden])_~_&&&]:shr-mt-0.5',
-      },
-    },
-  ],
 })
 
 export const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
@@ -195,6 +152,8 @@ export const ActualFormControl: FC<
     disabled?: boolean
     as?: string | ComponentType<any>
     inputWrapperRef: RefObject<HTMLDivElement>
+    /** `childrenWrapper` に追加するクラス名 */
+    childrenWrapperClassName?: string
   }
 > = ({
   label,
@@ -210,6 +169,7 @@ export const ActualFormControl: FC<
   className,
   children,
   inputWrapperRef,
+  childrenWrapperClassName,
   ...rest
 }) => {
   const isFieldset = as === 'fieldset'
@@ -257,10 +217,9 @@ export const ActualFormControl: FC<
       errorList: generators.errorList(),
       errorIcon: generators.errorIcon(),
       errorMessage: generators.errorMessage(),
-      // NOTE: innerMargin・isFieldsetはchildrenWrapperのスタイルにのみ影響するため、ここでのみ指定する
-      childrenWrapper: generators.childrenWrapper({ innerMargin, isFieldset }),
+      childrenWrapper: generators.childrenWrapper({ className: childrenWrapperClassName }),
     }
-  }, [innerMargin, isFieldset, label.unrecommendedHide, className])
+  }, [label.unrecommendedHide, className, childrenWrapperClassName])
 
   useEffect(() => {
     if (!describedbyIds || !inputWrapperRef.current) {
@@ -328,7 +287,7 @@ export const ActualFormControl: FC<
         managedHtmlFor={label.htmlFor}
         classNames={classNames}
       />
-      <div className={classNames.childrenWrapper} ref={inputWrapperRef}>
+      <div ref={inputWrapperRef} className={classNames.childrenWrapper}>
         {children}
       </div>
       <SupplementaryMessageText

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -157,8 +157,7 @@ export const ActualFormControl: FC<Props> = ({
     labelObjectConverter,
   )
   const baseId = useId()
-  const [childInputId, setChildInputId] = useState<string>('')
-  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
+  const managedHtmlFor = label.htmlFor || `${baseId}-htmlFor`
   const managedLabelId = label.id || `${baseId}-label`
   const labelTextRef = useRef<HTMLElement>(null)
   const isFieldset = as === 'fieldset'
@@ -209,41 +208,6 @@ export const ActualFormControl: FC<Props> = ({
       childrenWrapper: generators.childrenWrapper(),
     }
   }, [innerMargin, isFieldset, label.unrecommendedHide, className])
-
-  useEffect(() => {
-    if (
-      isFieldset ||
-      !inputWrapperRef.current ||
-      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
-      document.getElementById(managedHtmlFor)
-    ) {
-      return
-    }
-
-    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
-
-    if (!input) {
-      return
-    }
-
-    const inputId = input.getAttribute('id')
-
-    if (inputId) {
-      setChildInputId(inputId)
-    } else {
-      input.setAttribute('id', managedHtmlFor)
-    }
-
-    if (input instanceof HTMLInputElement && input.type === 'file') {
-      const attrName = 'aria-labelledby'
-      const inputLabelledByIds = input.getAttribute(attrName)
-
-      if (inputLabelledByIds) {
-        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
-        input.setAttribute(attrName, `${inputLabelledByIds} ${managedLabelId}`)
-      }
-    }
-  }, [managedHtmlFor, isFieldset, managedLabelId, inputWrapperRef])
 
   useEffect(() => {
     if (!describedbyIds || !inputWrapperRef.current) {
@@ -367,10 +331,61 @@ export const ActualFormControl: FC<Props> = ({
   )
 }
 
-export const FormControl: FC<Omit<Props, 'as' | 'disabled' | 'inputWrapperRef'>> = (props) => {
+export const FormControl: FC<Omit<Props, 'as' | 'disabled' | 'inputWrapperRef'>> = ({
+  label: orgLabel,
+  ...rest
+}) => {
+  const label = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
+    orgLabel,
+    labelObjectConverter,
+  )
+  const baseId = useId()
+  const [childInputId, setChildInputId] = useState<string>('')
+  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
+  const managedLabelId = label.id || `${baseId}-label`
   const inputWrapperRef = useRef<HTMLDivElement>(null)
 
-  return <ActualFormControl {...props} inputWrapperRef={inputWrapperRef} />
+  useEffect(() => {
+    if (
+      !inputWrapperRef.current ||
+      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
+      document.getElementById(managedHtmlFor)
+    ) {
+      return
+    }
+
+    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+
+    if (!input) {
+      return
+    }
+
+    const inputId = input.getAttribute('id')
+
+    if (inputId) {
+      setChildInputId(inputId)
+    } else {
+      input.setAttribute('id', managedHtmlFor)
+    }
+
+    if (input instanceof HTMLInputElement && input.type === 'file') {
+      const attrName = 'aria-labelledby'
+      const inputLabelledByIds = input.getAttribute(attrName)
+
+      if (inputLabelledByIds) {
+        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
+        input.setAttribute(attrName, `${inputLabelledByIds} ${managedLabelId}`)
+      }
+    }
+  }, [managedHtmlFor, managedLabelId])
+
+  return (
+    <ActualFormControl
+      {...rest}
+      label={{ ...label, htmlFor: managedHtmlFor, id: managedLabelId }}
+      inputWrapperRef={inputWrapperRef}
+    />
+  )
 }
 
 const LabelCluster = memo<

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -11,11 +11,11 @@ import {
   type RefObject,
   memo,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
 } from 'react'
-import { useId } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
@@ -30,7 +30,7 @@ import type { StatusLabel } from '../StatusLabel'
 type StatusLabelType = FunctionComponentElement<ComponentProps<typeof StatusLabel>>
 type IconType = ComponentProps<typeof Text>['icon']
 
-type ObjectLabelType = {
+export type ObjectLabelType = {
   text: ReactNode
   /** ラベルの表示タイプ */
   styleType?: TextProps['styleType']
@@ -69,7 +69,7 @@ type BaseProps = PropsWithChildren<{
 }>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'aria-labelledby'>
 
-const labelObjectConverter = (label: ReactNode) => ({ text: label })
+export const labelObjectConverter = (label: ReactNode) => ({ text: label })
 
 const classNameGenerator = tv({
   slots: {
@@ -136,8 +136,13 @@ const classNameGenerator = tv({
 
 const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
 
-export const ActualFormControl: FC<Props> = ({
-  label: orgLabel,
+export const ActualFormControl: FC<
+  Omit<Props, 'label'> & {
+    label: Omit<ObjectLabelType, 'htmlFor' | 'id'> &
+      Required<Pick<ObjectLabelType, 'htmlFor' | 'id'>>
+  }
+> = ({
+  label,
   subActionArea,
   innerMargin,
   statusLabels,
@@ -152,13 +157,6 @@ export const ActualFormControl: FC<Props> = ({
   inputWrapperRef,
   ...rest
 }) => {
-  const label = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
-    orgLabel,
-    labelObjectConverter,
-  )
-  const baseId = useId()
-  const managedHtmlFor = label.htmlFor || `${baseId}-htmlFor`
-  const managedLabelId = label.id || `${baseId}-label`
   const labelTextRef = useRef<HTMLElement>(null)
   const isFieldset = as === 'fieldset'
 
@@ -166,20 +164,20 @@ export const ActualFormControl: FC<Props> = ({
     const temp = []
 
     if (helpMessage) {
-      temp.push(`${managedHtmlFor}_helpMessage`)
+      temp.push(`${label.htmlFor}_helpMessage`)
     }
     if (exampleMessage) {
-      temp.push(`${managedHtmlFor}_exampleMessage`)
+      temp.push(`${label.htmlFor}_exampleMessage`)
     }
     if (supplementaryMessage) {
-      temp.push(`${managedHtmlFor}_supplementaryMessage`)
+      temp.push(`${label.htmlFor}_supplementaryMessage`)
     }
     if (errorMessages) {
-      temp.push(`${managedHtmlFor}_errorMessages`)
+      temp.push(`${label.htmlFor}_errorMessages`)
     }
 
     return temp.join(' ')
-  }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, managedHtmlFor])
+  }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, label.htmlFor])
 
   const actualStatusLabels = useMemo(
     () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
@@ -302,8 +300,8 @@ export const ActualFormControl: FC<Props> = ({
     >
       <LabelCluster
         isFieldset={isFieldset}
-        managedHtmlFor={managedHtmlFor}
-        managedLabelId={managedLabelId}
+        managedHtmlFor={label.htmlFor}
+        managedLabelId={label.id}
         unrecommendedHideLabel={label.unrecommendedHide}
         labelType={label.styleType}
         label={label.text}
@@ -313,11 +311,11 @@ export const ActualFormControl: FC<Props> = ({
         labelClassName={classNames.label}
         labelTextRef={labelTextRef}
       />
-      <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={managedHtmlFor} />
-      <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={managedHtmlFor} />
+      <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={label.htmlFor} />
+      <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={label.htmlFor} />
       <ErrorMessageList
         errorMessages={actualErrorMessages}
-        managedHtmlFor={managedHtmlFor}
+        managedHtmlFor={label.htmlFor}
         classNames={classNames}
       />
       <div className={classNames.childrenWrapper} ref={inputWrapperRef}>
@@ -325,7 +323,7 @@ export const ActualFormControl: FC<Props> = ({
       </div>
       <SupplementaryMessageText
         supplementaryMessage={supplementaryMessage}
-        managedHtmlFor={managedHtmlFor}
+        managedHtmlFor={label.htmlFor}
       />
     </Stack>
   )

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -134,7 +134,8 @@ const classNameGenerator = tv({
   ],
 })
 
-const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
+export const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
+export const SMARTHR_UI_LABEL_TEXT_SELECTOR = 'smarthr-ui-FormControl-labelText'
 
 export const ActualFormControl: FC<
   Omit<Props, 'label'> & {
@@ -157,7 +158,6 @@ export const ActualFormControl: FC<
   inputWrapperRef,
   ...rest
 }) => {
-  const labelTextRef = useRef<HTMLElement>(null)
   const isFieldset = as === 'fieldset'
 
   const describedbyIds = useMemo(() => {
@@ -249,10 +249,17 @@ export const ActualFormControl: FC<
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
   useEffect(() => {
-    if (!isFieldset || !inputWrapperRef.current || !labelTextRef.current) return
+    if (!isFieldset || !inputWrapperRef.current) return
+
+    // HINT: unrecommendedHideLabelがfalseの場合、同じテキストを持つ要素が2つレンダリングされるが
+    // どちらも同一文字列のため、1つ目を取得すれば十分
+    const labelTextEl = inputWrapperRef.current.parentElement?.querySelector(
+      `.${SMARTHR_UI_LABEL_TEXT_SELECTOR}`,
+    )
+    if (!labelTextEl) return
 
     const updateAriaLabels = () => {
-      const labelText = labelTextRef.current?.textContent || ''
+      const labelText = labelTextEl.textContent || ''
       if (!labelText) return
 
       const inputs =
@@ -281,7 +288,7 @@ export const ActualFormControl: FC<
 
     // label要素の変更を監視
     const observer = new MutationObserver(updateAriaLabels)
-    observer.observe(labelTextRef.current, {
+    observer.observe(labelTextEl, {
       childList: true,
       subtree: true,
       characterData: true,
@@ -309,7 +316,6 @@ export const ActualFormControl: FC<
         statusLabels={actualStatusLabels}
         subActionArea={subActionArea}
         labelClassName={classNames.label}
-        labelTextRef={labelTextRef}
       />
       <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={label.htmlFor} />
       <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={label.htmlFor} />
@@ -397,7 +403,6 @@ const LabelCluster = memo<
     managedLabelId: string
     labelClassName: string
     statusLabels: StatusLabelType[]
-    labelTextRef: React.RefObject<HTMLElement>
   }
 >(
   ({
@@ -411,12 +416,11 @@ const LabelCluster = memo<
     subActionArea,
     labelClassName,
     statusLabels,
-    labelTextRef,
   }) => {
     const body = (
       <>
-        <Text styleType={labelType} icon={labelIcon}>
-          <span ref={labelTextRef}>{label}</span>
+        <Text styleType={labelType} icon={labelIcon} className={SMARTHR_UI_LABEL_TEXT_SELECTOR}>
+          {label}
         </Text>
         <StatusLabelCluster statusLabels={statusLabels} />
       </>

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -62,10 +62,6 @@ type BaseProps = PropsWithChildren<{
   autoBindErrorInput?: boolean
   /** フォームコントロールの下に表示する補足メッセージ */
   supplementaryMessage?: ReactNode
-  /** `true` のとき、文字色を `TEXT_DISABLED` にする */
-  disabled?: boolean
-  as?: string | ComponentType<any>
-  inputWrapperRef: RefObject<HTMLDivElement>
 }>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'aria-labelledby'>
 
@@ -137,10 +133,68 @@ const classNameGenerator = tv({
 export const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
 export const SMARTHR_UI_LABEL_TEXT_SELECTOR = 'smarthr-ui-FormControl-labelText'
 
+export const FormControl: FC<Props> = ({ label: orgLabel, ...rest }) => {
+  const label = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
+    orgLabel,
+    labelObjectConverter,
+  )
+  const baseId = useId()
+  const [childInputId, setChildInputId] = useState<string>('')
+  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
+  const managedLabelId = label.id || `${baseId}-label`
+  const inputWrapperRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (
+      !inputWrapperRef.current ||
+      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
+      document.getElementById(managedHtmlFor)
+    ) {
+      return
+    }
+
+    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+
+    if (!input) {
+      return
+    }
+
+    const inputId = input.getAttribute('id')
+
+    if (inputId) {
+      setChildInputId(inputId)
+    } else {
+      input.setAttribute('id', managedHtmlFor)
+    }
+
+    if (input instanceof HTMLInputElement && input.type === 'file') {
+      const attrName = 'aria-labelledby'
+      const inputLabelledByIds = input.getAttribute(attrName)
+
+      if (inputLabelledByIds) {
+        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
+        input.setAttribute(attrName, `${inputLabelledByIds} ${managedLabelId}`)
+      }
+    }
+  }, [managedHtmlFor, managedLabelId])
+
+  return (
+    <ActualFormControl
+      {...rest}
+      label={{ ...label, htmlFor: managedHtmlFor, id: managedLabelId }}
+      inputWrapperRef={inputWrapperRef}
+    />
+  )
+}
+
 export const ActualFormControl: FC<
   Omit<Props, 'label'> & {
     label: Omit<ObjectLabelType, 'htmlFor' | 'id'> &
       Required<Pick<ObjectLabelType, 'htmlFor' | 'id'>>
+    /** `true` のとき、文字色を `TEXT_DISABLED` にする */
+    disabled?: boolean
+    as?: string | ComponentType<any>
+    inputWrapperRef: RefObject<HTMLDivElement>
   }
 > = ({
   label,
@@ -281,63 +335,6 @@ export const ActualFormControl: FC<
         managedHtmlFor={label.htmlFor}
       />
     </Stack>
-  )
-}
-
-export const FormControl: FC<Omit<Props, 'as' | 'disabled' | 'inputWrapperRef'>> = ({
-  label: orgLabel,
-  ...rest
-}) => {
-  const label = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
-    orgLabel,
-    labelObjectConverter,
-  )
-  const baseId = useId()
-  const [childInputId, setChildInputId] = useState<string>('')
-  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
-  const managedLabelId = label.id || `${baseId}-label`
-  const inputWrapperRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (
-      !inputWrapperRef.current ||
-      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
-      document.getElementById(managedHtmlFor)
-    ) {
-      return
-    }
-
-    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
-
-    if (!input) {
-      return
-    }
-
-    const inputId = input.getAttribute('id')
-
-    if (inputId) {
-      setChildInputId(inputId)
-    } else {
-      input.setAttribute('id', managedHtmlFor)
-    }
-
-    if (input instanceof HTMLInputElement && input.type === 'file') {
-      const attrName = 'aria-labelledby'
-      const inputLabelledByIds = input.getAttribute(attrName)
-
-      if (inputLabelledByIds) {
-        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
-        input.setAttribute(attrName, `${inputLabelledByIds} ${managedLabelId}`)
-      }
-    }
-  }, [managedHtmlFor, managedLabelId])
-
-  return (
-    <ActualFormControl
-      {...rest}
-      label={{ ...label, htmlFor: managedHtmlFor, id: managedLabelId }}
-      inputWrapperRef={inputWrapperRef}
-    />
   )
 }
 

--- a/packages/smarthr-ui/src/components/FormControl/index.ts
+++ b/packages/smarthr-ui/src/components/FormControl/index.ts
@@ -1,1 +1,6 @@
-export { ActualFormControl, FormControl } from './FormControl'
+export {
+  ActualFormControl,
+  FormControl,
+  labelObjectConverter,
+  type ObjectLabelType,
+} from './FormControl'

--- a/packages/smarthr-ui/src/components/FormControl/index.ts
+++ b/packages/smarthr-ui/src/components/FormControl/index.ts
@@ -3,4 +3,6 @@ export {
   FormControl,
   labelObjectConverter,
   type ObjectLabelType,
+  SMARTHR_UI_INPUT_SELECTOR,
+  SMARTHR_UI_LABEL_TEXT_SELECTOR,
 } from './FormControl'


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/pull/6830#discussion_r3820399762

## 概要

PR #6830 のレビューで指摘された、Fieldsetのlegend文言が変更された際にinputのaria-labelへ古いlegend文言が蓄積してしまう不具合を修正する。

`updateAriaLabels` は毎回 `aria-label` の現在値を起点に `accessibleName` を算出していた。legend要素とinput要素は `<fieldset>` 配下の別の部分木（兄弟関係）であり、legend変更時にMutationObserverが発火してもinput側のDOMノードは再生成されないため、既に書き込み済みの `aria-label`（前回のlegend文言を含む）がそのまま残り、そこへ新しいlegend文言がさらに追記されてしまう。

## 変更内容

- `WeakMap<HTMLInputElement, string>` でinput要素ごとに初回確定したアクセシブルネームを保持し、以降の再実行時はその値を起点に `aria-label` を再構築するよう修正
- legendを変更しても古いlegend文言が蓄積されないことを確認する回帰テストを追加

### 変更例

```tsx
// Before: legendを "旧legend" → "新legend" に変更すると
aria-label="input-accessible-name 旧legend 新legend" // 蓄積してしまう

// After
aria-label="input-accessible-name 新legend" // 常に最新のlegendのみ反映される
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

`Fieldset.test.tsx` の以下のテストで確認できます。

```
legendが変更されても、アクセシブルネームに古いlegend文言が蓄積されない
```

修正前のコードでこのテストが失敗すること（`input-accessible-name 旧legend 新legend` になること）を確認済み。