### PR TITLE
refactor(Input): InputWithTooltip・CurrencyInputの内部実装を簡潔化

### DIFF
--- a/packages/smarthr-ui/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -58,10 +58,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
         formatCurrencyValue,
         handleFocus: (e: FocusEvent<HTMLInputElement>) => {
           setIsFocused(true)
-
-          if (innerRef.current) {
-            formatValue(innerRef.current.value.replace(/,/g, ''))
-          }
+          formatValue(e.currentTarget.value.replace(/,/g, ''))
 
           latest.onFocus?.(e)
         },

--- a/packages/smarthr-ui/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
+++ b/packages/smarthr-ui/src/components/Input/InputWithTooltip/InputWithTooltip.tsx
@@ -15,12 +15,9 @@ const classNameGenerator = tv({
 
 export const InputWithTooltip = forwardRef<HTMLInputElement, Props>(
   ({ tooltipMessage, width, className, ...rest }, ref) => {
-    const style = useMemo(
-      () => ({
-        width: typeof width === 'number' ? `${width}px` : width,
-      }),
-      [width],
-    )
+    const style = {
+      width: typeof width === 'number' ? `${width}px` : width,
+    }
 
     const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InputWithTooltip` と `CurrencyInput` の内部実装に、不要なメモ化やref参照が残っていたため整理した。

## 変更内容

- `InputWithTooltip`: `style` オブジェクトの `useMemo` を削除。`width` は表示後に変わる可能性が低く、渡し先の `Tooltip` もその性質上memo化される見込みがないため、メモ化は不要と判断した
- `CurrencyInput`: `handleFocus` 内で `innerRef.current.value` を参照していた箇所を `e.currentTarget.value` に変更。両者は同じDOMノードを指すため、`innerRef.current` のnullチェックが不要になった
- 外部インターフェース（props）に変更なし

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookの `Input` / `CurrencyInput` で表示・動作に変化がないことを確認する