### PR TITLE
refactor(YearPicker): callback ref化とYearButtonのprops整理

### DIFF
--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -89,8 +89,6 @@ const ActualYearPicker: FC<ActualProps> = ({
             year={year}
             thisYear={thisYear}
             selected={selectedYear === year}
-            className={CLASS_NAMES.yearButton}
-            childrenStyle={CLASS_NAMES.yearWrapper}
             handleClick={handleSelectYear}
           />
         ))}
@@ -103,10 +101,8 @@ const YearButton = memo<{
   year: number
   thisYear: number
   selected: boolean
-  className: string
-  childrenStyle: string
   handleClick: (e: MouseEvent<HTMLButtonElement>) => void
-}>(({ year, thisYear, selected, handleClick, className, childrenStyle }) => {
+}>(({ year, thisYear, selected, handleClick }) => {
   const { localize } = useIntl()
   const isThisYear = thisYear === year
 
@@ -116,7 +112,7 @@ const YearButton = memo<{
       value={year}
       aria-pressed={selected}
       onClick={handleClick}
-      className={className}
+      className={CLASS_NAMES.yearButton}
       data-this-year={isThisYear}
       aria-label={
         isThisYear
@@ -127,7 +123,7 @@ const YearButton = memo<{
           : undefined
       }
     >
-      <span className={childrenStyle}>{year}</span>
+      <span className={CLASS_NAMES.yearWrapper}>{year}</span>
     </UnstyledButton>
   )
 })

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -2,11 +2,10 @@ import {
   type ComponentProps,
   type FC,
   type MouseEvent,
-  type RefObject,
+  type Ref,
   memo,
-  useEffect,
   useMemo,
-  useRef,
+  useState,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -57,6 +56,15 @@ const CLASS_NAMES = (() => {
   }
 })()
 
+const FOCUS_CALLBACK_REF = (node: HTMLButtonElement | null) => {
+  if (node) {
+    // HINT: 現在の年に一度focusを当てることでtab移動をしやすくする
+    // focusを当てたままでは違和感があるため、blurで解除している
+    node.focus()
+    node.blur()
+  }
+}
+
 export const YearPicker: FC<Props> = ({ isDisplayed, ...rest }) =>
   isDisplayed ? <ActualYearPicker {...rest} /> : null
 
@@ -68,9 +76,7 @@ const ActualYearPicker: FC<ActualProps> = ({
   id,
   ...rest
 }) => {
-  const focusingRef = useRef<HTMLButtonElement>(null)
-
-  const thisYear = useMemo(() => new Date().getFullYear(), [])
+  const [thisYear] = useState(() => new Date().getFullYear())
   const yearArray = useMemo(() => {
     const length = Math.max(Math.min(toYear, 9999) - fromYear + 1, 0)
     const result: number[] = []
@@ -82,25 +88,16 @@ const ActualYearPicker: FC<ActualProps> = ({
     return result
   }, [toYear, fromYear])
 
-  useEffect(() => {
-    if (focusingRef.current) {
-      // HINT: 現在の年に一度focusを当てることでtab移動をしやすくする
-      // focusを当てたままでは違和感があるため、blurで解除している
-      focusingRef.current.focus()
-      focusingRef.current.blur()
-    }
-  }, [])
-
   return (
     <div {...rest} id={id} className={CLASS_NAMES.overlay}>
       <Scroller className={CLASS_NAMES.container}>
         {yearArray.map((year) => (
           <YearButton
+            focusCallbackRef={FOCUS_CALLBACK_REF}
             key={year}
             year={year}
             thisYear={thisYear}
             selected={selectedYear === year}
-            focusingRef={focusingRef}
             className={CLASS_NAMES.yearButton}
             childrenStyle={CLASS_NAMES.yearWrapper}
             handleClick={handleSelectYear}
@@ -115,17 +112,17 @@ const YearButton = memo<{
   year: number
   thisYear: number
   selected: boolean
-  focusingRef: RefObject<HTMLButtonElement>
+  focusCallbackRef: Ref<HTMLButtonElement>
   className: string
   childrenStyle: string
   handleClick: (e: MouseEvent<HTMLButtonElement>) => void
-}>(({ year, thisYear, selected, focusingRef, handleClick, className, childrenStyle }) => {
+}>(({ year, thisYear, selected, focusCallbackRef, handleClick, className, childrenStyle }) => {
   const { localize } = useIntl()
   const isThisYear = thisYear === year
 
   return (
     <UnstyledButton
-      ref={isThisYear ? focusingRef : null}
+      ref={isThisYear ? focusCallbackRef : null}
       value={year}
       aria-pressed={selected}
       onClick={handleClick}

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -1,12 +1,4 @@
-import {
-  type ComponentProps,
-  type FC,
-  type MouseEvent,
-  type Ref,
-  memo,
-  useMemo,
-  useState,
-} from 'react'
+import { type ComponentProps, type FC, type MouseEvent, memo, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { useIntl } from '../../intl'
@@ -93,7 +85,6 @@ const ActualYearPicker: FC<ActualProps> = ({
       <Scroller className={CLASS_NAMES.container}>
         {yearArray.map((year) => (
           <YearButton
-            focusCallbackRef={FOCUS_CALLBACK_REF}
             key={year}
             year={year}
             thisYear={thisYear}
@@ -112,17 +103,16 @@ const YearButton = memo<{
   year: number
   thisYear: number
   selected: boolean
-  focusCallbackRef: Ref<HTMLButtonElement>
   className: string
   childrenStyle: string
   handleClick: (e: MouseEvent<HTMLButtonElement>) => void
-}>(({ year, thisYear, selected, focusCallbackRef, handleClick, className, childrenStyle }) => {
+}>(({ year, thisYear, selected, handleClick, className, childrenStyle }) => {
   const { localize } = useIntl()
   const isThisYear = thisYear === year
 
   return (
     <UnstyledButton
-      ref={isThisYear ? focusCallbackRef : null}
+      ref={isThisYear ? FOCUS_CALLBACK_REF : null}
       value={year}
       aria-pressed={selected}
       onClick={handleClick}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`YearPicker` は現在年のボタンへ一度フォーカスを当てる処理を `useRef` + `useEffect` で実装していたが、DOM要素マウント時にのみ実行すればよい副作用のため、callback refで表現する方がタイミング的により適切。

あわせて、`YearButton`（同一ファイル内のローカルコンポーネント）へモジュールスコープの定数をpropsで受け渡していた箇所を整理した。

## 変更内容

### 1. 現在年フォーカス用のuseEffectをcallback refに置き換え

- `focusingRef`（`useRef`）+ マウント時の `useEffect` を、モジュールレベルの安定した `FOCUS_CALLBACK_REF`（callback ref）に置き換え
- `thisYear` の算出を `useMemo` から `useState` の遅延初期化に変更（初回のみ計算すればよい値のため）

### 2. モジュールスコープの定数をYearButton内で直接参照

`FOCUS_CALLBACK_REF` および `CLASS_NAMES` は `YearPicker.tsx` のモジュールスコープに定義された定数であり、同一ファイル内の `YearButton` から直接参照できる。propsとして受け渡す必要がないため削除した。

```diff
 const YearButton = memo<{
   year: number
   thisYear: number
   selected: boolean
-  focusCallbackRef: Ref<HTMLButtonElement>
-  className: string
-  childrenStyle: string
   handleClick: (e: MouseEvent<HTMLButtonElement>) => void
-}>(({ year, thisYear, selected, focusCallbackRef, handleClick, className, childrenStyle }) => {
+}>(({ year, thisYear, selected, handleClick }) => {
```

`YearButton` のpropsは `year`・`thisYear`・`selected`・`handleClick` の4つになった。`YearButton` は `memo` されており年数分レンダリングされるため、props数の削減はそのまま比較コストの削減になる。

不要になった `Ref` 型のimportも削除した。

いずれも内部実装の変更のみで、公開インターフェースに変更はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- Chromatic で `Calendar` / `DatePicker` / `WarekiPicker` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

ローカルでの確認結果:

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- Calendar / DatePicker / WarekiPicker のテスト — 5ファイル 36件パス
