### PR TITLE
refactor(FormGroup): classNameGeneratorまわりを利用箇所に寄せて整理する

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -16,7 +16,7 @@ export const Fieldset: FC<
     /** `true` のとき、文字色を `TEXT_DISABLED` にする */
     disabled?: boolean
   }
-> = ({ legend: orgLegend, ...rest }) => {
+> = ({ legend: orgLegend, innerMargin, ...rest }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()
 
@@ -90,5 +90,14 @@ export const Fieldset: FC<
     return () => observer.disconnect()
   }, [])
 
-  return <FormGroup {...rest} as="fieldset" wrapperRef={wrapperRef} label={legend} />
+  return (
+    <FormGroup
+      {...rest}
+      as="fieldset"
+      wrapperRef={wrapperRef}
+      label={legend}
+      innerMargin={innerMargin}
+      fieldsetWithDefaultMargin={innerMargin === undefined}
+    />
+  )
 }

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -39,9 +39,6 @@ const classNameGenerator = tv({
       '[&:disabled_.smarthr-ui-Input]:shr-border-default/50 [&:disabled_.smarthr-ui-Input]:shr-bg-white-darken',
     ],
     label: 'smarthr-ui-FormControl-label',
-    errorList: 'shr-list-none',
-    errorIcon: ['smarthr-ui-FormControl-errorMessage-Icon', 'shr-text-danger'],
-    errorMessage: 'smarthr-ui-FormControl-errorMessage',
     childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
   },
   variants: {
@@ -121,9 +118,6 @@ export const FormGroup: FC<Props> = ({
       label: generators.label({
         className: label.unrecommendedHide ? visuallyHiddenTextClassName : '',
       }),
-      errorList: generators.errorList(),
-      errorIcon: generators.errorIcon(),
-      errorMessage: generators.errorMessage(),
       childrenWrapper: generators.childrenWrapper({
         fieldsetWithDefaultMargin: isFieldset && innerMargin === undefined,
       }),
@@ -200,11 +194,7 @@ export const FormGroup: FC<Props> = ({
       />
       <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={label.htmlFor} />
       <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={label.htmlFor} />
-      <ErrorMessageList
-        errorMessages={actualErrorMessages}
-        managedHtmlFor={label.htmlFor}
-        classNames={classNames}
-      />
+      <ErrorMessageList errorMessages={actualErrorMessages} managedHtmlFor={label.htmlFor} />
       <div className={classNames.childrenWrapper}>{children}</div>
       <SupplementaryMessageText
         supplementaryMessage={supplementaryMessage}
@@ -323,19 +313,16 @@ const ExampleMessageText = memo<Pick<Props, 'exampleMessage'> & { managedHtmlFor
 const ErrorMessageList = memo<{
   errorMessages: ReactNode[]
   managedHtmlFor: string
-  classNames: {
-    errorList: string
-    errorIcon: string
-    errorMessage: string
-  }
-}>(({ errorMessages, managedHtmlFor, classNames }) =>
+}>(({ errorMessages, managedHtmlFor }) =>
   errorMessages.length > 0 ? (
-    <div id={`${managedHtmlFor}_errorMessages`} className={classNames.errorList} role="alert">
+    <div id={`${managedHtmlFor}_errorMessages`} className="shr-list-none" role="alert">
       {errorMessages.map((message, index) => (
         <p key={index}>
           <Text
-            className={classNames.errorMessage}
-            icon={<FaCircleExclamationIcon className={classNames.errorIcon} />}
+            className="smarthr-ui-FormControl-errorMessage"
+            icon={
+              <FaCircleExclamationIcon className="smarthr-ui-FormControl-errorMessage-Icon shr-text-danger" />
+            }
           >
             {message}
           </Text>

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -22,6 +22,8 @@ type Props = CommonProps & {
   /** グループのラベル名 */
   label: Omit<ObjectLabelType, 'id' | 'htmlFor'> & Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
   as?: string | ComponentType<any>
+  /** `true` のとき、childrenWrapperの上部余白を広げる（FieldsetがinnerMargin未指定の場合に使用） */
+  fieldsetWithDefaultMargin?: boolean
   /** `true` のとき、文字色を `TEXT_DISABLED` にする */
   disabled?: boolean
 }
@@ -72,6 +74,7 @@ export const FormGroup: FC<Props> = ({
   as = 'div',
   className,
   children,
+  fieldsetWithDefaultMargin,
   ...rest
 }) => {
   const managedDescribedbyIdsRef = useRef<string[]>([])
@@ -118,11 +121,9 @@ export const FormGroup: FC<Props> = ({
       label: generators.label({
         className: label.unrecommendedHide ? visuallyHiddenTextClassName : '',
       }),
-      childrenWrapper: generators.childrenWrapper({
-        fieldsetWithDefaultMargin: isFieldset && innerMargin === undefined,
-      }),
+      childrenWrapper: generators.childrenWrapper({ fieldsetWithDefaultMargin }),
     }
-  }, [innerMargin, isFieldset, label.unrecommendedHide, className])
+  }, [fieldsetWithDefaultMargin, label.unrecommendedHide, className])
 
   useEffect(() => {
     if (!wrapperRef.current) {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` の `classNameGenerator` まわりを2点整理しました。

いずれも「`FormGroup` 本体で持つ必然性がない情報」を、実際に使う場所へ寄せる変更です。PR #6884 に続く整理になります。

## 変更内容

### 1. エラー表示のクラスを `ErrorMessageList` に直接記述

`errorList`・`errorIcon`・`errorMessage` の3スロットは、variantsの影響を受けない静的なクラスであり、`ErrorMessageList` からしか使われていませんでした。`FormGroup` 本体で生成して props で受け渡す必然性がないため、利用箇所に直接記述する形にしました。

```diff
 slots: {
   wrapper: [...],
   label: 'smarthr-ui-FormControl-label',
-  errorList: 'shr-list-none',
-  errorIcon: ['smarthr-ui-FormControl-errorMessage-Icon', 'shr-text-danger'],
-  errorMessage: 'smarthr-ui-FormControl-errorMessage',
   childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
 },
```

`ErrorMessageList` の props から `classNames` が不要になり、`memo` の比較対象も減っています。

### 2. 余白調整の判定を `Fieldset` に移す

`childrenWrapper` の余白調整は「`innerMargin` が未指定 かつ Fieldset」の場合に適用されます。このうち **Fieldsetであるかどうかは `Fieldset` 自身にとって自明** なため、判定を呼び出し側へ移し、`FormGroup` は結果を props で受け取るだけにしました。

```diff
-childrenWrapper: generators.childrenWrapper({
-  fieldsetWithDefaultMargin: isFieldset && innerMargin === undefined,
-}),
+childrenWrapper: generators.childrenWrapper({ fieldsetWithDefaultMargin }),
```

```diff
 // Fieldset.tsx
+innerMargin={innerMargin}
+fieldsetWithDefaultMargin={innerMargin === undefined}
```

### 結果

- `classNames` の `useMemo` は `wrapper`・`label`・`childrenWrapper` の3項目になった
- その依存配列から `innerMargin`・`isFieldset` が減った

## プロダクト側で対応が必要な事項

なし。

内部実装の変更のみで、`FormControl`・`Fieldset` の公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

スタイルとアクセシビリティの双方に関わるため、リファクタリング前後で出力が変化しないことを実測で比較しました。

**エラー表示（5パターン）**

エラーリストの `role`・`id`・`class`、メッセージの `class`、アイコンの `class`、メッセージ件数を記録。

1. `errorMessages` 1件
2. `errorMessages` 複数件
3. `errorMessages` に文字列を単体で渡した場合
4. `errorMessages` 無し（要素自体が生成されないこと）
5. Fieldset + `errorMessages`

アイコンの `shr-text-danger` が `Icon` 側のクラスと正しく合成されている点も確認しています。

**余白調整とスロットのクラス（9パターン）**

`wrapper`・`childrenWrapper`・`label` のclassを記録。

1. FormControl / `innerMargin` 未指定
2. FormControl / `innerMargin={0.5}`
3. Fieldset / `innerMargin` 未指定（余白調整が適用される唯一のケース）
4. Fieldset / `innerMargin={0.5}`
5. Fieldset / `innerMargin={0}`（falsyな境界値。`!innerMargin` と書くと誤適用されるため）
6. Fieldset / `innerMargin={1}`
7. `className` 指定時の合成
8. `unrecommendedHide` 時のlabelクラス
9. `innerMargin={0}` 時の `Stack` のgapクラス

いずれも**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * フォームグループ内の余白を、フィールドセットの設定に応じて適切に調整できるようになりました。
  * フィールドセットで余白を指定しない場合も、標準の余白が適用されます。
  * エラーメッセージの表示がより安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->