### PR TITLE
fix(MobileHeader): 特定条件でのHeaderへのcurrentTenantId・onTenantSelect転送漏れがあったため修正

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MobileHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MobileHeader.tsx
@@ -64,6 +64,8 @@ export const MobileHeader: FC<HeaderProps> = ({
             {...rest}
             className={`${className} min-[752px]:!shr-hidden`}
             tenants={isMenuAvailable ? undefined : tenants}
+            currentTenantId={isMenuAvailable ? undefined : currentTenantId}
+            onTenantSelect={isMenuAvailable ? undefined : onTenantSelect}
           >
             {children}
 


### PR DESCRIPTION
## 関連URL

- https://kufuinc.slack.com/archives/C02RE4WCM/p1787288276189779?thread_ts=1787108348.883889&cid=C02RE4WCM

## 概要

モバイル表示の `AppHeader` で、`navigations` を渡していない（＝ハンバーガーメニューを使わない）利用パターンの場合、`currentTenantId` と `onTenantSelect` が `Header` に届かず、以下の不具合が発生していました。

1. テナント名が別のマルチログインテナントのものになる（`tenants[0]` にフォールバックするため）
2. テナント切り替えのドロップダウンをクリックしても何も起きない

Desktop 表示では `DesktopHeader` が両 prop を正しく転送しているため問題なく、モバイル表示のみで再現していました。

## 変更内容

`MobileHeader` の内部実装で、`navigations` が未指定（`isMenuAvailable === false`）の場合に素の `Header` へ渡す props に `currentTenantId` / `onTenantSelect` を追加しました。`tenants` の既存の渡し方（`isMenuAvailable` による三項演算子）に揃えています。

## プロダクト側で対応が必要な事項

なし（バグ修正のみで、既存の利用側コードの変更は不要です）

## 確認方法

Storybook上で `AppHeader` の `navigations` なし・複数テナントのパターンでモバイル幅（751px以下）にして、テナント名表示とドロップダウン切り替えを確認してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ナビゲーションメニューの利用状況に応じて、テナント選択情報を適切に受け渡すよう改善しました。
  * モバイルヘッダーでのテナント選択動作の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->