### PR TITLE
refactor(Browser): changeイベントをwrapperへdelegateする

### DIFF
--- a/packages/smarthr-ui/src/components/Browser/Browser.tsx
+++ b/packages/smarthr-ui/src/components/Browser/Browser.tsx
@@ -8,10 +8,13 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
+import { findDelegateTarget } from '../../libs/delegate'
 
 import { BrowserColumn } from './BrowserColumn'
 import { ItemNode, type ItemNodeLike, RootNode } from './models'
 import { getElementIdFromNode } from './utils'
+
+const INPUT_SELECTOR = 'input[type="radio"][data-smarthr-ui-browser-item-input="true"]'
 
 const classNameGenerator = tv({
   slots: {
@@ -114,9 +117,13 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
 
     return {
       handleDelegateKeyDown,
-      handleChangeInput: hasOnSelectItem
-        ? (e: ChangeEvent<HTMLInputElement>) => {
-            latest.onSelectItem?.(e.currentTarget.value)
+      handleDelegateChange: hasOnSelectItem
+        ? (e: ChangeEvent<HTMLDivElement>) => {
+            const el = findDelegateTarget<HTMLInputElement>(e, INPUT_SELECTOR)
+
+            if (el) {
+              latest.onSelectItem?.(el.value)
+            }
           }
         : undefined,
     }
@@ -128,6 +135,7 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
       {...rest}
       role="application"
       onKeyDown={functions.handleDelegateKeyDown}
+      onChange={functions.handleDelegateChange}
       className={classNames.wrapper}
     >
       {columns.map((colItems, index) => (
@@ -136,7 +144,6 @@ export const Browser: FC<Props> = ({ value, items, onSelectItem, className, ...r
           items={colItems}
           index={index}
           value={selectedPath[index]}
-          handleChangeInput={functions.handleChangeInput}
           className={classNames.column}
         />
       ))}

--- a/packages/smarthr-ui/src/components/Browser/BrowserColumn.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserColumn.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type ComponentProps, type FC, memo, useMemo } from 'react'
+import { type ComponentProps, type FC, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { BrowserItem } from './BrowserItem'
@@ -11,7 +11,6 @@ type BaseProps = {
   value?: string
   items: ItemNode[]
   index: number
-  handleChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
 }
 type Props = BaseProps & Omit<ComponentProps<'ul'>, keyof BaseProps>
 
@@ -23,7 +22,6 @@ export const BrowserColumn: FC<Props> = ({
   items,
   index: columnIndex,
   value,
-  handleChangeInput,
   className,
   ...rest
 }) => {
@@ -40,14 +38,13 @@ export const BrowserColumn: FC<Props> = ({
           value={value}
           columnIndex={columnIndex}
           rowIndex={rowIndex}
-          handleChangeInput={handleChangeInput}
         />
       ))}
     </ul>
   )
 }
 
-type ListItemProps = Pick<Props, 'value' | 'handleChangeInput'> & {
+type ListItemProps = Pick<Props, 'value'> & {
   itemValue: ItemNode['value']
   itemLabel: ItemNode['label']
   itemHasChildren: boolean
@@ -56,7 +53,7 @@ type ListItemProps = Pick<Props, 'value' | 'handleChangeInput'> & {
 }
 
 const ListItem = memo<ListItemProps>(
-  ({ itemValue, itemLabel, itemHasChildren, value, columnIndex, rowIndex, handleChangeInput }) => {
+  ({ itemValue, itemLabel, itemHasChildren, value, columnIndex, rowIndex }) => {
     const selected = itemValue === value
     const ariaOwns = selected && itemHasChildren ? getColumnId(columnIndex + 1) : undefined
     const tabIndex = selected || (!value && columnIndex === 0 && rowIndex === 0) ? 0 : -1
@@ -70,7 +67,6 @@ const ListItem = memo<ListItemProps>(
           itemHasChildren={itemHasChildren}
           columnIndex={columnIndex}
           tabIndex={tabIndex}
-          handleChangeInput={handleChangeInput}
         />
       </li>
     )

--- a/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
+++ b/packages/smarthr-ui/src/components/Browser/BrowserItem.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type FC, type KeyboardEventHandler, memo, useMemo } from 'react'
+import { type FC, type KeyboardEventHandler, memo, useMemo } from 'react'
 import { tv } from 'tailwind-variants'
 
 import { FaAngleRightIcon } from '../Icon'
@@ -43,10 +43,13 @@ type Props = {
   itemHasChildren: boolean
   tabIndex: 0 | -1
   columnIndex: number
-  handleChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
 const KEYDOWN_REGEX = /^((Arrow(Right|Left|Up|Down))|Enter| )$/
+// HINT: changeの実処理はBrowserのwrapperへdelegateしている。
+// checkedを制御しているinputにonChangeが無いとReactが読み取り専用と誤認して警告するため、
+// 空のハンドラを渡して制御されていることを示す。
+const HANDLE_CHANGE = () => undefined
 const HANDLE_KEYDOWN: KeyboardEventHandler = (e) => {
   if (KEYDOWN_REGEX.test(e.key)) {
     e.preventDefault()
@@ -60,7 +63,6 @@ export const BrowserItem: FC<Props> = ({
   itemHasChildren,
   tabIndex,
   columnIndex,
-  handleChangeInput,
 }) => {
   const inputId = useMemo(() => getElementIdFromNode(itemValue), [itemValue])
   const actualClassName = useMemo(
@@ -73,13 +75,14 @@ export const BrowserItem: FC<Props> = ({
       <input
         id={inputId}
         type="radio"
+        data-smarthr-ui-browser-item-input="true"
         name={`column-${columnIndex}`}
         value={itemValue}
         checked={selected}
         tabIndex={tabIndex}
         className="shr-sr-only"
         onKeyDown={HANDLE_KEYDOWN}
-        onChange={handleChangeInput}
+        onChange={HANDLE_CHANGE}
       />
       <BodyCluster label={itemLabel} hasChildren={itemHasChildren} />
     </label>


### PR DESCRIPTION
## 関連URL

- #6894 （このPRのbase。先にマージされる想定です）

## 概要

`handleChangeInput` が `Browser` → `BrowserColumn` → `ListItem` → `BrowserItem` と4階層を貫通して渡されていました。イベント移譲に置き換え、中間コンポーネントから props を除去します。

あわせて、`onSelectItem` を渡さない場合に React が警告を出していた問題も解消します。

## 変更内容

### 1. changeイベントを wrapper へ delegate

React の `onChange` は native の `input` イベントに対応しておりバブルするため、`role="application"` の wrapper で受け取れます。

```tsx
// Browser.tsx
const INPUT_SELECTOR = 'input[type="radio"][data-smarthr-ui-browser-item-input="true"]'

handleDelegateChange: hasOnSelectItem
  ? (e: ChangeEvent<HTMLDivElement>) => {
      const el = findDelegateTarget<HTMLInputElement>(e, INPUT_SELECTOR)

      if (el) {
        latest.onSelectItem?.(el.value)
      }
    }
  : undefined,
```

`BrowserColumn`・`ListItem`・`BrowserItem` の props から `handleChangeInput` を削除しています。

### 2. 対象特定用の属性は Browser 専用のものを使う

`BrowserItem` の radio に `data-smarthr-ui-browser-item-input="true"` を付与し、セレクタに含めています。

共通規約である `data-smarthr-ui-input` は使いません。`Browser` を `FormControl` 配下に置いた場合、`CHILDREN_WRAPPER_INPUT_SELECTOR` に一致してしまい、label の `htmlFor` や `aria-describedby`・`aria-invalid` が先頭の radio へ結び付くためです。

実測では、共通属性を使うと **`FormControl` のラベルをクリックしただけで先頭の項目が選択される** 状態になりました。`Browser` は複数カラムのツリーであり「ラベルに対応する単一の入力要素」ではないため、この結び付きは不適切です。

UI上 `Browser` が `FormControl` 配下に置かれることは想定していませんが、念のため専用属性で切り分けています。

### 3. React の警告を解消

```tsx
// BrowserItem.tsx
// HINT: changeの実処理はBrowserのwrapperへdelegateしている。
// checkedを制御しているinputにonChangeが無いとReactが読み取り専用と誤認して警告するため、
// 空のハンドラを渡して制御されていることを示す。
const HANDLE_CHANGE = () => undefined
```

従来は `onChange={handleChangeInput}` が `onSelectItem` 未指定時に `undefined` となり、以下の警告が input の数だけ出ていました。

```
You provided a `checked` prop to a form field without an `onChange` handler.
This will render a read-only field. If the field should be mutable use `defaultChecked`.
Otherwise, set either `onChange` or `readOnly`.
```

delegate 先で処理している旨を示す空のハンドラを渡すことで解消しています。

## プロダクト側で対応が必要な事項

なし。公開インターフェースおよび利用者から見た挙動に変更はありません。

`onSelectItem` を渡さずに利用していた場合、開発時のコンソールに出ていた React の警告が出なくなります。

## 確認方法

- Chromatic で `Browser` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 挙動の同一性について

以下9パターンで、`onSelectItem` の呼び出し内容と checked 状態を記録し比較しました。

1. `onSelectItem` 未指定時の React 警告
2. `onSelectItem` 指定時の React 警告
3. クリックで発火（同一カラム）
4. クリックで発火（2カラム目）
5. label クリックで発火
6. 選択済み項目の再クリックでは発火しない
7. `onSelectItem` 未指定でクリックしても checked が props どおり復元される
8. キーボード操作で発火
9. 最深カラムでのクリックで発火

→ 1 の警告が消えた以外は**完全一致**。

また `FormControl` 配下に置いた場合について、label の `htmlFor` が radio を指さないこと、`aria-describedby`・`aria-invalid` が付与されないこと、ラベルクリックで選択が変わらないことを確認しています。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Browser` のテスト — 4ファイル 35件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)