### PR TITLE
refactor(InputFile): relay目的のuseImperativeHandleをやめinput要素を都度取得する方式に変更

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileMultiplyAppendable.tsx
@@ -5,7 +5,6 @@ import {
   type MouseEvent,
   forwardRef,
   useId,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -51,23 +50,10 @@ export const InputFileMultiplyAppendable = forwardRef<
     // Safari において、input.files への直接代入時に onChange が発火することを防ぐためのフラグ
     const isUpdatingFilesRef = useRef(false)
 
-    const innerRef = useRef<HTMLInputElement>(null)
-
-    // TODO: useMergeRefsが実装されたら修正
-    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-      ref,
-      () => innerRef.current,
-      [],
-    )
-
     const latest = useLatest({ onChange, files, previewFile })
 
     const functions = useMemo(() => {
-      const updateFiles = (newFiles: File[]) => {
-        if (!innerRef.current) {
-          return
-        }
-
+      const updateFiles = (input: HTMLInputElement, newFiles: File[]) => {
         latest.onChange?.(newFiles)
 
         const buff = new DataTransfer()
@@ -76,7 +62,7 @@ export const InputFileMultiplyAppendable = forwardRef<
         })
 
         isUpdatingFilesRef.current = true
-        innerRef.current.files = buff.files
+        input.files = buff.files
         isUpdatingFilesRef.current = false
 
         setFiles(newFiles)
@@ -91,10 +77,14 @@ export const InputFileMultiplyAppendable = forwardRef<
 
           const newFiles = Array.from(e.target.files ?? [])
 
-          updateFiles([...latest.files, ...newFiles])
+          updateFiles(e.target, [...latest.files, ...newFiles])
         },
         handleDelete: (e: MouseEvent<HTMLButtonElement>) => {
-          if (!innerRef.current) {
+          const input = e.currentTarget
+            .closest('.smarthr-ui-InputFile')
+            ?.querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"][type="file"]')
+
+          if (!input) {
             return
           }
 
@@ -102,9 +92,9 @@ export const InputFileMultiplyAppendable = forwardRef<
           const newFiles = latest.files.filter((_, i) => index !== i)
 
           // 削除後、同一ファイルを再選択可能にするためinput.valueをリセット
-          innerRef.current.value = ''
+          input.value = ''
 
-          updateFiles(newFiles)
+          updateFiles(input, newFiles)
         },
         handleClosePreview: () => {
           setPreviewFile(null)
@@ -143,7 +133,7 @@ export const InputFileMultiplyAppendable = forwardRef<
         <span className={classNames.inputWrapper}>
           <input
             {...rest}
-            ref={innerRef}
+            ref={ref}
             type="file"
             disabled={disabled}
             multiple


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InputFileMultiplyAppendable`は、外部からの`ref`にinput要素のDOMノードをそのまま渡すためだけに`useImperativeHandle(ref, () => innerRef.current, [])`というrelay-onlyな実装を使っていた（`useMergeRefs`が実装される前の暫定対応、コード内にもTODOコメントあり）。

## 変更内容

- relay-onlyな`useImperativeHandle`と、それを支えるための`innerRef`の保持自体を廃止
- `handleChange`はイベントの`e.target`からinput要素を取得
- `handleDelete`は`data-smarthr-ui-input`属性セレクタ（`FormControl`など他コンポーネントでも使用している既存の共通セレクタ）でinput要素を都度取得
- 外部からの`ref`はネイティブの`<input>`要素にそのまま渡すだけになった
- 挙動に変更はない

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで既存のInputFileMultiplyAppendableのストーリーを開き、ファイルの追加・削除が問題なく動作することを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 複数ファイルを追加できる入力欄で、ファイルの変更・削除時に選択状態が正しく更新されるよう改善しました。
  * ファイル削除後に、対象の入力欄が適切にリセットされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->