### PR TITLE
refactor(AppHeader): MenuDialogのunmount時clear処理をuseMergeRefsに統合

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
@@ -5,7 +5,6 @@ import {
   type ReactNode,
   type RefObject,
   useContext,
-  useEffect,
   useMemo,
   useRef,
 } from 'react'
@@ -13,6 +12,7 @@ import { CSSTransition } from 'react-transition-group'
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../../../hooks/useLatest'
+import { useMergeRefs } from '../../../../hooks/useMergeRefs'
 import { Localizer, useLocalize } from '../../../../intl'
 import { Button } from '../../../Button'
 import { FocusTrap } from '../../../Dialog'
@@ -108,30 +108,35 @@ export const Content: FC<
     setSelectedNavigationGroup,
   })
 
-  const functions = useMemo(
-    () => ({
-      handleDialogClose: () => latest.setIsOpen(false),
-      clearAppLauncher: () => latest.setIsAppLauncherSelected(false),
-      clearReleaseNote: () => latest.setIsReleaseNoteSelected(false),
-      clearNavigationGroup: () => latest.setSelectedNavigationGroup(null),
-    }),
-    [latest],
-  )
+  const functions = useMemo(() => {
+    const clearAppLauncher = () => latest.setIsAppLauncherSelected(false)
+    const clearReleaseNote = () => latest.setIsReleaseNoteSelected(false)
+    const clearNavigationGroup = () => latest.setSelectedNavigationGroup(null)
 
-  // HINT: Contentをanimationで非表示にしたい
-  // アニメーションが終われば、CSSTransitionのchildrenはunmountされるため、
-  // unmount時に操作内容のclearを行う
-  useEffect(
-    () => () => {
-      functions.clearReleaseNote()
-      functions.clearAppLauncher()
-      functions.clearNavigationGroup()
-    },
-    [functions],
-  )
+    return {
+      // HINT: Contentをanimationで非表示にしたい
+      // アニメーションが終われば、CSSTransitionのchildrenはunmountされるため、
+      // unmount時に操作内容のclearを行う
+      // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+      // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
+      callbackRef: () => () => {
+        clearReleaseNote()
+        clearAppLauncher()
+        clearNavigationGroup()
+      },
+      clearAppLauncher,
+      clearReleaseNote,
+      clearNavigationGroup,
+      handleDialogClose: () => latest.setIsOpen(false),
+    }
+  }, [latest])
+
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
+  const mergedRef = useMergeRefs(functions.callbackRef, domRef)
 
   return (
-    <Section role="dialog" aria-modal="true" className={CLASS_NAMES.wrapper} ref={domRef}>
+    <Section ref={mergedRef} role="dialog" aria-modal="true" className={CLASS_NAMES.wrapper}>
       <div className={CLASS_NAMES.header}>
         <Cluster justify="space-between" align="center">
           {isAppLauncherSelected ? (


### PR DESCRIPTION
## 関連URL

なし

## 概要

`AppHeader` の `MenuDialog` は、アニメーション終了後のunmount時に選択状態をclearする処理を `useEffect` のcleanup関数で実装していたが、`useMergeRefs` のcallback ref cleanup機能に統合することで、`useEffect` を1つ削減できる。

## 変更内容

- unmount時のclear処理（`clearReleaseNote`/`clearAppLauncher`/`clearNavigationGroup`）を行っていた `useEffect` を削除
- 代わりに `functions.callbackRef` としてcallback refのcleanup関数の形で実装し、`useMergeRefs(functions.callbackRef, domRef)` で既存の `domRef` とマージ
- `<Section ref={domRef}>` を `<Section ref={mergedRef}>` に変更

内部実装の変更のみで、公開インターフェースに変更はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のテスト・Storybookで動作に変化がないことを確認済み。