### PR TITLE
refactor(Combobox): useImperativeHandleをuseMergeRefsに置き換え、animation frameのcancel処理をrefに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -10,7 +10,6 @@ import {
   memo,
   useEffect,
   useId,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -20,6 +19,7 @@ import { tv } from 'tailwind-variants'
 
 import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useLatest } from '../../../hooks/useLatest'
+import { useMergeRefs } from '../../../hooks/useMergeRefs'
 import { useOuterClick } from '../../../hooks/useOuterClick'
 import { useTheme } from '../../../hooks/useTheme'
 import { useLocalize } from '../../../intl'
@@ -253,15 +253,6 @@ const ActualMultiCombobox = <T,>(
     }
   }, [latestForListBox])
 
-  // TODO: callbackRefにまとめたい
-  useEffect(
-    () => () => {
-      latestForListBox.deleteFrame.cancel()
-      latestForListBox.selectFrame.cancel()
-    },
-    [latestForListBox],
-  )
-
   const { listBoxProps, activeOption, handleKeyDownListBox, listBoxId, listBoxRef } = useListbox({
     options,
     dropdownHelpMessage,
@@ -441,10 +432,15 @@ const ActualMultiCombobox = <T,>(
 
   useOuterClick([triggerRef, listBoxRef], functions.blur)
 
-  useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-    ref,
-    () => inputRef.current,
-    [],
+  const mergedRef = useMergeRefs(inputRef, ref)
+
+  // TODO: callbackRefにまとめたい
+  useEffect(
+    () => () => {
+      latestForListBox.deleteFrame.cancel()
+      latestForListBox.selectFrame.cancel()
+    },
+    [latestForListBox],
   )
 
   useEffect(() => {
@@ -528,13 +524,13 @@ const ActualMultiCombobox = <T,>(
         <div className={classNames.inputWrapper}>
           <input
             {...rest}
+            ref={mergedRef}
             data-smarthr-ui-input="true"
             type="text"
             name={name}
             value={inputValue}
             disabled={disabled}
             required={required && selectedItems.length === 0}
-            ref={inputRef}
             onChange={functions.handleChangeInput}
             onFocus={functions.handleFocusInput}
             onCompositionStart={functions.handleCompositionStart}

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -8,7 +8,6 @@ import {
   type ReactNode,
   type Ref,
   memo,
-  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -231,6 +230,10 @@ const ActualMultiCombobox = <T,>(
     }
 
     return {
+      cleanupListBoxCallbackRef: () => () => {
+        latestForListBox.deleteFrame.cancel()
+        latestForListBox.selectFrame.cancel()
+      },
       handleDelete,
       handleSelect: (selected: ComboboxItem<T>) => {
         // HINT: Dropdown系コンポーネント内でComboboxを使うと、選択肢がportalで表現されている関係上Dropdownが閉じてしまう
@@ -433,15 +436,7 @@ const ActualMultiCombobox = <T,>(
 
   useOuterClick([triggerRef, listBoxRef], functions.blur)
 
-  const cleanupListBoxCallbackRef = useCallback(
-    () => () => {
-      latestForListBox.deleteFrame.cancel()
-      latestForListBox.selectFrame.cancel()
-    },
-    [latestForListBox],
-  )
-
-  const mergedRef = useMergeRefs(inputRef, cleanupListBoxCallbackRef, ref)
+  const mergedRef = useMergeRefs(inputRef, listBoxFunctions.cleanupListBoxCallbackRef, ref)
 
   useEffect(() => {
     if (latest.highlighted) {

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
   type Ref,
   memo,
+  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -432,16 +433,15 @@ const ActualMultiCombobox = <T,>(
 
   useOuterClick([triggerRef, listBoxRef], functions.blur)
 
-  const mergedRef = useMergeRefs(inputRef, ref)
-
-  // TODO: callbackRefにまとめたい
-  useEffect(
+  const cleanupListBoxCallbackRef = useCallback(
     () => () => {
       latestForListBox.deleteFrame.cancel()
       latestForListBox.selectFrame.cancel()
     },
     [latestForListBox],
   )
+
+  const mergedRef = useMergeRefs(inputRef, cleanupListBoxCallbackRef, ref)
 
   useEffect(() => {
     if (latest.highlighted) {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -10,7 +10,6 @@ import {
   type RefObject,
   memo,
   useEffect,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -21,6 +20,7 @@ import { tv } from 'tailwind-variants'
 import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useClick } from '../../../hooks/useClick'
 import { useLatest } from '../../../hooks/useLatest'
+import { useMergeRefs } from '../../../hooks/useMergeRefs'
 import { useTheme } from '../../../hooks/useTheme'
 import { Localizer } from '../../../intl'
 import { genericsForwardRef } from '../../../libs/util'
@@ -199,12 +199,6 @@ const ActualSingleCombobox = <T,>(
   const [isComposing, setIsComposing] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
 
-  useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-    ref,
-    () => inputRef.current,
-    [],
-  )
-
   const { options } = useSingleOptions({
     items,
     selected: selectedItem,
@@ -247,9 +241,6 @@ const ActualSingleCombobox = <T,>(
       noResultText,
     },
   )
-
-  // TODO: callbackRefにまとめ直したい
-  useEffect(() => selectFrame.cancel, [selectFrame.cancel])
 
   const latest = useLatest({
     onChange,
@@ -408,6 +399,11 @@ const ActualSingleCombobox = <T,>(
     functions.unfocus,
   )
 
+  // TODO: callbackRefにまとめ直したい
+  useEffect(() => selectFrame.cancel, [selectFrame.cancel])
+
+  const mergedRef = useMergeRefs(inputRef, ref)
+
   // selectedItem.label はプリミティブ値でないデータ型の可能性があり、そのまま useEffect の依存配列に入れると意図せぬエフェクトの実行を引き起こしてしまう可能性があるので、プリミティブ値である string 型に変換したものを依存配列に入れています。
   const selectedItemLabelText = innerText(selectedItem?.label)
   useEffect(() => {
@@ -441,7 +437,7 @@ const ActualSingleCombobox = <T,>(
     >
       <Input
         {...rest}
-        ref={inputRef}
+        ref={mergedRef}
         type="text"
         role="combobox"
         name={name}

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -9,6 +9,7 @@ import {
   type Ref,
   type RefObject,
   memo,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -399,10 +400,11 @@ const ActualSingleCombobox = <T,>(
     functions.unfocus,
   )
 
-  // TODO: callbackRefにまとめ直したい
-  useEffect(() => selectFrame.cancel, [selectFrame.cancel])
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
+  const cleanupCallbackRef = useCallback(() => selectFrame.cancel, [selectFrame.cancel])
 
-  const mergedRef = useMergeRefs(inputRef, ref)
+  const mergedRef = useMergeRefs(inputRef, cleanupCallbackRef, ref)
 
   // selectedItem.label はプリミティブ値でないデータ型の可能性があり、そのまま useEffect の依存配列に入れると意図せぬエフェクトの実行を引き起こしてしまう可能性があるので、プリミティブ値である string 型に変換したものを依存配列に入れています。
   const selectedItemLabelText = innerText(selectedItem?.label)


### PR DESCRIPTION
## 関連URL

なし

## 概要

`SingleCombobox`・`MultiCombobox`内で、外部refへの中継のためだけに使われていた`useImperativeHandle`をCLAUDE.mdのアンチパターン規約に沿って`useMergeRefs`へ置き換える。あわせて、`useAnimationFrame`のcancel処理を行うためだけの専用`useEffect`（TODOコメント付き）を、callback ref化して`useMergeRefs`のcleanup機構に統合する。

## 変更内容

- `SingleCombobox`・`MultiCombobox`双方で、`inputRef.current`を外部refへ中継するだけの`useImperativeHandle`を`useMergeRefs`に置き換え
- `SingleCombobox`: `selectFrame.cancel`を実行するためだけの`useEffect`を、callback ref化して`mergedRef`に統合
- `MultiCombobox`: `deleteFrame.cancel`/`selectFrame.cancel`を実行するためだけの`useEffect`（TODOコメント付き）を、callback ref化して`mergedRef`に統合。最終的に既存の`listBoxFunctions`（useMemo）のプロパティとして集約

## プロダクト側で対応が必要な事項

なし

## 確認方法

`SingleCombobox`・`MultiCombobox`のStorybookで、入力・選択・削除などの既存の動作に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SingleCombobox と MultiCombobox の参照処理を改善しました。
  * コンポーネントの再描画やアンマウント時に、不要な選択処理や削除処理が残りにくくなりました。
  * 外部から渡された参照と入力要素の参照を適切に統合し、コンボボックスの状態がより安定して更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->