### PR TITLE
fix(InputFile): FilePreviewDialogのFileViewer周りの余白を除去

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -109,6 +109,7 @@ export const FilePreviewDialog: FC<Props> = memo(
         height="75svh"
         size="M"
         resizable
+        contentPadding={0}
         footer={
           <Cluster justify="end" className="shr-px-1.5 shr-py-1">
             <Button onClick={handleDownload}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FilePreviewDialog`のデスクトップ表示（`ModelessDialog`使用時）で、`FileViewer`の周りに意図しない余白が残ってしまうパターンがあった。

## 変更内容

`ModelessDialog`は内部で`DialogBody`を使って`children`をラップしており、`contentPadding`を指定しない場合デフォルトで`1.5`の余白が付与される。`FileViewer`は自身で余白なしのレイアウト（幅いっぱいに広がるツールバー・背景）を想定して作られており、モバイル表示側（`Dialog`使用時）でも余白なしで配置されているため、デスクトップ側にも`contentPadding={0}`を指定して余白を除去した。

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookで`InputFile`のプレビュー機能を開き、デスクトップ表示（`ModelessDialog`）で`FileViewer`の周りに余白がなくなっていることを確認する。