### PR TITLE
fix(FormGroup): autoBindErrorInput解除後もaria-invalidが残る問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -52,17 +52,17 @@ export const Fieldset: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
 }
 
 const AutoBindErrorFieldset: FC<LowerProps> = (props) => {
-  const { wrapperRef, visibleErrorMessages, formGroupProps } = useFieldsetProps(props)
+  const { wrapperRef, visibleErrorMessages, ...rest } = useFieldsetProps(props)
 
   useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })
 
-  return <FormGroup {...formGroupProps} />
+  return <FormGroup {...rest} wrapperRef={wrapperRef} visibleErrorMessages={visibleErrorMessages} />
 }
 
 const ActualFieldset: FC<LowerProps> = (props) => {
-  const { formGroupProps } = useFieldsetProps(props)
+  const actualProps = useFieldsetProps(props)
 
-  return <FormGroup {...formGroupProps} />
+  return <FormGroup {...actualProps} />
 }
 
 const useFieldsetProps = ({
@@ -167,23 +167,19 @@ const useFieldsetProps = ({
   }, [])
 
   return {
-    wrapperRef,
+    ...rest,
+    ...describedByIdsRest,
     visibleErrorMessages,
-    formGroupProps: {
-      ...rest,
-      ...describedByIdsRest,
-      visibleErrorMessages,
-      as: 'fieldset',
-      wrapperRef,
-      label: legend,
-      helpMessage,
-      exampleMessage,
-      supplementaryMessage,
-      classNames,
-      LabelComponent,
-      innerMargin,
-      'aria-describedby': describedbyIds || undefined,
-    },
+    as: 'fieldset',
+    wrapperRef,
+    label: legend,
+    helpMessage,
+    exampleMessage,
+    supplementaryMessage,
+    classNames,
+    LabelComponent,
+    innerMargin,
+    'aria-describedby': describedbyIds || undefined,
   }
 }
 

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -11,6 +11,7 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 import { FormGroup } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR, LABEL_TEXT_SELECTOR } from './constants'
 import { classNameGenerator } from './style'
+import { useAutoBindErrorInput } from './useAutoBindErrorInput'
 import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
@@ -32,13 +33,39 @@ const fieldsetClassNameGenerator = tv({
   },
 })
 
-export const Fieldset: FC<
-  CommonProps & {
-    legend: ReactNode | Omit<ObjectLabelType, 'htmlFor'>
-    /** `true` のとき、文字色を `TEXT_DISABLED` にする */
-    disabled?: boolean
-  }
-> = ({
+type Props = CommonProps & {
+  legend: ReactNode | Omit<ObjectLabelType, 'htmlFor'>
+  /** `true` のとき、文字色を `TEXT_DISABLED` にする */
+  disabled?: boolean
+}
+type LowerProps = Omit<Props, 'autoBindErrorInput'>
+
+// HINT: useAutoBindErrorInputを呼ぶ/呼ばないでコンポーネントを分けている。
+// FormGroup側で分岐すると、切り替え時にFormGroup配下のみが再マウントされ、
+// ActualFieldsetのuseEffectがsetAttributeしたaria-label・aria-describedbyが
+// 復元されなくなる。分岐を最上位に置くことで、再マウント時にそれらのuseEffectも
+// 再実行されるようにしている。
+export const Fieldset: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
+  const Component = autoBindErrorInput ? AutoBindErrorFieldset : ActualFieldset
+
+  return <Component {...rest} />
+}
+
+const AutoBindErrorFieldset: FC<LowerProps> = (props) => {
+  const { wrapperRef, visibleErrorMessages, formGroupProps } = useFieldsetProps(props)
+
+  useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })
+
+  return <FormGroup {...formGroupProps} />
+}
+
+const ActualFieldset: FC<LowerProps> = (props) => {
+  const { formGroupProps } = useFieldsetProps(props)
+
+  return <FormGroup {...formGroupProps} />
+}
+
+const useFieldsetProps = ({
   legend: orgLegend,
   errorMessages: orgErrorMessages,
   helpMessage,
@@ -47,7 +74,7 @@ export const Fieldset: FC<
   innerMargin,
   className,
   ...rest
-}) => {
+}: LowerProps) => {
   const wrapperRef = useRef<HTMLDivElement>(null)
   const baseId = useId()
 
@@ -72,7 +99,7 @@ export const Fieldset: FC<
     id: baseLegend.id || `${baseId}-legend`,
   }
 
