### PR TITLE
refactor(RadioButtonPanel): 内部refをやめてdata属性セレクタでinput要素を取得

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -8,7 +8,6 @@ import {
   useCallback,
   useId,
   useMemo,
-  useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -129,14 +128,15 @@ const DescriptionRadioButtonPanel: FC<LowerProps> = ({
 
 const ActualRadioButtonPanel: FC<LowerProps> = ({ as, classNames, children, label, ...rest }) => {
   // 外側の装飾を押しても内側のラジオボタンが押せるようにする
-  const innerRef = useRef<HTMLInputElement>(null)
   const handleDelegateClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     // RadioButtonの要素（labelまたはinput）以外がクリックされた場合（description や Base の余白）
     if (!isRadioButtonElementClicked(e.nativeEvent.composedPath(), e.currentTarget)) {
       // Base要素のclickイベントは止める（実装の詳細を隠蔽し、input要素のclickのみを親に伝える）
       e.stopPropagation()
       // 手動でinputをクリック
-      innerRef.current?.click()
+      e.currentTarget
+        .querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"][type="radio"]')
+        ?.click()
     }
     // RadioButtonの要素（labelまたはinput）がクリックされた場合は何もしない
     // （ブラウザの標準動作でinputがクリックされ、そのイベントが親に伝わる）
@@ -144,7 +144,7 @@ const ActualRadioButtonPanel: FC<LowerProps> = ({ as, classNames, children, labe
 
   return (
     <Panel padding={1} onClick={handleDelegateClick} as={as} className={classNames.base}>
-      <RadioButton {...rest} ref={innerRef} className={classNames.radio}>
+      <RadioButton {...rest} className={classNames.radio}>
         {label}
       </RadioButton>
       {children}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`RadioButtonPanel`は装飾部分（description・余白）をクリックしても内側のラジオボタンが選択されるよう、クリックイベントを内部の`input`要素に委譲している。この委譲処理は`useRef`で内部の`RadioButton`の`input`要素を直接受け取り、`ref.current?.click()`する実装になっていたが、このために`RadioButton`へ`ref`を転送する必要があり、実装がやや複雑になっていた。

## 変更内容

- `useRef`によるinput要素の参照保持をやめ、smarthr-ui全体で使われている`data-smarthr-ui-input="true"`属性セレクタ（`FormControl`でも同様に使用）を使って、クリックイベントのdelegate先の`div`から`querySelector`で`input`要素を取得するように変更
- これにより`RadioButton`への`ref`転送が不要になった
- 挙動に変更はない

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで既存のRadioButtonPanelのストーリーを開き、パネルの余白やdescription部分をクリックしてラジオボタンが選択されることを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ラジオボタンパネルで選択肢をクリックした際の動作を改善しました。
  * パネル内の対象ラジオボタンが正しく選択されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->