### PR TITLE
refactor(FormGroup): aria-describedbyの管理をuseDescribedByIdsに切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -9,6 +9,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { FormGroup } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR, LABEL_TEXT_SELECTOR } from './constants'
+import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 
@@ -20,7 +21,15 @@ export const Fieldset: FC<
     /** `true` のとき、文字色を `TEXT_DISABLED` にする */
     disabled?: boolean
   }
-> = ({ legend: orgLegend, innerMargin, ...rest }) => {
+> = ({
+  legend: orgLegend,
+  errorMessages: orgErrorMessages,
+  helpMessage,
+  exampleMessage,
+  supplementaryMessage,
+  innerMargin,
+  ...rest
+}) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()
 
@@ -35,6 +44,15 @@ export const Fieldset: FC<
     htmlFor: `${baseId}-htmlFor`,
     id: baseLegend.id || `${baseId}-legend`,
   }
+
+  const calculatedDescribedByIds = useDescribedByIds({
+    wrapperRef,
+    htmlFor: legend.htmlFor,
+    errorMessages: orgErrorMessages,
+    helpMessage,
+    exampleMessage,
+    supplementaryMessage,
+  })
 
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
@@ -97,9 +115,13 @@ export const Fieldset: FC<
   return (
     <FormGroup
       {...rest}
+      {...calculatedDescribedByIds}
       as="fieldset"
       wrapperRef={wrapperRef}
       label={legend}
+      helpMessage={helpMessage}
+      exampleMessage={exampleMessage}
+      supplementaryMessage={supplementaryMessage}
       LabelComponent={LabelComponent}
       innerMargin={innerMargin}
       fieldsetWithDefaultMargin={innerMargin === undefined}

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -45,7 +45,7 @@ export const Fieldset: FC<
     id: baseLegend.id || `${baseId}-legend`,
   }
 
