### PR TITLE
fix(Browser): classNameが効かない・4カラム以上でレイアウトが崩れる不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -19,22 +19,15 @@ const classNameGenerator = tv({
     column: ['shr-min-w-[13em] shr-list-none', '[&_+_&]:shr-border-l-shorthand'],
   },
   variants: {
-    maxColumn: {
-      1: {
+    isSingleColumn: {
+      true: {
         column: 'shr-max-w-[theme(width.1/3)]',
       },
-      2: '',
-      3: '',
-    },
-  },
-  compoundVariants: [
-    {
-      maxColumn: [2, 3],
-      className: {
+      false: {
         column: 'last:shr-grow',
       },
     },
-  ],
+  },
 })
 
 type BaseProps = {
@@ -51,16 +44,15 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
   const rootNode = useMemo(() => RootNode.from({ children: items }), [items])
   const columns = useMemo(() => rootNode.toViewData(value), [rootNode, value])
 
+  const isSingleColumn = columns.length === 1
   const classNames = useMemo(() => {
     const { wrapper, column } = classNameGenerator()
 
     return {
       wrapper: wrapper({ className }),
-      column: column({
-        maxColumn: columns.length as 1 | 2 | 3,
-      }),
+      column: column({ isSingleColumn }),
     }
-  }, [className, columns.length])
+  }, [isSingleColumn, className])
 
   const selectedPath = useMemo(() => {
     if (!value) return []

--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -23,8 +23,8 @@ const classNameGenerator = tv({
       1: {
         column: 'shr-max-w-[theme(width.1/3)]',
       },
-      2: {},
-      3: {},
+      2: '',
+      3: '',
     },
   },
   compoundVariants: [
@@ -52,9 +52,10 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
   const columns = useMemo(() => rootNode.toViewData(value), [rootNode, value])
 
   const classNames = useMemo(() => {
-    const { wrapper, column } = classNameGenerator({ className })
+    const { wrapper, column } = classNameGenerator()
+
     return {
-      wrapper: wrapper(),
+      wrapper: wrapper({ className }),
       column: column({
         maxColumn: columns.length as 1 | 2 | 3,
       }),

--- a/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
@@ -9,38 +9,29 @@ import { getElementIdFromNode } from './utils'
 import type { ItemNode } from './models'
 
 const classNameGenerator = tv({
-  slots: {
-    label: [
-      'shr-block shr-rounded-m shr-px-1 shr-py-0.5',
-      'hover:shr-bg-white-darken',
-      'has-[:focus-visible]:shr-focus-indicator',
-    ],
-    input: 'shr-sr-only',
-  },
+  base: [
+    'shr-block shr-rounded-m shr-px-1 shr-py-0.5',
+    'hover:shr-bg-white-darken',
+    'has-[:focus-visible]:shr-focus-indicator',
+  ],
   variants: {
     selected: {
-      true: {
-        label: ['shr-bg-white-darken shr-font-bold', 'hover:shr-bg-column-darken'],
-      },
-      false: {},
+      true: ['shr-bg-white-darken shr-font-bold', 'hover:shr-bg-column-darken'],
     },
     hasChildren: {
-      true: {},
-      false: {},
+      false: '',
     },
   },
   compoundVariants: [
     {
       selected: true,
       hasChildren: false,
-      className: {
-        label: [
-          'shr-bg-main shr-text-white',
-          'hover:shr-bg-main-darken',
-          'forced-colors:shr-bg-[Highlight]',
-          'has-[:focus-visible]:shr-focus-indicator',
-        ],
-      },
+      className: [
+        'shr-bg-main shr-text-white',
+        'hover:shr-bg-main-darken',
+        'forced-colors:shr-bg-[Highlight]',
+        'has-[:focus-visible]:shr-focus-indicator',
+      ],
     },
   ],
 })
@@ -72,27 +63,23 @@ export const BrowserItem: FC<Props> = ({
   handleChangeInput,
 }) => {
   const inputId = useMemo(() => getElementIdFromNode(itemValue), [itemValue])
-  const classNames = useMemo(() => {
-    const { label, input } = classNameGenerator()
-
-    return {
-      label: label({ selected, hasChildren: itemHasChildren }),
-      input: input(),
-    }
-  }, [selected, itemHasChildren])
+  const actualClassName = useMemo(
+    () => classNameGenerator({ selected, hasChildren: itemHasChildren }),
+    [selected, itemHasChildren],
+  )
 
   return (
-    <label htmlFor={inputId} className={classNames.label}>
+    <label htmlFor={inputId} className={actualClassName}>
       <input
-        className={classNames.input}
-        type="radio"
         id={inputId}
+        type="radio"
         name={`column-${columnIndex}`}
         value={itemValue}
+        checked={selected}
         tabIndex={tabIndex}
+        className="shr-sr-only"
         onKeyDown={HANDLE_KEYDOWN}
         onChange={handleChangeInput}
-        checked={selected}
       />
       <BodyCluster label={itemLabel} hasChildren={itemHasChildren} />
     </label>

--- a/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
@@ -73,9 +73,10 @@ export const BrowserItem: FC<Props> = ({
 }) => {
   const inputId = useMemo(() => getElementIdFromNode(itemValue), [itemValue])
   const classNames = useMemo(() => {
-    const { label, input } = classNameGenerator({ selected, hasChildren: itemHasChildren })
+    const { label, input } = classNameGenerator()
+
     return {
-      label: label(),
+      label: label({ selected, hasChildren: itemHasChildren }),
       input: input(),
     }
   }, [selected, itemHasChildren])


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Browser` の tailwind-variants 定義を整理する過程で、2件の不具合を発見したため修正します。

- 公開propsである `className` が一切適用されていない
- カラムが4つ以上の場合に、最終カラムが余白を埋めない

あわせて `BrowserItem` の `tv` 定義も整理しています。

## 変更内容

### 1. `className` が適用されない不具合を修正（`Browser`）

```tsx
// Before
const { wrapper, column } = classNameGenerator({ className })
return { wrapper: wrapper(), ... }

// After
const { wrapper, column } = classNameGenerator()
return { wrapper: wrapper({ className }), ... }
```

`classNameGenerator` は `slots` を持つため、generator呼び出しの引数は variants の解決にのみ使われます。`className` をそこに渡していたため値が捨てられており、`<Browser className="foo">` が無効な状態でした。

`column` 側に混入せず `wrapper` にのみ付与されることを確認しています。

なお `slots` を持つ tv に generator経由で `className` を渡している箇所が他にないか全走査しましたが、`Browser` のみでした。`AccordionPanelItem` などにある同形の `classNameGenerator({ className })` は、いずれも `slots` を持たない tv のため正しく動作します。

### 2. カラムが4つ以上の場合の不具合を修正（`Browser`）

```tsx
// Before
variants: {
  maxColumn: { 1: { column: 'shr-max-w-[theme(width.1/3)]' }, 2: {}, 3: {} },
},
compoundVariants: [
  { maxColumn: [2, 3], className: { column: 'last:shr-grow' } },
],
// 呼び出し
column({ maxColumn: columns.length as 1 | 2 | 3 })

// After
variants: {
  isSingleColumn: {
    true: { column: 'shr-max-w-[theme(width.1/3)]' },
    false: { column: 'last:shr-grow' },
  },
},
// 呼び出し
column({ isSingleColumn })
```

`maxColumn` は `1` `2` `3` しか定義がなく、`columns.length` を `1 | 2 | 3` へキャストして渡していました。`RootNode#toViewData` は祖先・兄弟・子を積むため深さに上限がなく、4カラム以上ではどの variant にも一致せず `last:shr-grow` が失われていました。

実際の分岐は「唯一のカラムか否か」だけであるため boolean 化し、`isSingleColumn` にリネームしています。`true`・`false` の双方にスタイルを持たせることで `compoundVariants` も不要になりました。

依存配列も `columns.length` から `isSingleColumn` に変わるため、2→3のようなカラム数の変化では再計算されなくなります。

### 3. `BrowserItem` の `tv` 定義を整理

variants に依存するのは `label` スロットのみで、`input` は静的な `shr-sr-only` を返すだけでした。`slots` をやめて `base` に置き換え、`input` のクラスは利用箇所へ直接記述しています。

`classNames` オブジェクトが不要になり、`useMemo` の戻り値も文字列1つになりました。こちらは生成されるクラスに変化はありません。

## プロダクト側で対応が必要な事項

以下2点は、これまで期待どおりに動作していなかったものが修正されるため、表示が変わる可能性があります。

**`className` が適用されるようになります**

`<Browser className="...">` の指定がこれまで無視されていましたが、ルート要素へ付与されるようになります。無効であることを前提に別の手段（親要素へのスタイル指定など）で回避していた場合、指定が二重に効く可能性があります。

**4カラム以上で最終カラムが余白を埋めるようになります**

3カラム以下と同じレイアウトに揃います。4階層以上のネストを持つ `items` を渡している場合に影響します。

## 確認方法

- Chromatic で `Browser` に差分が出ていないこと（既存ストーリーは3カラム以下のため差分が出ない想定）
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

ルート要素のclass、各カラム（`ul`）のclass、カラム数を記録し、コミットごとに比較しました。

**`className` の修正（10パターン）**

1〜3カラム × `className` 有無、複数クラス指定、空リスト、カラム数の動的切り替え

→ `wrapper` にのみ `className` が付与され、`column` には混入しないことを確認。

**`maxColumn` のboolean化（14パターン）**

上記に加え、深いネストによる4カラム・5カラムのケース

→ 1〜3カラムは**完全一致**。4・5カラムで `last:shr-grow` が付与されるようになることを確認。

**`BrowserItem` の整理（8パターン）**

選択なし / 子を持つ項目の選択 / 子を持たない項目の選択（`compoundVariants` 適用）/ ネストした子 / 孫を持つ子 / 最深部の項目 / 選択の切り替え / 空リスト

→ `label`・`input` の生成クラスとも**完全一致**。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Browser` のテスト — 4ファイル 35件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)