### PR TITLE
refactor(FormGroup): 実際には使われていない条件分岐を整理する

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { type FC, type ReactNode, useId, useRef } from 'react'
+import { type FC, type ReactNode, useEffect, useId, useRef } from 'react'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 
-import { FormGroup } from './FormGroup'
+import { CHILDREN_WRAPPER_INPUT_SELECTOR, FormGroup, LABEL_TEXT_SELECTOR } from './FormGroup'
 
 import type { CommonProps, ObjectLabelType } from './type'
 
@@ -31,6 +31,64 @@ export const Fieldset: FC<
     htmlFor: `${baseId}-htmlFor`,
     id: baseLegend.id || `${baseId}-legend`,
   }
+
+  // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
+  // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
+  useEffect(() => {
+    if (!wrapperRef.current) return
+
+    const labelTextEl = wrapperRef.current.querySelector(LABEL_TEXT_SELECTOR)
+
+    if (!labelTextEl) return
+
+    // HINT: legend変更のたびにaria-labelへ古いlegend文言が蓄積しないよう、
+    // 初回に確定したアクセシブルネームをinput要素ごとに保持しておく
+    const baseAccessibleNames = new WeakMap<HTMLInputElement, string>()
+
+    const updateAriaLabels = () => {
+      const labelText = labelTextEl.textContent || ''
+      if (!labelText) return
+
+      const inputs = wrapperRef.current?.querySelectorAll<HTMLInputElement>(
+        CHILDREN_WRAPPER_INPUT_SELECTOR,
+      )
+      if (!inputs?.length) return
+
+      inputs.forEach((input: HTMLInputElement) => {
+        let accessibleName = baseAccessibleNames.get(input)
+
+        if (accessibleName === undefined) {
+          accessibleName =
+            input.getAttribute('aria-label') ||
+            (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
+              ? input.labels[0].textContent || ''
+              : '')
+          baseAccessibleNames.set(input, accessibleName)
+        }
+
+        if (
+          accessibleName &&
+          !accessibleName.includes(labelText) &&
+          !labelText.includes(accessibleName)
+        ) {
+          input.setAttribute('aria-label', `${accessibleName} ${labelText}`)
+        }
+      })
+    }
+
+    // 初回実行
+    updateAriaLabels()
+
+    // label要素の変更を監視
+    const observer = new MutationObserver(updateAriaLabels)
+    observer.observe(labelTextEl, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    })
+
+    return () => observer.disconnect()
+  }, [])
 
   return <FormGroup {...rest} as="fieldset" wrapperRef={wrapperRef} label={legend} />
 }

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -92,7 +92,7 @@ const classNameGenerator = tv({
 
 const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
 export const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-childrenWrapper ${SMARTHR_UI_INPUT_SELECTOR}`
-const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
+export const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
 
 export const FormGroup: FC<Props> = ({
   wrapperRef,
@@ -207,64 +207,6 @@ export const FormGroup: FC<Props> = ({
       }
     }
   }, [actualErrorMessages.length, autoBindErrorInput, wrapperRef])
-
-  // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
-  // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
-  useEffect(() => {
-    if (!isFieldset || !wrapperRef.current) return
-
-    const labelTextEl = wrapperRef.current.querySelector(LABEL_TEXT_SELECTOR)
-
-    if (!labelTextEl) return
-
-    // HINT: legend変更のたびにaria-labelへ古いlegend文言が蓄積しないよう、
-    // 初回に確定したアクセシブルネームをinput要素ごとに保持しておく
-    const baseAccessibleNames = new WeakMap<HTMLInputElement, string>()
-
-    const updateAriaLabels = () => {
-      const labelText = labelTextEl.textContent || ''
-      if (!labelText) return
-
-      const inputs = wrapperRef.current?.querySelectorAll<HTMLInputElement>(
-        CHILDREN_WRAPPER_INPUT_SELECTOR,
-      )
-      if (!inputs?.length) return
-
-      inputs.forEach((input: HTMLInputElement) => {
-        let accessibleName = baseAccessibleNames.get(input)
-
-        if (accessibleName === undefined) {
-          accessibleName =
-            input.getAttribute('aria-label') ||
-            (input.labels?.[0]?.classList.contains('smarthr-ui-VisuallyHiddenText')
-              ? input.labels[0].textContent || ''
-              : '')
-          baseAccessibleNames.set(input, accessibleName)
-        }
-
-        if (
-          accessibleName &&
-          !accessibleName.includes(labelText) &&
-          !labelText.includes(accessibleName)
-        ) {
-          input.setAttribute('aria-label', `${accessibleName} ${labelText}`)
-        }
-      })
-    }
-
-    // 初回実行
-    updateAriaLabels()
-
-    // label要素の変更を監視
-    const observer = new MutationObserver(updateAriaLabels)
-    observer.observe(labelTextEl, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    })
-
-    return () => observer.disconnect()
-  }, [isFieldset, wrapperRef])
 
   return (
     <Stack

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -16,7 +16,6 @@ import { Text, type TextProps } from '../Text'
 import { VisuallyHiddenText, visuallyHiddenTextClassName } from '../VisuallyHiddenText'
 
 import type { CommonProps, IconType, ObjectLabelType, StatusLabelType } from './type'
-import type { Gap } from '../../types'
 
 type Props = CommonProps & {
   wrapperRef: RefObject<HTMLDivElement>
@@ -46,48 +45,16 @@ const classNameGenerator = tv({
     childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
   },
   variants: {
-    innerMargin: {
-      0: {},
-      0.25: {},
-      0.5: {},
-      0.75: {},
-      1: {},
-      1.25: {},
-      1.5: {},
-      2: {},
-      2.5: {},
-      3: {},
-      3.5: {},
-      4: {},
-      8: {},
-      X3S: {},
-      XXS: {},
-      XS: {},
-      S: {},
-      M: {},
-      L: {},
-      XL: {},
-      XXL: {},
-      X3L: {},
-    } as { [key in Gap]: string },
-    isFieldset: {
-      true: {},
-      false: {},
-    },
-  },
-  compoundVariants: [
     // TODO: innerMarginが未指定、初期値の場合、かつFieldsetの場合、childrenの上部の余白を広げることで
     // FormControltとの差をわかりやすくしている
     // 微妙な方法ではあるので、必要に応じてinnerMarginではない属性を用意する
     // https://kufuinc.slack.com/archives/CGC58MW01/p1737944965871159?thread_ts=1737541173.404369&cid=CGC58MW01
-    {
-      innerMargin: undefined,
-      isFieldset: true,
-      class: {
+    fieldsetWithDefaultMargin: {
+      true: {
         childrenWrapper: '[:not([hidden])_~_&&&]:shr-mt-0.5',
       },
     },
-  ],
+  },
 })
 
 const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
@@ -157,7 +124,9 @@ export const FormGroup: FC<Props> = ({
       errorList: generators.errorList(),
       errorIcon: generators.errorIcon(),
       errorMessage: generators.errorMessage(),
-      childrenWrapper: generators.childrenWrapper({ innerMargin, isFieldset }),
+      childrenWrapper: generators.childrenWrapper({
+        fieldsetWithDefaultMargin: isFieldset && innerMargin === undefined,
+      }),
     }
   }, [innerMargin, isFieldset, label.unrecommendedHide, className])
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` に残っていた「実際には使われていない条件分岐」を2点整理しました。

いずれも `FormGroup` が `FormControl` と `Fieldset` の共通実装として切り出された経緯で残っていたもので、実態に合わせて整理します。

## 変更内容

### 1. legendのアクセシブルネーム付与処理を `Fieldset` に移譲

`FormGroup` が持っていた「Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームへ追加する」useEffectは、冒頭で `isFieldset` をチェックしており、実際には `Fieldset` 経由でしか動作していませんでした。

`FormGroup` は `src/index.ts` からexportされておらず、利用者は `FormControl` と `Fieldset` のみです。この処理は `Fieldset` 固有の責務のため移譲します。

移譲にあたって `isFieldset` によるガードが不要になっています（`Fieldset` は常に `as="fieldset"` のため）。

```diff
 useEffect(() => {
-  if (!isFieldset || !wrapperRef.current) return
+  if (!wrapperRef.current) return
```

`Fieldset` から参照する `LABEL_TEXT_SELECTOR` は、`CHILDREN_WRAPPER_INPUT_SELECTOR` と同様にexportしました。`FormGroup` は同ディレクトリ内のローカルコンポーネントのため、`Fieldset` がその内部仕様を知っていて問題ありません。

### 2. `classNameGenerator` のvariantsを実態に合わせて整理

`innerMargin`（22個）と `isFieldset`（2個）のvariantsは、いずれも空定義で `compoundVariants` の条件指定のためだけに存在していました。実際にクラスを付与するのは「`innerMargin` が未指定 かつ `isFieldset`」の1条件だけです。

この条件は呼び出し側で計算できるため、boolean 1つのvariantに畳み、`compoundVariants` を削除しました。

```diff
 variants: {
-  innerMargin: { 0:{}, 0.25:{}, ... 22個の空定義 } as { [key in Gap]: string },
-  isFieldset: { true: {}, false: {} },
-},
-compoundVariants: [
-  { innerMargin: undefined, isFieldset: true, class: { childrenWrapper: '...' } },
-],
+  fieldsetWithDefaultMargin: {
+    true: { childrenWrapper: '[:not([hidden])_~_&&&]:shr-mt-0.5' },
+  },
+},
```

```diff
-childrenWrapper: generators.childrenWrapper({ innerMargin, isFieldset }),
+childrenWrapper: generators.childrenWrapper({
+  fieldsetWithDefaultMargin: isFieldset && innerMargin === undefined,
+}),
```

variantsの型注釈でのみ使っていた `Gap` のimportも不要になったため削除しています。

なお、この余白調整の方法自体が微妙である旨のTODOコメントは、設計上の課題として `variants` 側に移して残しました。

### 結果

`FormGroup` に残る `isFieldset` の用途は `aria-describedby` の出し分けと上記variantの計算のみになり、条件分岐が整理されました。

## プロダクト側で対応が必要な事項

なし。

内部実装の変更のみで、`FormControl`・`Fieldset` の公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` および利用しているコンポーネントに差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 挙動の同一性について

アクセシビリティとスタイルの双方に関わる変更のため、リファクタリング前後で出力が変化しないことを実測で比較しました。

**アクセシビリティ（6パターン、masterと比較）**

input要素の `aria-label`・`aria-describedby` を記録して比較。

1. 可視ラベルが無いinputにlegend文言が付与される
2. legendを変更しても古い文言が蓄積しない（MutationObserverによる追従）
3. 複数input（RadioButton）へのlegend付与
4. `aria-label` を持たないinputには付与しない
5. `FormControl`（非Fieldset）では付与しない
6. `helpMessage` による `aria-describedby`

**生成クラス（8パターン、変更前後で比較）**

`wrapper`・`childrenWrapper`・`label` のclassを記録して比較。

1. FormControl / `innerMargin` 未指定
2. FormControl / `innerMargin={0.5}`
3. Fieldset / `innerMargin` 未指定（余白調整が適用される唯一のケース）
4. Fieldset / `innerMargin={0.5}`
5. Fieldset / `innerMargin={0}`（falsyな境界値。`!innerMargin` と書くと誤適用されるため）
6. Fieldset / `innerMargin={1}`
7. `className` 指定時の合成
8. `unrecommendedHide` 時のlabelクラス

いずれも**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **アクセシビリティ改善**
  - フィールドセット内で入力項目に個別の表示ラベルがない場合、凡例（legend）の文言をアクセシブルネームとして補足するよう改善しました。
  - 凡例やラベルの変更にも自動で追従し、スクリーンリーダー利用時に常に適切な項目名が読み上げられます。
  - 既存のラベル情報を維持し、同じ文言が重複して追加されないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->