### PR TITLE
refactor(FileViewer): ImageViewerのハイライト再計算をuseEffectからcallbackRefに変更

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -1,66 +1,10 @@
 'use client'
 
-import {
-  type ComponentProps,
-  type FC,
-  type Ref,
-  type SyntheticEvent,
-  memo,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react'
+import { type FC, type SyntheticEvent, memo, useCallback, useMemo, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
 import type { ViewerProps } from './types'
-
-const ImageDisplay = memo<
-  {
-    wrapperWidth: number
-    wrapperHeight: number
-    rotation: number
-    imgScale: number
-    imageRef: Ref<HTMLImageElement>
-    handleLoad?: (e: SyntheticEvent<HTMLImageElement>) => void
-    handleError?: ComponentProps<'img'>['onError']
-  } & Pick<ComponentProps<'img'>, 'src' | 'alt'>
->(
-  ({
-    wrapperWidth,
-    wrapperHeight,
-    rotation,
-    imgScale,
-    imageRef,
-    src,
-    alt,
-    handleLoad,
-    handleError,
-  }) => (
-    <div
-      style={{
-        width: wrapperWidth,
-        height: wrapperHeight,
-      }}
-      className="shr-relative shr-h-full shr-w-full"
-    >
-      {/* imgのload完了時にupdateViewConfigを呼び出さないと適切なサイズが取得できないため */}
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <img
-        src={src}
-        alt={alt}
-        onLoad={handleLoad}
-        onError={handleError}
-        className="shr-absolute shr-left-[50%] shr-top-[50%] shr-origin-top-left -shr-translate-x-1/2 -shr-translate-y-1/2"
-        ref={imageRef}
-        style={{
-          rotate: `${rotation}deg`,
-          scale: `${imgScale}`,
-        }}
-      />
-    </div>
-  ),
-)
 
 export const ImageViewer: FC<ViewerProps> = memo(
   ({ scale, rotation, file, width, handleLoad, handleLoadError }) => {
@@ -125,14 +69,28 @@ export const ImageViewer: FC<ViewerProps> = memo(
     )
 
     return (
-      <ImageDisplay
-        {...viewConfig}
-        imageRef={callbackRef}
-        src={file.url}
-        alt={file.alt}
-        handleLoad={functions.handleLoad}
-        handleError={handleLoadError}
-      />
+      <div
+        style={{
+          width: viewConfig.wrapperWidth,
+          height: viewConfig.wrapperHeight,
+        }}
+        className="shr-relative shr-h-full shr-w-full"
+      >
+        {/* imgのload完了時にupdateViewConfigを呼び出さないと適切なサイズが取得できないため */}
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+        <img
+          ref={callbackRef}
+          src={file.url}
+          alt={file.alt}
+          onLoad={functions.handleLoad}
+          onError={handleLoadError}
+          className="shr-absolute shr-left-[50%] shr-top-[50%] shr-origin-top-left -shr-translate-x-1/2 -shr-translate-y-1/2"
+          style={{
+            rotate: `${viewConfig.rotation}deg`,
+            scale: `${viewConfig.imgScale}`,
+          }}
+        />
+      </div>
     )
   },
 )

--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -23,7 +23,8 @@ const ImageDisplay = memo<
     imgScale: number
     imageRef: Ref<HTMLImageElement>
     handleLoad?: (e: SyntheticEvent<HTMLImageElement>) => void
-  } & Pick<ComponentProps<'img'>, 'src' | 'alt' | 'onError'>
+    handleError?: ComponentProps<'img'>['onError']
+  } & Pick<ComponentProps<'img'>, 'src' | 'alt'>
 >(
   ({
     wrapperWidth,
@@ -34,7 +35,7 @@ const ImageDisplay = memo<
     src,
     alt,
     handleLoad,
-    onError,
+    handleError,
   }) => (
     <div
       style={{
@@ -49,7 +50,7 @@ const ImageDisplay = memo<
         src={src}
         alt={alt}
         onLoad={handleLoad}
-        onError={onError}
+        onError={handleError}
         className="shr-absolute shr-left-[50%] shr-top-[50%] shr-origin-top-left -shr-translate-x-1/2 -shr-translate-y-1/2"
         ref={imageRef}
         style={{
@@ -130,7 +131,7 @@ export const ImageViewer: FC<ViewerProps> = memo(
         src={file.url}
         alt={file.alt}
         handleLoad={functions.handleLoad}
-        onError={handleLoadError}
+        handleError={handleLoadError}
       />
     )
   },

--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -3,9 +3,9 @@
 import {
   type ComponentProps,
   type FC,
-  type RefObject,
+  type Ref,
   memo,
-  useEffect,
+  useCallback,
   useMemo,
   useRef,
   useState,
@@ -21,7 +21,7 @@ const ImageDisplay = memo<
     wrapperHeight: number
     rotation: number
     imgScale: number
-    imageRef: RefObject<HTMLImageElement>
+    imageRef: Ref<HTMLImageElement>
     handleLoad?: () => void
   } & Pick<ComponentProps<'img'>, 'src' | 'alt' | 'onError'>
 >(
@@ -63,13 +63,12 @@ const ImageDisplay = memo<
 
 export const ImageViewer: FC<ViewerProps> = memo(
   ({ scale, rotation, file, width, handleLoad, handleLoadError }) => {
-    const imageRef = useRef<HTMLImageElement>(null)
-    const [viewConfig, setViewConfig] = useState({
+    const [viewConfig, setViewConfig] = useState(() => ({
       wrapperWidth: 0,
       wrapperHeight: 0,
       imgScale: 1,
       rotation: 0,
-    })
+    }))
 
     const latest = useLatest({
       handleLoad,
@@ -78,6 +77,7 @@ export const ImageViewer: FC<ViewerProps> = memo(
       width,
     })
 
+    const imageRef = useRef<HTMLImageElement | null>(null)
     // CSSのみではscale, transformの値を親に適用してスクロールするようにできないため、計算している
     const functions = useMemo(() => {
       const updateViewConfig = () => {
@@ -115,18 +115,24 @@ export const ImageViewer: FC<ViewerProps> = memo(
       }
     }, [latest])
 
-    useEffect(() => {
-      functions.updateViewConfig()
-    }, [scale, rotation, width, functions])
+    const callbackRef = useCallback(
+      (node: HTMLImageElement | null) => {
+        imageRef.current = node
+        functions.updateViewConfig()
+      },
+      // scale, rotation, widthの変化時にもcallbackRefを再実行し、updateViewConfigを再計算させるために必要
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [scale, rotation, width, functions],
+    )
 
     return (
       <ImageDisplay
         {...viewConfig}
+        imageRef={callbackRef}
         src={file.url}
         alt={file.alt}
         handleLoad={functions.handleLoad}
         onError={handleLoadError}
-        imageRef={imageRef}
       />
     )
   },

--- a/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/ImageViewer.tsx
@@ -4,10 +4,10 @@ import {
   type ComponentProps,
   type FC,
   type Ref,
+  type SyntheticEvent,
   memo,
   useCallback,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 
@@ -22,7 +22,7 @@ const ImageDisplay = memo<
     rotation: number
     imgScale: number
     imageRef: Ref<HTMLImageElement>
-    handleLoad?: () => void
+    handleLoad?: (e: SyntheticEvent<HTMLImageElement>) => void
   } & Pick<ComponentProps<'img'>, 'src' | 'alt' | 'onError'>
 >(
   ({
@@ -77,13 +77,10 @@ export const ImageViewer: FC<ViewerProps> = memo(
       width,
     })
 
-    const imageRef = useRef<HTMLImageElement | null>(null)
     // CSSのみではscale, transformの値を親に適用してスクロールするようにできないため、計算している
     const functions = useMemo(() => {
-      const updateViewConfig = () => {
-        const img = imageRef.current
-
-        if (!img?.complete) {
+      const updateViewConfig = (img: HTMLImageElement) => {
+        if (!img.complete) {
           return
         }
 
@@ -108,8 +105,8 @@ export const ImageViewer: FC<ViewerProps> = memo(
 
       return {
         updateViewConfig,
-        handleLoad: () => {
-          updateViewConfig()
+        handleLoad: (e: SyntheticEvent<HTMLImageElement>) => {
+          updateViewConfig(e.currentTarget)
           latest.handleLoad?.()
         },
       }
@@ -117,8 +114,9 @@ export const ImageViewer: FC<ViewerProps> = memo(
 
     const callbackRef = useCallback(
       (node: HTMLImageElement | null) => {
-        imageRef.current = node
-        functions.updateViewConfig()
+        if (node) {
+          functions.updateViewConfig(node)
+        }
       },
       // scale, rotation, widthの変化時にもcallbackRefを再実行し、updateViewConfigを再計算させるために必要
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## 関連URL

なし

## 概要

`feat/request-animation-frame` ブランチでの `PDFViewer` の `callbackRef` 化に合わせて、`ImageViewer` も `useEffect` ベースの再計算処理を `callbackRef` ベースに変更する。

## 変更内容

- `ImageViewer` の `updateViewConfig` 呼び出しを `useEffect` から `callbackRef` に変更
- `updateViewConfig` を引数で `img` 要素を受け取る形に変更し、`imageRef`（`useRef`）を削除
- `ImageDisplay` の `onError` prop を `handleError` にリネーム（内部コンポーネントが受け取るイベントハンドラの命名規則に統一）

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで `ImageViewer` の表示・拡大縮小・回転・エラー表示が問題ないことを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * 画像ビューアの表示処理を整理し、内部構成を簡素化しました。
  * 画像の読み込み時の表示更新およびエラー処理の動作は従来どおり維持されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->