### PR TITLE
refactor(Scroller): callbackRefをuseMergeRefsでinnerRef・外部refとマージ

### DIFF
--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -5,8 +5,8 @@ import {
   type ComponentType,
   type PropsWithChildren,
   forwardRef,
+  useCallback,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
@@ -80,7 +80,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
     },
     ref,
   ) => {
-    const innerRef = useRef<HTMLDivElement | null>(null)
     const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
 
     const actualClassName = useMemo(
@@ -93,52 +92,48 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
       [direction, styleType, className],
     )
 
-    const functions = useMemo(() => {
-      const autoTabIndex = () => {
-        const refCurrent = innerRef.current
+    const callbackRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        if (!node) return
 
-        if (!refCurrent) return
+        const autoTabIndex = () => {
+          let nextTabIndex: 0 | undefined = undefined
 
-        let nextTabIndex: 0 | undefined = undefined
+          switch (direction) {
+            case 'vertical':
+              nextTabIndex = node.scrollHeight > node.clientHeight ? 0 : undefined
+              break
+            case 'horizontal':
+              nextTabIndex = node.scrollWidth > node.clientWidth ? 0 : undefined
+              break
+            case 'both':
+              nextTabIndex =
+                node.scrollHeight > node.clientHeight || node.scrollWidth > node.clientWidth
+                  ? 0
+                  : undefined
+              break
+          }
 
-        switch (direction) {
-          case 'vertical':
-            nextTabIndex = refCurrent.scrollHeight > refCurrent.clientHeight ? 0 : undefined
-            break
-          case 'horizontal':
-            nextTabIndex = refCurrent.scrollWidth > refCurrent.clientWidth ? 0 : undefined
-            break
-          case 'both':
-            nextTabIndex =
-              refCurrent.scrollHeight > refCurrent.clientHeight ||
-              refCurrent.scrollWidth > refCurrent.clientWidth
-                ? 0
-                : undefined
-            break
+          setTabIndex(nextTabIndex)
         }
 
-        setTabIndex(nextTabIndex)
-      }
+        autoTabIndex()
 
-      let resizeObserver: ResizeObserver
+        const resizeObserver = new ResizeObserver(autoTabIndex)
+        resizeObserver.observe(node)
 
-      return {
-        callbackRef: (node: HTMLDivElement | null) => {
-          autoTabIndex()
-
-          if (node) {
-            resizeObserver ??= new ResizeObserver(autoTabIndex)
-            resizeObserver.observe(node)
-          } else {
-            resizeObserver?.disconnect()
-          }
-        },
-      }
-    }, [direction])
+        // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+        // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
+        return () => {
+          resizeObserver.disconnect()
+        }
+      },
+      [direction],
+    )
 
     // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
     // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
-    const mergedRef = useMergeRefs(innerRef, functions.callbackRef, ref)
+    const mergedRef = useMergeRefs(callbackRef, ref)
 
     const Wrapper = useSectionWrapper(Component)
     const body = (
@@ -147,10 +142,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
       </Component>
     )
 
-    if (Wrapper) {
-      return <Wrapper>{body}</Wrapper>
-    }
-
-    return body
+    return Wrapper ? <Wrapper>{body}</Wrapper> : body
   },
 )

--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -5,13 +5,13 @@ import {
   type ComponentType,
   type PropsWithChildren,
   forwardRef,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
+import { useMergeRefs } from '../../hooks/useMergeRefs'
 import { useSectionWrapper } from '../SectioningContent'
 
 type BaseProps = PropsWithChildren<
@@ -81,12 +81,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
     ref,
   ) => {
     const innerRef = useRef<HTMLDivElement | null>(null)
-
-    // as が切り替わると DOM 要素が変わるため、Component を依存配列に含める
-    // TODO: useMergeRefsが実装されたら修正する
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    useImperativeHandle(ref, () => innerRef.current!, [Component])
-
     const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
 
     const actualClassName = useMemo(
@@ -130,9 +124,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
 
       return {
         callbackRef: (node: HTMLDivElement | null) => {
-          // TODO: useMergeRefsが実装されたら修正する
-          innerRef.current = node
-
           autoTabIndex()
 
           if (node) {
@@ -145,14 +136,13 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
       }
     }, [direction])
 
+    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
+    const mergedRef = useMergeRefs(innerRef, functions.callbackRef, ref)
+
     const Wrapper = useSectionWrapper(Component)
     const body = (
-      <Component
-        {...rest}
-        ref={functions.callbackRef}
-        tabIndex={tabIndex}
-        className={actualClassName}
-      >
+      <Component {...rest} ref={mergedRef} tabIndex={tabIndex} className={actualClassName}>
         {children}
       </Component>
     )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useMergeRefs` フックの導入に合わせて、`Scroller` の内部の `callbackRef`・`innerRef`・外部から渡される `ref` を個別に管理していた実装を `useMergeRefs` で統合し、簡潔にする。

## 変更内容

- `innerRef`（`useRef`）を廃止し、`callbackRef` の引数で受け取った `node` を直接利用する形に変更
- ResizeObserverの生成・解除処理を、callbackRefの返り値のcleanup関数で行う形に変更（`useMergeRefs`がReact 18/19どちらでもcleanup関数に対応しているため）
- 内部callbackRefと外部から渡される`ref`を`useMergeRefs`で1つのrefにマージ

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで `Scroller` のスクロール・tabIndexの自動付与・`as` propによる要素切り替えが問題ないことを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * スクロール可能かどうかの判定を改善しました。
  * スクロール領域のサイズ変更時にも、キーボード操作に必要なフォーカス設定が適切に更新されるようになりました。
  * コンポーネントの終了後に不要な監視が残らないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->