### PR TITLE
fix(FormGroup): describedbyIdsの依存を安定させ、errorMessagesの判定漏れを修正する

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -92,25 +92,32 @@ export const FormGroup: FC<Props> = ({
       : [errorMessages]
     : []
 
+  const helpMessageId = helpMessage ? `${label.htmlFor}_helpMessage` : undefined
+  const exampleMessageId = exampleMessage ? `${label.htmlFor}_exampleMessage` : undefined
+  const supplementaryMessageId = supplementaryMessage
+    ? `${label.htmlFor}_supplementaryMessage`
+    : undefined
+  const visibleErrorMessages = actualErrorMessages.length > 0
+  const errorMessagesId = visibleErrorMessages ? `${label.htmlFor}_errorMessages` : undefined
+
   const describedbyIds = useMemo(() => {
     const temp: string[] = []
 
-    if (helpMessage) {
-      temp.push(`${label.htmlFor}_helpMessage`)
+    if (helpMessageId) {
+      temp.push(helpMessageId)
     }
-    if (exampleMessage) {
-      temp.push(`${label.htmlFor}_exampleMessage`)
+    if (exampleMessageId) {
+      temp.push(exampleMessageId)
     }
-    if (supplementaryMessage) {
-      temp.push(`${label.htmlFor}_supplementaryMessage`)
+    if (supplementaryMessageId) {
+      temp.push(supplementaryMessageId)
     }
-    if (errorMessages) {
-      temp.push(`${label.htmlFor}_errorMessages`)
+    if (errorMessagesId) {
+      temp.push(errorMessagesId)
     }
 
     return temp.join(' ')
-    // TODO: ReactNodeやarrayなど不安定な値をそのまま依存配列に含めているので調整する
-  }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, label.htmlFor])
+  }, [helpMessageId, exampleMessageId, supplementaryMessageId, errorMessagesId])
 
   const classNames = useMemo(() => {
     const generators = classNameGenerator()
@@ -163,13 +170,13 @@ export const FormGroup: FC<Props> = ({
     const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
 
     if (input) {
-      if (actualErrorMessages.length > 0) {
+      if (visibleErrorMessages) {
         input.setAttribute('aria-invalid', 'true')
       } else {
         input.removeAttribute('aria-invalid')
       }
     }
-  }, [actualErrorMessages.length, autoBindErrorInput, wrapperRef])
+  }, [visibleErrorMessages, autoBindErrorInput, wrapperRef])
 
   return (
     <Stack
@@ -193,7 +200,7 @@ export const FormGroup: FC<Props> = ({
         labelClassName={classNames.label}
       />
       {helpMessage && (
-        <p className="smarthr-ui-FormControl-helpMessage" id={`${label.htmlFor}_helpMessage`}>
+        <p className="smarthr-ui-FormControl-helpMessage" id={helpMessageId}>
           {helpMessage}
         </p>
       )}
@@ -202,14 +209,14 @@ export const FormGroup: FC<Props> = ({
           as="p"
           color="TEXT_GREY"
           italic
-          id={`${label.htmlFor}_exampleMessage`}
+          id={exampleMessageId}
           className="smarthr-ui-FormControl-exampleMessage"
         >
           {exampleMessage}
         </Text>
       )}
-      {actualErrorMessages.length > 0 && (
-        <div id={`${label.htmlFor}_errorMessages`} className="shr-list-none" role="alert">
+      {visibleErrorMessages && (
+        <div id={errorMessagesId} className="shr-list-none" role="alert">
           {actualErrorMessages.map((message, index) => (
             <p key={index}>
               <Text
@@ -230,7 +237,7 @@ export const FormGroup: FC<Props> = ({
           as="p"
           size="S"
           color="TEXT_GREY"
-          id={`${label.htmlFor}_supplementaryMessage`}
+          id={supplementaryMessageId}
           className="smarthr-ui-FormControl-supplementaryMessage"
         >
           {supplementaryMessage}

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -85,13 +85,12 @@ export const FormGroup: FC<Props> = ({
     [statusLabels],
   )
 
-  const actualErrorMessages = useMemo(() => {
-    if (!errorMessages) {
-      return []
-    }
-
-    return Array.isArray(errorMessages) ? errorMessages : [errorMessages]
-  }, [errorMessages])
+  // HINT: memo化している箇所がないため毎回計算している
+  const actualErrorMessages = errorMessages
+    ? Array.isArray(errorMessages)
+      ? errorMessages
+      : [errorMessages]
+    : []
 
   const describedbyIds = useMemo(() => {
     const temp: string[] = []

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -80,6 +80,8 @@ export const FormGroup: FC<Props> = ({
   const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
+  // HINT: statusLabelsは設定されない場合が大半、かつ設定されてもRequiredLabelでmemo化されているため
+  // memo化がかなりの確率で有用
   const actualStatusLabels = useMemo(
     () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
     [statusLabels],

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -80,6 +80,19 @@ export const FormGroup: FC<Props> = ({
   const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
 
+  const actualStatusLabels = useMemo(
+    () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
+    [statusLabels],
+  )
+
+  const actualErrorMessages = useMemo(() => {
+    if (!errorMessages) {
+      return []
+    }
+
+    return Array.isArray(errorMessages) ? errorMessages : [errorMessages]
+  }, [errorMessages])
+
   const describedbyIds = useMemo(() => {
     const temp: string[] = []
 
@@ -99,19 +112,6 @@ export const FormGroup: FC<Props> = ({
     return temp.join(' ')
     // TODO: ReactNodeやarrayなど不安定な値をそのまま依存配列に含めているので調整する
   }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, label.htmlFor])
-
-  const actualStatusLabels = useMemo(
-    () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
-    [statusLabels],
-  )
-
-  const actualErrorMessages = useMemo(() => {
-    if (!errorMessages) {
-      return []
-    }
-
-    return Array.isArray(errorMessages) ? errorMessages : [errorMessages]
-  }, [errorMessages])
 
   const classNames = useMemo(() => {
     const generators = classNameGenerator()


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` の `useMemo` まわりを整理し、あわせて `aria-describedby` の判定漏れを修正します。

`describedbyIds` の依存配列には `ReactNode` や配列をそのまま含めており、コード内にも「不安定な値を依存配列に含めている」というTODOが残っていました。これを解消します。

PR #6886 に続く `FormGroup` の整理です。

## 変更内容

### 1. propsを正規化するuseMemoを先頭側に移動

`actualStatusLabels`・`actualErrorMessages` を、それらを踏まえた派生値（`describedbyIds`・`classNames`）より前に移動しました。値の依存が上から下へ読める並びになります。

宣言位置の移動のみで、JSXと依存配列に変更はありません。

### 2. `actualErrorMessages` のuseMemoを外す

利用先は `useEffect` の依存配列（`.length` のみ参照）とJSX内での直接描画だけで、memo化されたコンポーネントに渡していません。参照の安定性が求められる箇所がないためuseMemoを外しました。

PR #6886 で `ErrorMessageList` をインライン化した結果、memo化されたコンポーネントへ渡す経路が消えたことによる帰結です。

なお `actualStatusLabels` はmemo化を維持しています。`LabelCluster`（memo）にpropsとして渡すため参照の安定性に意味があり、判断理由はコメントとして残しました。

### 3. メッセージのidを事前計算し、describedbyIdsの依存を安定させる

各メッセージのidを事前に算出し、依存配列を**文字列または `undefined` のプリミティブ**に置き換えました。

```diff
-    // TODO: ReactNodeやarrayなど不安定な値をそのまま依存配列に含めているので調整する
-  }, [helpMessage, exampleMessage, supplementaryMessage, errorMessages, label.htmlFor])
+  }, [helpMessageId, exampleMessageId, supplementaryMessageId, errorMessagesId])
```

これにより、`helpMessage` にJSX要素を渡していても、id文字列が同じであれば再計算されなくなります。

### 4. `errorMessages` の判定漏れを修正（バグ修正）

従来は `if (errorMessages)` で判定していたため、**空配列 `[]` はtruthy** となり `aria-describedby` にidが追加されていました。一方でエラー表示自体は `length > 0` で判定されるため描画されず、**存在しない要素を参照する `aria-describedby`** が生成されていました。

idの算出を `visibleErrorMessages`（= `length > 0`）から導出することで、表示条件と `aria-describedby` の判定が同一のソースになり、この不整合が構造的に起きなくなります。

## プロダクト側で対応が必要な事項

`errorMessages` に空配列 `[]` を渡していた場合、これまで入力要素の `aria-describedby` に `xxx_errorMessages` というidが付与されていましたが、参照先の要素は存在しませんでした。本PRによりこのidは付与されなくなります。

スクリーンリーダーが解決できないid参照が解消されるため、アクセシビリティ上の改善となります。表示上の変化はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

各メッセージの `id`、入力要素の `aria-describedby`・`aria-invalid`、Fieldsetの `aria-describedby` を記録し、masterと比較しました。

1. `helpMessage` のみ
2. `exampleMessage` のみ
3. `supplementaryMessage` のみ
4. `errorMessages` のみ
5. **`errorMessages` に空配列**（上記のバグ修正対象）
6. 全メッセージ併用（`aria-describedby` の順序）
7. メッセージ無し
8. Fieldset + 全メッセージ
9. `errorMessages` を後から追加（`aria-invalid` の追従）
10. `errorMessages` を後から削除（`aria-invalid` の解除）
11. `helpMessage` を文字列からJSX要素に変更（`aria-describedby` が維持されること）

**11パターン中10パターンが完全一致**し、差が出たのは 5 の空配列のケースのみでした（上記のバグ修正による意図した変化）。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ**
  * フォームのエラー状態を適切に認識できるよう改善しました。
  * 補助メッセージやエラーメッセージの関連付けを整理し、支援技術での読み上げを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->