### PR TITLE
refactor(FormGroup): 状態管理をFormControl・Fieldsetに移譲する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,21 @@ export const Wrapper: FC<{ onClick?: () => void }> = ({ onClick }) => {
 - `interface` ではなく `type` を使用（ESLint ルール `@typescript-eslint/consistent-type-definitions` で強制）
 
 ### インポート
-- インライン型インポートを使用（`import { type Foo }`）— `@typescript-eslint/consistent-type-imports` で強制
+- 型インポートの形式は2つのESLintルールの組み合わせで決まる。**どちらも自動修正されるため、手で書き分ける必要はない**
+  - `@typescript-eslint/consistent-type-imports`（`fixStyle: 'inline-type-imports'`）: 型を値と同じimport文にまとめ、`type` 修飾子を付ける
+  - `@typescript-eslint/no-import-type-side-effects`: import文の指定子が**すべて型**の場合、`import type { ... }` 形式に変換する
+
+  ```typescript
+  // ✅ 値と型が混在する場合はインライン形式
+  import { type FC, useState } from 'react'
+
+  // ✅ すべて型の場合は import type 形式
+  // （`import { type ComponentProps, type ReactNode }` と書いても自動でこの形に修正される）
+  import type { ComponentProps, ReactNode } from 'react'
+  ```
+
+  **注意**: 「すべて型なのに `import type` になっている」のはルール違反ではなく、ルールが要求する正しい形。
+  インライン形式へ直すよう指摘された場合は誤りなので従わない。
 - ワイルドカードの禁止: `export *`、`export * as`、`import * as` は禁止（Icons のみ例外）
 
 ### アクセシビリティ

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -6,7 +6,7 @@ import { FormGroup } from './FormGroup'
 
 import type { CommonProps, ObjectLabelType } from './type'
 
-const legendObjectConverter = (label: ReactNode) => ({ text: label })
+const legendObjectConverter = (legend: ReactNode) => ({ text: legend })
 
 export const Fieldset: FC<
   CommonProps & {
@@ -26,7 +26,7 @@ export const Fieldset: FC<
     ...baseLegend,
     // TODO: fieldsetなので本質的にhtmlForは不要なはず。調整する
     htmlFor: baseLegend.htmlFor || `${baseId}-htmlFor`,
-    id: baseLegend.id || `${baseId}-label`,
+    id: baseLegend.id || `${baseId}-legend`,
   }
 
   return <FormGroup {...rest} as="fieldset" wrapperRef={wrapperRef} label={legend} />

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -10,7 +10,7 @@ const legendObjectConverter = (legend: ReactNode) => ({ text: legend })
 
 export const Fieldset: FC<
   CommonProps & {
-    legend: ReactNode | ObjectLabelType
+    legend: ReactNode | Omit<ObjectLabelType, 'htmlFor'>
     /** `true` のとき、文字色を `TEXT_DISABLED` にする */
     disabled?: boolean
   }
@@ -24,8 +24,9 @@ export const Fieldset: FC<
   )
   const legend = {
     ...baseLegend,
-    // TODO: fieldsetなので本質的にhtmlForは不要なはず。調整する
-    htmlFor: baseLegend.htmlFor || `${baseId}-htmlFor`,
+    // HINT: Fieldsetなので本質的にhtmlForは不要なのだがhtmlForを使って
+    // 最初のinputと各種ヒントをaria-describedbyでつなげているため必要
+    htmlFor: `${baseId}-htmlFor`,
     id: baseLegend.id || `${baseId}-legend`,
   }
 

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -1,18 +1,18 @@
-import { type ComponentProps, type FC, type ReactNode, useId, useRef } from 'react'
+import { type FC, type ReactNode, useId, useRef } from 'react'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 
 import { FormGroup } from './FormGroup'
 
-import type { ObjectLabelType } from './type'
-
-type FormControlType = ComponentProps<typeof FormGroup>
+import type { CommonProps, ObjectLabelType } from './type'
 
 const legendObjectConverter = (label: ReactNode) => ({ text: label })
 
 export const Fieldset: FC<
