### PR TITLE
refactor(FormGroup): 薄いサブコンポーネントをインライン化する

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -195,7 +195,22 @@ export const FormGroup: FC<Props> = ({
       />
       <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={label.htmlFor} />
       <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={label.htmlFor} />
-      <ErrorMessageList errorMessages={actualErrorMessages} managedHtmlFor={label.htmlFor} />
+      {actualErrorMessages.length > 0 ? (
+        <div id={`${label.htmlFor}_errorMessages`} className="shr-list-none" role="alert">
+          {actualErrorMessages.map((message, index) => (
+            <p key={index}>
+              <Text
+                className="smarthr-ui-FormControl-errorMessage"
+                icon={
+                  <FaCircleExclamationIcon className="smarthr-ui-FormControl-errorMessage-Icon shr-text-danger" />
+                }
+              >
+                {message}
+              </Text>
+            </p>
+          ))}
+        </div>
+      ) : null}
       <div className={classNames.childrenWrapper}>{children}</div>
       <SupplementaryMessageText
         supplementaryMessage={supplementaryMessage}
@@ -309,28 +324,6 @@ const ExampleMessageText = memo<Pick<Props, 'exampleMessage'> & { managedHtmlFor
         {exampleMessage}
       </Text>
     ) : null,
-)
-
-const ErrorMessageList = memo<{
-  errorMessages: ReactNode[]
-  managedHtmlFor: string
-}>(({ errorMessages, managedHtmlFor }) =>
-  errorMessages.length > 0 ? (
-    <div id={`${managedHtmlFor}_errorMessages`} className="shr-list-none" role="alert">
-      {errorMessages.map((message, index) => (
-        <p key={index}>
-          <Text
-            className="smarthr-ui-FormControl-errorMessage"
-            icon={
-              <FaCircleExclamationIcon className="smarthr-ui-FormControl-errorMessage-Icon shr-text-danger" />
-            }
-          >
-            {message}
-          </Text>
-        </p>
-      ))}
-    </div>
-  ) : null,
 )
 
 const SupplementaryMessageText = memo<

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -193,9 +193,23 @@ export const FormGroup: FC<Props> = ({
         subActionArea={subActionArea}
         labelClassName={classNames.label}
       />
-      <HelpMessageParagraph helpMessage={helpMessage} managedHtmlFor={label.htmlFor} />
-      <ExampleMessageText exampleMessage={exampleMessage} managedHtmlFor={label.htmlFor} />
-      {actualErrorMessages.length > 0 ? (
+      {helpMessage && (
+        <p className="smarthr-ui-FormControl-helpMessage" id={`${label.htmlFor}_helpMessage`}>
+          {helpMessage}
+        </p>
+      )}
+      {exampleMessage && (
+        <Text
+          as="p"
+          color="TEXT_GREY"
+          italic
+          id={`${label.htmlFor}_exampleMessage`}
+          className="smarthr-ui-FormControl-exampleMessage"
+        >
+          {exampleMessage}
+        </Text>
+      )}
+      {actualErrorMessages.length > 0 && (
         <div id={`${label.htmlFor}_errorMessages`} className="shr-list-none" role="alert">
           {actualErrorMessages.map((message, index) => (
             <p key={index}>
@@ -210,9 +224,9 @@ export const FormGroup: FC<Props> = ({
             </p>
           ))}
         </div>
-      ) : null}
+      )}
       <div className={classNames.childrenWrapper}>{children}</div>
-      {supplementaryMessage ? (
+      {supplementaryMessage && (
         <Text
           as="p"
           size="S"
@@ -222,7 +236,7 @@ export const FormGroup: FC<Props> = ({
         >
           {supplementaryMessage}
         </Text>
-      ) : null}
+      )}
     </Stack>
   )
 }
@@ -257,7 +271,11 @@ const LabelCluster = memo<
         <Text styleType={labelType} icon={labelIcon}>
           <span className="smarthr-ui-FormControl-labelText">{label}</span>
         </Text>
-        <StatusLabelCluster statusLabels={statusLabels} />
+        {statusLabels.length > 0 && (
+          <Cluster gap={0.25} as="span">
+            {statusLabels}
+          </Cluster>
+        )}
       </>
     )
 
@@ -299,36 +317,4 @@ const LabelCluster = memo<
       </>
     )
   },
-)
-
-const StatusLabelCluster = memo<{ statusLabels: StatusLabelType[] }>(({ statusLabels }) =>
-  statusLabels.length === 0 ? null : (
-    <Cluster gap={0.25} as="span">
-      {statusLabels}
-    </Cluster>
-  ),
-)
-
-const HelpMessageParagraph = memo<Pick<Props, 'helpMessage'> & { managedHtmlFor: string }>(
-  ({ helpMessage, managedHtmlFor }) =>
-    helpMessage ? (
-      <p className="smarthr-ui-FormControl-helpMessage" id={`${managedHtmlFor}_helpMessage`}>
-        {helpMessage}
-      </p>
-    ) : null,
-)
-
-const ExampleMessageText = memo<Pick<Props, 'exampleMessage'> & { managedHtmlFor: string }>(
-  ({ exampleMessage, managedHtmlFor }) =>
-    exampleMessage ? (
-      <Text
-        as="p"
-        color="TEXT_GREY"
-        italic
-        id={`${managedHtmlFor}_exampleMessage`}
-        className="smarthr-ui-FormControl-exampleMessage"
-      >
-        {exampleMessage}
-      </Text>
-    ) : null,
 )

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -212,10 +212,17 @@ export const FormGroup: FC<Props> = ({
         </div>
       ) : null}
       <div className={classNames.childrenWrapper}>{children}</div>
-      <SupplementaryMessageText
-        supplementaryMessage={supplementaryMessage}
-        managedHtmlFor={label.htmlFor}
-      />
+      {supplementaryMessage ? (
+        <Text
+          as="p"
+          size="S"
+          color="TEXT_GREY"
+          id={`${label.htmlFor}_supplementaryMessage`}
+          className="smarthr-ui-FormControl-supplementaryMessage"
+        >
+          {supplementaryMessage}
+        </Text>
+      ) : null}
     </Stack>
   )
 }
