### PR TITLE
refactor: requestAnimationFrameのcancel漏れを解消

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -113,6 +113,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
     setSortType,
     onChangeSearchQuery,
     onClickClearSearchQuery,
+    callbackRef,
   } = useAppLauncher(baseFeatures)
 
   const translated = useLocalize({
@@ -131,7 +132,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
   })
 
   return (
-    <div className={CLASS_NAMES.wrapper}>
+    <div ref={callbackRef} className={CLASS_NAMES.wrapper}>
       <div className={CLASS_NAMES.searchArea}>
         <SearchInput
           name="search"

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
@@ -59,6 +59,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
     setSortType,
     onChangeSearchQuery,
     onClickClearSearchQuery,
+    callbackRef,
   } = useAppLauncher(baseFeatures)
 
   const { searchInputTitle } = useLocalize({
@@ -69,7 +70,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
   })
 
   return (
-    <div className={CLASS_NAMES.wrapper}>
+    <div ref={callbackRef} className={CLASS_NAMES.wrapper}>
       <div className={CLASS_NAMES.searchArea}>
         <SearchInput
           name="search"

--- a/packages/smarthr-ui/src/components/AppHeader/hooks/useAppLauncher.ts
+++ b/packages/smarthr-ui/src/components/AppHeader/hooks/useAppLauncher.ts
@@ -1,5 +1,7 @@
 import { type ChangeEvent, useCallback, useEffect, useState } from 'react'
 
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
+
 import type { Launcher } from '../types'
 
 export const useAppLauncher = (baseFeatures: Array<Launcher['feature']>) => {
@@ -50,13 +52,24 @@ export const useAppLauncher = (baseFeatures: Array<Launcher['feature']>) => {
     (e: ChangeEvent<HTMLInputElement>) => changeSearchQuery(e.currentTarget.value),
     [changeSearchQuery],
   )
+
+  const clearSearchQueryFrame = useAnimationFrame()
+
   const onClickClearSearchQuery = useCallback(() => {
     // HINT: 別のスレッドにしないとドロップダウンが閉じてしまう
-    // TODO: cancelする
-    requestAnimationFrame(() => {
+    clearSearchQueryFrame.request(() => {
       changeSearchQuery('')
     })
-  }, [changeSearchQuery])
+  }, [changeSearchQuery, clearSearchQueryFrame])
+
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) {
+        clearSearchQueryFrame.cancel()
+      }
+    },
+    [clearSearchQueryFrame],
+  )
 
   return {
     features,
@@ -68,6 +81,7 @@ export const useAppLauncher = (baseFeatures: Array<Launcher['feature']>) => {
     setSortType,
     onChangeSearchQuery,
     onClickClearSearchQuery,
+    callbackRef,
   }
 }
 