-  Omit<FormControlType, 'as' | 'label' | 'wrapperRef'> & {
+  CommonProps & {
     legend: ReactNode | ObjectLabelType
+    /** `true` のとき、文字色を `TEXT_DISABLED` にする */
+    disabled?: boolean
   }
 > = ({ legend: orgLegend, ...rest }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -24,6 +24,7 @@ export const Fieldset: FC<
   )
   const legend = {
     ...baseLegend,
+    // TODO: fieldsetなので本質的にhtmlForは不要なはず。調整する
     htmlFor: baseLegend.htmlFor || `${baseId}-htmlFor`,
     id: baseLegend.id || `${baseId}-label`,
   }

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type FC, type ReactNode, useId, useRef } from 'react'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -1,11 +1,32 @@
+import { type ComponentProps, type FC, type ReactNode, useId, useRef } from 'react'
+
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
+
 import { FormGroup } from './FormGroup'
 
-import type { ComponentProps, FC, ReactNode } from 'react'
+import type { ObjectLabelType } from './type'
 
 type FormControlType = ComponentProps<typeof FormGroup>
 
+const legendObjectConverter = (label: ReactNode) => ({ text: label })
+
 export const Fieldset: FC<
   Omit<FormControlType, 'as' | 'label' | 'wrapperRef'> & {
-    legend: Omit<Exclude<FormControlType['label'], ReactNode>, 'htmlFor'> | ReactNode
+    legend: ReactNode | ObjectLabelType
   }
-> = ({ legend, ...rest }) => <FormGroup {...rest} label={legend} as="fieldset" />
+> = ({ legend: orgLegend, ...rest }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const baseId = useId()
+
+  const baseLegend = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
+    orgLegend,
+    legendObjectConverter,
+  )
+  const legend = {
+    ...baseLegend,
+    htmlFor: baseLegend.htmlFor || `${baseId}-htmlFor`,
+    id: baseLegend.id || `${baseId}-label`,
+  }
+
+  return <FormGroup {...rest} as="fieldset" wrapperRef={wrapperRef} label={legend} />
+}

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps, FC, ReactNode } from 'react'
 type FormControlType = ComponentProps<typeof FormGroup>
 
 export const Fieldset: FC<
