### PR TITLE
feat(DoughnutChart): 柄を無効化するdisablePatternsを追加

### DIFF
--- a/packages/charts/src/components/DoughnutChart/DoughnutChart.stories.tsx
+++ b/packages/charts/src/components/DoughnutChart/DoughnutChart.stories.tsx
@@ -36,6 +36,7 @@ export const Playground: Story = {
     title: { control: 'text' },
     thickness: { control: 'radio', options: ['S', 'M', 'L'] },
     options: { control: 'object' },
+    disablePatterns: { control: 'boolean' },
   },
 }
 
@@ -50,6 +51,14 @@ export const Title: Story = {
   args: {
     data: doughnutSmall,
     title: '雇用形態の内訳',
+  },
+}
+
+export const WithoutPattern: Story = {
+  name: 'disablePatterns',
+  args: {
+    data: doughnutSmall,
+    disablePatterns: true,
   },
 }
 

--- a/packages/charts/src/components/DoughnutChart/DoughnutChart.tsx
+++ b/packages/charts/src/components/DoughnutChart/DoughnutChart.tsx
@@ -28,6 +28,10 @@ type Props = {
   children?: React.ReactNode
   className?: string
   options?: Partial<ChartOptions<'doughnut'>>
+  /**
+   * ドーナツグラフの柄を無効化するか
+   */
+  disablePatterns?: boolean
 }
 
 export const DoughnutChart: React.FC<Props> = ({
@@ -37,11 +41,15 @@ export const DoughnutChart: React.FC<Props> = ({
   children,
   className,
   options: externalOptions,
+  disablePatterns,
 }) => {
   const chartId = useId()
   const chartRef = useRef<Chart<'doughnut'>>(null)
   const segmentCount = data.labels?.length ?? data.datasets[0]?.data.length ?? 0
-  const chartColors = useMemo(() => getChartColors<'doughnut'>(segmentCount), [segmentCount])
+  const chartColors = useMemo(
+    () => getChartColors<'doughnut'>(segmentCount, disablePatterns),
+    [segmentCount, disablePatterns],
+  )
   const { chartArea, chartAreaPlugin } = useChartAreaTracker()
 
   const ariaLabel = useMemo(() => {

--- a/packages/charts/src/components/DoughnutChart/VRTDoughnutChart.stories.tsx
+++ b/packages/charts/src/components/DoughnutChart/VRTDoughnutChart.stories.tsx
@@ -40,7 +40,12 @@ export default {
         <DoughnutChart data={doughnutWithZero} title="値0を含む" />
       </div>
 
-      {/* パターン7: 中央コンテンツあり（タイトルなし＝凡例分だけ上にずれる） */}
+      {/* パターン7: 柄なし（disablePatterns＝全セグメントが単色になること） */}
+      <div className="shr-h-[400px]">
+        <DoughnutChart data={doughnutSmall} title="柄なし" disablePatterns />
+      </div>
+
+      {/* パターン8: 中央コンテンツあり（タイトルなし＝凡例分だけ上にずれる） */}
       <div className="shr-h-[400px]">
         <DoughnutChart data={doughnutSmall}>
           <Text size="XXL" weight="bold">
@@ -52,7 +57,7 @@ export default {
         </DoughnutChart>
       </div>
 
-      {/* パターン8: 中央コンテンツあり＋タイトルあり（タイトル分もずれること） */}
+      {/* パターン9: 中央コンテンツあり＋タイトルあり（タイトル分もずれること） */}
       <div className="shr-h-[400px]">
         <DoughnutChart data={doughnutSmall} title="雇用形態の内訳">
           <Text size="XXL" weight="bold">


### PR DESCRIPTION
## 関連URL

なし

## 概要

DaoughnutChart に `disabledPattens` を追加しました

## 変更内容

- `DoughnutChart` に `disablePatterns?: boolean` を追加
- Storyにパターンを追加

未指定時は従来どおり「柄あり」（`getChartColors` 側のデフォルト `false`）のため、既存の利用箇所の見た目は変わりません。

### 使用例

```tsx
// 従来どおり（柄あり）
<DoughnutChart data={data} />

// 柄を無効化（全セグメントが単色になる）
<DoughnutChart data={data} disablePatterns />
```

## プロダクト側で対応が必要な事項

なし


## 確認方法

Storybook の `Charts/DoughnutChart` で確認できます。

- `disablePatterns` ストーリー：全セグメントが単色になっていること
- `Playground` の `disablePatterns` トグル：オン／オフで柄が切り替わること
- `Default` ストーリー：従来どおり2番目以降のセグメントに柄が付いていること（既定動作が変わっていないこと）

Chromatic では `Charts/DoughnutChart/VRT` に柄なしのパターンを追加しているため、差分として柄なしのドーナツが1つ増えます。既存パターンに差分が出ないことも併せて確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ドーナツチャートで、セグメントの柄（パターン）を無効化できるようになりました。
  - `disablePatterns`を有効にすると、すべてのセグメントが単色で表示され、よりシンプルで見やすいチャートを作成できます。
  - 設定変更時も、表示内容が正しく更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->