--- a/packages/smarthr-ui/src/components/AppHeader/hooks/useAppLauncher.ts
+++ b/packages/smarthr-ui/src/components/AppHeader/hooks/useAppLauncher.ts
@@ -52,6 +52,7 @@ export const useAppLauncher = (baseFeatures: Array<Launcher['feature']>) => {
   )
   const onClickClearSearchQuery = useCallback(() => {
     // HINT: 別のスレッドにしないとドロップダウンが閉じてしまう
+    // TODO: cancelする
     requestAnimationFrame(() => {
       changeSearchQuery('')
     })

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -256,10 +256,10 @@ const ActualMultiCombobox = <T,>(
   // TODO: callbackRefにまとめたい
   useEffect(
     () => () => {
-      deleteFrame.cancel()
-      selectFrame.cancel()
+      latestForListBox.deleteFrame.cancel()
+      latestForListBox.selectFrame.cancel()
     },
-    [deleteFrame, selectFrame],
+    [latestForListBox],
   )
 
   const { listBoxProps, activeOption, handleKeyDownListBox, listBoxId, listBoxRef } = useListbox({

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -18,6 +18,7 @@ import {
 import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useLatest } from '../../../hooks/useLatest'
 import { useOuterClick } from '../../../hooks/useOuterClick'
 import { useTheme } from '../../../hooks/useTheme'
@@ -188,6 +189,8 @@ const ActualMultiCombobox = <T,>(
     isItemSelected,
   })
   const inputRef = useRef<HTMLInputElement>(null)
+  const deleteFrame = useAnimationFrame()
+  const selectFrame = useAnimationFrame()
 
   // eslint-disable-next-line local-rules/best-practice-for-use-latest
   const latestForListBox = useLatest({
@@ -196,6 +199,8 @@ const ActualMultiCombobox = <T,>(
     onSelect,
     onChangeInput,
     selectedItems,
+    deleteFrame,
+    selectFrame,
   })
 
   const listBoxFunctions = useMemo(() => {
@@ -217,9 +222,8 @@ const ActualMultiCombobox = <T,>(
 
       if (handlers.length > 0) {
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-        // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-        // TODO: cancelする
-        requestAnimationFrame(() => {
+        // 処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        latestForListBox.deleteFrame.request(() => {
           handlers.forEach((h) => h(item))
         })
       }
@@ -229,9 +233,8 @@ const ActualMultiCombobox = <T,>(
       handleDelete,
       handleSelect: (selected: ComboboxItem<T>) => {
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-        // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-        // TODO: cancelする
-        requestAnimationFrame(() => {
+        // 処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        latestForListBox.selectFrame.request(() => {
           const matchedSelectedItem = latestForListBox.selectedItems.find((item) =>
             areItemsEqual(item, selected),
           )
@@ -249,6 +252,15 @@ const ActualMultiCombobox = <T,>(
       },
     }
   }, [latestForListBox])
+
+  // TODO: callbackRefにまとめたい
+  useEffect(
+    () => () => {
+      deleteFrame.cancel()
+      selectFrame.cancel()
+    },
+    [deleteFrame, selectFrame],
+  )
 
   const { listBoxProps, activeOption, handleKeyDownListBox, listBoxId, listBoxRef } = useListbox({
     options,

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -218,6 +218,7 @@ const ActualMultiCombobox = <T,>(
       if (handlers.length > 0) {
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        // TODO: cancelする
         requestAnimationFrame(() => {
           handlers.forEach((h) => h(item))
         })
@@ -229,6 +230,7 @@ const ActualMultiCombobox = <T,>(
       handleSelect: (selected: ComboboxItem<T>) => {
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        // TODO: cancelする
         requestAnimationFrame(() => {
           const matchedSelectedItem = latestForListBox.selectedItems.find((item) =>
             areItemsEqual(item, selected),

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -225,6 +225,7 @@ const ActualSingleCombobox = <T,>(
 
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        // TODO: cancelする
         requestAnimationFrame(() => {
           setIsExpanded(false)
           // HINT:

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -192,6 +192,7 @@ const ActualSingleCombobox = <T,>(
   const triggerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const clearButtonRef = useRef<HTMLButtonElement>(null)
+  const unmountRef = useRef<{ clearOnSelectId: number | null }>({ clearOnSelectId: null })
   const [isFocused, setIsFocused] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const [inputValue, setInputValue] = useState('')
@@ -225,8 +226,7 @@ const ActualSingleCombobox = <T,>(
 
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
         // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-        // TODO: cancelする
-        requestAnimationFrame(() => {
+        unmountRef.current.clearOnSelectId = requestAnimationFrame(() => {
           setIsExpanded(false)
           // HINT:
           // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
@@ -244,6 +244,16 @@ const ActualSingleCombobox = <T,>(
       triggerRef,
       noResultText,
     },
+  )
+
+  // TODO: callbackRefにまとめ直したい
+  useEffect(
+    () => () => {
+      if (unmountRef.current.clearOnSelectId !== null) {
+        cancelAnimationFrame(unmountRef.current.clearOnSelectId)
+      }
+    },
+    [],
   )
 
   const latest = useLatest({

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -18,6 +18,7 @@ import {
 import innerText from 'react-innertext'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useClick } from '../../../hooks/useClick'
 import { useLatest } from '../../../hooks/useLatest'
 import { useTheme } from '../../../hooks/useTheme'
@@ -192,7 +193,6 @@ const ActualSingleCombobox = <T,>(
   const triggerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const clearButtonRef = useRef<HTMLButtonElement>(null)
-  const unmountRef = useRef<{ clearOnSelectId: number | null }>({ clearOnSelectId: null })
   const [isFocused, setIsFocused] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const [inputValue, setInputValue] = useState('')
@@ -213,6 +213,8 @@ const ActualSingleCombobox = <T,>(
     isFilteringDisabled: !isEditing,
   })
 
+  const selectFrame = useAnimationFrame()
+
   const { listBoxProps, activeOption, handleKeyDownListBox, listBoxId, listBoxRef } = useListbox<T>(
     {
       options,
@@ -225,8 +227,8 @@ const ActualSingleCombobox = <T,>(
         onChangeSelected?.(selected)
 
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-        // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-        unmountRef.current.clearOnSelectId = requestAnimationFrame(() => {
+        // 処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+        selectFrame.request(() => {
           setIsExpanded(false)
           // HINT:
           // - 制御コンポーネントの場合に親側でinputValueを更新できるように、選択時にonChangeInputを空文字で発火する
@@ -247,14 +249,7 @@ const ActualSingleCombobox = <T,>(
   )
 
   // TODO: callbackRefにまとめ直したい
-  useEffect(
-    () => () => {
-      if (unmountRef.current.clearOnSelectId !== null) {
-        cancelAnimationFrame(unmountRef.current.clearOnSelectId)
-      }
-    },
-    [],
-  )
+  useEffect(() => selectFrame.cancel, [selectFrame.cancel])
 
   const latest = useLatest({
     onChange,

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../hooks/useAnimationFrame'
 import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'
 import { useLatest } from '../../hooks/useLatest'
 import { usePortal } from '../../hooks/usePortal'
@@ -111,7 +112,9 @@ export const useListbox = <T,>({
 
   const theme = useTheme()
 
-  const latest = useLatest({ onAdd, onSelect, activeOption, options, triggerRef, theme })
+  const addFrame = useAnimationFrame()
+
+  const latest = useLatest({ onAdd, onSelect, activeOption, options, triggerRef, theme, addFrame })
   const hasOnAdd = !!onAdd
 
   const functions = useMemo(() => {
@@ -231,9 +234,8 @@ export const useListbox = <T,>({
       handleAdd: hasOnAdd
         ? (option: ComboboxOption<T>) => {
             // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
-            // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
-            // TODO: cancelする
-            requestAnimationFrame(() => {
+            // 処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+            latest.addFrame.request(() => {
               latest.onAdd!(option.item.value)
             })
           }
@@ -247,6 +249,9 @@ export const useListbox = <T,>({
       },
     }
   }, [hasOnAdd, latest])
+
+  // TODO: callbackRefにまとめ直したい
+  useEffect(() => addFrame.cancel, [addFrame.cancel])
 
   useEffect(() => {
     // props の変更によって activeOption の状態が変わりうるので、実態を反映する

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -232,6 +232,7 @@ export const useListbox = <T,>({
         ? (option: ComboboxOption<T>) => {
             // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
             // requestAnimationFrameを追加、処理を遅延させることで正常に閉じる/閉じないの判定を行えるようにする
+            // TODO: cancelする
             requestAnimationFrame(() => {
               latest.onAdd!(option.item.value)
             })

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../hooks/useAnimationFrame'
 import { useLatest } from '../../hooks/useLatest'
 import { useOuterClick } from '../../hooks/useOuterClick'
 import { useTheme } from '../../hooks/useTheme'
@@ -148,6 +149,8 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       parseStringDate(value, parseInput),
     )
 
+    const closeFrame = useAnimationFrame()
+
     const latest = useLatest({
       onChange,
       onChangeDate,
@@ -157,6 +160,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       onBlur,
       isInputFocused,
       selectedDate,
+      closeFrame,
     })
 
     const functions = useMemo(() => {
@@ -246,8 +250,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
           if (ESCAPE_KEY_REGEX.test(e.key)) {
             e.stopPropagation()
             // delay hiding calendar because calendar will be displayed when input is focused
-            // TODO: cancelする
-            requestAnimationFrame(closeCalendar)
+            latest.closeFrame.request(closeCalendar)
 
             if (inputRef.current) inputRef.current.focus()
           }
@@ -266,8 +269,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         handleSelectDateCalendar: (e: ChangeLikeEvent, selected: Date | null) => {
           updateDate(e, selected)
           // delay hiding calendar because calendar will be displayed when input is focused
-          // TODO: cancelする
-          requestAnimationFrame(closeCalendar)
+          latest.closeFrame.request(closeCalendar)
 
           if (inputRef.current) inputRef.current.focus()
         },
@@ -358,6 +360,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
 
       return () => {
         window.removeEventListener('keydown', handleKeyDown)
+        latest.closeFrame.cancel()
       }
     }, [functions, latest])
 

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -246,6 +246,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
           if (ESCAPE_KEY_REGEX.test(e.key)) {
             e.stopPropagation()
             // delay hiding calendar because calendar will be displayed when input is focused
+            // TODO: cancelする
             requestAnimationFrame(closeCalendar)
 
             if (inputRef.current) inputRef.current.focus()
@@ -265,6 +266,7 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
         handleSelectDateCalendar: (e: ChangeLikeEvent, selected: Date | null) => {
           updateDate(e, selected)
           // delay hiding calendar because calendar will be displayed when input is focused
+          // TODO: cancelする
           requestAnimationFrame(closeCalendar)
 
           if (inputRef.current) inputRef.current.focus()

--- a/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
+++ b/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
@@ -27,6 +27,7 @@ export const useDisclosure = (id: string): UseDisclosureResult => {
     () => ({
       safeSetExpanded: (value: boolean | ((prev: boolean) => boolean)) => {
         // DisclosureTrigger と DisclosureContent のレンダリング順序に影響しないように animation frame を待ってから state を更新する
+        // TODO: cancelする
         requestAnimationFrame(() => {
           const next = typeof value === 'function' ? value(latest.expanded) : value
 

--- a/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
+++ b/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 
+import { useAnimationFrame } from '../../hooks/useAnimationFrame'
 import { useLatest } from '../../hooks/useLatest'
 
 const DISCLOSURE_CHANGE_EVENT = 'smarthr-ui:disclosure-change'
@@ -21,14 +22,14 @@ type UseDisclosureResult = [expanded: boolean, setExpanded: Setter]
  */
 export const useDisclosure = (id: string): UseDisclosureResult => {
   const [expanded, setExpanded] = useState(false)
-  const latest = useLatest({ id, expanded })
+  const frame = useAnimationFrame()
+  const latest = useLatest({ id, expanded, frame })
 
   const functions = useMemo(
     () => ({
       safeSetExpanded: (value: boolean | ((prev: boolean) => boolean)) => {
         // DisclosureTrigger と DisclosureContent のレンダリング順序に影響しないように animation frame を待ってから state を更新する
-        // TODO: cancelする
-        requestAnimationFrame(() => {
+        latest.frame.request(() => {
           const next = typeof value === 'function' ? value(latest.expanded) : value
 
           if (next !== latest.expanded) {
@@ -54,9 +55,10 @@ export const useDisclosure = (id: string): UseDisclosureResult => {
     document.addEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
 
     return () => {
+      frame.cancel()
       document.removeEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
     }
-  }, [functions])
+  }, [frame, functions])
 
   return [expanded, functions.safeSetExpanded]
 }

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from 'react'
 
+import { useAnimationFrame } from '../../hooks/useAnimationFrame'
 import { useLatest } from '../../hooks/useLatest'
 import { usePortal } from '../../hooks/usePortal'
 
@@ -65,13 +66,8 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   })
 
   const triggerElementRef = useRef<HTMLDivElement>(null)
-  const cancelFrameIdsRef = useRef<{
-    open: number | null
-    close: number | null
-  }>({
-    open: null,
-    close: null,
-  })
+  const openFrame = useAnimationFrame()
+  const closeFrame = useAnimationFrame()
 
   const latest = useLatest({
     active,
@@ -80,6 +76,8 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     onOpen,
     onClose,
     createPortal,
+    openFrame,
+    closeFrame,
   })
 
   const functions = useMemo(() => {
@@ -89,7 +87,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     DropdownContentRoot.displayName = 'DropdownContentRoot'
     const actualClose = () => {
       if (latest.onClose) {
-        cancelFrameIdsRef.current.close = requestAnimationFrame(() => latest.onClose?.())
+        latest.closeFrame.request(() => latest.onClose?.())
       }
     }
 
@@ -104,7 +102,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           setTriggerRect(rect)
 
           if (latest.onOpen) {
-            cancelFrameIdsRef.current.open = requestAnimationFrame(() => latest.onOpen?.())
+            latest.openFrame.request(() => latest.onOpen?.())
           }
         }
       },
@@ -136,16 +134,10 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
 
   useEffect(
     () => () => {
-      const { open, close } = cancelFrameIdsRef.current
-
-      if (open !== null) {
-        cancelAnimationFrame(open)
-      }
-      if (close !== null) {
-        cancelAnimationFrame(close)
-      }
+      latest.openFrame.cancel()
+      latest.closeFrame.cancel()
     },
-    [],
+    [latest],
   )
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -86,16 +86,28 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
       handleClickTrigger: (rect: Rect) => {
         if (latest.active) {
           setActive(false)
-          if (latest.onClose) requestAnimationFrame(() => latest.onClose?.())
+
+          if (latest.onClose) {
+            // TODO: cancelする
+            requestAnimationFrame(() => latest.onClose?.())
+          }
         } else {
           setActive(true)
           setTriggerRect(rect)
-          if (latest.onOpen) requestAnimationFrame(() => latest.onOpen?.())
+
+          if (latest.onOpen) {
+            // TODO: cancelする
+            requestAnimationFrame(() => latest.onOpen?.())
+          }
         }
       },
       handleDelegateClickCloser: () => {
         setActive(false)
-        if (latest.onClose) requestAnimationFrame(() => latest.onClose?.())
+
+        if (latest.onClose) {
+          // TODO: cancelする
+          requestAnimationFrame(() => latest.onClose?.())
+        }
 
         // return focus to the Trigger
         getFirstTabbable(triggerElementRef)?.focus()
@@ -110,6 +122,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           setActive(false)
 
           if (latest.onClose) {
+            // TODO: cancelする
             requestAnimationFrame(() => latest.onClose?.())
           }
         }

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -65,6 +65,13 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
   })
 
   const triggerElementRef = useRef<HTMLDivElement>(null)
+  const cancelFrameIdsRef = useRef<{
+    open: number | null
+    close: number | null
+  }>({
+    open: null,
+    close: null,
+  })
 
   const latest = useLatest({
     active,
@@ -80,34 +87,30 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     const DropdownContentRoot: FC<{ children: ReactNode }> = (props) =>
       latest.active ? latest.createPortal(props.children) : null
     DropdownContentRoot.displayName = 'DropdownContentRoot'
+    const actualClose = () => {
+      if (latest.onClose) {
+        cancelFrameIdsRef.current.close = requestAnimationFrame(() => latest.onClose?.())
+      }
+    }
 
     return {
       DropdownContentRoot,
       handleClickTrigger: (rect: Rect) => {
         if (latest.active) {
           setActive(false)
-
-          if (latest.onClose) {
-            // TODO: cancelする
-            requestAnimationFrame(() => latest.onClose?.())
-          }
+          actualClose()
         } else {
           setActive(true)
           setTriggerRect(rect)
 
           if (latest.onOpen) {
-            // TODO: cancelする
-            requestAnimationFrame(() => latest.onOpen?.())
+            cancelFrameIdsRef.current.open = requestAnimationFrame(() => latest.onOpen?.())
           }
         }
       },
       handleDelegateClickCloser: () => {
         setActive(false)
-
-        if (latest.onClose) {
-          // TODO: cancelする
-          requestAnimationFrame(() => latest.onClose?.())
-        }
+        actualClose()
 
         // return focus to the Trigger
         getFirstTabbable(triggerElementRef)?.focus()
@@ -120,11 +123,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           !latest.isChildPortal(e.target)
         ) {
           setActive(false)
-
-          if (latest.onClose) {
-            // TODO: cancelする
-            requestAnimationFrame(() => latest.onClose?.())
-          }
+          actualClose()
         }
       },
       updateTriggerRect: () => {
@@ -134,6 +133,20 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
       },
     }
   }, [latest])
+
+  useEffect(
+    () => () => {
+      const { open, close } = cancelFrameIdsRef.current
+
+      if (open !== null) {
+        cancelAnimationFrame(open)
+      }
+      if (close !== null) {
+        cancelAnimationFrame(close)
+      }
+    },
+    [],
+  )
 
   useEffect(() => {
     if (!active) return

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ComponentProps, type FC, memo, useEffect, useMemo, useRef, useState } from 'react'
+import { type ComponentProps, type FC, memo, useCallback, useMemo, useRef, useState } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf'
 
 import { useLatest } from '../../hooks/useLatest'
@@ -77,7 +77,6 @@ export const PDFViewer: FC<Props> = memo(
     const matches = search?.matches
     const currentMatchIndex = search?.currentMatchIndex
     const [pdfNumPages, setPdfNumPages] = useState(1)
-    const rootRef = useRef<HTMLDivElement>(null)
 
     const latest = useLatest({
       rotation,
@@ -108,38 +107,42 @@ export const PDFViewer: FC<Props> = memo(
       }
     }, [latest])
 
-    useEffect(() => {
-      const root = rootRef.current
-      if (!root) return
-      root
-        .querySelectorAll(`mark.highlight.${SELECTED_MATCH_CLASS}`)
-        .forEach((el) => el.classList.remove(SELECTED_MATCH_CLASS))
+    const cancelApplyIdRef = useRef<number | null>(null)
+    const callbackRef = useCallback(
+      (node: HTMLElement | null) => {
+        if (node) {
+          node
+            .querySelectorAll(`mark.highlight.${SELECTED_MATCH_CLASS}`)
+            .forEach((el) => el.classList.remove(SELECTED_MATCH_CLASS))
 
-      if (currentMatchIndex === undefined || currentMatchIndex < 0) return
+          if (currentMatchIndex === undefined || currentMatchIndex < 0) return
 
-      const start = performance.now()
-      let id = 0
-      const apply = () => {
-        const els = root.querySelectorAll(matchSelector(currentMatchIndex))
-        if (els.length > 0) {
-          els.forEach((el) => el.classList.add(SELECTED_MATCH_CLASS))
-          els[0].scrollIntoView({ block: 'center', behavior: 'smooth' })
-          return
+          const start = performance.now()
+          const apply = () => {
+            const els = node.querySelectorAll(matchSelector(currentMatchIndex))
+
+            if (els.length > 0) {
+              els.forEach((el) => el.classList.add(SELECTED_MATCH_CLASS))
+              els[0].scrollIntoView({ block: 'center', behavior: 'smooth' })
+            } else if (performance.now() - start < 1000) {
+              cancelApplyIdRef.current = requestAnimationFrame(apply)
+            }
+          }
+          cancelApplyIdRef.current = requestAnimationFrame(apply)
+        } else if (cancelApplyIdRef.current !== null) {
+          cancelAnimationFrame(cancelApplyIdRef.current)
         }
-        if (performance.now() - start < 1000) {
-          id = requestAnimationFrame(apply)
-        }
-      }
-      id = requestAnimationFrame(apply)
-      return () => cancelAnimationFrame(id)
-    }, [currentMatchIndex, matches])
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- matchesの変化でcallbackRefを再実行し、ハイライトを再適用させるために必要
+      },
+      [currentMatchIndex, matches],
+    )
 
     return (
       <>
         {/* TODO: 外部CSSをsmarthr-uiから読み込んでもらえるようにする機構ができたら消す */}
         <ReactPDFStyle />
         <HighlightOverrideStyle />
-        <Scroller ref={rootRef} direction="both" className="shr-h-full">
+        <Scroller ref={callbackRef} direction="both" className="shr-h-full">
           <Document
             options={options}
             file={file.url}

--- a/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/PDFViewer.tsx
@@ -132,8 +132,8 @@ export const PDFViewer: FC<Props> = memo(
         } else if (cancelApplyIdRef.current !== null) {
           cancelAnimationFrame(cancelApplyIdRef.current)
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- matchesの変化でcallbackRefを再実行し、ハイライトを再適用させるために必要
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- matchesの変化でcallbackRefを再実行し、ハイライトを再適用させるために必要
       [currentMatchIndex, matches],
     )
 

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -121,6 +121,7 @@ const AutoPageTitleHeading: FC<
       pseudoTitle.setAttribute('aria-live', 'polite')
       document.body.prepend(pseudoTitle)
 
+      // TODO: cancelする
       requestAnimationFrame(() => {
         pseudoTitle.textContent = document.title
       })

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useLatest } from '../../../hooks/useLatest'
 import { IS_NEXT_JS } from '../../../libs/nextjs'
 import { STYLE_TYPE_MAP, Text, type TextProps } from '../../Text'
@@ -98,7 +99,8 @@ const AutoPageTitleHeading: FC<
   // HINT: h1のテキストをMutationObserverで監視するために内部でrefを保持しつつ、利用者のrefにも要素を渡す
   const innerRef = useRef<HTMLHeadingElement | null>(null)
 
-  const latest = useLatest({ pageTitle, pageTitleSuffix, pseudoTitleId })
+  const titleFrame = useAnimationFrame()
+  const latest = useLatest({ pageTitle, pageTitleSuffix, pseudoTitleId, titleFrame })
 
   const functions = useMemo(() => {
     const updateTitle = () => {
@@ -121,8 +123,7 @@ const AutoPageTitleHeading: FC<
       pseudoTitle.setAttribute('aria-live', 'polite')
       document.body.prepend(pseudoTitle)
 
-      // TODO: cancelする
-      requestAnimationFrame(() => {
+      latest.titleFrame.request(() => {
         pseudoTitle.textContent = document.title
       })
     }
@@ -143,6 +144,7 @@ const AutoPageTitleHeading: FC<
           })
         } else {
           observer?.disconnect()
+          latest.titleFrame.cancel()
 
           const pseudoTitle = document.getElementById(latest.pseudoTitleId)
 

--- a/packages/smarthr-ui/src/hooks/useAnimationFrame.test.ts
+++ b/packages/smarthr-ui/src/hooks/useAnimationFrame.test.ts
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react'
+
+import { useAnimationFrame } from './useAnimationFrame'
+
+describe('useAnimationFrame', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requestを呼ぶとrequestAnimationFrameでcallbackが実行される', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 1
+    })
+
+    const { result } = renderHook(() => useAnimationFrame())
+    const callback = vi.fn()
+
+    result.current.request(callback)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('requestを連続して呼ぶと前回予約したフレームがcancelされる', () => {
+    let idCounter = 0
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => ++idCounter)
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')
+
+    const { result } = renderHook(() => useAnimationFrame())
+
+    result.current.request(() => {})
+    result.current.request(() => {})
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledTimes(1)
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('cancelを呼ぶと予約中のフレームがcancelされる', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1)
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')
+
+    const { result } = renderHook(() => useAnimationFrame())
+
+    result.current.request(() => {})
+    result.current.cancel()
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('予約前にcancelを呼んでも何も起きない', () => {
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame')
+
+    const { result } = renderHook(() => useAnimationFrame())
+
+    result.current.cancel()
+
+    expect(cancelAnimationFrameSpy).not.toHaveBeenCalled()
+  })
+
+  it('再レンダリングされてもrequest/cancelの参照が変わらない', () => {
+    const { result, rerender } = renderHook(() => useAnimationFrame())
+    const firstRequest = result.current.request
+    const firstCancel = result.current.cancel
+
+    rerender()
+
+    expect(result.current.request).toBe(firstRequest)
+    expect(result.current.cancel).toBe(firstCancel)
+  })
+})

--- a/packages/smarthr-ui/src/hooks/useAnimationFrame.ts
+++ b/packages/smarthr-ui/src/hooks/useAnimationFrame.ts
@@ -1,0 +1,36 @@
+import { useMemo, useRef } from 'react'
+
+/**
+ * requestAnimationFrameを実行するためのフック。
+ * requestを呼ぶたびに前回予約したフレームを自動でcancelしてから新しいフレームを予約する。
+ *
+ * cancelは任意のタイミングで呼び出せるため、アンマウント時のクリーンアップなどに使用する。
+ *
+ * @example
+ * const frame = useAnimationFrame()
+ *
+ * frame.request(() => {
+ *   // 実行したい処理
+ * })
+ *
+ * useEffect(() => frame.cancel, [frame.cancel])
+ */
+export function useAnimationFrame() {
+  const cancelIdRef = useRef<number | null>(null)
+
+  return useMemo(() => {
+    const cancel = () => {
+      if (cancelIdRef.current !== null) {
+        cancelAnimationFrame(cancelIdRef.current)
+        cancelIdRef.current = null
+      }
+    }
+    return {
+      request: (callback: () => void) => {
+        cancel()
+        cancelIdRef.current = requestAnimationFrame(callback)
+      },
+      cancel,
+    }
+  }, [])
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

各コンポーネントで使われていた`requestAnimationFrame`のうち、アンマウント時に`cancelAnimationFrame`が呼ばれていない箇所が複数あった。アンマウント後にコールバックが発火し、破棄済みのstateを更新するなどの不具合を防ぐため、cancel処理を追加した。

## 変更内容

- 再利用可能な`useAnimationFrame`フックを追加（`request`でフレームを予約し、前回分は自動cancel。`cancel`で明示的にcancel可能）
- 以下のコンポーネントで`requestAnimationFrame`のcancel漏れを解消
  - `SingleCombobox`
  - `Combobox`の`useListbox`
  - `MultiCombobox`
  - `AppHeader`の`AppLauncher`（`callbackRef`でアンマウント検知）
  - `PageHeading`（`callbackRef`でアンマウント検知）
  - `DatePicker`
  - `Disclosure`
  - `Dropdown`（`useAnimationFrame`は使わず、複数フレームIDを保持する専用実装で対応）

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 各コンポーネントの既存テストがすべてパスすることを確認済み
- `useAnimationFrame`フックの単体テストを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ドロップダウン、コンボボックス、日付選択、開閉パネルなどの操作を改善し、選択・開閉・入力クリアがより安定して動作するようになりました。
  * 画面遷移やコンポーネントの再表示時に、不要な処理が残り続ける問題を防止しました。
  * PDF検索結果の選択箇所が正しくハイライトされ、対象位置へ自動スクロールされるよう改善しました。
  * ページ見出しやアプリランチャーの表示更新を安定化しました。

* **テスト**
  * アニメーションを伴う処理の実行・キャンセル動作を追加検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->