-  const { describedbyIds, ...describedByIdsRest } = useDescribedByIds({
+  const { describedbyIds, visibleErrorMessages, ...describedByIdsRest } = useDescribedByIds({
     wrapperRef,
     htmlFor: legend.htmlFor,
     errorMessages: orgErrorMessages,
@@ -139,22 +166,25 @@ export const Fieldset: FC<
     return () => observer.disconnect()
   }, [])
 
-  return (
-    <FormGroup
-      {...rest}
-      {...describedByIdsRest}
-      as="fieldset"
-      wrapperRef={wrapperRef}
-      label={legend}
-      helpMessage={helpMessage}
-      exampleMessage={exampleMessage}
-      supplementaryMessage={supplementaryMessage}
-      classNames={classNames}
-      LabelComponent={LabelComponent}
-      innerMargin={innerMargin}
-      aria-describedby={describedbyIds || undefined}
-    />
-  )
+  return {
+    wrapperRef,
+    visibleErrorMessages,
+    formGroupProps: {
+      ...rest,
+      ...describedByIdsRest,
+      visibleErrorMessages,
+      as: 'fieldset',
+      wrapperRef,
+      label: legend,
+      helpMessage,
+      exampleMessage,
+      supplementaryMessage,
+      classNames,
+      LabelComponent,
+      innerMargin,
+      'aria-describedby': describedbyIds || undefined,
+    },
+  }
 }
 
 const LabelComponent = memo<LabelComponentProps>(

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -10,17 +10,44 @@ import { VisuallyHiddenText } from '../VisuallyHiddenText'
 import { FormGroup } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 import { classNameGenerator } from './style'
+import { useAutoBindErrorInput } from './useAutoBindErrorInput'
 import { useDescribedByIds } from './useDescribedByIds'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 
 const labelObjectConverter = (label: ReactNode) => ({ text: label })
 
-export const FormControl: FC<
-  CommonProps & {
-    label: ReactNode | ObjectLabelType
-  }
-> = ({
+type Props = CommonProps & {
+  label: ReactNode | ObjectLabelType
+}
+type LowerProps = Omit<Props, 'autoBindErrorInput'>
+
+// HINT: useAutoBindErrorInputを呼ぶ/呼ばないでコンポーネントを分けている。
+// FormGroup側で分岐すると、切り替え時にFormGroup配下のみが再マウントされ、
+// ActualFormControlのuseEffectがsetAttributeしたid・aria-describedbyが
+// 復元されなくなる。分岐を最上位に置くことで、再マウント時にそれらのuseEffectも
+// 再実行されるようにしている。
+export const FormControl: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
+  const Component = autoBindErrorInput ? AutoBindErrorFormControl : ActualFormControl
+
+  return <Component {...rest} />
+}
+
+const AutoBindErrorFormControl: FC<LowerProps> = (props) => {
+  const { wrapperRef, visibleErrorMessages, formGroupProps } = useFormControlProps(props)
+
+  useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })
+
+  return <FormGroup {...formGroupProps} />
+}
+
+const ActualFormControl: FC<LowerProps> = (props) => {
+  const { formGroupProps } = useFormControlProps(props)
+
+  return <FormGroup {...formGroupProps} />
+}
+
+const useFormControlProps = ({
   label: orgLabel,
   errorMessages: orgErrorMessages,
   helpMessage,
@@ -28,7 +55,7 @@ export const FormControl: FC<
   supplementaryMessage,
   className,
   ...rest
-}) => {
+}: LowerProps) => {
   const classNames = useMemo(() => {
     const generators = classNameGenerator()
 
@@ -94,19 +121,21 @@ export const FormControl: FC<
     }
   }, [label.htmlFor, label.id])
 
