### PR TITLE
refactor(InformationPanel): 内部実装を整理

### DIFF
--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -134,10 +134,6 @@ export const InformationPanel: FC<Props> = ({
   const id = useId()
   const contentId = `${id}-content`
 
-  useEffect(() => {
-    setActive(activeProps)
-  }, [activeProps])
-
   const classNames = useMemo(() => {
     const {
       wrapper,
@@ -158,6 +154,10 @@ export const InformationPanel: FC<Props> = ({
       content: content(),
     }
   }, [type, bold, className])
+
+  useEffect(() => {
+    setActive(activeProps)
+  }, [activeProps])
 
   return (
     <Panel

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -160,12 +160,7 @@ export const InformationPanel: FC<Props> = ({
   }, [activeProp])
 
   return (
-    <Panel
-      {...rest}
-      as="section"
-      data-active={(active || false).toString()}
-      className={classNames.wrapper}
-    >
+    <Panel {...rest} as="section" data-active={active} className={classNames.wrapper}>
       <Sidebar align="baseline" right className={classNames.header}>
         {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
         <MemoizedHeading

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -123,14 +123,14 @@ export const InformationPanel: FC<Props> = ({
   heading,
   type = 'info',
   toggleable,
-  active: activeProps = true,
+  active: activeProp = true,
   bold,
   className,
   children,
   onClickTrigger,
   ...rest
 }) => {
-  const [active, setActive] = useState(activeProps)
+  const [active, setActive] = useState(activeProp)
   const id = useId()
   const contentId = `${id}-content`
 
@@ -156,8 +156,8 @@ export const InformationPanel: FC<Props> = ({
   }, [type, bold, className])
 
   useEffect(() => {
-    setActive(activeProps)
-  }, [activeProps])
+    setActive(activeProp)
+  }, [activeProp])
 
   return (
     <Panel


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InformationPanel` の内部実装に、記述順序の分かりにくさや冗長な処理が残っていたため整理した。

## 変更内容

- `activeProp` を反映する `useEffect` を `classNames` 計算より前に移動し、stateの初期化・同期処理をまとめて上部に配置
- props名 `activeProps`（複数形）を `activeProp`（単数）にリネーム（値はboolean単体のため）
- `data-active={(active || false).toString()}` を `data-active={active}` に簡潔化
  - `active` は常にboolean値のため `|| false` は冗長
  - React は `data-*` 属性値を自動的に文字列化するため `.toString()` も不要
- 外部インターフェース（props）に変更なし

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookの `InformationPanel` で表示・開閉動作に変化がないことを確認する