### PR TITLE
refactor(Checkbox): useImperativeHandleをuseMergeRefsに置き換え

### DIFF
--- a/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
@@ -7,12 +7,12 @@ import {
   memo,
   useEffect,
   useId,
-  useImperativeHandle,
   useMemo,
   useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useMergeRefs } from '../../hooks/useMergeRefs'
 import { FaCheckIcon, FaMinusIcon } from '../Icon'
 
 export type Props = PropsWithChildren<
@@ -84,11 +84,7 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
     const defaultId = useId()
     const checkBoxId = id || defaultId
 
-    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-      ref,
-      () => inputRef.current,
-      [],
-    )
+    const mergedRef = useMergeRefs(inputRef, ref)
 
     useEffect(() => {
       if (inputRef.current) {
@@ -101,7 +97,7 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
         <span className={classNames.innerWrapper}>
           <input
             {...rest}
-            ref={inputRef}
+            ref={mergedRef}
             type="checkbox"
             id={checkBoxId}
             checked={checked}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Checkbox` コンポーネントの `useImperativeHandle` は、内部の `inputRef.current` を外部の `ref` にそのまま中継するためだけに使われていた。独自の命令的APIを提供していないため、CLAUDE.mdの規約に従い `useMergeRefs` に置き換える。

## 変更内容

- `useImperativeHandle(ref, () => inputRef.current, [])` を `useMergeRefs(inputRef, ref)` に置き換え
- `<input ref={mergedRef}>` に変更

内部実装の変更のみで、公開インターフェースに変更はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテスト・Storybookで動作に変化がないことを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * チェックボックスの参照処理を改善し、外部から指定した参照と内部処理の参照が正しく連携するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->