-  return (
-    <FormGroup
-      {...rest}
-      {...calculatedDescribedByIds}
-      wrapperRef={wrapperRef}
-      label={label}
-      helpMessage={helpMessage}
-      exampleMessage={exampleMessage}
-      supplementaryMessage={supplementaryMessage}
-      classNames={classNames}
-      LabelComponent={LabelComponent}
-    />
-  )
+  return {
+    wrapperRef,
+    visibleErrorMessages: calculatedDescribedByIds.visibleErrorMessages,
+    formGroupProps: {
+      ...rest,
+      ...calculatedDescribedByIds,
+      wrapperRef,
+      label,
+      helpMessage,
+      exampleMessage,
+      supplementaryMessage,
+      classNames,
+      LabelComponent,
+    },
+  }
 }
 
 const LabelComponent = memo<LabelComponentProps>(

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -34,17 +34,17 @@ export const FormControl: FC<Props> = ({ autoBindErrorInput = true, ...rest }) =
 }
 
 const AutoBindErrorFormControl: FC<LowerProps> = (props) => {
-  const { wrapperRef, visibleErrorMessages, formGroupProps } = useFormControlProps(props)
+  const { wrapperRef, visibleErrorMessages, ...rest } = useFormControlProps(props)
 
   useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })
 
-  return <FormGroup {...formGroupProps} />
+  return <FormGroup {...rest} wrapperRef={wrapperRef} visibleErrorMessages={visibleErrorMessages} />
 }
 
 const ActualFormControl: FC<LowerProps> = (props) => {
-  const { formGroupProps } = useFormControlProps(props)
+  const actualProps = useFormControlProps(props)
 
-  return <FormGroup {...formGroupProps} />
+  return <FormGroup {...actualProps} />
 }
 
 const useFormControlProps = ({
@@ -122,19 +122,15 @@ const useFormControlProps = ({
   }, [label.htmlFor, label.id])
 
   return {
+    ...rest,
+    ...calculatedDescribedByIds,
     wrapperRef,
-    visibleErrorMessages: calculatedDescribedByIds.visibleErrorMessages,
-    formGroupProps: {
-      ...rest,
-      ...calculatedDescribedByIds,
-      wrapperRef,
-      label,
-      helpMessage,
-      exampleMessage,
-      supplementaryMessage,
-      classNames,
-      LabelComponent,
-    },
+    label,
+    helpMessage,
+    exampleMessage,
+    supplementaryMessage,
+    classNames,
+    LabelComponent,
   }
 }
 

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -26,8 +26,41 @@ type Props = Omit<CommonProps, 'errorMessages' | 'className'> &
       childrenWrapper: string
     }
   }
+type LowerProps = Omit<Props, 'autoBindErrorInput'>
 
