### PR TITLE
refactor(FormGroup): ラベルの描画をLabelBody・LabelClusterに共通化する

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -5,10 +5,9 @@ import { tv } from 'tailwind-variants'
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
-import { Text } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import { FormGroup } from './FormGroup'
+import { FormGroup, LabelBody } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR, LABEL_TEXT_SELECTOR } from './constants'
 import { classNameGenerator } from './style'
 import { useAutoBindErrorInput } from './useAutoBindErrorInput'
@@ -193,16 +192,9 @@ const LabelComponent = memo<LabelComponentProps>(
     statusLabels,
   }) => {
     const body = (
-      <>
-        <Text styleType={labelType} icon={labelIcon}>
-          <span className="smarthr-ui-FormControl-labelText">{label}</span>
-        </Text>
-        {statusLabels.length > 0 && (
-          <Cluster gap={0.25} as="span">
-            {statusLabels}
-          </Cluster>
-        )}
-      </>
+      <LabelBody styleType={labelType} icon={labelIcon} statusLabels={statusLabels}>
+        {label}
+      </LabelBody>
     )
     const legend = <VisuallyHiddenText as="legend">{body}</VisuallyHiddenText>
 

--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -7,7 +7,7 @@ import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import { FormGroup, LabelBody } from './FormGroup'
+import { FormGroup, LabelBody, LabelCluster } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR, LABEL_TEXT_SELECTOR } from './constants'
 import { classNameGenerator } from './style'
 import { useAutoBindErrorInput } from './useAutoBindErrorInput'
@@ -196,17 +196,17 @@ const LabelComponent = memo<LabelComponentProps>(
         {label}
       </LabelBody>
     )
+    // HINT: legendはfieldsetのchildrenの先頭に設置することがmarkupとして求められる
+    // そのためUIの調整を可能にするため、常にvisuallyHiddenでfieldsetのchildrenの先頭に埋め込む
     const legend = <VisuallyHiddenText as="legend">{body}</VisuallyHiddenText>
 
     if (unrecommendedHideLabel) {
       return legend
     }
 
