### PR TITLE
refactor(FloatArea): tv()の構成をslotsからbase+variantsに簡潔化

### DIFF
--- a/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
@@ -69,10 +69,9 @@ export const FloatArea: FC<Props> = ({
     () => classNameGenerator({ bottom: bottom ?? 1.5, className }),
     [bottom, className],
   )
-  const actualStyle = useMemo(() => ({ ...style, zIndex }), [style, zIndex])
 
   return (
-    <Panel {...rest} layer={3} padding={1} className={actualClassName} style={actualStyle}>
+    <Panel {...rest} layer={3} padding={1} className={actualClassName} style={{ ...style, zIndex }}>
       <Stack gap={0.5}>
         <Cluster>
           {tertiaryButton}

--- a/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
@@ -12,8 +12,6 @@ import type { Gap } from '../../types'
 const classNameGenerator = tv({
   slots: {
     wrapper: 'smarthr-ui-FloatArea shr-sticky shr-z-fixed-menu -shr-mx-0.5',
-    mainButtonCluster: 'shr-ms-auto',
-    responseMessageWrapper: 'shr-ms-auto',
   },
   variants: {
     bottom: {
@@ -118,12 +116,10 @@ export const FloatArea: FC<Props> = ({
   ...rest
 }) => {
   const classNames = useMemo(() => {
-    const { wrapper, mainButtonCluster, responseMessageWrapper } = classNameGenerator()
+    const { wrapper } = classNameGenerator()
 
     return {
       wrapper: wrapper({ bottom, className }),
-      mainButtonCluster: mainButtonCluster(),
-      responseMessageWrapper: responseMessageWrapper(),
     }
   }, [bottom, className])
   const actualStyle = useMemo(() => ({ ...style, zIndex }), [style, zIndex])
@@ -133,13 +129,13 @@ export const FloatArea: FC<Props> = ({
       <Stack gap={0.5}>
         <Cluster>
           {tertiaryButton}
-          <Cluster gap={1} className={classNames.mainButtonCluster}>
+          <Cluster gap={1} className="shr-ms-auto">
             {secondaryButton}
             {primaryButton}
           </Cluster>
         </Cluster>
         {responseStatus && (
-          <p className={classNames.responseMessageWrapper}>
+          <p className="shr-ms-auto">
             <ResponseMessage status={responseStatus.status}>{responseStatus.text}</ResponseMessage>
           </p>
         )}

--- a/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
@@ -36,9 +36,6 @@ const classNameGenerator = tv({
       X3L: 'shr-bottom-4',
     } as { [key in CharRelativeSize | AbstractSize]: string },
   },
-  defaultVariants: {
-    bottom: 1.5,
-  },
 })
 
 type BaseProps = {
@@ -69,7 +66,7 @@ export const FloatArea: FC<Props> = ({
   ...rest
 }) => {
   const actualClassName = useMemo(
-    () => classNameGenerator({ bottom, className }),
+    () => classNameGenerator({ bottom: bottom ?? 1.5, className }),
     [bottom, className],
   )
   const actualStyle = useMemo(() => ({ ...style, zIndex }), [style, zIndex])

--- a/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
@@ -7,81 +7,34 @@ import { ResponseMessage } from '../ResponseMessage'
 
 import type { ResponseStatusWithoutProcessing } from '../../hooks/useResponseStatus'
 import type { AbstractSize, CharRelativeSize } from '../../themes'
-import type { Gap } from '../../types'
 
 const classNameGenerator = tv({
-  slots: {
-    wrapper: 'smarthr-ui-FloatArea shr-sticky shr-z-fixed-menu -shr-mx-0.5',
-  },
+  base: 'smarthr-ui-FloatArea shr-sticky shr-z-fixed-menu -shr-mx-0.5',
   variants: {
     bottom: {
-      0: {
-        wrapper: 'shr-bottom-0',
-      },
-      0.25: {
-        wrapper: 'shr-bottom-0.25',
-      },
-      0.5: {
-        wrapper: 'shr-bottom-0.5',
-      },
-      0.75: {
-        wrapper: 'shr-bottom-0.75',
-      },
-      1: {
-        wrapper: 'shr-bottom-1',
-      },
-      1.25: {
-        wrapper: 'shr-bottom-1.25',
-      },
-      1.5: {
-        wrapper: 'shr-bottom-1.5',
-      },
-      2: {
-        wrapper: 'shr-bottom-2',
-      },
-      2.5: {
-        wrapper: 'shr-bottom-2.5',
-      },
-      3: {
-        wrapper: 'shr-bottom-3',
-      },
-      3.5: {
-        wrapper: 'shr-bottom-3.5',
-      },
-      4: {
-        wrapper: 'shr-bottom-4',
-      },
-      8: {
-        wrapper: 'shr-bottom-8',
-      },
-      X3S: {
-        wrapper: 'shr-bottom-0.25',
-      },
-      XXS: {
-        wrapper: 'shr-bottom-0.5',
-      },
-      XS: {
-        wrapper: 'shr-bottom-1',
-      },
-      S: {
-        wrapper: 'shr-bottom-1.5',
-      },
-      M: {
-        wrapper: 'shr-bottom-2',
-      },
-      L: {
-        wrapper: 'shr-bottom-2.5',
-      },
-      XL: {
-        wrapper: 'shr-bottom-3',
-      },
-      XXL: {
-        wrapper: 'shr-bottom-3.5',
-      },
-      X3L: {
-        wrapper: 'shr-bottom-4',
-      },
-    } as { [key in Gap]: { wrapper: string } },
+      0: 'shr-bottom-0',
+      0.25: 'shr-bottom-0.25',
+      0.5: 'shr-bottom-0.5',
+      0.75: 'shr-bottom-0.75',
+      1: 'shr-bottom-1',
+      1.25: 'shr-bottom-1.25',
+      1.5: 'shr-bottom-1.5',
+      2: 'shr-bottom-2',
+      2.5: 'shr-bottom-2.5',
+      3: 'shr-bottom-3',
+      3.5: 'shr-bottom-3.5',
+      4: 'shr-bottom-4',
+      8: 'shr-bottom-8',
+      X3S: 'shr-bottom-0.25',
+      XXS: 'shr-bottom-0.5',
+      XS: 'shr-bottom-1',
+      S: 'shr-bottom-1.5',
+      M: 'shr-bottom-2',
+      L: 'shr-bottom-2.5',
+      XL: 'shr-bottom-3',
+      XXL: 'shr-bottom-3.5',
+      X3L: 'shr-bottom-4',
+    } as { [key in CharRelativeSize | AbstractSize]: string },
   },
   defaultVariants: {
     bottom: 1.5,
@@ -115,17 +68,14 @@ export const FloatArea: FC<Props> = ({
   className,
   ...rest
 }) => {
-  const classNames = useMemo(() => {
-    const { wrapper } = classNameGenerator()
-
-    return {
-      wrapper: wrapper({ bottom, className }),
-    }
-  }, [bottom, className])
+  const actualClassName = useMemo(
+    () => classNameGenerator({ bottom, className }),
+    [bottom, className],
+  )
   const actualStyle = useMemo(() => ({ ...style, zIndex }), [style, zIndex])
 
   return (
-    <Panel {...rest} layer={3} padding={1} className={classNames.wrapper} style={actualStyle}>
+    <Panel {...rest} layer={3} padding={1} className={actualClassName} style={actualStyle}>
       <Stack gap={0.5}>
         <Cluster>
           {tertiaryButton}

--- a/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/FloatArea.tsx
@@ -118,10 +118,10 @@ export const FloatArea: FC<Props> = ({
   ...rest
 }) => {
   const classNames = useMemo(() => {
-    const { wrapper, mainButtonCluster, responseMessageWrapper } = classNameGenerator({ bottom })
+    const { wrapper, mainButtonCluster, responseMessageWrapper } = classNameGenerator()
 
     return {
-      wrapper: wrapper({ className }),
+      wrapper: wrapper({ bottom, className }),
       mainButtonCluster: mainButtonCluster(),
       responseMessageWrapper: responseMessageWrapper(),
     }


### PR DESCRIPTION
## 関連URL

なし

## 概要

FloatArea の tv() 定義・classNames 生成処理を簡潔化する。

## 変更内容

- tv() の構成を slots 構文から base + variants に変更（wrapper 以外の className は動的な variant を持たないため）
- variant を持たない静的な className（mainButtonCluster・responseMessageWrapper 相当）を JSX へ直接指定するように変更
- bottom の variant 適用箇所を wrapper 呼び出し時に統一
- defaultVariants を廃止し、呼び出し側で bottom のデフォルト値（1.5）を指定
- classNames・style の useMemo をシンプル化（Panel は children に ReactNode を受け取るため memo 化してもメリットがなく、style の memo 化は不要と判断）

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybook で FloatArea の表示・bottom の各バリエーションが問題なく動作することを確認