### PR TITLE
refactor(SegmentedControl): callbackRefのref管理をuseCallbackRefCleanupForReact18に置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -7,12 +7,12 @@ import {
   type ReactNode,
   memo,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
+import { useMergeRefs } from '../../hooks/useMergeRefs'
 import { Button } from '../Button'
 
 export type Option = {
@@ -83,7 +83,6 @@ export const SegmentedControl: FC<Props> = ({
   ...rest
 }) => {
   const [isFocused, setIsFocused] = useState(false)
-  const innerRef = useRef<HTMLDivElement | null>(null)
 
   const classNames = useMemo(() => {
     const { container, buttonGroup, button } = classNameGenerator()
@@ -99,66 +98,67 @@ export const SegmentedControl: FC<Props> = ({
 
   const hasOnClickOption = !!onClickOption
 
-  const functions = useMemo(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!latest.isFocused || !innerRef.current || !document.activeElement) {
-        return
-      }
-
-      let radios: NodeListOf<Element> | Element[] = innerRef.current.querySelectorAll(
-        '[role="radio"]:not(:disabled)',
-      )
-
-      if (radios.length < 2) {
-        return
-      }
-
-      radios = Array.from(radios)
-
-      const focusedIndex = radios.indexOf(document.activeElement)
-
-      if (focusedIndex === -1) {
-        return
-      }
-
-      switch (e.key) {
-        case 'Down':
-        case 'ArrowDown':
-        case 'Right':
-        case 'ArrowRight': {
-          const nextIndex = focusedIndex + 1
-          const nextRadio = radios[nextIndex % radios.length]
-
-          if (nextRadio instanceof HTMLButtonElement) {
-            nextRadio.focus()
-          }
-
-          break
-        }
-        case 'Up':
-        case 'ArrowUp':
-        case 'Left':
-        case 'ArrowLeft': {
-          const nextIndex = focusedIndex - 1
-          const nextRadio = radios[(nextIndex + radios.length) % radios.length]
-
-          if (nextRadio instanceof HTMLButtonElement) {
-            nextRadio.focus()
-          }
-
-          break
-        }
-      }
-    }
-
-    return {
-      // TODO: useMergeRefsが実装された修正する
+  const functions = useMemo(
+    () => ({
       callbackRef: (node: HTMLDivElement | null) => {
-        innerRef.current = node
+        if (!node) {
+          return
+        }
 
-        if (node) {
-          document.addEventListener('keydown', handleKeyDown)
-        } else {
+        const handleKeyDown = (e: KeyboardEvent) => {
+          if (!latest.isFocused || !document.activeElement) {
+            return
+          }
+
+          let radios: NodeListOf<Element> | Element[] = node.querySelectorAll(
+            '[role="radio"]:not(:disabled)',
+          )
+
+          if (radios.length < 2) {
+            return
+          }
+
+          radios = Array.from(radios)
+
+          const focusedIndex = radios.indexOf(document.activeElement)
+
+          if (focusedIndex === -1) {
+            return
+          }
+
+          switch (e.key) {
+            case 'Down':
+            case 'ArrowDown':
+            case 'Right':
+            case 'ArrowRight': {
+              const nextIndex = focusedIndex + 1
+              const nextRadio = radios[nextIndex % radios.length]
+
+              if (nextRadio instanceof HTMLButtonElement) {
+                nextRadio.focus()
+              }
+
+              break
+            }
+            case 'Up':
+            case 'ArrowUp':
+            case 'Left':
+            case 'ArrowLeft': {
+              const nextIndex = focusedIndex - 1
+              const nextRadio = radios[(nextIndex + radios.length) % radios.length]
+
+              if (nextRadio instanceof HTMLButtonElement) {
+                nextRadio.focus()
+              }
+
+              break
+            }
+          }
+        }
+
+        document.addEventListener('keydown', handleKeyDown)
+
+        return () => {
           document.removeEventListener('keydown', handleKeyDown)
         }
       },
@@ -169,15 +169,18 @@ export const SegmentedControl: FC<Props> = ({
         : undefined,
       handleDelegateFocus: () => setIsFocused(true),
       handleDelegateBlur: () => setIsFocused(false),
-    }
-  }, [hasOnClickOption, latest])
+    }),
+    [hasOnClickOption, latest],
+  )
+
+  const mergedRef = useMergeRefs(functions.callbackRef)
 
   const excludesSelected = !value || options.every((option) => option.value !== value)
 
   return (
     <div
       {...rest}
-      ref={functions.callbackRef}
+      ref={mergedRef}
       role="toolbar"
       onFocus={functions.handleDelegateFocus}
       onBlur={functions.handleDelegateBlur}

--- a/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/SegmentedControl.tsx
@@ -11,8 +11,8 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useCallbackRefCleanupForReact18 } from '../../hooks/useCallbackRefCleanupForReact18'
 import { useLatest } from '../../hooks/useLatest'
-import { useMergeRefs } from '../../hooks/useMergeRefs'
 import { Button } from '../Button'
 
 export type Option = {
@@ -173,14 +173,14 @@ export const SegmentedControl: FC<Props> = ({
     [hasOnClickOption, latest],
   )
 
-  const mergedRef = useMergeRefs(functions.callbackRef)
+  const callbackRef = useCallbackRefCleanupForReact18(functions.callbackRef)
 
   const excludesSelected = !value || options.every((option) => option.value !== value)
 
   return (
     <div
       {...rest}
-      ref={mergedRef}
+      ref={callbackRef}
       role="toolbar"
       onFocus={functions.handleDelegateFocus}
       onBlur={functions.handleDelegateBlur}

--- a/packages/smarthr-ui/src/hooks/useCallbackRefCleanupForReact18.test.ts
+++ b/packages/smarthr-ui/src/hooks/useCallbackRefCleanupForReact18.test.ts
@@ -1,0 +1,94 @@
+import { renderHook } from '@testing-library/react'
+
+import { useCallbackRefCleanupForReact18 } from './useCallbackRefCleanupForReact18'
+
+describe('useCallbackRefCleanupForReact18', () => {
+  test('nodeがtruthyのときcallbackがnode付きで呼ばれる', () => {
+    const callback = vi.fn()
+
+    const { result } = renderHook(() => useCallbackRefCleanupForReact18(callback))
+
+    result.current('node')
+
+    expect(callback).toHaveBeenCalledWith('node')
+  })
+
+  test('アタッチ前にnodeがnullで呼ばれるとcallbackがnull付きで呼ばれる', () => {
+    const callback = vi.fn()
+
+    const { result } = renderHook(() => useCallbackRefCleanupForReact18(callback))
+
+    result.current(null)
+
+    expect(callback).toHaveBeenCalledWith(null)
+  })
+
+  test('callbackが返したcleanup関数はnodeがnullで呼ばれたときに実行される', () => {
+    const cleanup = vi.fn()
+    const callback = vi.fn(() => cleanup)
+
+    const { result } = renderHook(() => useCallbackRefCleanupForReact18(callback))
+
+    result.current('node')
+    expect(cleanup).not.toHaveBeenCalled()
+
+    result.current(null)
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('callbackがcleanup関数を返さない場合、nodeがnullで呼ばれるとcallback自体がnull付きで呼ばれる', () => {
+    const callback = vi.fn()
+
+    const { result } = renderHook(() => useCallbackRefCleanupForReact18(callback))
+
+    result.current('node')
+    result.current(null)
+
+    expect(callback).toHaveBeenNthCalledWith(2, null)
+  })
+
+  test('再アタッチ時は新しいcleanup関数に差し替わる', () => {
+    const firstCleanup = vi.fn()
+    const secondCleanup = vi.fn()
+    const callback = vi.fn().mockReturnValueOnce(firstCleanup).mockReturnValueOnce(secondCleanup)
+
+    const { result } = renderHook(() => useCallbackRefCleanupForReact18(callback))
+
+    result.current('first')
+    result.current(null)
+    expect(firstCleanup).toHaveBeenCalledTimes(1)
+
+    result.current('second')
+    result.current(null)
+    expect(secondCleanup).toHaveBeenCalledTimes(1)
+    expect(firstCleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('callbackの参照が変わらなければ返り値の関数は同一の参照を保つ', () => {
+    const callback = vi.fn()
+
+    const { result, rerender } = renderHook(() => useCallbackRefCleanupForReact18(callback))
+
+    const first = result.current
+    rerender()
+    const second = result.current
+
+    expect(first).toBe(second)
+  })
+
+  test('callbackの参照が変わると返り値の関数の参照も変わる', () => {
+    const firstCallback = vi.fn()
+    const secondCallback = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ callback }) => useCallbackRefCleanupForReact18(callback),
+      { initialProps: { callback: firstCallback } },
+    )
+
+    const first = result.current
+    rerender({ callback: secondCallback })
+    const second = result.current
+
+    expect(first).not.toBe(second)
+  })
+})

--- a/packages/smarthr-ui/src/hooks/useCallbackRefCleanupForReact18.ts
+++ b/packages/smarthr-ui/src/hooks/useCallbackRefCleanupForReact18.ts
@@ -1,0 +1,63 @@
+import { useCallback, useRef } from 'react'
+
+/**
+ * callback ref が返す cleanup 関数を、React 18 でも正しく実行されるようにするフック。
+ *
+ * React 19 では callback ref が返した関数を React がデタッチ時に自動で呼び出すが、
+ * React 18 にはその仕組みがなく、返り値は無視されてしまう。
+ * このフックは node のアタッチ/デタッチを自前で管理し、返り値の cleanup 関数を
+ * デタッチ時（node が null で呼ばれたとき）に確実に実行することで、
+ * React 18/19 どちらでも同じ挙動になるようにする。
+ *
+ * cleanup 関数を返さなかった場合は、React 19 と同様に callback 自体を
+ * node = null で呼び直す（useMergeRefs の cleanupRef と同じフォールバック）。
+ * そのため callback 側で node が null の場合の処理を書いても問題ない。
+ *
+ * callback は呼び出し側で useCallback によりメモ化して渡す。
+ * callback の参照が変わると返り値の関数の参照も変わる。
+ *
+ * React 18 のサポートが不要になったら、このフックは削除して
+ * callback ref をそのまま渡す形に戻せる。
+ *
+ * このフックが返す関数はどのパスでも値を返さない（常に undefined）ため、
+ * React からは「cleanup 関数を返さない callback ref」として扱われる。
+ * そのため React 19 でも自動 cleanup 呼び出しの対象にはならず、
+ * デタッチ時は常に React から node = null で呼び直される。
+ * これにより React 18/19 のどちらでも同じ呼び出され方になり、
+ * cleanup の実行はフック内部の分岐だけで完結する。
+ *
+ * @example
+ * const callbackRef = useCallbackRefCleanupForReact18(
+ *   useCallback((node: HTMLDivElement | null) => {
+ *     if (!node) return
+ *
+ *     const observer = new MutationObserver(...)
+ *     observer.observe(node, {...})
+ *
+ *     return () => observer.disconnect()
+ *   }, []),
+ * )
+ */
+export const useCallbackRefCleanupForReact18 = <T>(
+  callback: (node: T | null) => (() => void) | void,
+) => {
+  const cleanupRef = useRef<(() => void) | void>(undefined)
+
+  return useCallback(
+    (node: T | null) => {
+      if (node) {
+        cleanupRef.current = callback(node)
+        return
+      }
+
+      if (cleanupRef.current) {
+        cleanupRef.current()
+      } else {
+        callback(null)
+      }
+
+      cleanupRef.current = undefined
+    },
+    [callback],
+  )
+}

--- a/packages/smarthr-ui/src/hooks/useCallbackRefCleanupForReact18.ts
+++ b/packages/smarthr-ui/src/hooks/useCallbackRefCleanupForReact18.ts
@@ -38,7 +38,7 @@ import { useCallback, useRef } from 'react'
  *   }, []),
  * )
  */
-export const useCallbackRefCleanupForReact18 = <T>(
+export const useCallbackRefCleanupForReact18 = <T extends Element>(
   callback: (node: T | null) => (() => void) | void,
 ) => {
   const cleanupRef = useRef<(() => void) | void>(undefined)


### PR DESCRIPTION
## 関連URL

なし

## 概要

SegmentedControl の callbackRef 内で行っていた keydown イベントリスナーの登録・解除処理を、React 18/19 で同じ挙動になるよう管理するために `useCallbackRefCleanupForReact18` を導入する。

## 変更内容

- `innerRef`（useRef）を廃止し、callbackRef が返す cleanup 関数を React 18 でも確実に実行する `useCallbackRefCleanupForReact18` フックに置き換え
- 合成対象の ref が1つのみで ref のマージが不要なため、`useMergeRefs` より軽量な `useCallbackRefCleanupForReact18` を使用

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で SegmentedControl の矢印キーでのフォーカス移動が問題なく動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * セグメントコントロールのキーボード操作に関する内部処理を改善しました。
  * React 18環境でも、要素の接続・切断時に必要な後処理が正しく実行されるようになりました。
* **テスト**
  * 要素の再接続や後処理の実行など、関連する動作のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->