-    const renderedLegend = (
-      <Cluster aria-hidden="true" align="center" className="smarthr-ui-FormControl-label">
-        {body}
-      </Cluster>
-    )
+    // HINT: 先述のfieldsetのmarkupの制約のため、UI上に表示されるlegendのdummyにはaria-hiddenを設定し
+    // UI・スクリーンリーダーともに１つだけ設定されているかのように見せかける
+    const renderedLegend = <LabelCluster aria-hidden="true">{body}</LabelCluster>
 
     if (subActionArea) {
       return (

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -6,7 +6,7 @@ import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import { FormGroup, LabelBody } from './FormGroup'
+import { FormGroup, LabelBody, LabelCluster } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 import { classNameGenerator } from './style'
 import { useAutoBindErrorInput } from './useAutoBindErrorInput'
@@ -160,11 +160,7 @@ const LabelComponent = memo<LabelComponentProps>(
       return <VisuallyHiddenText {...attrs}>{body}</VisuallyHiddenText>
     }
 
-    const renderedLabel = (
-      <Cluster {...attrs} align="center" className="smarthr-ui-FormControl-label">
-        {body}
-      </Cluster>
-    )
+    const renderedLabel = <LabelCluster {...attrs}>{body}</LabelCluster>
 
     if (subActionArea) {
       return (

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -4,10 +4,9 @@ import { type FC, type ReactNode, memo, useEffect, useId, useMemo, useRef, useSt
 
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
-import { Text } from '../Text'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import { FormGroup } from './FormGroup'
+import { FormGroup, LabelBody } from './FormGroup'
 import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
 import { classNameGenerator } from './style'
 import { useAutoBindErrorInput } from './useAutoBindErrorInput'
@@ -146,16 +145,9 @@ const LabelComponent = memo<LabelComponentProps>(
     statusLabels,
   }) => {
     const body = (
-      <>
-        <Text styleType={labelType} icon={labelIcon}>
-          <span className="smarthr-ui-FormControl-labelText">{label}</span>
-        </Text>
-        {statusLabels.length > 0 && (
-          <Cluster gap={0.25} as="span">
-            {statusLabels}
-          </Cluster>
-        )}
-      </>
+      <LabelBody styleType={labelType} icon={labelIcon} statusLabels={statusLabels}>
+        {label}
+      </LabelBody>
     )
 
     const attrs = {

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,4 +1,11 @@
-import { type ComponentProps, type ComponentType, type FC, type RefObject, useMemo } from 'react'
+import {
+  type ComponentProps,
+  type ComponentType,
+  type FC,
+  type PropsWithChildren,
+  type RefObject,
+  useMemo,
+} from 'react'
 
 import { FaCircleExclamationIcon } from '../Icon'
 import { Cluster, Stack } from '../Layout'
@@ -134,4 +141,12 @@ export const LabelBody: FC<
       </Cluster>
     )}
   </>
+)
+
+export const LabelCluster: FC<
+  PropsWithChildren<{ as?: 'label'; htmlFor?: string; id?: string; 'aria-hidden'?: 'true' }>
+> = ({ children, ...rest }) => (
+  <Cluster {...rest} align="center" className="smarthr-ui-FormControl-label">
+    {children}
+  </Cluster>
 )

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -1,7 +1,7 @@
-import { type ComponentType, type FC, type RefObject, useMemo } from 'react'
+import { type ComponentProps, type ComponentType, type FC, type RefObject, useMemo } from 'react'
 
 import { FaCircleExclamationIcon } from '../Icon'
-import { Stack } from '../Layout'
+import { Cluster, Stack } from '../Layout'
 import { Text } from '../Text'
 
 import type { CommonProps, LabelComponentProps, ObjectLabelType } from './type'
@@ -119,3 +119,19 @@ export const FormGroup: FC<Props> = ({
     </Stack>
   )
 }
+
+export const LabelBody: FC<
+  Pick<ComponentProps<typeof Text>, 'styleType' | 'icon' | 'children'> &
+    Pick<LabelComponentProps, 'statusLabels'>
+> = ({ styleType, icon, children, statusLabels }) => (
+  <>
+    <Text styleType={styleType} icon={icon}>
+      <span className="smarthr-ui-FormControl-labelText">{children}</span>
+    </Text>
+    {statusLabels.length > 0 && (
+      <Cluster gap={0.25} as="span">
+        {statusLabels}
+      </Cluster>
+    )}
+  </>
+)


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormControl` と `Fieldset` の `LabelComponent` は、ラベルの描画部分が重複していました。共通部分を `LabelBody`・`LabelCluster` として切り出します。

あわせて、Fieldsetがlegendを2つ描画している理由（markup上の制約）をコメントとして記録しました。

PR #6892 に続く `FormGroup` の整理です。

## 変更内容

### 1. ラベル本体の描画を `LabelBody` に共通化

`Text` とstatus labelsの `Cluster` の組み立てが、両ファイルで完全に同一でした。

```tsx
// FormGroup.tsx
export const LabelBody: FC<
  Pick<ComponentProps<typeof Text>, 'styleType' | 'icon' | 'children'> &
    Pick<LabelComponentProps, 'statusLabels'>
> = ({ styleType, icon, children, statusLabels }) => (
  <>
    <Text styleType={styleType} icon={icon}>
      <span className="smarthr-ui-FormControl-labelText">{children}</span>
    </Text>
    {statusLabels.length > 0 && (
      <Cluster gap={0.25} as="span">
        {statusLabels}
      </Cluster>
    )}
  </>
)
```

`label` はchildrenで受け取る形にしました。props型は `ComponentProps<typeof Text>` からPickしているため、`Text` の型変更に追従します。

### 2. ラベルを囲む `Cluster` を `LabelCluster` に共通化

`align="center"` と `smarthr-ui-FormControl-label` の指定が重複していました。

```tsx
export const LabelCluster: FC<
  PropsWithChildren<{ as?: 'label'; htmlFor?: string; id?: string; 'aria-hidden'?: 'true' }>
> = ({ children, ...rest }) => (
  <Cluster {...rest} align="center" className="smarthr-ui-FormControl-label">
    {children}
  </Cluster>
)
```

利用側は以下のようになります。

```tsx
// FormControl: labelとして描画
const renderedLabel = <LabelCluster {...attrs}>{body}</LabelCluster>

// Fieldset: legendのdummyとして描画
const renderedLegend = <LabelCluster aria-hidden="true">{body}</LabelCluster>
```

### 3. Fieldsetのlegendに関するコメントを追加

```tsx
// HINT: legendはfieldsetのchildrenの先頭に設置することがmarkupとして求められる
// そのためUIの調整を可能にするため、常にvisuallyHiddenでfieldsetのchildrenの先頭に埋め込む
const legend = <VisuallyHiddenText as="legend">{body}</VisuallyHiddenText>

// HINT: 先述のfieldsetのmarkupの制約のため、UI上に表示されるlegendのdummyにはaria-hiddenを設定し
// UI・スクリーンリーダーともに１つだけ設定されているかのように見せかける
const renderedLegend = <LabelCluster aria-hidden="true">{body}</LabelCluster>
```

legendが2つ描画される構造はコードだけでは意図が読み取れず、重複として誤って削除される恐れがあるため記録しました。

### 配置について

`LabelBody`・`LabelCluster` は `FormGroup.tsx` に配置しています。`LabelComponent` が組み立てるものであり、最終的に `FormGroup` 内へ描画されるためです。独立したファイルへの切り出しも検討しましたが、分離するほどのものではないと判断しました。

なお `Cluster` のimportは両ファイルに残ります。`subActionArea` の外側ラッパー（`justify="space-between"`）で使い続けるためです。

## プロダクト側で対応が必要な事項

なし。公開インターフェースに変更はありません。

## 確認方法

- Chromatic で `FormControl` / `Fieldset` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

ラベル領域の **innerHTML をそのまま記録**し、構造の変化を検出できる形でコミットごとに比較しました。

**LabelBody（12パターン）**

`labelText` のタグ・内容・個数、StatusLabel数、アイコン数、`legend` のテキスト、`label` の `for`

FormControl・Fieldsetそれぞれの基本形 / statusLabels（1件・複数件・空配列）/ icon / styleType / unrecommendedHide / subActionArea

**LabelCluster（12パターン）**

`LabelCluster` に渡る属性（`aria-hidden`・`for`・`id`）とクラス、innerHTML、`subActionArea` 有無によるルート直下の構造

上記に加え、label objectでのid指定

いずれも**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- 影響範囲のテスト（FormGroup / AccordionPanel / Dialog / Dropdown / InputFile）— 15ファイル 47件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フォームラベルの本文、アイコン、ステータス表示を統一的に扱えるようになりました。
  * ラベル要素にクラスターレイアウトを利用できるようになりました。

* **アクセシビリティ**
  * 視覚的なラベル表示とスクリーンリーダー向けの凡例を適切に分離しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->