### PR TITLE
refactor(DefinitionList): styleのuseMemoを削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,17 @@ const Foo = ({ color }: { color: string }) => (
 )
 ```
 
+**例外: `Layout` ディレクトリ以下のコンポーネント**
+
+`src/components/Layout/` 以下のコンポーネント（`Stack`, `Cluster` など）はレイアウト用の薄いラッパーという特性上、今後も `React.memo` 化される見込みが皆無です。そのため、これらのコンポーネントに渡す `style` などのオブジェクト・配列をメモ化する必要はありません。
+
+```tsx
+// ✅ StackはLayout配下でmemo化されないため、styleのメモ化は不要
+const Foo = ({ maxColumns }: { maxColumns?: number }) => (
+  <Stack style={{ flexBasis: maxColumns ? `calc(100% / ${maxColumns})` : undefined }} />
+)
+```
+
 #### useLatest + functions パターン
 複数のイベントハンドラーやコールバックを安定化する際は、`useLatest` フックと `useMemo` で統合した `functions` オブジェクトを使用します。
 

--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
@@ -69,19 +69,19 @@ export const DefinitionListItem: FC<Props> = ({
       description: cs.description(),
     }
   }, [className, fullWidth])
-  const style = useMemo(
-    () => ({
-      flexBasis:
-        // fullWidth の方が強い
-        !fullWidth && maxColumns
-          ? `calc((100% - ${theme.spacingByChar(1.5)} * ${maxColumns - 1}) / ${maxColumns})`
-          : undefined,
-    }),
-    [fullWidth, maxColumns, theme],
-  )
 
   return (
-    <Stack gap={0.25} className={classNames.wrapper} style={style}>
+    <Stack
+      gap={0.25}
+      className={classNames.wrapper}
+      style={{
+        flexBasis:
+          // fullWidth の方が強い
+          !fullWidth && maxColumns
+            ? `calc((100% - ${theme.spacingByChar(1.5)} * ${maxColumns - 1}) / ${maxColumns})`
+            : undefined,
+      }}
+    >
       <DefinitionTerm styleType={term.styleType} className={classNames.term}>
         {term.text}
       </DefinitionTerm>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DefinitionListItem` の `style` オブジェクトが `useMemo` でメモ化されていたが、渡し先の `Stack` コンポーネントは `React.memo` 化されておらず、メモ化による再レンダリング抑制効果がないため不要な `useMemo` だった。

あわせて、`Layout` ディレクトリ以下のコンポーネント（`Stack` など）はレイアウト用の薄いラッパーという特性上、今後も `React.memo` 化される見込みが皆無であるため、これらに渡す `style` などのオブジェクト・配列をメモ化する必要がない旨を `CLAUDE.md` に明記した。

## 変更内容

- `DefinitionListItem.tsx`: `Stack` に渡す `style` オブジェクトの `useMemo` を削除し、JSX内にインライン化
- `CLAUDE.md`: 「unstableな値のmemo化」セクションに、`Layout` ディレクトリ以下のコンポーネントを例外とする旨を追記

## プロダクト側で対応が必要な事項

なし

## 確認方法

`DefinitionListItem` の見た目・挙動に変更はないため、既存のStorybookストーリーで表示崩れがないことを確認すれば十分です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * レイアウト関連コンポーネントの利用時における、値のメモ化に関するガイドラインとコード例を追加しました。

* **リファクタリング**
  * 定義リスト項目のレイアウト処理を簡素化しました。
  * 表示結果やレイアウトの動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->