-  Omit<FormControlType, 'as' | 'label'> & {
+  Omit<FormControlType, 'as' | 'label' | 'wrapperRef'> & {
     legend: Omit<Exclude<FormControlType['label'], ReactNode>, 'htmlFor'> | ReactNode
   }
 > = ({ legend, ...rest }) => <FormGroup {...rest} label={legend} as="fieldset" />

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -19,7 +19,9 @@ import type { ObjectLabelType } from './type'
 const labelObjectConverter = (label: ReactNode) => ({ text: label })
 
 export const FormControl: FC<
-  Omit<ComponentProps<typeof FormGroup>, 'as' | 'disabled' | 'wrapperRef'>
+  Omit<ComponentProps<typeof FormGroup>, 'as' | 'label' | 'disabled' | 'wrapperRef'> & {
+    label: ReactNode | ObjectLabelType
+  }
 > = ({ label: orgLabel, ...rest }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -1,25 +1,17 @@
 'use client'
 
-import {
-  type ComponentProps,
-  type FC,
-  type ReactNode,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from 'react'
+import { type FC, type ReactNode, useEffect, useId, useRef, useState } from 'react'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 
 import { CHILDREN_WRAPPER_INPUT_SELECTOR, FormGroup } from './FormGroup'
 
-import type { ObjectLabelType } from './type'
+import type { CommonProps, ObjectLabelType } from './type'
 
 const labelObjectConverter = (label: ReactNode) => ({ text: label })
 
 export const FormControl: FC<
-  Omit<ComponentProps<typeof FormGroup>, 'as' | 'label' | 'disabled' | 'wrapperRef'> & {
+  CommonProps & {
     label: ReactNode | ObjectLabelType
   }
 > = ({ label: orgLabel, ...rest }) => {

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -1,7 +1,72 @@
 'use client'
 
-import { FormGroup } from './FormGroup'
+import {
+  type ComponentProps,
+  type FC,
+  type ReactNode,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react'
 
-import type { ComponentProps, FC } from 'react'
+import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 
-export const FormControl: FC<Omit<ComponentProps<typeof FormGroup>, 'as' | 'disabled'>> = FormGroup
+import { CHILDREN_WRAPPER_INPUT_SELECTOR, FormGroup } from './FormGroup'
+
+import type { ObjectLabelType } from './type'
+
+const labelObjectConverter = (label: ReactNode) => ({ text: label })
+
+export const FormControl: FC<
+  Omit<ComponentProps<typeof FormGroup>, 'as' | 'disabled' | 'wrapperRef'>
+> = ({ label: orgLabel, ...rest }) => {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const baseId = useId()
+  const [childInputId, setChildInputId] = useState<string>('')
+
+  const baseLabel = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
+    orgLabel,
+    labelObjectConverter,
+  )
+  const label = {
+    ...baseLabel,
+    htmlFor: baseLabel.htmlFor || childInputId || `${baseId}-htmlFor`,
+    id: baseLabel.id || `${baseId}-label`,
+  }
+
+  useEffect(() => {
+    if (
+      !wrapperRef.current ||
+      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
+      document.getElementById(label.htmlFor)
+    ) {
+      return
+    }
+
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
+
+    if (!input) {
+      return
+    }
+
+    const inputId = input.getAttribute('id')
+
+    if (inputId) {
+      setChildInputId(inputId)
+    } else {
+      input.setAttribute('id', label.htmlFor)
+    }
+
+    if (input instanceof HTMLInputElement && input.type === 'file') {
+      const inputLabelledByIds = input.getAttribute('aria-labelledby')
+
+      if (inputLabelledByIds) {
+        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
+        input.setAttribute('aria-labelledby', `${inputLabelledByIds} ${label.id}`)
+      }
+    }
+  }, [label.htmlFor, label.id])
+
+  return <FormGroup {...rest} wrapperRef={wrapperRef} label={label} />
+}

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -14,10 +14,8 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import { useId } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { FaCircleExclamationIcon } from '../Icon'
 import { Cluster, Stack } from '../Layout'
 import { Text, type TextProps } from '../Text'
@@ -30,9 +28,9 @@ import type { IconType, ObjectLabelType } from './type'
 type StatusLabelType = FunctionComponentElement<ComponentProps<typeof StatusLabel>>
 
 type BaseProps = PropsWithChildren<{
-  wrapperRef?: RefObject<HTMLDivElement>
+  wrapperRef: RefObject<HTMLDivElement>
   /** グループのラベル名 */
-  label: ReactNode | ObjectLabelType
+  label: Omit<ObjectLabelType, 'id' | 'htmlFor'> & Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
   /** タイトル右の領域 */
   subActionArea?: ReactNode
   /** タイトル群と子要素の間の間隔調整用（基本的には不要） */
@@ -54,8 +52,6 @@ type BaseProps = PropsWithChildren<{
   as?: string | ComponentType<any>
 }>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'aria-labelledby'>
-
-const labelObjectConverter = (label: ReactNode) => ({ text: label })
 
 const classNameGenerator = tv({
   slots: {
@@ -125,8 +121,8 @@ export const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-children
 const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
 
 export const FormGroup: FC<Props> = ({
-  wrapperRef: orgWrapperRef,
-  label: orgLabel,
+  wrapperRef,
+  label,
   subActionArea,
   innerMargin,
   statusLabels,
@@ -140,15 +136,6 @@ export const FormGroup: FC<Props> = ({
   children,
   ...rest
 }) => {
-  const label = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
-    orgLabel,
-    labelObjectConverter,
-  )
-  const baseId = useId()
-  const managedHtmlFor = label.htmlFor || `${baseId}-htmlFor`
-  const managedLabelId = label.id || `${baseId}-label`
-  const baseWrapperRef = useRef<HTMLDivElement>(null)
-  const wrapperRef = orgWrapperRef || baseWrapperRef
   const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
@@ -156,20 +143,20 @@ export const FormGroup: FC<Props> = ({
     const temp: string[] = []
 
     if (helpMessage) {
-      temp.push(`${managedHtmlFor}_helpMessage`)
+      temp.push(`${label.htmlFor}_helpMessage`)
     }
     if (exampleMessage) {
-      temp.push(`${managedHtmlFor}_exampleMessage`)
+      temp.push(`${label.htmlFor}_exampleMessage`)
     }
     if (supplementaryMessage) {
-      temp.push(`${managedHtmlFor}_supplementaryMessage`)
+      temp.push(`${label.htmlFor}_supplementaryMessage`)
     }
     if (errorMessages) {
-      temp.push(`${managedHtmlFor}_errorMessages`)
+      temp.push(`${label.htmlFor}_errorMessages`)
     }
 
     return temp.join(' ')
-  }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, managedHtmlFor])
+  }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, label.htmlFor])
 
   const actualStatusLabels = useMemo(
     () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
@@ -315,8 +302,8 @@ export const FormGroup: FC<Props> = ({
     >
       <LabelCluster
         isFieldset={isFieldset}
-        managedHtmlFor={managedHtmlFor}
-        managedLabelId={managedLabelId}
+        managedHtmlFor={label.htmlFor}
+        managedLabelId={label.id}
         unrecommendedHideLabel={label.unrecommendedHide}
         labelType={label.styleType}
         label={label.text}
@@ -325,17 +312,17 @@ export const FormGroup: FC<Props> = ({
         subActionArea={subActionArea}
         labelClassName={classNames.label}
       />
-      <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={managedHtmlFor} />
-      <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={managedHtmlFor} />
+      <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={label.htmlFor} />
+      <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={label.htmlFor} />
       <ErrorMessageList
         errorMessages={actualErrorMessages}
-        managedHtmlFor={managedHtmlFor}
+        managedHtmlFor={label.htmlFor}
         classNames={classNames}
       />
       <div className={classNames.childrenWrapper}>{children}</div>
       <SupplementaryMessageText
         supplementaryMessage={supplementaryMessage}
-        managedHtmlFor={managedHtmlFor}
+        managedHtmlFor={label.htmlFor}
       />
     </Stack>
   )

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,12 +1,8 @@
 'use client'
 
 import {
-  type ComponentProps,
-  type ComponentPropsWithoutRef,
   type ComponentType,
   type FC,
-  type FunctionComponentElement,
-  type PropsWithChildren,
   type ReactNode,
   type RefObject,
   memo,
@@ -21,37 +17,17 @@ import { Cluster, Stack } from '../Layout'
 import { Text, type TextProps } from '../Text'
 import { VisuallyHiddenText, visuallyHiddenTextClassName } from '../VisuallyHiddenText'
 
+import type { CommonProps, IconType, ObjectLabelType, StatusLabelType } from './type'
 import type { Gap } from '../../types'
-import type { StatusLabel } from '../StatusLabel'
-import type { IconType, ObjectLabelType } from './type'
 
-type StatusLabelType = FunctionComponentElement<ComponentProps<typeof StatusLabel>>
-
-type BaseProps = PropsWithChildren<{
+type Props = CommonProps & {
   wrapperRef: RefObject<HTMLDivElement>
   /** グループのラベル名 */
   label: Omit<ObjectLabelType, 'id' | 'htmlFor'> & Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
-  /** タイトル右の領域 */
-  subActionArea?: ReactNode
-  /** タイトル群と子要素の間の間隔調整用（基本的には不要） */
-  innerMargin?: Gap
-  /** タイトルの隣に表示する `StatusLabel` の配列 */
-  statusLabels?: StatusLabelType | StatusLabelType[]
-  /** タイトルの下に表示するヘルプメッセージ */
-  helpMessage?: ReactNode
-  /** タイトルの下に表示する入力例 */
-  exampleMessage?: ReactNode
-  /** タイトルの下に表示するエラーメッセージ */
-  errorMessages?: ReactNode | ReactNode[]
-  /** エラーがある場合に自動的に入力要素を error にするかどうか */
-  autoBindErrorInput?: boolean
-  /** フォームコントロールの下に表示する補足メッセージ */
-  supplementaryMessage?: ReactNode
+  as?: string | ComponentType<any>
   /** `true` のとき、文字色を `TEXT_DISABLED` にする */
   disabled?: boolean
-  as?: string | ComponentType<any>
-}>
-type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'aria-labelledby'>
+}
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -8,11 +8,11 @@ import {
   type FunctionComponentElement,
   type PropsWithChildren,
   type ReactNode,
+  type RefObject,
   memo,
   useEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react'
 import { useId } from 'react'
 import { tv } from 'tailwind-variants'
@@ -25,24 +25,12 @@ import { VisuallyHiddenText, visuallyHiddenTextClassName } from '../VisuallyHidd
 
 import type { Gap } from '../../types'
 import type { StatusLabel } from '../StatusLabel'
+import type { IconType, ObjectLabelType } from './type'
 
 type StatusLabelType = FunctionComponentElement<ComponentProps<typeof StatusLabel>>
-type IconType = ComponentProps<typeof Text>['icon']
 
-type ObjectLabelType = {
-  text: ReactNode
-  /** ラベルの表示タイプ */
-  styleType?: TextProps['styleType']
-  /** ラベル左に設置するアイコン */
-  icon?: IconType
-  /** ラベルを視覚的に隠すかどうか */
-  unrecommendedHide?: boolean
-  /** ラベルを紐づける入力要素のID属性と同じ値 */
-  htmlFor?: string
-  /** ラベルに適用する `id` 値 */
-  id?: string
-}
 type BaseProps = PropsWithChildren<{
+  wrapperRef?: RefObject<HTMLDivElement>
   /** グループのラベル名 */
   label: ReactNode | ObjectLabelType
   /** タイトル右の領域 */
@@ -133,10 +121,11 @@ const classNameGenerator = tv({
 })
 
 const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
-const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-childrenWrapper ${SMARTHR_UI_INPUT_SELECTOR}`
+export const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-childrenWrapper ${SMARTHR_UI_INPUT_SELECTOR}`
 const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
 
 export const FormGroup: FC<Props> = ({
+  wrapperRef: orgWrapperRef,
   label: orgLabel,
   subActionArea,
   innerMargin,
@@ -156,10 +145,10 @@ export const FormGroup: FC<Props> = ({
     labelObjectConverter,
   )
   const baseId = useId()
-  const [childInputId, setChildInputId] = useState<string>('')
-  const managedHtmlFor = label.htmlFor || childInputId || `${baseId}-htmlFor`
+  const managedHtmlFor = label.htmlFor || `${baseId}-htmlFor`
   const managedLabelId = label.id || `${baseId}-label`
-  const wrapperRef = useRef<HTMLDivElement>(null)
+  const baseWrapperRef = useRef<HTMLDivElement>(null)
+  const wrapperRef = orgWrapperRef || baseWrapperRef
   const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
@@ -211,40 +200,6 @@ export const FormGroup: FC<Props> = ({
   }, [innerMargin, isFieldset, label.unrecommendedHide, className])
 
   useEffect(() => {
-    if (
-      isFieldset ||
-      !wrapperRef.current ||
-      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
-      document.getElementById(managedHtmlFor)
-    ) {
-      return
-    }
-
-    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
-
-    if (!input) {
-      return
-    }
-
-    const inputId = input.getAttribute('id')
-
-    if (inputId) {
-      setChildInputId(inputId)
-    } else {
-      input.setAttribute('id', managedHtmlFor)
-    }
-
-    if (input instanceof HTMLInputElement && input.type === 'file') {
-      const inputLabelledByIds = input.getAttribute('aria-labelledby')
-
-      if (inputLabelledByIds) {
-        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
-        input.setAttribute('aria-labelledby', `${inputLabelledByIds} ${managedLabelId}`)
-      }
-    }
-  }, [managedHtmlFor, isFieldset, managedLabelId])
-
-  useEffect(() => {
     if (!wrapperRef.current) {
       return
     }
@@ -273,7 +228,7 @@ export const FormGroup: FC<Props> = ({
     }
 
     managedDescribedbyIdsRef.current = describedbyIdTokens
-  }, [describedbyIds])
+  }, [describedbyIds, wrapperRef])
 
   useEffect(() => {
     if (!autoBindErrorInput || !wrapperRef.current) {
@@ -289,7 +244,7 @@ export const FormGroup: FC<Props> = ({
         input.removeAttribute('aria-invalid')
       }
     }
-  }, [actualErrorMessages.length, autoBindErrorInput])
+  }, [actualErrorMessages.length, autoBindErrorInput, wrapperRef])
 
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
@@ -347,7 +302,7 @@ export const FormGroup: FC<Props> = ({
     })
 
     return () => observer.disconnect()
-  }, [isFieldset])
+  }, [isFieldset, wrapperRef])
 
   return (
     <Stack

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentType,
   type FC,

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -132,6 +132,7 @@ export const FormGroup: FC<Props> = ({
     }
 
     return temp.join(' ')
+    // TODO: ReactNodeやarrayなど不安定な値をそのまま依存配列に含めているので調整する
   }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, label.htmlFor])
 
   const actualStatusLabels = useMemo(
@@ -148,7 +149,7 @@ export const FormGroup: FC<Props> = ({
   }, [errorMessages])
 
   const classNames = useMemo(() => {
-    const generators = classNameGenerator({ innerMargin, isFieldset })
+    const generators = classNameGenerator()
 
     return {
       wrapper: generators.wrapper({ className }),
@@ -158,7 +159,7 @@ export const FormGroup: FC<Props> = ({
       errorList: generators.errorList(),
       errorIcon: generators.errorIcon(),
       errorMessage: generators.errorMessage(),
-      childrenWrapper: generators.childrenWrapper(),
+      childrenWrapper: generators.childrenWrapper({ innerMargin, isFieldset }),
     }
   }, [innerMargin, isFieldset, label.unrecommendedHide, className])
 

--- a/packages/smarthr-ui/src/components/FormGroup/type.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/type.ts
@@ -1,7 +1,16 @@
+import type { Gap } from '../../types'
+import type { StatusLabel } from '../StatusLabel'
 import type { Text, TextProps } from '../Text'
-import type { ComponentProps, ReactNode } from 'react'
+import type {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  FunctionComponentElement,
+  PropsWithChildren,
+  ReactNode,
+} from 'react'
 
 export type IconType = ComponentProps<typeof Text>['icon']
+export type StatusLabelType = FunctionComponentElement<ComponentProps<typeof StatusLabel>>
 
 export type ObjectLabelType = {
   text: ReactNode
@@ -16,3 +25,24 @@ export type ObjectLabelType = {
   /** ラベルに適用する `id` 値 */
   id?: string
 }
+
+type BaseCommonProps = PropsWithChildren<{
+  /** タイトル右の領域 */
+  subActionArea?: ReactNode
+  /** タイトル群と子要素の間の間隔調整用（基本的には不要） */
+  innerMargin?: Gap
+  /** タイトルの隣に表示する `StatusLabel` の配列 */
+  statusLabels?: StatusLabelType | StatusLabelType[]
+  /** タイトルの下に表示するヘルプメッセージ */
+  helpMessage?: ReactNode
+  /** タイトルの下に表示する入力例 */
+  exampleMessage?: ReactNode
+  /** タイトルの下に表示するエラーメッセージ */
+  errorMessages?: ReactNode | ReactNode[]
+  /** エラーがある場合に自動的に入力要素を error にするかどうか */
+  autoBindErrorInput?: boolean
+  /** フォームコントロールの下に表示する補足メッセージ */
+  supplementaryMessage?: ReactNode
+}>
+export type CommonProps = BaseCommonProps &
+  Omit<ComponentPropsWithoutRef<'div'>, keyof BaseCommonProps | 'aria-labelledby'>

--- a/packages/smarthr-ui/src/components/FormGroup/type.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/type.ts
@@ -1,0 +1,18 @@
+import type { Text, TextProps } from '../Text'
+import type { ComponentProps, ReactNode } from 'react'
+
+export type IconType = ComponentProps<typeof Text>['icon']
+
+export type ObjectLabelType = {
+  text: ReactNode
+  /** ラベルの表示タイプ */
+  styleType?: TextProps['styleType']
+  /** ラベル左に設置するアイコン */
+  icon?: IconType
+  /** ラベルを視覚的に隠すかどうか */
+  unrecommendedHide?: boolean
+  /** ラベルを紐づける入力要素のID属性と同じ値 */
+  htmlFor?: string
+  /** ラベルに適用する `id` 値 */
+  id?: string
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` は `FormControl` と `Fieldset` の共通実装として切り出されたコンポーネントですが、`label` のオブジェクト変換・`htmlFor`/`id` の採番・input要素へのid紐付けといった状態管理を自身で抱えていました。

このうち input要素へのid紐付け処理は `as="fieldset"` の場合に早期returnするため、実際には `FormControl` 経由でしか動作していませんでした。`FormGroup` は `src/index.ts` からexportされておらず、利用者は `FormControl` と `Fieldset` のみであるため、この処理は `FormControl` 固有の責務と言えます。

そこで状態管理を `FormControl` と `Fieldset` それぞれに移し、`FormGroup` は正規化済みの値を受け取って描画するだけのコンポーネントにしました。

## 変更内容

### 1. input要素へのid紐付け処理を `FormControl` に移譲

`FormGroup` が持っていた紐付け用の `useEffect` を `FormControl` に移し、`FormGroup` からは削除しました。

`FormGroup` は `wrapperRef` をpropsとして受け取る形になります。

### 2. `label` の正規化とid採番を `FormControl`・`Fieldset` に移譲

`useObjectAttributes` によるオブジェクト変換と、`useId` による `htmlFor`・`id` の採番を呼び出し側に移しました。

```tsx
// FormControl.tsx / Fieldset.tsx（いずれも同様の構造）
const baseLabel = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
  orgLabel,
  labelObjectConverter,
)
const label = {
  ...baseLabel,
  htmlFor: baseLabel.htmlFor || `${baseId}-htmlFor`,
  id: baseLabel.id || `${baseId}-label`,
}
```

`FormGroup` のprops型では `htmlFor`・`id` を必須にし、呼び出し側での補完漏れを型で防げるようにしています。

```tsx
label: Omit<ObjectLabelType, 'id' | 'htmlFor'> & Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
```

結果として `FormGroup` からは `useId`・`useState`・`useObjectAttributes` が不要になりました。

### 3. 共通のprops・型を `type.ts` に集約

3ファイルで重複していたprops定義を `CommonProps` として `type.ts` に切り出しました。JSDocコメントの管理も1箇所になります。

```tsx
// type.ts
type BaseCommonProps = PropsWithChildren<{
  subActionArea?: ReactNode
  innerMargin?: Gap
  statusLabels?: StatusLabelType | StatusLabelType[]
  helpMessage?: ReactNode
  exampleMessage?: ReactNode
  errorMessages?: ReactNode | ReactNode[]
  autoBindErrorInput?: boolean
  supplementaryMessage?: ReactNode
}>

export type CommonProps = BaseCommonProps &
  Omit<ComponentPropsWithoutRef<'div'>, keyof BaseCommonProps | 'aria-labelledby'>
```

`CommonProps` が `PropsWithChildren` とdiv要素の属性を含むため、`FormControl`・`Fieldset` は `FormGroup` の型から派生させなくても `children`・`className`・`data-*` などを従来どおり受け取れます。

あわせて `ObjectLabelType`・`IconType`・`StatusLabelType` も `type.ts` に集約しました。

## プロダクト側で対応が必要な事項

なし。

`FormControl` の `label`、`Fieldset` の `legend` は従来どおり `ReactNode` と `ObjectLabelType` の両方を受け取ります。公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` および両者を利用しているコンポーネントに差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 公開インターフェースの同一性について

props の型の組み立て方を変更したため、利用側から渡せる props が変わっていないことを型レベルで確認しました。

`children`・`className`・`id`・`data-*` および独自props（`helpMessage`・`exampleMessage`・`errorMessages`・`supplementaryMessage`・`innerMargin`・`autoBindErrorInput`）を渡すコードを用意し、masterと本ブランチの双方で型エラーが出ないことを確認しています。

### 生成DOMの同一性について

内部実装の変更が大きいため、リファクタリング前後で生成されるDOMが変化しないことを実測で比較しました。

以下6パターンについて、`input` の `id`・`aria-labelledby`・`aria-describedby`・`aria-invalid`・`aria-label`、`label` の `for`・`id`、`legend` のテキストを記録して比較しています。

1. input に id 無し
2. input に id 有り（既存idを尊重するか）
3. `helpMessage`・`errorMessages` による `aria-describedby`・`aria-invalid`
4. InputFile の `aria-labelledby` への label id 追加
5. Fieldset（`as="fieldset"`）でid紐付けを行わないこと
6. `label` をオブジェクトで渡した場合の `htmlFor`・`id` の尊重

結果は `useId` の採番（`_r_1_` → `_r_2_` など）以外は完全一致でした。採番がずれるのは `FormControl`・`Fieldset` が独自に `useId` を呼ぶようになり消費数が変わったためで、値自体は不透明な内部IDのため利用側への影響はありません。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / DatePicker / Combobox / Dialog / WarekiPicker / Textarea / InputFile / AccordionPanel / Dropdown）— 23ファイル 103件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * フォームのラベルにIDや関連付け情報を自動設定できるようになりました。
  * 入力項目のラベル、説明、エラーメッセージの関連付けを改善しました。
  * ファイル入力でのアクセシビリティ対応を強化しました。
  * フィールドセットで無効状態を指定できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->