### PR TITLE
refactor(FormControl): 内部refとquerySelectorの構成を簡潔化

### DIFF
--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -159,7 +159,7 @@ export const ActualFormControl: FC<Props> = ({
   const [childInputId, setChildInputId] = useState<string>('')
   const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
   const managedLabelId = label.id || `${baseId}-label`
-  const stackRef = useRef<HTMLDivElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
@@ -213,14 +213,14 @@ export const ActualFormControl: FC<Props> = ({
   useEffect(() => {
     if (
       isFieldset ||
-      !stackRef.current ||
+      !wrapperRef.current ||
       // HINT: 対象idを持つ要素が既に存在する場合、何もしない
       document.getElementById(managedHtmlFor)
     ) {
       return
     }
 
-    const input = stackRef.current
+    const input = wrapperRef.current
       .querySelector(CHILDREN_WRAPPER_SELECTOR)
       ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
 
@@ -237,22 +237,21 @@ export const ActualFormControl: FC<Props> = ({
     }
 
     if (input instanceof HTMLInputElement && input.type === 'file') {
-      const attrName = 'aria-labelledby'
-      const inputLabelledByIds = input.getAttribute(attrName)
+      const inputLabelledByIds = input.getAttribute('aria-labelledby')
 
       if (inputLabelledByIds) {
         // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
-        input.setAttribute(attrName, `${inputLabelledByIds} ${managedLabelId}`)
+        input.setAttribute('aria-labelledby', `${inputLabelledByIds} ${managedLabelId}`)
       }
     }
   }, [managedHtmlFor, isFieldset, managedLabelId])
 
   useEffect(() => {
-    if (!stackRef.current) {
+    if (!wrapperRef.current) {
       return
     }
 
-    const input = stackRef.current
+    const input = wrapperRef.current
       .querySelector(CHILDREN_WRAPPER_SELECTOR)
       ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
 
@@ -260,8 +259,7 @@ export const ActualFormControl: FC<Props> = ({
       return
     }
 
-    const attrName = 'aria-describedby'
-    const ariaDescribedBy = input.getAttribute(attrName) || ''
+    const ariaDescribedBy = input.getAttribute('aria-describedby') || ''
     const currentTokens = ariaDescribedBy ? ariaDescribedBy.split(' ') : []
     // HINT: 自分が過去に付与したid以外（=外部由来のid）だけを残す
     const externalTokens = currentTokens.filter(
@@ -272,9 +270,9 @@ export const ActualFormControl: FC<Props> = ({
 
     if (nextValue !== ariaDescribedBy) {
       if (nextValue) {
-        input.setAttribute(attrName, nextValue)
+        input.setAttribute('aria-describedby', nextValue)
       } else {
-        input.removeAttribute(attrName)
+        input.removeAttribute('aria-describedby')
       }
     }
 
@@ -282,21 +280,19 @@ export const ActualFormControl: FC<Props> = ({
   }, [describedbyIds])
 
   useEffect(() => {
-    if (!autoBindErrorInput || !stackRef.current) {
+    if (!autoBindErrorInput || !wrapperRef.current) {
       return
     }
 
-    const input = stackRef.current
+    const input = wrapperRef.current
       .querySelector(CHILDREN_WRAPPER_SELECTOR)
       ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
 
     if (input) {
-      const attrName = 'aria-invalid'
-
       if (actualErrorMessages.length > 0) {
-        input.setAttribute(attrName, 'true')
+        input.setAttribute('aria-invalid', 'true')
       } else {
-        input.removeAttribute(attrName)
+        input.removeAttribute('aria-invalid')
       }
     }
   }, [actualErrorMessages.length, autoBindErrorInput])
@@ -304,10 +300,10 @@ export const ActualFormControl: FC<Props> = ({
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
   useEffect(() => {
-    if (!isFieldset || !stackRef.current) return
+    if (!isFieldset || !wrapperRef.current) return
 
-    const childrenWrapper = stackRef.current.querySelector(CHILDREN_WRAPPER_SELECTOR)
-    const labelTextEl = stackRef.current.querySelector(LABEL_TEXT_SELECTOR)
+    const childrenWrapper = wrapperRef.current.querySelector(CHILDREN_WRAPPER_SELECTOR)
+    const labelTextEl = wrapperRef.current.querySelector(LABEL_TEXT_SELECTOR)
 
     if (!childrenWrapper || !labelTextEl) return
 
@@ -361,7 +357,7 @@ export const ActualFormControl: FC<Props> = ({
   return (
     <Stack
       {...rest}
-      ref={stackRef}
+      ref={wrapperRef}
       as={as}
       gap={innerMargin ?? 0.5}
       aria-describedby={isFieldset && describedbyIds ? describedbyIds : undefined}

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -81,11 +81,11 @@ const classNameGenerator = tv({
       '[&:disabled_.smarthr-ui-FormControl-supplementaryMessage]:shr-text-color-inherit',
       '[&:disabled_.smarthr-ui-Input]:shr-border-default/50 [&:disabled_.smarthr-ui-Input]:shr-bg-white-darken',
     ],
-    label: ['smarthr-ui-FormControl-label'],
-    errorList: ['shr-list-none'],
+    label: 'smarthr-ui-FormControl-label',
+    errorList: 'shr-list-none',
     errorIcon: ['smarthr-ui-FormControl-errorMessage-Icon', 'shr-text-danger'],
-    errorMessage: ['smarthr-ui-FormControl-errorMessage'],
-    childrenWrapper: ['smarthr-ui-FormControl-childrenWrapper'],
+    errorMessage: 'smarthr-ui-FormControl-errorMessage',
+    childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
   },
   variants: {
     innerMargin: {

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -153,11 +153,10 @@ export const ActualFormControl: FC<Props> = ({
     orgLabel,
     labelObjectConverter,
   )
-  const defaultHtmlFor = useId()
-  const defaultLabelId = useId()
+  const baseId = useId()
   const [childInputId, setChildInputId] = useState<string>('')
-  const managedHtmlFor = label.htmlFor || childInputId || defaultHtmlFor
-  const managedLabelId = label.id || defaultLabelId
+  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
+  const managedLabelId = label.id || `${baseId}-label`
   const inputWrapperRef = useRef<HTMLDivElement>(null)
   const labelTextRef = useRef<HTMLElement>(null)
   const managedDescribedbyIdsRef = useRef<string[]>([])

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -133,7 +133,7 @@ const classNameGenerator = tv({
 })
 
 const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
-const CHILDREN_WRAPPER_SELECTOR = '.smarthr-ui-FormControl-childrenWrapper'
+const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-childrenWrapper ${SMARTHR_UI_INPUT_SELECTOR}`
 const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
 
 export const ActualFormControl: FC<Props> = ({
@@ -220,9 +220,7 @@ export const ActualFormControl: FC<Props> = ({
       return
     }
 
-    const input = wrapperRef.current
-      .querySelector(CHILDREN_WRAPPER_SELECTOR)
-      ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
 
     if (!input) {
       return
@@ -251,9 +249,7 @@ export const ActualFormControl: FC<Props> = ({
       return
     }
 
-    const input = wrapperRef.current
-      .querySelector(CHILDREN_WRAPPER_SELECTOR)
-      ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
 
     if (!input) {
       return
@@ -284,9 +280,7 @@ export const ActualFormControl: FC<Props> = ({
       return
     }
 
-    const input = wrapperRef.current
-      .querySelector(CHILDREN_WRAPPER_SELECTOR)
-      ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
 
     if (input) {
       if (actualErrorMessages.length > 0) {
@@ -302,10 +296,9 @@ export const ActualFormControl: FC<Props> = ({
   useEffect(() => {
     if (!isFieldset || !wrapperRef.current) return
 
-    const childrenWrapper = wrapperRef.current.querySelector(CHILDREN_WRAPPER_SELECTOR)
     const labelTextEl = wrapperRef.current.querySelector(LABEL_TEXT_SELECTOR)
 
-    if (!childrenWrapper || !labelTextEl) return
+    if (!labelTextEl) return
 
     // HINT: legend変更のたびにaria-labelへ古いlegend文言が蓄積しないよう、
     // 初回に確定したアクセシブルネームをinput要素ごとに保持しておく
@@ -315,8 +308,10 @@ export const ActualFormControl: FC<Props> = ({
       const labelText = labelTextEl.textContent || ''
       if (!labelText) return
 
-      const inputs = childrenWrapper.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
-      if (!inputs.length) return
+      const inputs = wrapperRef.current?.querySelectorAll<HTMLInputElement>(
+        CHILDREN_WRAPPER_INPUT_SELECTOR,
+      )
+      if (!inputs?.length) return
 
       inputs.forEach((input: HTMLInputElement) => {
         let accessibleName = baseAccessibleNames.get(input)

--- a/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormControl/FormControl.tsx
@@ -85,7 +85,7 @@ const classNameGenerator = tv({
     errorList: ['shr-list-none'],
     errorIcon: ['smarthr-ui-FormControl-errorMessage-Icon', 'shr-text-danger'],
     errorMessage: ['smarthr-ui-FormControl-errorMessage'],
-    childrenWrapper: [],
+    childrenWrapper: ['smarthr-ui-FormControl-childrenWrapper'],
   },
   variants: {
     innerMargin: {
@@ -133,6 +133,8 @@ const classNameGenerator = tv({
 })
 
 const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
+const CHILDREN_WRAPPER_SELECTOR = '.smarthr-ui-FormControl-childrenWrapper'
+const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
 
 export const ActualFormControl: FC<Props> = ({
   label: orgLabel,
@@ -157,8 +159,7 @@ export const ActualFormControl: FC<Props> = ({
   const [childInputId, setChildInputId] = useState<string>('')
   const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
   const managedLabelId = label.id || `${baseId}-label`
-  const inputWrapperRef = useRef<HTMLDivElement>(null)
-  const labelTextRef = useRef<HTMLElement>(null)
+  const stackRef = useRef<HTMLDivElement>(null)
   const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
@@ -212,14 +213,16 @@ export const ActualFormControl: FC<Props> = ({
   useEffect(() => {
     if (
       isFieldset ||
-      !inputWrapperRef?.current ||
+      !stackRef.current ||
       // HINT: 対象idを持つ要素が既に存在する場合、何もしない
       document.getElementById(managedHtmlFor)
     ) {
       return
     }
 
-    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+    const input = stackRef.current
+      .querySelector(CHILDREN_WRAPPER_SELECTOR)
+      ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
 
     if (!input) {
       return
@@ -245,11 +248,13 @@ export const ActualFormControl: FC<Props> = ({
   }, [managedHtmlFor, isFieldset, managedLabelId])
 
   useEffect(() => {
-    if (!inputWrapperRef?.current) {
+    if (!stackRef.current) {
       return
     }
 
-    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+    const input = stackRef.current
+      .querySelector(CHILDREN_WRAPPER_SELECTOR)
+      ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
 
     if (!input) {
       return
@@ -277,11 +282,13 @@ export const ActualFormControl: FC<Props> = ({
   }, [describedbyIds])
 
   useEffect(() => {
-    if (!autoBindErrorInput || !inputWrapperRef?.current) {
+    if (!autoBindErrorInput || !stackRef.current) {
       return
     }
 
-    const input = inputWrapperRef.current.querySelector(SMARTHR_UI_INPUT_SELECTOR)
+    const input = stackRef.current
+      .querySelector(CHILDREN_WRAPPER_SELECTOR)
+      ?.querySelector(SMARTHR_UI_INPUT_SELECTOR)
 
     if (input) {
       const attrName = 'aria-invalid'
@@ -297,18 +304,22 @@ export const ActualFormControl: FC<Props> = ({
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
   useEffect(() => {
-    if (!isFieldset || !inputWrapperRef.current || !labelTextRef.current) return
+    if (!isFieldset || !stackRef.current) return
+
+    const childrenWrapper = stackRef.current.querySelector(CHILDREN_WRAPPER_SELECTOR)
+    const labelTextEl = stackRef.current.querySelector(LABEL_TEXT_SELECTOR)
+
+    if (!childrenWrapper || !labelTextEl) return
 
     // HINT: legend変更のたびにaria-labelへ古いlegend文言が蓄積しないよう、
     // 初回に確定したアクセシブルネームをinput要素ごとに保持しておく
     const baseAccessibleNames = new WeakMap<HTMLInputElement, string>()
 
     const updateAriaLabels = () => {
-      const labelText = labelTextRef.current?.textContent || ''
+      const labelText = labelTextEl.textContent || ''
       if (!labelText) return
 
-      const inputs =
-        inputWrapperRef.current!.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
+      const inputs = childrenWrapper.querySelectorAll<HTMLInputElement>(SMARTHR_UI_INPUT_SELECTOR)
       if (!inputs.length) return
 
       inputs.forEach((input: HTMLInputElement) => {
@@ -338,7 +349,7 @@ export const ActualFormControl: FC<Props> = ({
 
     // label要素の変更を監視
     const observer = new MutationObserver(updateAriaLabels)
-    observer.observe(labelTextRef.current, {
+    observer.observe(labelTextEl, {
       childList: true,
       subtree: true,
       characterData: true,
@@ -350,6 +361,7 @@ export const ActualFormControl: FC<Props> = ({
   return (
     <Stack
       {...rest}
+      ref={stackRef}
       as={as}
       gap={innerMargin ?? 0.5}
       aria-describedby={isFieldset && describedbyIds ? describedbyIds : undefined}
@@ -366,7 +378,6 @@ export const ActualFormControl: FC<Props> = ({
         statusLabels={actualStatusLabels}
         subActionArea={subActionArea}
         labelClassName={classNames.label}
-        labelTextRef={labelTextRef}
       />
       <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={managedHtmlFor} />
       <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={managedHtmlFor} />
@@ -375,9 +386,7 @@ export const ActualFormControl: FC<Props> = ({
         managedHtmlFor={managedHtmlFor}
         classNames={classNames}
       />
-      <div className={classNames.childrenWrapper} ref={inputWrapperRef}>
-        {children}
-      </div>
+      <div className={classNames.childrenWrapper}>{children}</div>
       <SupplementaryMessageText
         supplementaryMessage={supplementaryMessage}
         managedHtmlFor={managedHtmlFor}
@@ -397,7 +406,6 @@ const LabelCluster = memo<
     managedLabelId: string
     labelClassName: string
     statusLabels: StatusLabelType[]
-    labelTextRef: React.RefObject<HTMLElement>
   }
 >(
   ({
@@ -411,12 +419,11 @@ const LabelCluster = memo<
     subActionArea,
     labelClassName,
     statusLabels,
-    labelTextRef,
   }) => {
     const body = (
       <>
         <Text styleType={labelType} icon={labelIcon}>
-          <span ref={labelTextRef}>{label}</span>
+          <span className="smarthr-ui-FormControl-labelText">{label}</span>
         </Text>
         <StatusLabelCluster statusLabels={statusLabels} />
       </>


### PR DESCRIPTION
## 関連URL

なし

## 概要

FormControl内部で入力要素・ラベルテキストへの参照方法が冗長だったため、簡潔化した。

## 変更内容

- `defaultHtmlFor`/`defaultLabelId`用の2回の`useId()`呼び出しを、1回の`useId()`から導出する形にまとめた
- `inputWrapperRef`/`labelTextRef`という複数のrefを廃止し、`Stack`全体に単一の`wrapperRef`を設定。子要素側にマーカークラス（`smarthr-ui-FormControl-childrenWrapper`, `smarthr-ui-FormControl-labelText`）を付与し、`wrapperRef`からの`querySelector`で対象要素を検索する方式に統一した
- `childrenWrapper`と`smarthr-ui-input`を組み合わせた2段階の`querySelector`呼び出しを、子孫結合子で結合した1つのセレクタ（`CHILDREN_WRAPPER_INPUT_SELECTOR`）による1回の呼び出しに統合した
- 挙動・出力されるDOM構造に変更はない

## プロダクト側で対応が必要な事項

なし

## 確認方法

既存のFormControl関連テスト（Fieldset, InputFile, Textareaなど、FormControlを利用するコンポーネントのテスト）がすべてパスすることを確認済み。Storybookでの表示にも変更はない。