### PR TITLE
fix(charts): smarthr-uiをdevDependenciesにも追加しビルド順序を保証

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -81,6 +81,7 @@
     "react-intl": "^10.1.18",
     "rimraf": "^6.0.1",
     "rollup": "^4.62.3",
+    "smarthr-ui": "workspace:^",
     "storybook": "9.1.20",
     "styled-components": "^5.3.11",
     "tailwind-variants": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,6 @@ importers:
       react-chartjs-2:
         specifier: ^5.3.1
         version: 5.3.1(chart.js@4.5.1)(react@19.2.8)
-      smarthr-ui:
-        specifier: workspace:^
-        version: link:../smarthr-ui
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^29.0.3
@@ -172,6 +169,9 @@ importers:
       rollup:
         specifier: ^4.62.3
         version: 4.62.3
+      smarthr-ui:
+        specifier: workspace:^
+        version: link:../smarthr-ui
       storybook:
         specifier: 9.1.20
         version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/actions/runs/32681882061

## 概要

`release`ワークフローの`publish`ジョブ（`pnpm -r publish --no-git-checks --access public --provenance`）が直近の実行で継続的に失敗していた。

原因を調査したところ、`charts`パッケージの`prepublishOnly`（`build`）が`smarthr-ui`パッケージのビルド完了前に実行されてしまい、`charts/tailwind.config.js`が参照する`smarthr-ui/lib/smarthr-ui-preset.cjs`が存在せずビルドに失敗していた。

```
Error: Cannot find module '.../packages/charts/node_modules/smarthr-ui/lib/smarthr-ui-preset.cjs'
```

`charts`の`package.json`では`smarthr-ui`が`peerDependencies`にのみ記載されており、`dependencies`/`devDependencies`には存在しなかったため、pnpmが`-r`実行時のトポロジカルなビルド順序解決の対象として認識できていなかった。

## 変更内容

- `packages/charts/package.json`の`devDependencies`に`"smarthr-ui": "workspace:^"`を追加
- これにより`pnpm -r`実行時に`smarthr-ui`のビルドが`charts`のビルドより先に完了することが保証される
- `smarthr-ui`のみ、`charts`のみ、両方同時のいずれのリリースパターンでも、`pnpm -r publish`は全パッケージをビルドした上でバージョン変更のあるパッケージのみ実際にpublishする仕様のため、今回の修正で全パターンに対応できることをローカルで`pnpm -r run build`を実行し確認済み

## プロダクト側で対応が必要な事項

なし（CI/publishパイプラインの内部修正のみ）

## 確認方法

- ローカルで`packages/smarthr-ui`と`packages/charts`の`lib`/`esm`をクリーンな状態から`pnpm -r --filter smarthr-ui --filter @smarthr/smarthr-ui-charts run build`で実行し、`smarthr-ui`のビルドが先に完了した上で`charts`のビルドが成功することを確認済み
- マージ後の次回リリースで`release`ワークフローの`publish`ジョブが成功することを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * チャート関連パッケージの開発環境に、SmartHR UIを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->