### PR TITLE
fix(RemoteDialogTrigger): onOpen等のコールバックが状態更新前に発火する不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/FormDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/FormDialog.test.tsx
@@ -1,0 +1,97 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type FC, useState } from 'react'
+
+import { IntlProvider } from '../../../intl'
+import { Button } from '../../Button'
+import { Input } from '../../Input'
+
+import { FormDialog } from './FormDialog'
+import { RemoteDialogTrigger } from './RemoteDialogTrigger'
+
+// HINT: useRemoteTrigger内部でrequestAnimationFrame経由で遅延実行されるonOpen/onCloseを待つ。
+// actでラップしないと、フレーム内でのstate更新がテスト側に反映されるタイミングが保証されない
+const waitForAnimationFrame = () =>
+  act(() => new Promise((resolve) => requestAnimationFrame(resolve)))
+
+type Item = { id: string; title: string }
+
+const ITEMS: Item[] = [
+  { id: '1', title: 'テンプレートA' },
+  { id: '2', title: 'テンプレートB' },
+]
+
+// HINT: 「一覧の各行のボタンから共通のダイアログを開き、onOpenでクリックした行の値を初期値にする」
+// という利用方法の回帰を検知するための再現コード
+const TargetDialog: FC<{ selected?: Item }> = ({ selected }) => {
+  const [value, setValue] = useState('')
+
+  return (
+    <FormDialog
+      id="repro-dialog"
+      heading="複製"
+      actionButton={{ text: '複製', theme: 'primary' }}
+      onOpen={() => setValue(selected ? `（コピー）${selected.title}` : '')}
+      onClose={() => setValue('')}
+      onSubmit={async (_e, { close }) => close()}
+    >
+      <Input
+        name="title"
+        aria-label="テンプレート名"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </FormDialog>
+  )
+}
+
+const Page: FC = () => {
+  const [selected, setSelected] = useState<Item | undefined>(undefined)
+
+  return (
+    <IntlProvider locale="ja">
+      {ITEMS.map((item) => (
+        <RemoteDialogTrigger
+          key={item.id}
+          targetId="repro-dialog"
+          onClick={(open) => {
+            // クリックされた行を確定してから開く
+            setSelected(item)
+            open()
+          }}
+        >
+          <Button>{item.title}を複製</Button>
+        </RemoteDialogTrigger>
+      ))}
+      <TargetDialog selected={selected} />
+    </IntlProvider>
+  )
+}
+
+describe('FormDialog（RemoteDialogTrigger経由）のonOpenが参照するprops', () => {
+  it('初回に開いたときも、クリックした行の値で初期化される', async () => {
+    const user = userEvent.setup()
+    render(<Page />)
+
+    await user.click(screen.getByRole('button', { name: 'テンプレートAを複製' }))
+    await waitForAnimationFrame()
+
+    expect(screen.getByLabelText('テンプレート名')).toHaveValue('（コピー）テンプレートA')
+  })
+
+  it('閉じた直後に間を空けず別の行を開いても、前に開いた行の値が残らない', async () => {
+    const user = userEvent.setup()
+    render(<Page />)
+
+    await user.click(screen.getByRole('button', { name: 'テンプレートAを複製' }))
+    await waitForAnimationFrame()
+
+    // HINT: キャンセルで閉じた直後（フレームが経過する前）に別の行を開いても、
+    // onCloseではなく最新のonOpenが正しく反映されることを確認する
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+    await user.click(screen.getByRole('button', { name: 'テンプレートBを複製' }))
+    await waitForAnimationFrame()
+
+    expect(screen.getByLabelText('テンプレート名')).toHaveValue('（コピー）テンプレートB')
+  })
+})

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.test.ts
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { TRIGGER_EVENT, useRemoteTrigger } from './useRemoteTrigger'
+
+const waitForAnimationFrame = () => new Promise((resolve) => requestAnimationFrame(resolve))
+
+const dispatchTriggerEvent = (id: string) => {
+  document.dispatchEvent(new CustomEvent(TRIGGER_EVENT, { detail: { id } }))
+}
+
+describe('useRemoteTrigger', () => {
+  test('TRIGGER_EVENTを受け取るとisOpenは同期的にtrueになる', () => {
+    const { result } = renderHook(() => useRemoteTrigger({ id: 'test' }))
+
+    act(() => {
+      dispatchTriggerEvent('test')
+    })
+
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  test('onOpen・onToggleは同期的には呼ばれず、次のアニメーションフレームで呼ばれる', async () => {
+    const onOpen = vi.fn()
+    const onToggle = vi.fn()
+    renderHook(() => useRemoteTrigger({ id: 'test', onOpen, onToggle }))
+
+    act(() => {
+      dispatchTriggerEvent('test')
+    })
+
+    // HINT: 状態更新の反映を待つ利用者側の処理と競合しないよう、次のフレームまでは呼ばれない
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(onToggle).not.toHaveBeenCalled()
+
+    await waitForAnimationFrame()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledExactlyOnceWith(true)
+  })
+
+  test('同一フレーム内で連続してトグルすると、最後の状態のみ通知される', async () => {
+    const onOpen = vi.fn()
+    const onClose = vi.fn()
+    const onToggle = vi.fn()
+    const { result } = renderHook(() => useRemoteTrigger({ id: 'test', onOpen, onClose, onToggle }))
+
+    act(() => {
+      dispatchTriggerEvent('test')
+      result.current.handleClickClose()
+    })
+
+    await waitForAnimationFrame()
+
+    // HINT: open用に予約されたフレームはclose時にcancelされるため、onOpenは呼ばれない
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledExactlyOnceWith(false)
+  })
+
+  test('アンマウント後は保留中のコールバックが呼ばれない', async () => {
+    const onOpen = vi.fn()
+    const onToggle = vi.fn()
+    const { unmount } = renderHook(() => useRemoteTrigger({ id: 'test', onOpen, onToggle }))
+
+    act(() => {
+      dispatchTriggerEvent('test')
+    })
+    unmount()
+
+    await waitForAnimationFrame()
+
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  test('onClickCloseが指定されている場合、close処理を呼び出すまでisOpenはtrueのまま', () => {
+    const onClickClose = vi.fn()
+    const { result } = renderHook(() => useRemoteTrigger({ id: 'test', onClickClose }))
+
+    act(() => {
+      dispatchTriggerEvent('test')
+    })
+
+    act(() => {
+      result.current.handleClickClose()
+    })
+
+    expect(onClickClose).toHaveBeenCalledTimes(1)
+    expect(result.current.isOpen).toBe(true)
+
+    act(() => {
+      onClickClose.mock.calls[0][0]()
+    })
+
+    expect(result.current.isOpen).toBe(false)
+  })
+})

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.ts
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.ts
@@ -36,11 +36,14 @@ export function useRemoteTrigger({
   const functions = useMemo(() => {
     const updateIsOpen = (newIsOpen: boolean) => {
       setIsOpen(newIsOpen)
-      // HINT: 利用者側でstateの更新が行われている可能性があるため、遅延させる
-      latest.toggleFrame.request(() => {
-        latest.onToggle?.(newIsOpen)
-        latest[newIsOpen ? 'onOpen' : 'onClose']?.()
-      })
+
+      if (latest.onToggle || latest[newIsOpen ? 'onOpen' : 'onClose']) {
+        // HINT: 利用者側でstateの更新が行われている可能性があるため、遅延させる
+        latest.toggleFrame.request(() => {
+          latest.onToggle?.(newIsOpen)
+          latest[newIsOpen ? 'onOpen' : 'onClose']?.()
+        })
+      }
     }
 
     return {

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.ts
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useLatest } from '../../../hooks/useLatest'
 
 export const TRIGGER_EVENT = 'smarthr-ui:remote-dialog-trigger-dispatch'
@@ -14,34 +15,39 @@ type Props = {
 }
 
 export function useRemoteTrigger({
-  onClickClose: orgOnClickClose,
-  onPressEscape: orgOnPressEscape,
+  onClickClose,
+  onPressEscape,
   onToggle,
   onOpen,
   onClose,
   id,
 }: Props) {
   const [isOpen, setIsOpen] = useState(false)
+  const toggleFrame = useAnimationFrame()
   const latest = useLatest({
     onToggle,
     onOpen,
     onClose,
-    orgOnClickClose,
-    orgOnPressEscape,
+    onClickClose,
+    onPressEscape,
+    toggleFrame,
   })
 
   const functions = useMemo(() => {
     const updateIsOpen = (newIsOpen: boolean) => {
       setIsOpen(newIsOpen)
-      latest.onToggle?.(newIsOpen)
-      latest[newIsOpen ? 'onOpen' : 'onClose']?.()
+      // HINT: 利用者側でstateの更新が行われている可能性があるため、遅延させる
+      latest.toggleFrame.request(() => {
+        latest.onToggle?.(newIsOpen)
+        latest[newIsOpen ? 'onOpen' : 'onClose']?.()
+      })
     }
 
     return {
       updateIsOpen,
       handleClickClose: () => {
-        if (latest.orgOnClickClose) {
-          return latest.orgOnClickClose(() => {
+        if (latest.onClickClose) {
+          return latest.onClickClose(() => {
             updateIsOpen(false)
           })
         }
@@ -49,8 +55,8 @@ export function useRemoteTrigger({
         updateIsOpen(false)
       },
       handlePressEscape: () => {
-        if (latest.orgOnPressEscape) {
-          return latest.orgOnPressEscape(() => {
+        if (latest.onPressEscape) {
+          return latest.onPressEscape(() => {
             updateIsOpen(false)
           })
         }
@@ -70,9 +76,11 @@ export function useRemoteTrigger({
     document.addEventListener(TRIGGER_EVENT, handler)
 
     return () => {
+      // HINT: アンマウント後に予約済みのonToggle・onOpen・onCloseが呼ばれないようにする
+      toggleFrame.cancel()
       document.removeEventListener(TRIGGER_EVENT, handler)
     }
-  }, [id, functions])
+  }, [id, toggleFrame, functions])
 
   return {
     isOpen,


### PR DESCRIPTION
## 関連URL

- https://app.notion.com/p/smarthr-ui-RemoteDialogTrigger-onOpen-1-props-v99-0-0-3c337b6398eb80e6acf6f0ccf3ac787f

## 概要

`RemoteDialogTrigger`系（`ActionDialog`/`MessageDialog`/`FormDialog`/`StepFormDialog`）が内部で使用する`useRemoteTrigger`において、`onOpen`・`onClose`・`onToggle`が「1レンダー前のprops」を参照してしまう不具合があった。

- v98.1.0までは、これらのコールバックは`useEffect(() => {...}, [isOpen])`内、つまりコミット後に呼ばれていた
- v99.0.0で依存配列の安定化のためにこの`useEffect`を廃止し、DOMのネイティブイベントリスナー内で同期的に呼び出すよう変更した結果、利用者側が「行を選択するstate更新→ダイアログを開く」のように、自分自身のstate更新と同じタイミングでダイアログの開閉を行うケースにおいて、コミットが確定する前に古い`props`を`useLatest`経由で読んでしまう回帰が発生していた

## 変更内容

- `onToggle`・`onOpen`・`onClose`の呼び出しを`requestAnimationFrame`で次のフレームまで遅延させ、利用者側の状態更新のコミットを待ってから呼び出すようにした（`useLatest`が最新の`props`を返すようになる）
- コンポーネントのアンマウント時に、予約済みの呼び出しを`cancel`するようにした（アンマウント後にコールバックが呼ばれてしまう不具合も併せて解消）
- `onToggle`・`onOpen`・`onClose`がいずれも指定されていない場合は、`requestAnimationFrame`の予約自体を行わないようにした
- 内部パラメータ名`orgOnClickClose`・`orgOnPressEscape`を`onClickClose`・`onPressEscape`にリネーム（透過的に渡すpropsの命名規則に統一。動作に変化はない）
- テストを追加し、以下を保証した
  - `useRemoteTrigger.test.ts`: `onOpen`・`onToggle`が同期的には呼ばれず次のアニメーションフレームで呼ばれること、同一フレーム内で連続してトグルした場合は最後の状態のみ通知されること、アンマウント後は保留中のコールバックが呼ばれないこと
  - `FormDialog.test.tsx`: 「一覧の各行のボタンから共通のダイアログを開き、`onOpen`でクリックした行の値を初期値にする」という実利用パターンを再現し、閉じた直後に間を空けず別の行を開いても前の行の値が残らないことを保証する回帰テスト

## プロダクト側で対応が必要な事項

なし。`onToggle`・`onOpen`・`onClose`の発火タイミングが1フレーム分遅延するが、通常の利用方法において影響はない想定。

## 確認方法

- `npx vitest run src/components/Dialog/RemoteDialogTrigger` で関連テストが全てパスすることを確認済み
- `npx eslint` でエラーがないことを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ダイアログを別の行から開き直した際、最新の選択値が初期値として正しく反映されるよう改善しました。
  * ダイアログの開閉操作やクリック・Escape操作時のコールバック実行を安定化しました。
  * ダイアログを閉じた直後の操作や、画面遷移後に不要な処理が実行される問題を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->