### PR TITLE
refactor(AppNavi): tailwind-variantsの定義を整理する

### DIFF
--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdown.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdown.tsx
@@ -39,10 +39,10 @@ export const AppNaviDropdown: FC<AppNaviDropdownProps> = ({
   displayCaret,
 }) => {
   const classNames = useMemo(() => {
-    const { wrapper, icon } = classNameGenerator({ active: current, displayCaret })
+    const { wrapper, icon } = classNameGenerator({ active: current })
 
     return {
-      wrapper: wrapper(),
+      wrapper: wrapper({ displayCaret }),
       icon: icon(),
     }
   }, [current, displayCaret])

--- a/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/AppNaviDropdownMenuButton.tsx
@@ -23,24 +23,21 @@ const classNameGenerator = tv({
   slots: {
     trigger: [
       'smarthr-ui-AppNavi-dropdownMenuButton',
-      [
-        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-border-none',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-px-0.5',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-text-grey',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-rounded-none',
-      ],
-      [
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:shr-relative',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:shr-text-black',
-      ],
-      [
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-content-[""]',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-absolute',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-bottom-0',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-inset-x-0',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-h-0.25',
-        '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-bg-main',
-      ],
+      // trigger
+      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-border-none',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-px-0.5',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-text-grey',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-rounded-none',
+      // trigger has current
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:shr-relative',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:shr-text-black',
+      // trigger:after has current
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-content-[""]',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-absolute',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-bottom-0',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-inset-x-0',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-h-0.25',
+      '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-bg-main',
     ],
     actionItem: [
       // HINT: DropdownMenuButton内で設定されるclassNameより優先度を上げる必要がある
@@ -50,6 +47,7 @@ const classNameGenerator = tv({
   },
 })
 const { trigger, actionItem } = classNameGenerator()
+const TRIGGER_CLASSNAME = trigger()
 
 const renderItemList = (children: ReactNode) =>
   Children.map(children, (item): ReactNode => {
@@ -74,6 +72,9 @@ const renderItemList = (children: ReactNode) =>
 
 export const AppNaviDropdownMenuButton: FC<Props> = ({ label, onOpen, onClose, children }) => (
   <DropdownMenuButton
+    className={TRIGGER_CLASSNAME}
+    onOpen={onOpen}
+    onClose={onClose}
     trigger={
       <>
         {label}
@@ -81,9 +82,6 @@ export const AppNaviDropdownMenuButton: FC<Props> = ({ label, onOpen, onClose, c
         <span hidden>{children}</span>
       </>
     }
-    onOpen={onOpen}
-    onClose={onClose}
-    className={trigger()}
   >
     {renderItemList(children)}
   </DropdownMenuButton>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`AppNavi` 配下の `tv()` 定義に、実質的な意味を持たない記述とレンダリングごとの再計算がありました。整理します。

生成されるクラスに変化はありません。

## 変更内容

### 1. `AppNaviDropdownMenuButton` の `trigger` スロットを平坦化

3つのネスト配列が置かれていましたが、tailwind-variants 上は意味を持たず、視覚的なグルーピングでしかありませんでした。平坦化し、意図をコメントで示す形にしています。

```tsx
// Before
trigger: [
  'smarthr-ui-AppNavi-dropdownMenuButton',
  [
    '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-border-none',
    // ...
  ],
  [
    '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:shr-relative',
    // ...
  ],
  // ...
],

// After
trigger: [
  'smarthr-ui-AppNavi-dropdownMenuButton',
  // trigger
  '[&_.smarthr-ui-DropdownMenuButton-trigger]:shr-border-none',
  // ...
  // trigger has current
  '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:shr-relative',
  // ...
  // trigger:after has current
  '[&_.smarthr-ui-DropdownMenuButton-trigger:has([aria-current])]:after:shr-content-[""]',
  // ...
],
```

配列の区切りでは「なぜまとまっているのか」が読み取れませんでしたが、コメントにより `trigger` 自体・`has([aria-current])` 時・その `::after` という3つの意図が言葉で読めるようになります。

### 2. `trigger()` の結果を定数化

```tsx
const { trigger, actionItem } = classNameGenerator()
const TRIGGER_CLASSNAME = trigger()
```

引数なしで結果が不変にもかかわらず、レンダリングのたびに `trigger()` が呼ばれていました。

### 3. `AppNaviDropdown` の `displayCaret` をスロット呼び出しへ移動

```tsx
// Before
const { wrapper, icon } = classNameGenerator({ active: current, displayCaret })
return { wrapper: wrapper(), icon: icon() }

// After
const { wrapper, icon } = classNameGenerator({ active: current })
return { wrapper: wrapper({ displayCaret }), icon: icon() }
```

`displayCaret` は `wrapper` スロットにしか影響しないため、スロット呼び出し側で渡すのが素直です。

`extend: itemClassNameGenerator` から継承している `active` は `wrapper`・`icon` の両方に効くため、generator 側に残しています。

## プロダクト側で対応が必要な事項

なし。公開インターフェースおよび生成されるクラスに変更はありません。

## 確認方法

- Chromatic で `AppNavi` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

ルート要素・アイテム要素のクラスと `aria-current` を記録し、コミットごとに比較しました。

**`AppNaviDropdownMenuButton`（7パターン）**

基本形 / `current` 付き / `DropdownMenuGroup` 経由 / `Fragment` 経由 / 子要素の独自 `className` / 再レンダリング / `trigger` の innerHTML

**`AppNaviDropdown`（11パターン）**

`current` × `displayCaret` の全4組み合わせ / それぞれの明示的な `false` 指定 / `icon` の有無 / `current`・`displayCaret` それぞれの動的切り替え

いずれも**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `AppNavi` / `Dropdown` のテスト — 14件パス

## 補足（本PRの対象外）

`AppNaviDropdown` では、コンポーネント識別用の `smarthr-ui-AppNavi-dropdown` が `displayCaret` の variant 内に置かれており、`displayCaret` を指定しない場合はクラスが付きません。

```ts
displayCaret: {
  true: {
    wrapper: [
      'smarthr-ui-AppNavi-dropdown',
      // ...
    ],
  },
},
```

他のコンポーネントでは識別クラスを `slots` 側に置くのが通例のため、意図しない状態の可能性があります。ただし外部から参照されうるクラス名の付与条件が変わり、利用者側のスタイル指定に影響しうるため、本PRでは触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ナビゲーションのドロップダウンにおける矢印アイコンやラッパーの表示スタイルを整理しました。
  - ドロップダウンメニューボタンのスタイル適用を安定化しました。
  - 既存の表示や操作性に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->