### PR TITLE
refactor(ControlledStepFormDialog): ボタン関連の型をtype.tsに切り出し、ReturnTypeへの依存を解消

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
@@ -22,14 +22,11 @@ import {
   type StepFormDialogContentInnerProps,
 } from './StepFormDialogContentInner'
 import { StepFormDialogContext, StepFormDialogProvider } from './StepFormDialogProvider'
-import {
-  type ButtonArgType,
-  type ObjectButtonType,
-  useStepFormDialogButton,
-} from './useStepFormDialogButton'
+import { useStepFormDialogButton } from './useStepFormDialogButton'
 
 import type { FocusTrapRef } from '../FocusTrap'
 import type { DialogProps /** コンテンツなにもないDialogの基本props */ } from '../types'
+import type { ButtonArgType, ObjectButtonType } from './type'
 
 type ObjectHeadingType = Omit<StepFormDialogContentInnerProps['heading'], 'id'>
 type HeadingType = ReactNode | ObjectHeadingType

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
@@ -22,7 +22,7 @@ import { dialogContentInner } from '../dialogInnerStyle'
 
 import { StepFormDialogContext, type StepItem } from './StepFormDialogProvider'
 
-import type { useStepFormDialogButton } from './useStepFormDialogButton'
+import type { CommonButtonType } from './type'
 
 type StepFormHelpers = {
   /** 指定したステップに移動する関数 */
@@ -32,8 +32,6 @@ type StepFormHelpers = {
   /** 現在のステップ情報 */
   currentStep: StepItem
 }
-
-type CommonButtonType = ReturnType<typeof useStepFormDialogButton>
 
 export type BaseProps = PropsWithChildren<
   DialogBodyProps & {

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/type.ts
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/type.ts
@@ -1,0 +1,29 @@
+import type { StepItem } from './StepFormDialogProvider'
+import type { ReactNode } from 'react'
+
+export type ButtonThemeType = 'primary' | 'secondary' | 'danger'
+type VariableFunctionType<T> = (currentStep: StepItem) => T
+
+export type ButtonArgType =
+  ReactNode | ((currentStep: StepItem, defaultText: ReactNode) => ReactNode)
+
+export type ObjectButtonType = {
+  text?: ButtonArgType
+  /** ボタンを非表示にするかどうか */
+  hidden?: boolean | VariableFunctionType<boolean>
+  /** ボタンを無効にするかどうか */
+  disabled?: boolean | VariableFunctionType<boolean>
+  /** ボタンのスタイル */
+  theme?: ButtonThemeType | VariableFunctionType<ButtonThemeType>
+}
+
+/** useStepFormDialogButtonが返すボタンの実際の表示情報 */
+export type CommonButtonType = {
+  text: ReactNode
+  theme?: ButtonThemeType
+  disabled?: boolean
+  hidden?: boolean
+  functionCall: {
+    text: boolean
+  }
+}

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/useStepFormDialogButton.ts
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/useStepFormDialogButton.ts
@@ -3,20 +3,7 @@ import { type ReactNode, useMemo } from 'react'
 import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
 
 import type { StepItem } from './StepFormDialogProvider'
-
-type ButtonThemeType = 'primary' | 'secondary' | 'danger'
-export type ButtonArgType =
-  ReactNode | ((currentStep: StepItem, defaultText: ReactNode) => ReactNode)
-type VariableFunctionType<T> = (currentStep: StepItem) => T
-export type ObjectButtonType = {
-  text?: ButtonArgType
-  /** ボタンを非表示にするかどうか */
-  hidden?: boolean | VariableFunctionType<boolean>
-  /** ボタンを無効にするかどうか */
-  disabled?: boolean | VariableFunctionType<boolean>
-  /** ボタンのスタイル */
-  theme?: ButtonThemeType | VariableFunctionType<ButtonThemeType>
-}
+import type { ButtonArgType, ButtonThemeType, CommonButtonType, ObjectButtonType } from './type'
 
 const buttonObjectConverter = (text: ButtonArgType): ObjectButtonType => ({
   text,
@@ -35,13 +22,13 @@ export const useStepFormDialogButton = ({
   button,
   currentStep,
   defaultValues: { text: defaultText, theme: defaultTheme },
-}: Props) => {
+}: Props): CommonButtonType => {
   const temp = useObjectAttributes<ButtonArgType | ObjectButtonType, ObjectButtonType>(
     button,
     buttonObjectConverter,
   )
 
-  const actualButton = useMemo(() => {
+  const actualButton = useMemo((): CommonButtonType => {
     let text = temp.text ?? defaultText
     let textFunc = false
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useStepFormDialogButton` は `ControlledStepFormDialog` からしか利用されていない内部フックだが、`StepFormDialogContentInner` がそのボタン情報の型を `ReturnType<typeof useStepFormDialogButton>` で参照していたため、実装（フック）と型定義が密結合になっていた。

## 変更内容

- `type.ts` にボタン関連の型（`ButtonThemeType`・`ButtonArgType`・`ObjectButtonType`・新規 `ActualButtonType`）を定義
  - `ActualButtonType` は `useStepFormDialogButton` の戻り値の実体を表す型
- `useStepFormDialogButton.ts`: 上記の型を `type.ts` からimportし、戻り値に `ActualButtonType` の型注釈を明示
- `StepFormDialogContentInner.tsx`: `ReturnType<typeof useStepFormDialogButton>` ではなく `type.ts` の `ActualButtonType` を参照するように変更（`useStepFormDialogButton` へのimportを削除）
- `ControlledStepFormDialog.tsx`: `ButtonArgType`/`ObjectButtonType` の型importを `useStepFormDialogButton.ts` ではなく `type.ts` から取得するように変更

これにより `useStepFormDialogButton` を参照する箇所が `ControlledStepFormDialog.tsx`（フック呼び出し）のみになり、今後の整理がしやすくなる。

## プロダクト側で対応が必要な事項

なし（内部実装のみの変更で公開APIへの影響なし）

## 確認方法

- `npx tsc --noEmit -p tsconfig.build.json` で型エラーがないことを確認
- `npx eslint` で対象ファイルにlintエラーがないことを確認
- `npx vitest run src/components/Dialog` で既存テストが全てパスすることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ステップ形式のダイアログで使用するボタン設定の型を整理しました。
  * ボタンのテキスト、テーマ、表示・無効状態をより柔軟に指定できるようになりました。
  * 既存のダイアログ動作に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->