### PR TITLE
refactor(AppLauncher): enableNewバリアントの適用範囲をappsButtonスロットに限定

### DIFF
--- a/packages/smarthr-ui/src/components/Header/AppLauncher/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/Header/AppLauncher/AppLauncher.tsx
@@ -85,12 +85,12 @@ export const AppLauncher: FC<Props> = ({
   }, [apps])
 
   const classNames = useMemo(() => {
-    const { appsButton, contentWrapper, category, appList, link, footer } = classNameGenerator({
-      enableNew,
-    })
+    const { appsButton, contentWrapper, category, appList, link, footer } = classNameGenerator()
 
     return {
-      appsButton: appsButton(),
+      appsButton: appsButton({
+        enableNew,
+      }),
       contentWrapper: contentWrapper(),
       category: category(),
       appList: appList(),


### PR DESCRIPTION
## 関連URL

なし

## 概要

`AppLauncher` の `classNameGenerator()` 呼び出し時に `enableNew` をトップレベルで渡していたが、この variant は `appsButton` スロットにしか定義されておらず、渡し方が影響範囲を誤解させる書き方になっていた。

## 変更内容

- `classNameGenerator({ enableNew })` ではなく、`appsButton({ enableNew })` のようにスロット単位で `enableNew` を渡すように変更
- 出力されるクラス名に変更はなく、影響範囲が `appsButton` スロットのみであることをコード上明確にしただけ
- 外部インターフェース（props）に変更なし

## プロダクト側で対応が必要な事項

なし

## 確認方法

Storybookの `AppLauncher` で表示に変化がないことを確認する