-  const calculatedDescribedByIds = useDescribedByIds({
+  const { describedbyIds, ...describedByIdsRest } = useDescribedByIds({
     wrapperRef,
     htmlFor: legend.htmlFor,
     errorMessages: orgErrorMessages,
@@ -115,7 +115,7 @@ export const Fieldset: FC<
   return (
     <FormGroup
       {...rest}
-      {...calculatedDescribedByIds}
+      {...describedByIdsRest}
       as="fieldset"
       wrapperRef={wrapperRef}
       label={legend}
@@ -125,6 +125,7 @@ export const Fieldset: FC<
       LabelComponent={LabelComponent}
       innerMargin={innerMargin}
       fieldsetWithDefaultMargin={innerMargin === undefined}
+      aria-describedby={describedbyIds || undefined}
     />
   )
 }

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -7,7 +7,8 @@ import { Cluster } from '../Layout'
 import { Text } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import { CHILDREN_WRAPPER_INPUT_SELECTOR, FormGroup, LABEL_TEXT_SELECTOR } from './FormGroup'
+import { FormGroup } from './FormGroup'
+import { CHILDREN_WRAPPER_INPUT_SELECTOR, LABEL_TEXT_SELECTOR } from './constants'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -9,6 +9,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { FormGroup } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
+import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 
@@ -18,7 +19,14 @@ export const FormControl: FC<
   CommonProps & {
     label: ReactNode | ObjectLabelType
   }
-> = ({ label: orgLabel, ...rest }) => {
+> = ({
+  label: orgLabel,
+  errorMessages: orgErrorMessages,
+  helpMessage,
+  exampleMessage,
+  supplementaryMessage,
+  ...rest
+}) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()
   const [childInputId, setChildInputId] = useState<string>('')
@@ -32,6 +40,15 @@ export const FormControl: FC<
     htmlFor: baseLabel.htmlFor || childInputId || `${baseId}-htmlFor`,
     id: baseLabel.id || `${baseId}-label`,
   }
+
+  const calculatedDescribedByIds = useDescribedByIds({
+    wrapperRef,
+    htmlFor: label.htmlFor,
+    errorMessages: orgErrorMessages,
+    helpMessage,
+    exampleMessage,
+    supplementaryMessage,
+  })
 
   useEffect(() => {
     if (
@@ -67,7 +84,16 @@ export const FormControl: FC<
   }, [label.htmlFor, label.id])
 
   return (
-    <FormGroup {...rest} wrapperRef={wrapperRef} label={label} LabelComponent={LabelComponent} />
+    <FormGroup
+      {...rest}
+      {...calculatedDescribedByIds}
+      wrapperRef={wrapperRef}
+      label={label}
+      helpMessage={helpMessage}
+      exampleMessage={exampleMessage}
+      supplementaryMessage={supplementaryMessage}
+      LabelComponent={LabelComponent}
+    />
   )
 }
 

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -7,7 +7,8 @@ import { Cluster } from '../Layout'
 import { Text } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import { CHILDREN_WRAPPER_INPUT_SELECTOR, FormGroup } from './FormGroup'
+import { FormGroup } from './FormGroup'
+import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,9 +1,12 @@
-import { type ComponentType, type FC, type RefObject, useEffect, useMemo, useRef } from 'react'
+import { type ComponentType, type FC, type RefObject, useEffect, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { FaCircleExclamationIcon } from '../Icon'
 import { Stack } from '../Layout'
 import { Text } from '../Text'
+
+import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
+import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 
@@ -46,10 +49,6 @@ const classNameGenerator = tv({
   },
 })
 
-const SMARTHR_UI_INPUT_SELECTOR = '[data-smarthr-ui-input="true"]'
-export const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-childrenWrapper ${SMARTHR_UI_INPUT_SELECTOR}`
-export const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'
-
 export const FormGroup: FC<Props> = ({
   wrapperRef,
   label,
@@ -58,7 +57,7 @@ export const FormGroup: FC<Props> = ({
   statusLabels,
   helpMessage,
   exampleMessage,
-  errorMessages,
+  errorMessages: orgErrorMessages,
   autoBindErrorInput = true,
   supplementaryMessage,
   as = 'div',
@@ -68,49 +67,7 @@ export const FormGroup: FC<Props> = ({
   LabelComponent,
   ...rest
 }) => {
-  const managedDescribedbyIdsRef = useRef<string[]>([])
   const isFieldset = as === 'fieldset'
-
-  // HINT: statusLabelsは設定されない場合が大半、かつ設定されてもRequiredLabelでmemo化されているため
-  // memo化がかなりの確率で有用
-  const actualStatusLabels = useMemo(
-    () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
-    [statusLabels],
-  )
-
-  // HINT: memo化している箇所がないため毎回計算している
-  const actualErrorMessages = errorMessages
-    ? Array.isArray(errorMessages)
-      ? errorMessages
-      : [errorMessages]
-    : []
-
-  const helpMessageId = helpMessage ? `${label.htmlFor}_helpMessage` : undefined
-  const exampleMessageId = exampleMessage ? `${label.htmlFor}_exampleMessage` : undefined
-  const supplementaryMessageId = supplementaryMessage
-    ? `${label.htmlFor}_supplementaryMessage`
-    : undefined
-  const visibleErrorMessages = actualErrorMessages.length > 0
-  const errorMessagesId = visibleErrorMessages ? `${label.htmlFor}_errorMessages` : undefined
-
-  const describedbyIds = useMemo(() => {
-    const temp: string[] = []
-
-    if (helpMessageId) {
-      temp.push(helpMessageId)
-    }
-    if (exampleMessageId) {
-      temp.push(exampleMessageId)
-    }
-    if (supplementaryMessageId) {
-      temp.push(supplementaryMessageId)
-    }
-    if (errorMessagesId) {
-      temp.push(errorMessagesId)
-    }
-
-    return temp.join(' ')
-  }, [helpMessageId, exampleMessageId, supplementaryMessageId, errorMessagesId])
 
   const classNames = useMemo(() => {
     const generators = classNameGenerator()
@@ -121,36 +78,29 @@ export const FormGroup: FC<Props> = ({
     }
   }, [fieldsetWithDefaultMargin, className])
 
-  useEffect(() => {
-    if (!wrapperRef.current) {
-      return
-    }
+  // HINT: statusLabelsは設定されない場合が大半、かつ設定されてもRequiredLabelでmemo化されているため
+  // memo化がかなりの確率で有用
+  const actualStatusLabels = useMemo(
+    () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
+    [statusLabels],
+  )
 
-    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
-
-    if (!input) {
-      return
-    }
-
-    const ariaDescribedBy = input.getAttribute('aria-describedby') || ''
-    const currentTokens = ariaDescribedBy ? ariaDescribedBy.split(' ') : []
-    // HINT: 自分が過去に付与したid以外（=外部由来のid）だけを残す
-    const externalTokens = currentTokens.filter(
-      (token) => !managedDescribedbyIdsRef.current.includes(token),
-    )
-    const describedbyIdTokens = describedbyIds ? describedbyIds.split(' ') : []
-    const nextValue = [...externalTokens, ...describedbyIdTokens].join(' ')
-
-    if (nextValue !== ariaDescribedBy) {
-      if (nextValue) {
-        input.setAttribute('aria-describedby', nextValue)
-      } else {
-        input.removeAttribute('aria-describedby')
-      }
-    }
-
-    managedDescribedbyIdsRef.current = describedbyIdTokens
-  }, [describedbyIds, wrapperRef])
+  const {
+    errorMessages,
+    visibleErrorMessages,
+    helpMessageId,
+    exampleMessageId,
+    supplementaryMessageId,
+    errorMessagesId,
+    describedbyIds,
+  } = useDescribedByIds({
+    wrapperRef,
+    htmlFor: label.htmlFor,
+    errorMessages: orgErrorMessages,
+    helpMessage,
+    exampleMessage,
+    supplementaryMessage,
+  })
 
   useEffect(() => {
     if (!autoBindErrorInput || !wrapperRef.current) {
@@ -205,7 +155,7 @@ export const FormGroup: FC<Props> = ({
       )}
       {visibleErrorMessages && (
         <div id={errorMessagesId} className="shr-list-none" role="alert">
-          {actualErrorMessages.map((message, index) => (
+          {errorMessages.map((message, index) => (
             <p key={index}>
               <Text
                 className="smarthr-ui-FormControl-errorMessage"

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -6,21 +6,24 @@ import { Stack } from '../Layout'
 import { Text } from '../Text'
 
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
-import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
+import type { useDescribedByIds } from './useDescribedByIds'
 
-type Props = CommonProps & {
-  wrapperRef: RefObject<HTMLDivElement>
-  /** グループのラベル名 */
-  label: Omit<ObjectLabelType, 'id' | 'htmlFor'> & Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
-  as?: string | ComponentType<any>
-  /** `true` のとき、childrenWrapperの上部余白を広げる（FieldsetがinnerMargin未指定の場合に使用） */
-  fieldsetWithDefaultMargin?: boolean
-  /** `true` のとき、文字色を `TEXT_DISABLED` にする */
-  disabled?: boolean
-  LabelComponent: FC<LabelComponentProps>
-}
+// HINT: errorMessagesを含む各idはuseDescribedByIdsで算出済みの値を受け取る
+type Props = Omit<CommonProps, 'errorMessages'> &
+  ReturnType<typeof useDescribedByIds> & {
+    wrapperRef: RefObject<HTMLDivElement>
+    /** グループのラベル名 */
+    label: Omit<ObjectLabelType, 'id' | 'htmlFor'> &
+      Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
+    as?: string | ComponentType<any>
+    /** `true` のとき、childrenWrapperの上部余白を広げる（FieldsetがinnerMargin未指定の場合に使用） */
+    fieldsetWithDefaultMargin?: boolean
+    /** `true` のとき、文字色を `TEXT_DISABLED` にする */
+    disabled?: boolean
+    LabelComponent: FC<LabelComponentProps>
+  }
 
 const classNameGenerator = tv({
   slots: {
@@ -57,7 +60,7 @@ export const FormGroup: FC<Props> = ({
   statusLabels,
   helpMessage,
   exampleMessage,
-  errorMessages: orgErrorMessages,
+  errorMessages,
   autoBindErrorInput = true,
   supplementaryMessage,
   as = 'div',
@@ -65,6 +68,12 @@ export const FormGroup: FC<Props> = ({
   children,
   fieldsetWithDefaultMargin,
   LabelComponent,
+  visibleErrorMessages,
+  helpMessageId,
+  exampleMessageId,
+  supplementaryMessageId,
+  errorMessagesId,
+  describedbyIds,
   ...rest
 }) => {
   const isFieldset = as === 'fieldset'
@@ -84,23 +93,6 @@ export const FormGroup: FC<Props> = ({
     () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
     [statusLabels],
   )
-
-  const {
-    errorMessages,
-    visibleErrorMessages,
-    helpMessageId,
-    exampleMessageId,
-    supplementaryMessageId,
-    errorMessagesId,
-    describedbyIds,
-  } = useDescribedByIds({
-    wrapperRef,
-    htmlFor: label.htmlFor,
-    errorMessages: orgErrorMessages,
-    helpMessage,
-    exampleMessage,
-    supplementaryMessage,
-  })
 
   useEffect(() => {
     if (!autoBindErrorInput || !wrapperRef.current) {

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -12,7 +12,7 @@ import type { useDescribedByIds } from './useDescribedByIds'
 
 // HINT: errorMessagesを含む各idはuseDescribedByIdsで算出済みの値を受け取る
 type Props = Omit<CommonProps, 'errorMessages'> &
-  ReturnType<typeof useDescribedByIds> & {
+  Omit<ReturnType<typeof useDescribedByIds>, 'describedbyIds'> & {
     wrapperRef: RefObject<HTMLDivElement>
     /** グループのラベル名 */
     label: Omit<ObjectLabelType, 'id' | 'htmlFor'> &
@@ -73,11 +73,8 @@ export const FormGroup: FC<Props> = ({
   exampleMessageId,
   supplementaryMessageId,
   errorMessagesId,
-  describedbyIds,
   ...rest
 }) => {
-  const isFieldset = as === 'fieldset'
-
   const classNames = useMemo(() => {
     const generators = classNameGenerator()
 
@@ -116,7 +113,6 @@ export const FormGroup: FC<Props> = ({
       ref={wrapperRef}
       as={as}
       gap={innerMargin ?? 0.5}
-      aria-describedby={isFieldset && describedbyIds ? describedbyIds : undefined}
       className={classNames.wrapper}
     >
       <LabelComponent

--- a/packages/smarthr-ui/src/components/FormGroup/constants.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/constants.ts
@@ -1,0 +1,2 @@
+export const CHILDREN_WRAPPER_INPUT_SELECTOR = `.smarthr-ui-FormControl-childrenWrapper [data-smarthr-ui-input="true"]`
+export const LABEL_TEXT_SELECTOR = '.smarthr-ui-FormControl-labelText'

--- a/packages/smarthr-ui/src/components/FormGroup/useDescribedByIds.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/useDescribedByIds.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useMemo, useRef } from 'react'
+import { type ReactNode, type RefObject, useEffect, useMemo, useRef } from 'react'
 
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 
@@ -13,6 +13,8 @@ type Props = Pick<
   htmlFor: string
 }
 
+const EMPTY_ERROR_MESSAGES: ReactNode[] = []
+
 export const useDescribedByIds = ({
   wrapperRef,
   htmlFor,
@@ -21,12 +23,15 @@ export const useDescribedByIds = ({
   exampleMessage,
   supplementaryMessage,
 }: Props) => {
-  // HINT: memo化している箇所がないため毎回計算している
+  // HINT: errorMessagesの利用方法とReactNodeのためuseMemoでは適切にmemo化しにくい
+  // undefined、もしくは空配列の場合は定数のEMPTY_ERROR_MESSAGESと差し替えることで安定化する
   const actualErrorMessages = errorMessages
     ? Array.isArray(errorMessages)
-      ? errorMessages
+      ? errorMessages.length === 0
+        ? EMPTY_ERROR_MESSAGES
+        : errorMessages
       : [errorMessages]
-    : []
+    : EMPTY_ERROR_MESSAGES
 
   const helpMessageId = helpMessage ? `${htmlFor}_helpMessage` : undefined
   const exampleMessageId = exampleMessage ? `${htmlFor}_exampleMessage` : undefined

--- a/packages/smarthr-ui/src/components/FormGroup/useDescribedByIds.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/useDescribedByIds.ts
@@ -1,0 +1,100 @@
+import { type RefObject, useEffect, useMemo, useRef } from 'react'
+
+import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
+
+import type { CommonProps } from './type'
+
+type Props = Pick<
+  CommonProps,
+  'helpMessage' | 'exampleMessage' | 'errorMessages' | 'supplementaryMessage'
+> & {
+  wrapperRef: RefObject<HTMLDivElement>
+  /** 各メッセージのidを組み立てる接頭辞。labelのhtmlForと同じ値 */
+  htmlFor: string
+}
+
+export const useDescribedByIds = ({
+  wrapperRef,
+  htmlFor,
+  errorMessages,
+  helpMessage,
+  exampleMessage,
+  supplementaryMessage,
+}: Props) => {
+  // HINT: memo化している箇所がないため毎回計算している
+  const actualErrorMessages = errorMessages
+    ? Array.isArray(errorMessages)
+      ? errorMessages
+      : [errorMessages]
+    : []
+
+  const helpMessageId = helpMessage ? `${htmlFor}_helpMessage` : undefined
+  const exampleMessageId = exampleMessage ? `${htmlFor}_exampleMessage` : undefined
+  const supplementaryMessageId = supplementaryMessage
+    ? `${htmlFor}_supplementaryMessage`
+    : undefined
+  const visibleErrorMessages = actualErrorMessages.length > 0
+  const errorMessagesId = visibleErrorMessages ? `${htmlFor}_errorMessages` : undefined
+
+  const describedbyIds = useMemo(() => {
+    const temp: string[] = []
+
+    if (helpMessageId) {
+      temp.push(helpMessageId)
+    }
+    if (exampleMessageId) {
+      temp.push(exampleMessageId)
+    }
+    if (supplementaryMessageId) {
+      temp.push(supplementaryMessageId)
+    }
+    if (errorMessagesId) {
+      temp.push(errorMessagesId)
+    }
+
+    return temp.join(' ')
+  }, [helpMessageId, exampleMessageId, supplementaryMessageId, errorMessagesId])
+
+  const managedDescribedbyIdsRef = useRef<string[]>([])
+
+  useEffect(() => {
+    if (!wrapperRef.current) {
+      return
+    }
+
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
+
+    if (!input) {
+      return
+    }
+
+    const ariaDescribedBy = input.getAttribute('aria-describedby') || ''
+    const currentTokens = ariaDescribedBy ? ariaDescribedBy.split(' ') : []
+    // HINT: 自分が過去に付与したid以外（=外部由来のid）だけを残す
+    const externalTokens = currentTokens.filter(
+      (token) => !managedDescribedbyIdsRef.current.includes(token),
+    )
+    const describedbyIdTokens = describedbyIds ? describedbyIds.split(' ') : []
+    const nextValue = [...externalTokens, ...describedbyIdTokens].join(' ')
+
+    if (nextValue !== ariaDescribedBy) {
+      if (nextValue) {
+        input.setAttribute('aria-describedby', nextValue)
+      } else {
+        input.removeAttribute('aria-describedby')
+      }
+    }
+
+    managedDescribedbyIdsRef.current = describedbyIdTokens
+  }, [describedbyIds, wrapperRef])
+
+  return {
+    errorMessages: actualErrorMessages,
+    visibleErrorMessages,
+    helpMessageId,
+    exampleMessageId,
+    supplementaryMessageId,
+    errorMessagesId,
+    describedbyIds,
+  }
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` が抱えていた `aria-describedby` まわりの処理を `useDescribedByIds` として切り出し、`FormControl` と `Fieldset` の双方から呼び出す形に整理します。

これにより `FormGroup` から `isFieldset`（`as === 'fieldset'`）による分岐が**完全になくなり**、算出済みの値を受け取って描画するだけのコンポーネントになります。

PR #6888 に続く `FormGroup` の整理です。

## 変更内容

### 1. `useDescribedByIds` の切り出し

各メッセージのid算出と、input要素への `aria-describedby` 付与をフックにまとめました。

`FormControl` と `Fieldset` の双方から利用するため、CLAUDE.md の「同ディレクトリ内の複数コンポーネントから利用されるカスタムフック」に該当します（`Disclosure/useDisclosure.ts` と同じ位置づけ）。

あわせてselector関係の定数を `constants.ts` へ移動しています。フックが `CHILDREN_WRAPPER_INPUT_SELECTOR` を参照するため、`FormGroup.tsx` に置いたままだと循環参照になるためです。

### 2. `errorMessages` が空の場合の参照を安定させる

`errorMessages` は `ReactNode | ReactNode[]` のため、`useMemo` の依存配列に含めても参照が毎回変わり適切にmemo化できません。undefinedまたは空配列の場合に定数へ差し替えることで、その範囲だけでも参照を安定させています。

### 3. `FormControl`・`Fieldset` からフックを呼ぶ

`FormGroup` はフックの戻り値を受け取るだけになります。

`FormGroup` のprops型は `ReturnType<typeof useDescribedByIds>` を交差させる形にしました。フックの戻り値と二重管理にならず、`errorMessages` も正規化済みの `ReactNode[]` で受け取れるため、`CommonProps` 由来の未正規化な型との衝突も解消されます。

### 4. `aria-describedby` の付与を `Fieldset` へ

`FormGroup` は `aria-describedby` を `isFieldset` の場合のみ付与していましたが、この条件は `Fieldset` 側では自明です。付与自体を `Fieldset` へ移しました。

props型では `describedbyIds` を `Omit` し、`FormGroup` が受け取らないことを型で表現しています。

### 結果

| コンポーネント | 役割 |
|---|---|
| `FormControl` | label正規化、id採番、inputへのid紐付け、`<label>` 描画 |
| `Fieldset` | legend正規化、id採番、アクセシブルネーム付与、`<legend>` 描画、`aria-describedby` 付与 |
| `FormGroup` | 算出済みの値を受け取って描画するのみ |
| `useDescribedByIds` | id算出とinputへの `aria-describedby` 付与（2コンポーネント共通） |

## プロダクト側で対応が必要な事項

なし。公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

`aria-describedby` はアクセシビリティの根幹となる属性のため、コミットごとに実測で比較しました。

**フック切り出し（12パターン）**

各メッセージ単体・`errorMessages` の1件/複数件/文字列単体/空配列・全併用・Fieldset併用・rerenderでの追加/削除

**空配列時の参照安定化（9パターン）**

未指定・空配列・1件・複数件・文字列単体に加え、rerenderでの空配列/1件/未指定の遷移

**各コンポーネントからの呼び出し（12パターン）**

FormControl・Fieldsetそれぞれの各メッセージ単体・全併用・メッセージ無し

**`aria-describedby` の移動（10パターン）**

Fieldsetのメッセージ無し・helpMessage・errorMessages・全併用・空配列、FormControl側で付与されないこと、rerenderでの追加/削除

記録した属性は各メッセージの `id`、input要素の `aria-describedby`・`aria-invalid`、fieldsetの `aria-describedby` です。いずれも**完全一致**でした。`aria-describedby=""` の空属性が出力されないことも `hasAttribute` で確認しています。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **アクセシビリティ**
  - フォームの入力項目やフィールドセットで、ヘルプ、例、補足、エラーメッセージが適切に関連付けられるようになりました。
  - 既存の説明情報を維持しながら、スクリーンリーダーで各メッセージを正しく確認できます。
  - エラー発生時の入力項目の状態が、より正確に伝わるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->