@@ -324,20 +331,4 @@ const ExampleMessageText = memo<Pick<Props, 'exampleMessage'> & { managedHtmlFor
         {exampleMessage}
       </Text>
     ) : null,
-)
-
-const SupplementaryMessageText = memo<
-  Pick<Props, 'supplementaryMessage'> & { managedHtmlFor: string }
->(({ supplementaryMessage, managedHtmlFor }) =>
-  supplementaryMessage ? (
-    <Text
-      as="p"
-      size="S"
-      color="TEXT_GREY"
-      id={`${managedHtmlFor}_supplementaryMessage`}
-      className="smarthr-ui-FormControl-supplementaryMessage"
-    >
-      {supplementaryMessage}
-    </Text>
-  ) : null,
 )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` には、要素を1つ返すだけの薄いサブコンポーネントが5つ定義されていました。いずれも `FormGroup`（または `LabelCluster`）からしか使われておらず、コンポーネント境界を設ける利点が乏しいためインライン化します。

特に `ErrorMessageList` は、`memo` 化していても比較が必ず外れる構造になっていました。

PR #6885 に続く `FormGroup` の整理です。

## 変更内容

### 1. `ErrorMessageList` のインライン化（memoを外す）

`errorMessages` は利用者側で `errorMessages={['エラー']}` のようにインライン配列を渡すのが一般的なため、レンダリングのたびに参照が変わります。`actualErrorMessages` の `useMemo` も再計算され、`memo` の props 比較は必ず不一致になっていました。

比較コストを払っても外れることが確定している `memo` のため、コンポーネントごとインライン化しています。

### 2. `SupplementaryMessageText` のインライン化

### 3. `HelpMessageParagraph`・`ExampleMessageText`・`StatusLabelCluster` のインライン化

あわせて条件分岐の書き方を `&&` に統一しました。

### 結果

サブコンポーネントは `LabelCluster` の1つだけになりました。`LabelCluster` はpropsが9個あり、インライン化すると本体のJSXが大きくなりすぎるため残しています。

| コンポーネント | 対応 |
|---|---|
| `ErrorMessageList` | インライン化 |
| `SupplementaryMessageText` | インライン化 |
| `HelpMessageParagraph` | インライン化 |
| `ExampleMessageText` | インライン化 |
| `StatusLabelCluster` | インライン化 |
| `LabelCluster` | `memo` のまま維持 |

## プロダクト側で対応が必要な事項

なし。

内部実装の変更のみで、`FormControl`・`Fieldset` の公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

コミットごとに、対象箇所のDOMがmasterと変化しないことを実測で比較しました。

**エラー表示（9パターン）**

`role`・`id`・`class`・タグ名・本文・件数・`aria-invalid`・`aria-describedby`、`childrenWrapper` とのDOM順序を記録。

1件 / 複数件 / 文字列単体 / 未指定 / 空配列 / Fieldset併用 / `helpMessage` との `aria-describedby` 合成 / rerenderでの追加・削除

**補足メッセージ（9パターン）**

タグ名・`id`・`class`・本文・`aria-describedby`、`childrenWrapper` とのDOM順序を記録。

文字列 / 未指定 / 空文字 / ReactNode / `helpMessage` 併用 / 全メッセージ併用 / Fieldset併用 / rerenderでの追加・削除

**ラベル領域とメッセージ（9パターン）**

ラベル領域の **innerHTMLと子要素数**（`Cluster` の有無を検出するため）、各メッセージの本文・`id`・`class`、StatusLabelの個数、`aria-describedby` を記録。

statusLabels 無し / 1件 / 複数件 / 空配列 / `helpMessage` / `exampleMessage` / 全併用 / `unrecommendedHide` 併用 / Fieldset併用

いずれも**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
