### PR TITLE
fix(Fieldset): legend変更時にaria-labelへ古いlegend文言が蓄積する不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
+++ b/packages/smarthr-ui/src/components/Fieldset/Fieldset.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import { FormControl } from '../FormControl'
 import { Input } from '../Input'
@@ -80,5 +80,29 @@ describe('Fieldset', () => {
       screen.getByRole('textbox', { name: '追加されないラベル1の子ラベル' }),
     ).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: '追加されないラベル2' })).toBeInTheDocument()
+  })
+
+  it('legendが変更されても、アクセシブルネームに古いlegend文言が蓄積されない', async () => {
+    const { rerender } = render(
+      <form>
+        <Fieldset legend="旧legend">
+          <Input name="test" aria-label="input-accessible-name" />
+        </Fieldset>
+      </form>,
+    )
+
+    rerender(
+      <form>
+        <Fieldset legend="新legend">
+          <Input name="test" aria-label="input-accessible-name" />
+        </Fieldset>
+      </form>,
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('textbox', { name: 'input-accessible-name 新legend' }),
+      ).toBeInTheDocument(),
+    )
   })
 })

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -300,6 +300,10 @@ export const ActualFormControl: FC<Props> = ({
   useEffect(() => {
     if (!isFieldset || !inputWrapperRef.current || !labelTextRef.current) return
 
+    // HINT: legend変更のたびにaria-labelへ古いlegend文言が蓄積しないよう、
+    // 初回に確定したアクセシブルネームをinput要素ごとに保持しておく
+    const baseAccessibleNames = new WeakMap<HTMLInputElement, string>()
+
     const updateAriaLabels = () => {
       const labelText = labelTextRef.current?.textContent || ''
       if (!labelText) return
@@ -309,11 +313,16 @@ export const ActualFormControl: FC<Props> = ({
       if (!inputs.length) return
 
       inputs.forEach((input: HTMLInputElement) => {
-        const accessibleName =
-          input.getAttribute('aria-label') ||
-          (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
-            ? input.labels[0].textContent
-            : '')
+        let accessibleName = baseAccessibleNames.get(input)
+
+        if (accessibleName === undefined) {
+          accessibleName =
+            input.getAttribute('aria-label') ||
+            (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
+              ? input.labels[0].textContent || ''
+              : '')
+          baseAccessibleNames.set(input, accessibleName)
+        }
 
         if (
           accessibleName &&


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/pull/6833 （クローズ済みPRの修正内容のみを、現在のmasterのコード構造に合わせて再適用したもの）

## 概要

`Fieldset`配下で可視ラベルを持たないinput要素にlegend文言をアクセシブルネームとして付与する処理（`FormControl.tsx`の`updateAriaLabels`）で、legendの文言を変更すると、古いlegend文言が`aria-label`に蓄積し続けてしまう不具合があった。

`updateAriaLabels`は毎回`aria-label`の現在値を起点にaccessibleNameを算出していた。legend要素とinput要素は`<fieldset>`配下の別の部分木（兄弟関係）であり、legend変更時にMutationObserverが発火してもinput側のDOMノードは再生成されないため、既に書き込み済みの`aria-label`（前回のlegend文言を含む）がそのまま残り、そこへ新しいlegend文言がさらに追記されてしまっていた。

## 変更内容

- `WeakMap<HTMLInputElement, string>`でinput要素ごとに初回確定したアクセシブルネームを保持し、以降の再実行時はその値を起点に`aria-label`を再構築するよう修正
- legendを変更しても古いlegend文言が蓄積されないことを確認する回帰テストを追加

### 変更例

```tsx
// Before: legendを "旧legend" → "新legend" に変更すると
aria-label="input-accessible-name 旧legend 新legend" // 蓄積してしまう

// After
aria-label="input-accessible-name 新legend" // 常に最新のlegendのみ反映される
```

## プロダクト側で対応が必要な事項

なし

## 確認方法

`Fieldset.test.tsx`の以下のテストで確認できます。

```
legendが変更されても、アクセシブルネームに古いlegend文言が蓄積されない
```

修正前のコードでこのテストが失敗すること（`input-accessible-name 旧legend 新legend`になること）を確認済み。