### PR TITLE
refactor(FormGroup): tvをvariantsの有無で分割しstyle.tsに切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { type FC, type ReactNode, memo, useEffect, useId, useRef } from 'react'
+import { type FC, type ReactNode, memo, useEffect, useId, useMemo, useRef } from 'react'
+import { tv } from 'tailwind-variants'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
@@ -9,11 +10,27 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { FormGroup } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR, LABEL_TEXT_SELECTOR } from './constants'
+import { classNameGenerator } from './style'
 import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 
 const legendObjectConverter = (legend: ReactNode) => ({ text: legend })
+
+const fieldsetClassNameGenerator = tv({
+  extend: classNameGenerator,
+  variants: {
+    // TODO: innerMarginが未指定、初期値の場合、childrenの上部の余白を広げることで
+    // FormControlとの差をわかりやすくしている
+    // 微妙な方法ではあるので、必要に応じてinnerMarginではない属性を用意する
+    // https://kufuinc.slack.com/archives/CGC58MW01/p1737944965871159?thread_ts=1737541173.404369&cid=CGC58MW01
+    withDefaultMargin: {
+      true: {
+        childrenWrapper: '[:not([hidden])_~_&&&]:shr-mt-0.5',
+      },
+    },
+  },
+})
 
 export const Fieldset: FC<
   CommonProps & {
@@ -28,10 +45,20 @@ export const Fieldset: FC<
   exampleMessage,
   supplementaryMessage,
   innerMargin,
+  className,
   ...rest
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()
+
+  const classNames = useMemo(() => {
+    const generators = fieldsetClassNameGenerator()
+
+    return {
+      wrapper: generators.wrapper({ className }),
+      childrenWrapper: generators.childrenWrapper({ withDefaultMargin: innerMargin === undefined }),
+    }
+  }, [innerMargin, className])
 
   const baseLegend = useObjectAttributes<ReactNode | ObjectLabelType, ObjectLabelType>(
     orgLegend,
@@ -122,9 +149,9 @@ export const Fieldset: FC<
       helpMessage={helpMessage}
       exampleMessage={exampleMessage}
       supplementaryMessage={supplementaryMessage}
+      classNames={classNames}
       LabelComponent={LabelComponent}
       innerMargin={innerMargin}
-      fieldsetWithDefaultMargin={innerMargin === undefined}
       aria-describedby={describedbyIds || undefined}
     />
   )

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FC, type ReactNode, memo, useEffect, useId, useRef, useState } from 'react'
+import { type FC, type ReactNode, memo, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
@@ -9,6 +9,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
 import { FormGroup } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
+import { classNameGenerator } from './style'
 import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
@@ -25,8 +26,18 @@ export const FormControl: FC<
   helpMessage,
   exampleMessage,
   supplementaryMessage,
+  className,
   ...rest
 }) => {
+  const classNames = useMemo(() => {
+    const generators = classNameGenerator()
+
+    return {
+      wrapper: generators.wrapper({ className }),
+      childrenWrapper: generators.childrenWrapper(),
+    }
+  }, [className])
+
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()
   const [childInputId, setChildInputId] = useState<string>('')
@@ -92,6 +103,7 @@ export const FormControl: FC<
       helpMessage={helpMessage}
       exampleMessage={exampleMessage}
       supplementaryMessage={supplementaryMessage}
+      classNames={classNames}
       LabelComponent={LabelComponent}
     />
   )

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -56,6 +56,7 @@ export const FormGroup: FC<Props> = ({
     [statusLabels],
   )
 
+  // TODO: autoBindErrorInputによってコンポーネントを実行し分けるように修正する
   useEffect(() => {
     if (!autoBindErrorInput || !wrapperRef.current) {
       return

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,5 +1,4 @@
 import { type ComponentType, type FC, type RefObject, useEffect, useMemo } from 'react'
-import { tv } from 'tailwind-variants'
 
 import { FaCircleExclamationIcon } from '../Icon'
 import { Stack } from '../Layout'
@@ -10,47 +9,23 @@ import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 import type { useDescribedByIds } from './useDescribedByIds'
 
-// HINT: errorMessagesを含む各idはuseDescribedByIdsで算出済みの値を受け取る
-type Props = Omit<CommonProps, 'errorMessages'> &
+// HINT: errorMessagesを含む各idはuseDescribedByIdsで、classNamesは各コンポーネントで
+// 算出済みの値を受け取る
+type Props = Omit<CommonProps, 'errorMessages' | 'className'> &
   Omit<ReturnType<typeof useDescribedByIds>, 'describedbyIds'> & {
     wrapperRef: RefObject<HTMLDivElement>
     /** グループのラベル名 */
     label: Omit<ObjectLabelType, 'id' | 'htmlFor'> &
       Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>
     as?: string | ComponentType<any>
-    /** `true` のとき、childrenWrapperの上部余白を広げる（FieldsetがinnerMargin未指定の場合に使用） */
-    fieldsetWithDefaultMargin?: boolean
     /** `true` のとき、文字色を `TEXT_DISABLED` にする */
     disabled?: boolean
     LabelComponent: FC<LabelComponentProps>
+    classNames: {
+      wrapper: string
+      childrenWrapper: string
+    }
   }
-
-const classNameGenerator = tv({
-  slots: {
-    wrapper: [
-      'smarthr-ui-FormControl',
-      'shr-mx-[unset] shr-border-none shr-p-[unset]',
-      'disabled:shr-text-disabled',
-      '[&:disabled_.smarthr-ui-FormControl-label_>_span]:shr-text-disabled',
-      '[&:disabled_.smarthr-ui-FormControl-exampleMessage]:shr-text-color-inherit',
-      '[&:disabled_.smarthr-ui-FormControl-errorMessage-Icon]:shr-text-color-inherit',
-      '[&:disabled_.smarthr-ui-FormControl-supplementaryMessage]:shr-text-color-inherit',
-      '[&:disabled_.smarthr-ui-Input]:shr-border-default/50 [&:disabled_.smarthr-ui-Input]:shr-bg-white-darken',
-    ],
-    childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
-  },
-  variants: {
-    // TODO: innerMarginが未指定、初期値の場合、かつFieldsetの場合、childrenの上部の余白を広げることで
-    // FormControltとの差をわかりやすくしている
-    // 微妙な方法ではあるので、必要に応じてinnerMarginではない属性を用意する
-    // https://kufuinc.slack.com/archives/CGC58MW01/p1737944965871159?thread_ts=1737541173.404369&cid=CGC58MW01
-    fieldsetWithDefaultMargin: {
-      true: {
-        childrenWrapper: '[:not([hidden])_~_&&&]:shr-mt-0.5',
-      },
-    },
-  },
-})
 
 export const FormGroup: FC<Props> = ({
   wrapperRef,
@@ -64,9 +39,8 @@ export const FormGroup: FC<Props> = ({
   autoBindErrorInput = true,
   supplementaryMessage,
   as = 'div',
-  className,
   children,
-  fieldsetWithDefaultMargin,
+  classNames,
   LabelComponent,
   visibleErrorMessages,
   helpMessageId,
@@ -75,15 +49,6 @@ export const FormGroup: FC<Props> = ({
   errorMessagesId,
   ...rest
 }) => {
-  const classNames = useMemo(() => {
-    const generators = classNameGenerator()
-
-    return {
-      wrapper: generators.wrapper({ className }),
-      childrenWrapper: generators.childrenWrapper({ fieldsetWithDefaultMargin }),
-    }
-  }, [fieldsetWithDefaultMargin, className])
-
   // HINT: statusLabelsは設定されない場合が大半、かつ設定されてもRequiredLabelでmemo化されているため
   // memo化がかなりの確率で有用
   const actualStatusLabels = useMemo(

--- a/packages/smarthr-ui/src/components/FormGroup/style.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/style.ts
@@ -1,0 +1,17 @@
+import { tv } from 'tailwind-variants'
+
+export const classNameGenerator = tv({
+  slots: {
+    wrapper: [
+      'smarthr-ui-FormControl',
+      'shr-mx-[unset] shr-border-none shr-p-[unset]',
+      'disabled:shr-text-disabled',
+      '[&:disabled_.smarthr-ui-FormControl-label_>_span]:shr-text-disabled',
+      '[&:disabled_.smarthr-ui-FormControl-exampleMessage]:shr-text-color-inherit',
+      '[&:disabled_.smarthr-ui-FormControl-errorMessage-Icon]:shr-text-color-inherit',
+      '[&:disabled_.smarthr-ui-FormControl-supplementaryMessage]:shr-text-color-inherit',
+      '[&:disabled_.smarthr-ui-Input]:shr-border-default/50 [&:disabled_.smarthr-ui-Input]:shr-bg-white-darken',
+    ],
+    childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
+  },
+})


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormGroup` の `classNameGenerator` が持つvariantsは `fieldsetWithDefaultMargin` の1つだけで、これは **Fieldset固有の条件** でした。`FormControl` 経由では常にfalseになります。

variantsを持たない定義を `style.ts` へ切り出し、`Fieldset` 側でextendする形に整理します。

PR #6889 に続く `FormGroup` の整理です。

## 変更内容

### 1. variantsを持たない定義を `style.ts` へ

```tsx
// style.ts
export const classNameGenerator = tv({
  slots: {
    wrapper: [ /* 静的クラス */ ],
    childrenWrapper: 'smarthr-ui-FormControl-childrenWrapper',
  },
})
```

### 2. `Fieldset` でextendして余白調整のvariantを追加

```tsx
// Fieldset.tsx
const fieldsetClassNameGenerator = tv({
  extend: classNameGenerator,
  variants: {
    withDefaultMargin: {
      true: { childrenWrapper: '[:not([hidden])_~_&&&]:shr-mt-0.5' },
    },
  },
})
```

variant名は `Fieldset` 内では自明な `fieldset` を落として `withDefaultMargin` にしています。余白調整の方法自体が微妙である旨のTODOコメントも、このvariantの位置へ移しました。

### 3. `FormGroup` は `classNames` をpropsで受け取る

`FormGroup` から `tv` の呼び出しと `fieldsetWithDefaultMargin` propsが不要になりました。各コンポーネント側で算出して渡します。

```tsx
// FormControl.tsx
const classNames = useMemo(() => {
  const generators = classNameGenerator()

  return {
    wrapper: generators.wrapper({ className }),
    childrenWrapper: generators.childrenWrapper(),
  }
}, [className])
```

```tsx
// Fieldset.tsx
const classNames = useMemo(() => {
  const generators = fieldsetClassNameGenerator()

  return {
    wrapper: generators.wrapper({ className }),
    childrenWrapper: generators.childrenWrapper({ withDefaultMargin: innerMargin === undefined }),
  }
}, [innerMargin, className])
```

`className` は `classNames.wrapper` にマージ済みのため、`FormGroup` のprops型からは `Omit` しています。

### 4. `autoBindErrorInput` に関するTODOを追加

`aria-invalid` を制御する `useEffect` は `autoBindErrorInput` がfalseの場合に何もせず抜けます。propsによる分岐ではなくコンポーネントの出し分けで表現できる可能性があるため、TODOとして記録しました。

## プロダクト側で対応が必要な事項

なし。公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成クラスの同一性について

`extend` による合成が元の `variants` と同一の結果になることを実測で比較しました。

`wrapper` と `childrenWrapper` のclassを記録し、以下10パターンで検証しています。

1. FormControl / `innerMargin` 未指定
2. FormControl / `innerMargin={0.5}`
3. **Fieldset / `innerMargin` 未指定**（余白調整が適用される唯一のケース）
4. Fieldset / `innerMargin={0.5}`
5. Fieldset / `innerMargin={0}`（falsyな境界値。`!innerMargin` と書くと誤適用されるため）
6. Fieldset / `innerMargin={1}`
7. FormControl / `className` 指定
8. Fieldset / `className` 指定
9. FormControl / `disabled`（子孫セレクタ）
10. Fieldset / `disabled` + `className`

結果は分割前と**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル改善**
  - フォーム項目の余白やレイアウトのスタイル適用を整理し、より一貫した表示になるよう改善しました。
  - 無効状態のラベル文字色、入力欄の境界線、背景色の表示を統一しました。
  - フォームグループ内のラッパー要素に対するスタイル適用を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->