-export const FormGroup: FC<Props> = ({
+export const FormGroup: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
+  const Component = autoBindErrorInput ? AutoBindErrorFormGroup : ActualFormGroup
+
+  return <Component {...rest} />
+}
+
+const AutoBindErrorFormGroup: FC<LowerProps> = ({ visibleErrorMessages, wrapperRef, ...rest }) => {
+  useEffect(() => {
+    if (!wrapperRef.current) {
+      return
+    }
+
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
+
+    if (input) {
+      if (visibleErrorMessages) {
+        input.setAttribute('aria-invalid', 'true')
+      } else {
+        input.removeAttribute('aria-invalid')
+      }
+    }
+  }, [visibleErrorMessages, wrapperRef])
+
+  return (
+    <ActualFormGroup
+      {...rest}
+      wrapperRef={wrapperRef}
+      visibleErrorMessages={visibleErrorMessages}
+    />
+  )
+}
+
+const ActualFormGroup: FC<LowerProps> = ({
   wrapperRef,
   label,
   subActionArea,
@@ -36,7 +69,6 @@ export const FormGroup: FC<Props> = ({
   helpMessage,
   exampleMessage,
   errorMessages,
-  autoBindErrorInput = true,
   supplementaryMessage,
   as = 'div',
   children,
@@ -55,23 +87,6 @@ export const FormGroup: FC<Props> = ({
     () => (statusLabels ? (Array.isArray(statusLabels) ? statusLabels : [statusLabels]) : []),
     [statusLabels],
   )
-
-  // TODO: autoBindErrorInputによってコンポーネントを実行し分けるように修正する
-  useEffect(() => {
-    if (!autoBindErrorInput || !wrapperRef.current) {
-      return
-    }
-
-    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
-
-    if (input) {
-      if (visibleErrorMessages) {
-        input.setAttribute('aria-invalid', 'true')
-      } else {
-        input.removeAttribute('aria-invalid')
-      }
-    }
-  }, [visibleErrorMessages, autoBindErrorInput, wrapperRef])
 
   return (
     <Stack

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,17 +1,16 @@
-import { type ComponentType, type FC, type RefObject, useEffect, useMemo } from 'react'
+import { type ComponentType, type FC, type RefObject, useMemo } from 'react'
 
 import { FaCircleExclamationIcon } from '../Icon'
 import { Stack } from '../Layout'
 import { Text } from '../Text'
-
-import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
 import type { useDescribedByIds } from './useDescribedByIds'
 
 // HINT: errorMessagesを含む各idはuseDescribedByIdsで、classNamesは各コンポーネントで
 // 算出済みの値を受け取る
-type Props = Omit<CommonProps, 'errorMessages' | 'className'> &
+// autoBindErrorInputによる分岐はFormControl・Fieldset側で行うため、ここでは受け取らない
+type Props = Omit<CommonProps, 'errorMessages' | 'className' | 'autoBindErrorInput'> &
   Omit<ReturnType<typeof useDescribedByIds>, 'describedbyIds'> & {
     wrapperRef: RefObject<HTMLDivElement>
     /** グループのラベル名 */
@@ -26,41 +25,8 @@ type Props = Omit<CommonProps, 'errorMessages' | 'className'> &
       childrenWrapper: string
     }
   }
-type LowerProps = Omit<Props, 'autoBindErrorInput'>
 
-export const FormGroup: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
-  const Component = autoBindErrorInput ? AutoBindErrorFormGroup : ActualFormGroup
-
-  return <Component {...rest} />
-}
-
-const AutoBindErrorFormGroup: FC<LowerProps> = ({ visibleErrorMessages, wrapperRef, ...rest }) => {
-  useEffect(() => {
-    if (!wrapperRef.current) {
-      return
-    }
-
-    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
-
-    if (input) {
-      if (visibleErrorMessages) {
-        input.setAttribute('aria-invalid', 'true')
-      } else {
-        input.removeAttribute('aria-invalid')
-      }
-    }
-  }, [visibleErrorMessages, wrapperRef])
-
-  return (
-    <ActualFormGroup
-      {...rest}
-      wrapperRef={wrapperRef}
-      visibleErrorMessages={visibleErrorMessages}
-    />
-  )
-}
-
-const ActualFormGroup: FC<LowerProps> = ({
+export const FormGroup: FC<Props> = ({
   wrapperRef,
   label,
   subActionArea,

--- a/packages/smarthr-ui/src/components/FormGroup/useAutoBindErrorInput.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/useAutoBindErrorInput.ts
@@ -1,0 +1,33 @@
+import { type RefObject, useEffect } from 'react'
+
+import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
+
+/**
+ * エラーがある場合に、子のinput要素へaria-invalidを付与するフック。
+ *
+ * HINT: このフックを呼ぶ/呼ばないでコンポーネントを分けているため、propsによる分岐は行わない。
+ * 詳細な理由はFormControl・Fieldsetの分岐箇所のコメントを参照。
+ */
+export const useAutoBindErrorInput = ({
+  wrapperRef,
+  visibleErrorMessages,
+}: {
+  wrapperRef: RefObject<HTMLDivElement>
+  visibleErrorMessages: boolean
+}) => {
+  useEffect(() => {
+    if (!wrapperRef.current) {
+      return
+    }
+
+    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
+
+    if (input) {
+      if (visibleErrorMessages) {
+        input.setAttribute('aria-invalid', 'true')
+      } else {
+        input.removeAttribute('aria-invalid')
+      }
+    }
+  }, [visibleErrorMessages, wrapperRef])
+}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`aria-invalid` を制御する `useEffect` は、`autoBindErrorInput` がfalseの場合に何もせず抜けていました。propsによる分岐をやめ、`autoBindErrorInput` がtrueの場合のみ該当の処理を持つコンポーネントを描画する形に変更します。

あわせて、`autoBindErrorInput` をtrueからfalseに変更した際に `aria-invalid` が残り続ける不具合も解消します。

PR #6891 で追加したTODOの実装です。

## 変更内容

### 1. `aria-invalid` の制御を `useAutoBindErrorInput` に切り出し

`FormControl`・`Fieldset` の双方から呼び出すため、CLAUDE.md の「同ディレクトリ内の複数コンポーネントから利用されるカスタムフック」に該当します。

### 2. 分岐を `FormControl`・`Fieldset` の最上位に置く

```tsx
// HINT: useAutoBindErrorInputを呼ぶ/呼ばないでコンポーネントを分けている。
// FormGroup側で分岐すると、切り替え時にFormGroup配下のみが再マウントされ、
// ActualFormControlのuseEffectがsetAttributeしたid・aria-describedbyが
// 復元されなくなる。分岐を最上位に置くことで、再マウント時にそれらのuseEffectも
// 再実行されるようにしている。
export const FormControl: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
  const Component = autoBindErrorInput ? AutoBindErrorFormControl : ActualFormControl

  return <Component {...rest} />
}

const AutoBindErrorFormControl: FC<LowerProps> = (props) => {
  const { wrapperRef, visibleErrorMessages, ...rest } = useFormControlProps(props)

  useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })

  return <FormGroup {...rest} wrapperRef={wrapperRef} visibleErrorMessages={visibleErrorMessages} />
}

const ActualFormControl: FC<LowerProps> = (props) => {
  const actualProps = useFormControlProps(props)

  return <FormGroup {...actualProps} />
}
```

**分岐位置が重要です。** `FormGroup` 内で分岐すると、切り替え時に `FormGroup` 配下のみが再マウントされ、`FormControl`・`Fieldset` の `useEffect` が `setAttribute` した `id`・`aria-describedby`・`aria-label` が復元されません（依存配列が変化しないため再実行されない）。

分岐を最上位に置くことで、再マウント範囲にそれらの `useEffect` が含まれ、初回実行として属性が再付与されます。この意図はコード内のコメントにも記録しています。

共通処理は `useFormControlProps`・`useFieldsetProps` として切り出し、`FormGroup` に渡すpropsを返します。

### 3. `FormGroup` から `autoBindErrorInput` を除去

props型からも `Omit` し、`FormGroup` が受け取らないことを型で表現しています。これで `FormGroup` からprops由来の条件分岐がなくなりました。

## プロダクト側で対応が必要な事項

`autoBindErrorInput` をtrueからfalseに動的に変更した場合、これまで入力要素に付与済みの `aria-invalid="true"` が残り続けていましたが、本PRにより正しく付与されなくなります。

従来は `useEffect` 内で早期returnしていたため、既に付与された属性が削除されないままでした。

表示上の変化はなく、スクリーンリーダーへ誤った状態が伝わる問題が解消されるため、アクセシビリティ上の改善となります。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

入力要素の `aria-invalid`・`id`・`aria-describedby`、ルート要素のタグ・class、`childrenWrapper` のclass、`label` の `for`、`legend` のテキスト、エラー件数、StatusLabel数を記録し、コミットごとに比較しました。

**分岐の移動（13パターン、masterと比較）**

FormControl・Fieldsetそれぞれの `autoBindErrorInput` 未指定/false、全メッセージ併用、`className`・`disabled`、`innerMargin`、エラーの後追加/削除、および `autoBindErrorInput` の動的切り替え（true→false / false→true）

→ 12パターンが完全一致。差の1件は上記の `aria-invalid` の不具合解消によるものです。動的切り替えの2ケースで `id`・`aria-describedby` が保持されることも確認しています（分岐位置を誤ると失われる箇所）。

**フック戻り値のフラット化（12パターン）**

上記に `subActionArea`・`unrecommendedHide` を加えたパターン

→ 完全一致。propsの渡し方が変わっても取りこぼしがないことを確認しました。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - フォームの入力項目でエラーが表示されている場合、自動的に `aria-invalid` が設定されるようになりました。
  - エラーが解消された場合は、`aria-invalid` が自動的に解除されます。
  - 入力コントロールとフィールドセットのエラー状態が、より適切に支援技術へ伝わるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->