### PR TITLE
refactor(DropZone): refのDOM中継処理をuseMergeRefsとDOMクエリに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -4,17 +4,16 @@ import {
   type ChangeEvent,
   type ComponentPropsWithRef,
   type DragEvent,
+  type MouseEvent,
   type PropsWithChildren,
   forwardRef,
   memo,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
-import { useMergeRefs } from '../../hooks/useMergeRefs'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { FaFolderOpenIcon } from '../Icon'
@@ -77,7 +76,6 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
     },
     ref,
   ) => {
-    const fileRef = useRef<HTMLInputElement>(null)
     const [filesDraggedOver, setFilesDraggedOver] = useState(false)
 
     const classNames = useMemo(() => {
@@ -90,15 +88,19 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
 
     const latest = useLatest({ onSelectFiles })
 
-    const functions = useMemo(
-      () => ({
+    const functions = useMemo(() => {
+      const inputFileSelector = 'input[type="file"][data-smarthr-ui-input="true"]'
+
+      return {
         handleDrop: (e: DragEvent<HTMLElement>) => {
           overrideEventDefault(e)
           setFilesDraggedOver(false)
 
           if (e.dataTransfer.types.includes('Files')) {
-            if (fileRef.current) {
-              fileRef.current.files = e.dataTransfer.files
+            const input = e.currentTarget.querySelector<HTMLInputElement>(inputFileSelector)
+
+            if (input) {
+              input.files = e.dataTransfer.files
             }
             latest.onSelectFiles(e, e.dataTransfer.files)
           }
@@ -113,14 +115,14 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
         handleChange: (e: ChangeEvent<HTMLInputElement>) => {
           latest.onSelectFiles(e, e.target.files)
         },
-        handleClickButton: () => {
-          fileRef.current!.click()
+        handleClickButton: (e: MouseEvent<HTMLButtonElement>) => {
+          e.currentTarget
+            .closest('.smarthr-ui-DropZone')
+            ?.querySelector<HTMLInputElement>(inputFileSelector)
+            ?.click()
         },
-      }),
-      [latest],
-    )
-
-    const mergedRef = useMergeRefs(fileRef, ref)
+      }
+    }, [latest])
 
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -144,7 +146,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
           {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
           <input
             {...rest}
-            ref={mergedRef}
+            ref={ref}
             type="file"
             multiple={multiple}
             disabled={disabled}
@@ -163,7 +165,7 @@ const SelectButton = memo<{
   label?: string
   disabled?: boolean
   error?: boolean
-  handleClick: () => void
+  handleClick: (e: MouseEvent<HTMLButtonElement>) => void
   className: string
 }>(({ label, disabled, error, handleClick, className }) => (
   <Button

--- a/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/DropZone.tsx
@@ -7,7 +7,6 @@ import {
   type PropsWithChildren,
   forwardRef,
   memo,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -15,6 +14,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
+import { useMergeRefs } from '../../hooks/useMergeRefs'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
 import { FaFolderOpenIcon } from '../Icon'
@@ -120,11 +120,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
       [latest],
     )
 
-    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-      ref,
-      () => fileRef.current,
-      [],
-    )
+    const mergedRef = useMergeRefs(fileRef, ref)
 
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -148,7 +144,7 @@ export const DropZone = forwardRef<HTMLInputElement, Props>(
           {/* eslint-disable-next-line smarthr/a11y-input-in-form-control */}
           <input
             {...rest}
-            ref={fileRef}
+            ref={mergedRef}
             type="file"
             multiple={multiple}
             disabled={disabled}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useImperativeHandle` によるDOMノードの中継や、内部で保持していた `fileRef` を、`useMergeRefs` およびDOMクエリベースの実装に置き換え、実装をシンプルにする。

## 変更内容

- `useImperativeHandle(ref, () => fileRef.current, [])` を `useMergeRefs(fileRef, ref)` に置き換え
- その後、`fileRef` 自体を削除。`handleDrop` は `e.currentTarget.querySelector('input[type="file"][data-smarthr-ui-input="true"]')` でinput要素を取得するように変更し、`handleClickButton` と同様のDOMクエリ方式に統一
- `fileRef` が不要になったことで `useMergeRefs` も不要になり、`<input>` には外部から渡された `ref` をそのまま設定
- `handleDrop` と `handleClickButton` で重複していたセレクタ文字列 `input[type="file"][data-smarthr-ui-input="true"]` を `inputFileSelector` としてまとめて共通化

## プロダクト側で対応が必要な事項

なし（内部実装のリファクタリングのみで、公開APIへの変更はなし）

## 確認方法

既存のテスト（`DropZone.test.tsx`）およびStorybookでドラッグ&ドロップ・ボタンクリックによるファイル選択が問題なく動作することを確認