### PR TITLE
feat(AppHeader): アプリ一覧の遅延読み込みを追加

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -192,6 +192,29 @@ describe('AppHeader', () => {
       // Desktop・Mobile 両方のパネルに同じ結果が反映される
       expect(links.length).toBeGreaterThanOrEqual(1)
     })
+
+    it('Mobile側から先に開いた場合もfetchFeaturesが呼ばれ、取得結果が表示される', async () => {
+      const { fetchFeatures, resolve } = deferredFetchFeatures()
+      const user = userEvent.setup()
+      renderAppHeader({ fetchFeatures })
+
+      // Mobile側のハンバーガーメニューから「アプリ一覧」を開く
+      await user.click(screen.getByRole('button', { name: 'メニューを開く' }))
+      await user.click(screen.getByRole('button', { name: 'アプリ一覧' }))
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('処理中')).toBeInTheDocument()
+
+      await act(async () => resolve([buildFeature('1', 'アプリA')]))
+
+      // Desktop の Dropdown は閉じたままなので、Mobile のパネルにのみ表示される
+      expect(await screen.findByRole('link', { name: /アプリA/ })).toBeInTheDocument()
+
+      // その後Desktop側を開いても再取得しない
+      await clickAppLauncherButton(false)
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('navigationsが無い場合', () => {

--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -1,0 +1,195 @@
+import { act, render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+import { IntlProvider } from '../../intl'
+
+import { AppHeader } from './AppHeader'
+
+import type { Launcher } from './types'
+
+describe('AppHeader', () => {
+  let originalMatchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia
+    // HINT: AppHeader/hooks/useMediaQuery.ts が素の matchMedia() を呼ぶため、jsdom 用にスタブする
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  const NAVIGATIONS = [{ children: 'ナビゲーション1', href: 'https://example.com/nav1' }]
+
+  const buildFeature = (id: string, name: string): Launcher['feature'] => ({
+    id,
+    name,
+    url: `https://example.com/${id}`,
+    favorite: true,
+  })
+
+  const DEFAULT_PROPS = { appName: 'テストアプリ', navigations: NAVIGATIONS }
+
+  const renderAppHeader = (props: Partial<React.ComponentProps<typeof AppHeader>> = {}) =>
+    render(
+      <IntlProvider locale="ja">
+        <AppHeader {...DEFAULT_PROPS} {...props} />
+      </IntlProvider>,
+    )
+
+  // HINT: fetchFeatures を任意のタイミングで resolve/reject できるようにする
+  const deferredFetchFeatures = () => {
+    let resolve!: (features: Array<Launcher['feature']>) => void
+    let reject!: (error: unknown) => void
+    const fetchFeatures = vi.fn(
+      () =>
+        new Promise<Array<Launcher['feature']>>((res, rej) => {
+          resolve = res
+          reject = rej
+        }),
+    )
+
+    return {
+      fetchFeatures,
+      resolve: (features: Array<Launcher['feature']>) => resolve(features),
+      reject: () => reject(new Error('failed')),
+    }
+  }
+
+  describe('既存の features prop（後方互換）', () => {
+    it('featuresが空の場合、「アプリ」ボタンが表示されない', () => {
+      renderAppHeader({ features: [] })
+
+      expect(screen.queryByRole('button', { name: 'アプリ' })).not.toBeInTheDocument()
+    })
+
+    it('featuresが1件以上ある場合、「アプリ」ボタンが表示される', () => {
+      renderAppHeader({ features: [buildFeature('1', 'アプリA')] })
+
+      expect(screen.getByRole('button', { name: 'アプリ' })).toBeInTheDocument()
+    })
+
+    it('「アプリ」ボタンを開くとfeaturesの内容がそのまま表示される', () => {
+      renderAppHeader({ features: [buildFeature('1', 'アプリA')] })
+
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+
+      expect(screen.getByRole('link', { name: /アプリA/ })).toBeInTheDocument()
+    })
+  })
+
+  describe('fetchFeatures による遅延ロード', () => {
+    it('初期表示では「アプリ」ボタンが表示されるが、fetchFeaturesは呼ばれない', () => {
+      const { fetchFeatures } = deferredFetchFeatures()
+      renderAppHeader({ fetchFeatures })
+
+      expect(screen.getByRole('button', { name: 'アプリ' })).toBeInTheDocument()
+      expect(fetchFeatures).not.toHaveBeenCalled()
+    })
+
+    it('「アプリ」ボタンを開くとfetchFeaturesが呼ばれ、Loader表示後に一覧が表示される', async () => {
+      const { fetchFeatures, resolve } = deferredFetchFeatures()
+      renderAppHeader({ fetchFeatures })
+
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('処理中')).toBeInTheDocument()
+
+      await act(async () => resolve([buildFeature('1', 'アプリA')]))
+
+      expect(await screen.findByRole('link', { name: /アプリA/ })).toBeInTheDocument()
+      expect(screen.queryByText('処理中')).not.toBeInTheDocument()
+    })
+
+    it('解決結果が空配列の場合、該当なしメッセージを表示する', async () => {
+      const { fetchFeatures, resolve } = deferredFetchFeatures()
+      renderAppHeader({ fetchFeatures })
+
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await act(async () => resolve([]))
+
+      expect(await screen.findByText('該当するアプリが見つかりませんでした。')).toBeInTheDocument()
+    })
+
+    it('失敗した場合エラーメッセージを表示し、再度開くと再試行できる', async () => {
+      const first = deferredFetchFeatures()
+      const { fetchFeatures } = first
+      renderAppHeader({ fetchFeatures })
+
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await act(async () => first.reject())
+
+      expect(await screen.findByText(/アプリ一覧の読み込みに失敗しました/)).toBeInTheDocument()
+
+      // HINT: Dropdownはトグルのため、この操作は見た目上パネルを閉じるクリックだが、
+      // エラー後は再試行フラグが戻っているため、このクリックで再度fetchFeaturesが呼ばれる
+      const second = deferredFetchFeatures()
+      fetchFeatures.mockImplementationOnce(second.fetchFeatures)
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: true }).click())
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(2)
+
+      // パネルを開き直して再試行の結果を確認する（開き直し自体は再フェッチを起こさない）
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      expect(fetchFeatures).toHaveBeenCalledTimes(2)
+
+      await act(async () => second.resolve([buildFeature('1', 'アプリA')]))
+      expect(await screen.findByRole('link', { name: /アプリA/ })).toBeInTheDocument()
+    })
+
+    it('同一マウント中に開閉を繰り返してもfetchFeaturesは1回だけ呼ばれる（キャッシュ）', async () => {
+      const { fetchFeatures, resolve } = deferredFetchFeatures()
+      renderAppHeader({ fetchFeatures })
+
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await act(async () => resolve([buildFeature('1', 'アプリA')]))
+      await screen.findByRole('link', { name: /アプリA/ })
+
+      // 閉じて再度開く
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: true }).click())
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole('link', { name: /アプリA/ })).toBeInTheDocument()
+    })
+
+    it('Desktop・Mobileのどちらから開いてもfetchFeaturesの呼び出しは1回だけ', async () => {
+      const { fetchFeatures, resolve } = deferredFetchFeatures()
+      const user = userEvent.setup()
+      renderAppHeader({ fetchFeatures })
+
+      // Desktop側の「アプリ」を開く
+      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+
+      // Mobile側のハンバーガーメニューから「アプリ一覧」を開く
+      await user.click(screen.getByRole('button', { name: 'メニューを開く' }))
+      await user.click(screen.getByRole('button', { name: 'アプリ一覧' }))
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+
+      await act(async () => resolve([buildFeature('1', 'アプリA')]))
+
+      const links = await screen.findAllByRole('link', { name: /アプリA/ })
+      // Desktop・Mobile 両方のパネルに同じ結果が反映される
+      expect(links.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('navigationsが無い場合', () => {
+    it('mobileのメニューボタン自体が表示されない', () => {
+      renderAppHeader({ navigations: undefined, features: [buildFeature('1', 'アプリA')] })
+
+      expect(screen.queryByRole('button', { name: 'メニューを開く' })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -86,6 +86,14 @@ describe('AppHeader', () => {
     })
   })
 
+  // HINT: DesktopのDropdownはonOpenをrequestAnimationFrame経由で呼び出すため、
+  //  クリック後に1フレーム待たないとfetchFeaturesの呼び出しが観測できない
+  const clickAppLauncherButton = (expanded: boolean) =>
+    act(async () => {
+      screen.getByRole('button', { name: 'アプリ', expanded }).click()
+      await new Promise(requestAnimationFrame)
+    })
+
   describe('fetchFeatures による遅延ロード', () => {
     it('初期表示では「アプリ」ボタンが表示されるが、fetchFeaturesは呼ばれない', () => {
       const { fetchFeatures } = deferredFetchFeatures()
@@ -99,7 +107,7 @@ describe('AppHeader', () => {
       const { fetchFeatures, resolve } = deferredFetchFeatures()
       renderAppHeader({ fetchFeatures })
 
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await clickAppLauncherButton(false)
 
       expect(fetchFeatures).toHaveBeenCalledTimes(1)
       expect(screen.getByText('処理中')).toBeInTheDocument()
@@ -114,33 +122,34 @@ describe('AppHeader', () => {
       const { fetchFeatures, resolve } = deferredFetchFeatures()
       renderAppHeader({ fetchFeatures })
 
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await clickAppLauncherButton(false)
       await act(async () => resolve([]))
 
       expect(await screen.findByText('該当するアプリが見つかりませんでした。')).toBeInTheDocument()
     })
 
-    it('失敗した場合エラーメッセージを表示し、再度開くと再試行できる', async () => {
+    it('失敗した場合エラーメッセージを表示し、パネルを開き直したときに再試行する', async () => {
       const first = deferredFetchFeatures()
       const { fetchFeatures } = first
       renderAppHeader({ fetchFeatures })
 
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await clickAppLauncherButton(false)
       await act(async () => first.reject())
 
       expect(await screen.findByText(/アプリ一覧の読み込みに失敗しました/)).toBeInTheDocument()
 
-      // HINT: Dropdownはトグルのため、この操作は見た目上パネルを閉じるクリックだが、
-      // エラー後は再試行フラグが戻っているため、このクリックで再度fetchFeaturesが呼ばれる
+      // パネルを閉じるだけのクリックでは再試行しない
       const second = deferredFetchFeatures()
       fetchFeatures.mockImplementationOnce(second.fetchFeatures)
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: true }).click())
+      await clickAppLauncherButton(true)
+
+      expect(fetchFeatures).toHaveBeenCalledTimes(1)
+
+      // 開き直したときに再試行される
+      await clickAppLauncherButton(false)
 
       expect(fetchFeatures).toHaveBeenCalledTimes(2)
-
-      // パネルを開き直して再試行の結果を確認する（開き直し自体は再フェッチを起こさない）
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
-      expect(fetchFeatures).toHaveBeenCalledTimes(2)
+      expect(screen.getByText('処理中')).toBeInTheDocument()
 
       await act(async () => second.resolve([buildFeature('1', 'アプリA')]))
       expect(await screen.findByRole('link', { name: /アプリA/ })).toBeInTheDocument()
@@ -150,13 +159,13 @@ describe('AppHeader', () => {
       const { fetchFeatures, resolve } = deferredFetchFeatures()
       renderAppHeader({ fetchFeatures })
 
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await clickAppLauncherButton(false)
       await act(async () => resolve([buildFeature('1', 'アプリA')]))
       await screen.findByRole('link', { name: /アプリA/ })
 
       // 閉じて再度開く
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: true }).click())
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await clickAppLauncherButton(true)
+      await clickAppLauncherButton(false)
 
       expect(fetchFeatures).toHaveBeenCalledTimes(1)
       expect(screen.getByRole('link', { name: /アプリA/ })).toBeInTheDocument()
@@ -168,7 +177,7 @@ describe('AppHeader', () => {
       renderAppHeader({ fetchFeatures })
 
       // Desktop側の「アプリ」を開く
-      act(() => screen.getByRole('button', { name: 'アプリ', expanded: false }).click())
+      await clickAppLauncherButton(false)
       expect(fetchFeatures).toHaveBeenCalledTimes(1)
 
       // Mobile側のハンバーガーメニューから「アプリ一覧」を開く

--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -58,6 +58,10 @@ export const AppHeader: FC<HeaderProps> = ({
     ? (lazyFeatures.data ?? EMPTY_FEATURES)
     : (features ?? EMPTY_FEATURES)
   const isAppLauncherAvailable = !!fetchFeatures || resolvedFeatures.length > 0
+  // HINT: Desktopは Dropdown の onOpen（requestAnimationFrame経由）で取得を開始するため、
+  //  パネルが開いてから実際に取得が始まるまでに1フレームの猶予がある。
+  //  fetchFeatures 指定時に未取得かつ未エラーの状態はすべて取得中として扱い、その間に「該当なし」が表示されるのを防ぐ
+  const featuresLoading = !!fetchFeatures && lazyFeatures.data === null && !lazyFeatures.error
 
   // HINT: Desktop,Mobileの両ヘッダーは常にHTML上に存在し、cssでvisibleを切り替えることでSSR環境でのレイアウトシフトが発生しないようにしています
   // 表示切替は画面幅によって決まり、SSR環境では判定出来ないためです
@@ -69,7 +73,7 @@ export const AppHeader: FC<HeaderProps> = ({
         desktopNavigationAdditionalContent={desktopNavigationAdditionalContent}
         features={resolvedFeatures}
         isAppLauncherAvailable={isAppLauncherAvailable}
-        featuresLoading={lazyFeatures.loading}
+        featuresLoading={featuresLoading}
         featuresError={lazyFeatures.error}
         handleOpenAppLauncher={functions.handleOpenAppLauncher}
       >
@@ -80,7 +84,7 @@ export const AppHeader: FC<HeaderProps> = ({
         mobileAdditionalContent={mobileAdditionalContent}
         features={resolvedFeatures}
         isAppLauncherAvailable={isAppLauncherAvailable}
-        featuresLoading={lazyFeatures.loading}
+        featuresLoading={featuresLoading}
         featuresError={lazyFeatures.error}
         handleOpenAppLauncher={functions.handleOpenAppLauncher}
       >

--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -43,11 +43,17 @@ export const AppHeader: FC<HeaderProps> = ({
         if (latest.fetchFeatures && !latest.lazyFeatures.loading && !latest.lazyFeatures.data) {
           setLazyFeatures({ loading: true, error: false, data: null })
 
-          latest.fetchFeatures().then(
-            (data) => setLazyFeatures({ loading: false, error: false, data }),
-            // HINT: 失敗時は次回オープンで再試行できるようにする
-            () => setLazyFeatures({ loading: false, error: true, data: null }),
-          )
+          // HINT: 失敗時は次回オープンで再試行できるようにする
+          const handleError = () => setLazyFeatures({ loading: false, error: true, data: null })
+
+          try {
+            latest
+              .fetchFeatures()
+              .then((data) => setLazyFeatures({ loading: false, error: false, data }), handleError)
+          } catch {
+            // HINT: fetchFeatures が Promise を返す前に同期的に throw した場合も、loading のままにしない
+            handleError()
+          }
         }
       },
     }),

--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -32,26 +32,21 @@ export const AppHeader: FC<HeaderProps> = ({
     error: boolean
     data: Array<Launcher['feature']> | null
   }>({ loading: false, error: false, data: null })
-  // HINT: Desktop・Mobileの両ヘッダーが常にマウントされているため、
-  // どちらから開いても fetchFeatures の呼び出しが1回だけになるようフラグで制御する
-  const requestedRef = useRef(false)
 
-  const latest = useLatest({ fetchFeatures })
+  const latest = useLatest({ fetchFeatures, lazyFeatures })
 
   const functions = useMemo(
     () => ({
       handleOpenAppLauncher: () => {
-        if (latest.fetchFeatures && !requestedRef.current) {
-          requestedRef.current = true
+        // HINT: Desktop・Mobileの両ヘッダーが常にマウントされているため、取得中・取得済みの場合はスキップし、
+        //  どちらから開いても fetchFeatures の呼び出しが1回だけになるようにする
+        if (latest.fetchFeatures && !latest.lazyFeatures.loading && !latest.lazyFeatures.data) {
           setLazyFeatures({ loading: true, error: false, data: null })
 
           latest.fetchFeatures().then(
             (data) => setLazyFeatures({ loading: false, error: false, data }),
-            () => {
-              // HINT: 失敗時は次回オープンで再試行できるようにする
-              requestedRef.current = false
-              setLazyFeatures({ loading: false, error: true, data: null })
-            },
+            // HINT: 失敗時は次回オープンで再試行できるようにする
+            () => setLazyFeatures({ loading: false, error: true, data: null }),
           )
         }
       },

--- a/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,23 +1,68 @@
 'use client'
 
+import { useMemo, useRef, useState } from 'react'
+
+import { useLatest } from '../../hooks/useLatest'
+
 import { DesktopHeader } from './components/desktop/DesktopHeader'
 import { MobileHeader } from './components/mobile/MobileHeader'
 import { mediaQuery, useMediaQuery } from './hooks/useMediaQuery'
 
-import type { HeaderProps } from './types'
+import type { HeaderProps, Launcher } from './types'
 import type { FC } from 'react'
+
+const EMPTY_FEATURES: Array<Launcher['feature']> = []
 
 export const AppHeader: FC<HeaderProps> = ({
   children,
   desktopAdditionalContent,
   desktopNavigationAdditionalContent,
   mobileAdditionalContent,
+  features,
+  fetchFeatures,
   ...rest
 }) => {
   // NOTE: ヘッダーの出し分けは CSS によって行われているので、useMediaQuery による children の出し分けは本来不要ですが、
   //  wovn の言語切替カスタム UI の挿入対象となる DOM ("wovn-embedded-widget-anchor" クラスを持った div) が複数描画されていると、
   //  wovn のスクリプトの仕様上1つ目の DOM にしか UI が挿入されないため、やむを得ず children のみ React のレンダリングレベルでの出し分けをしています。
   const isDesktop = useMediaQuery(mediaQuery.desktop)
+
+  const [lazyFeatures, setLazyFeatures] = useState<{
+    loading: boolean
+    error: boolean
+    data: Array<Launcher['feature']> | null
+  }>({ loading: false, error: false, data: null })
+  // HINT: Desktop・Mobileの両ヘッダーが常にマウントされているため、
+  // どちらから開いても fetchFeatures の呼び出しが1回だけになるようフラグで制御する
+  const requestedRef = useRef(false)
+
+  const latest = useLatest({ fetchFeatures })
+
+  const functions = useMemo(
+    () => ({
+      handleOpenAppLauncher: () => {
+        if (latest.fetchFeatures && !requestedRef.current) {
+          requestedRef.current = true
+          setLazyFeatures({ loading: true, error: false, data: null })
+
+          latest.fetchFeatures().then(
+            (data) => setLazyFeatures({ loading: false, error: false, data }),
+            () => {
+              // HINT: 失敗時は次回オープンで再試行できるようにする
+              requestedRef.current = false
+              setLazyFeatures({ loading: false, error: true, data: null })
+            },
+          )
+        }
+      },
+    }),
+    [latest],
+  )
+
+  const resolvedFeatures = fetchFeatures
+    ? (lazyFeatures.data ?? EMPTY_FEATURES)
+    : (features ?? EMPTY_FEATURES)
+  const isAppLauncherAvailable = !!fetchFeatures || resolvedFeatures.length > 0
 
   // HINT: Desktop,Mobileの両ヘッダーは常にHTML上に存在し、cssでvisibleを切り替えることでSSR環境でのレイアウトシフトが発生しないようにしています
   // 表示切替は画面幅によって決まり、SSR環境では判定出来ないためです
@@ -27,10 +72,23 @@ export const AppHeader: FC<HeaderProps> = ({
         {...rest}
         desktopAdditionalContent={desktopAdditionalContent}
         desktopNavigationAdditionalContent={desktopNavigationAdditionalContent}
+        features={resolvedFeatures}
+        isAppLauncherAvailable={isAppLauncherAvailable}
+        featuresLoading={lazyFeatures.loading}
+        featuresError={lazyFeatures.error}
+        handleOpenAppLauncher={functions.handleOpenAppLauncher}
       >
         {isDesktop ? children : undefined}
       </DesktopHeader>
-      <MobileHeader {...rest} mobileAdditionalContent={mobileAdditionalContent}>
+      <MobileHeader
+        {...rest}
+        mobileAdditionalContent={mobileAdditionalContent}
+        features={resolvedFeatures}
+        isAppLauncherAvailable={isAppLauncherAvailable}
+        featuresLoading={lazyFeatures.loading}
+        featuresError={lazyFeatures.error}
+        handleOpenAppLauncher={functions.handleOpenAppLauncher}
+      >
         {isDesktop ? undefined : children}
       </MobileHeader>
     </>

--- a/packages/smarthr-ui/src/components/AppHeader/README.md
+++ b/packages/smarthr-ui/src/components/AppHeader/README.md
@@ -20,6 +20,7 @@ export type HeaderProps = ComponentProps<typeof Header> & {
   desktopNavigationAdditionalContent?: ReactNode
   releaseNote?: ReleaseNoteProps | null
   features?: Array<Launcher['feature']>
+  fetchFeatures?: () => Promise<Array<Launcher['feature']>>
   mobileAdditionalContent?: ReactNode
 }
 ```
@@ -40,6 +41,11 @@ export type HeaderProps = ComponentProps<typeof Header> & {
   - AppNavi コンポーネントの buttons にはなかった、ドロップダウン内でのナビゲーションのグルーピングができるようになっています。
     - storybook の「VRT Navigation Dropdown Group」を参考にしてください。
   - **navigations props に値が渡されているときのみ、モバイル表示時にハンバーガーメニューが表示されます。独自実装の ハンバーガーメニューが存在する場合は、navigations props を利用するタイミングで移行してください。**
+- `features` / `fetchFeatures`
+  - どちらもアプリランチャー（ヘッダーの「アプリ」ボタン）に表示するアプリ一覧を渡す props です。
+  - `fetchFeatures` を指定すると、アプリランチャーを開いたタイミング（デスクトップの「アプリ」ボタン押下 / モバイルの「アプリ一覧」タップ）で呼び出してアプリ一覧を取得します（遅延ロード）。取得中は Loader、失敗時はエラーメッセージを表示し、失敗時は次にランチャーを開いたときに再試行します。
+  - `fetchFeatures` を指定した場合、`features` は無視されます。
+  - デスクトップ・モバイルのどちらから開いても呼び出しは1回だけで、初回取得に成功した結果は同一マウント中キャッシュされます。
 - `desktopAdditionalContent`
   - ユーザー名をクリックしたときのドロップダウンの、「個人設定」の下に入れたいものがある場合に使います。
   - 見た目の共通化のため、乱用は避けてください

--- a/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherFeatures.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherFeatures.tsx
@@ -4,7 +4,9 @@ import { tv } from 'tailwind-variants'
 import { Localizer } from '../../../../intl'
 import { AnchorButton } from '../../../Button'
 import { FaArrowRightIcon, FaStarIcon } from '../../../Icon'
+import { Center } from '../../../Layout'
 import { LineClamp } from '../../../LineClamp'
+import { Loader } from '../../../Loader'
 import { Text } from '../../../Text'
 import { mediaQuery, useMediaQuery } from '../../hooks/useMediaQuery'
 
@@ -15,6 +17,8 @@ import type { Launcher } from '../../types'
 const classNameGenerator = tv({
   slots: {
     empty: ['shr-p-1 shr-text-center'],
+    loadError: ['shr-whitespace-pre-wrap shr-p-1 shr-text-center'],
+    loading: ['shr-py-3'],
     list: ['shr-list-none', '[&>li]:shr-px-0.5 [&>li]:shr-py-0.25'],
     listItem: [
       'smarthr-ui-AppLauncher-listItem',
@@ -25,10 +29,12 @@ const classNameGenerator = tv({
 })
 
 const CLASS_NAMES = (() => {
-  const { empty, list, listItem } = classNameGenerator()
+  const { empty, loadError, loading, list, listItem } = classNameGenerator()
 
   return {
     empty: empty(),
+    loadError: loadError(),
+    loading: loading(),
     list: list(),
     listItem: listItem(),
   }
@@ -37,10 +43,41 @@ const CLASS_NAMES = (() => {
 type Props = {
   features: Array<Launcher['feature']>
   page: Launcher['page']
+  loading?: boolean
+  error?: boolean
 }
 
-export const AppLauncherFeatures: FC<Props> = ({ features, page }) =>
-  features.length === 0 ? <EmptyList /> : <FeatureList features={features} page={page} />
+export const AppLauncherFeatures: FC<Props> = ({ features, page, loading, error }) => {
+  if (loading) {
+    return <LoadingList />
+  }
+
+  if (error) {
+    return <LoadErrorText />
+  }
+
+  return features.length === 0 ? <EmptyList /> : <FeatureList features={features} page={page} />
+}
+
+const LoadingList = memo(() => (
+  <Center className={CLASS_NAMES.loading}>
+    <Loader />
+  </Center>
+))
+
+const LoadErrorText = memo(() => (
+  <div className={CLASS_NAMES.loadError}>
+    <Text size="S">
+      <Translate>
+        <Localizer
+          id="smarthr-ui/AppHeader/Launcher/loadError"
+          defaultText={`アプリ一覧の読み込みに失敗しました。
+時間をおいて、やり直してください。`}
+        />
+      </Translate>
+    </Text>
+  </div>
+))
 
 const EmptyList = memo(() => (
   <div className={CLASS_NAMES.empty}>

--- a/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherFeatures.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/common/AppLauncherFeatures.tsx
@@ -68,13 +68,11 @@ const LoadingList = memo(() => (
 const LoadErrorText = memo(() => (
   <div className={CLASS_NAMES.loadError}>
     <Text size="S">
-      <Translate>
-        <Localizer
-          id="smarthr-ui/AppHeader/Launcher/loadError"
-          defaultText={`アプリ一覧の読み込みに失敗しました。
+      <Localizer
+        id="smarthr-ui/AppHeader/Launcher/loadError"
+        defaultText={`アプリ一覧の読み込みに失敗しました。
 時間をおいて、やり直してください。`}
-        />
-      </Translate>
+      />
     </Text>
   </div>
 ))

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/AppLauncher.tsx
@@ -23,6 +23,8 @@ import type { Launcher } from '../../types'
 
 type Props = {
   features: Array<Launcher['feature']>
+  loading?: boolean
+  error?: boolean
 }
 
 const appLauncher = tv({
@@ -102,7 +104,7 @@ const CLASS_NAMES = (() => {
   }
 })()
 
-export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
+export const AppLauncher: FC<Props> = ({ features: baseFeatures, loading, error }) => {
   const {
     features,
     page,
@@ -175,7 +177,12 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
             </Cluster>
 
             <Scroller className={CLASS_NAMES.scrollArea}>
-              <AppLauncherFeatures features={features} page={page} />
+              <AppLauncherFeatures
+                features={features}
+                page={page}
+                loading={loading}
+                error={error}
+              />
             </Scroller>
           </Section>
         </div>

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
@@ -79,12 +79,8 @@ export const DesktopHeader: FC<InternalHeaderProps> = ({
           {!enableNew && (
             <>
               {isAppLauncherAvailable && (
-                <Dropdown>
-                  <AppLauncherButton
-                    enableNew={enableNew}
-                    className={classNames.appsButton}
-                    handleClick={handleOpenAppLauncher}
-                  >
+                <Dropdown onOpen={handleOpenAppLauncher}>
+                  <AppLauncherButton enableNew={enableNew} className={classNames.appsButton}>
                     <Localizer
                       id="smarthr-ui/AppHeader/DesktopHeader/appLauncherLabel"
                       defaultText="アプリ"
@@ -168,10 +164,10 @@ export const DesktopHeader: FC<InternalHeaderProps> = ({
 }
 
 const AppLauncherButton = memo<
-  Pick<HeaderProps, 'enableNew'> & PropsWithChildren<{ className: string; handleClick: () => void }>
->(({ enableNew, children, className, handleClick }) => (
+  Pick<HeaderProps, 'enableNew'> & PropsWithChildren<{ className: string }>
+>(({ enableNew, children, className }) => (
   <DropdownTrigger>
-    <Button prefix={enableNew ?? <FaToolboxIcon />} className={className} onClick={handleClick}>
+    <Button prefix={enableNew ?? <FaToolboxIcon />} className={className}>
       <Translate>{children}</Translate>
     </Button>
   </DropdownTrigger>

--- a/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/desktop/DesktopHeader.tsx
@@ -18,7 +18,7 @@ import { AppLauncher } from './AppLauncher'
 import { Navigation } from './Navigation'
 import { UserInfo } from './UserInfo'
 
-import type { HeaderProps } from '../../types'
+import type { HeaderProps, InternalHeaderProps } from '../../types'
 
 const classNameGenerator = tv({
   slots: {
@@ -32,7 +32,7 @@ const classNameGenerator = tv({
   },
 })
 
-export const DesktopHeader: FC<HeaderProps> = ({
+export const DesktopHeader: FC<InternalHeaderProps> = ({
   enableNew,
   className = '',
   appName,
@@ -47,6 +47,10 @@ export const DesktopHeader: FC<HeaderProps> = ({
   desktopNavigationAdditionalContent,
   releaseNote,
   features,
+  isAppLauncherAvailable,
+  featuresLoading,
+  featuresError,
+  handleOpenAppLauncher,
   locale: localeProps,
   ...rest
 }) => {
@@ -74,16 +78,24 @@ export const DesktopHeader: FC<HeaderProps> = ({
         <Cluster align="center" className="shr--me-0.25">
           {!enableNew && (
             <>
-              {features && features.length > 0 && (
+              {isAppLauncherAvailable && (
                 <Dropdown>
-                  <AppLauncherButton enableNew={enableNew} className={classNames.appsButton}>
+                  <AppLauncherButton
+                    enableNew={enableNew}
+                    className={classNames.appsButton}
+                    handleClick={handleOpenAppLauncher}
+                  >
                     <Localizer
                       id="smarthr-ui/AppHeader/DesktopHeader/appLauncherLabel"
                       defaultText="アプリ"
                     />
                   </AppLauncherButton>
                   <DropdownContent controllable>
-                    <AppLauncher features={features} />
+                    <AppLauncher
+                      features={features}
+                      loading={featuresLoading}
+                      error={featuresError}
+                    />
                   </DropdownContent>
                 </Dropdown>
               )}
@@ -156,10 +168,10 @@ export const DesktopHeader: FC<HeaderProps> = ({
 }
 
 const AppLauncherButton = memo<
-  Pick<HeaderProps, 'enableNew'> & PropsWithChildren<{ className: string }>
->(({ enableNew, children, className }) => (
+  Pick<HeaderProps, 'enableNew'> & PropsWithChildren<{ className: string; handleClick: () => void }>
+>(({ enableNew, children, className, handleClick }) => (
   <DropdownTrigger>
-    <Button prefix={enableNew ?? <FaToolboxIcon />} className={className}>
+    <Button prefix={enableNew ?? <FaToolboxIcon />} className={className} onClick={handleClick}>
       <Translate>{children}</Translate>
     </Button>
   </DropdownTrigger>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncher.tsx
@@ -20,6 +20,8 @@ import type { Launcher } from '../../types'
 
 type Props = {
   features: Array<Launcher['feature']>
+  loading?: boolean
+  error?: boolean
 }
 
 const classNameGenerator = tv({
@@ -48,7 +50,7 @@ const CLASS_NAMES = (() => {
   }
 })()
 
-export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
+export const AppLauncher: FC<Props> = ({ features: baseFeatures, loading, error }) => {
   const {
     features,
     page,
@@ -98,7 +100,7 @@ export const AppLauncher: FC<Props> = ({ features: baseFeatures }) => {
       </Cluster>
 
       <Scroller className={CLASS_NAMES.scrollArea} styleType="scroll">
-        <AppLauncherFeatures features={features} page={page} />
+        <AppLauncherFeatures features={features} page={page} loading={loading} error={error} />
       </Scroller>
 
       <BottomArea className={CLASS_NAMES.bottomArea}>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncherContext.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncherContext.tsx
@@ -3,11 +3,19 @@ import { type Dispatch, type SetStateAction, createContext } from 'react'
 import type { Launcher } from '../../types'
 
 export const AppLauncherContext = createContext<{
-  features: Array<Launcher['feature']> | null | undefined
+  features: Array<Launcher['feature']>
+  isAppLauncherAvailable: boolean
+  featuresLoading: boolean
+  featuresError: boolean
+  handleOpenAppLauncher: () => void
   isAppLauncherSelected: boolean
   setIsAppLauncherSelected: Dispatch<SetStateAction<boolean>>
 }>({
-  features: null,
+  features: [],
+  isAppLauncherAvailable: false,
+  featuresLoading: false,
+  featuresError: false,
+  handleOpenAppLauncher: () => {},
   isAppLauncherSelected: false,
   setIsAppLauncherSelected: () => {},
 })

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
@@ -126,7 +126,7 @@ const ActualFeatureButton: FC<
     setIsAppLauncherSelected: (selected: boolean) => void
   }>
 > = ({ handleOpenAppLauncher, setIsAppLauncherSelected, children, className }) => {
-  const onClick = useCallback(() => {
+  const handleClick = useCallback(() => {
     handleOpenAppLauncher()
     setIsAppLauncherSelected(true)
   }, [handleOpenAppLauncher, setIsAppLauncherSelected])
@@ -138,7 +138,7 @@ const ActualFeatureButton: FC<
         wide
         prefix={<FaToolboxIcon />}
         suffix={<FaAngleRightIcon className="shr-ms-auto" />}
-        onClick={onClick}
+        onClick={handleClick}
       >
         <Translate>{children}</Translate>
       </Button>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
@@ -103,12 +103,13 @@ const OpenButton = memo<{ alt: ReactNode; onClick: () => void }>(({ onClick, alt
 ))
 
 const FeatureButton = memo<PropsWithChildren<{ className: string }>>(({ children, className }) => {
-  const { features, setIsAppLauncherSelected } = useContext(AppLauncherContext)
+  const { isAppLauncherAvailable, handleOpenAppLauncher, setIsAppLauncherSelected } =
+    useContext(AppLauncherContext)
 
   return (
-    features &&
-    features.length > 0 && (
+    isAppLauncherAvailable && (
       <ActualFeatureButton
+        handleOpenAppLauncher={handleOpenAppLauncher}
         setIsAppLauncherSelected={setIsAppLauncherSelected}
         className={className}
       >
@@ -119,9 +120,16 @@ const FeatureButton = memo<PropsWithChildren<{ className: string }>>(({ children
 })
 
 const ActualFeatureButton: FC<
-  PropsWithChildren<{ className: string; setIsAppLauncherSelected: (selected: boolean) => void }>
-> = ({ setIsAppLauncherSelected, children, className }) => {
-  const onClick = useCallback(() => setIsAppLauncherSelected(true), [setIsAppLauncherSelected])
+  PropsWithChildren<{
+    className: string
+    handleOpenAppLauncher: () => void
+    setIsAppLauncherSelected: (selected: boolean) => void
+  }>
+> = ({ handleOpenAppLauncher, setIsAppLauncherSelected, children, className }) => {
+  const onClick = useCallback(() => {
+    handleOpenAppLauncher()
+    setIsAppLauncherSelected(true)
+  }, [handleOpenAppLauncher, setIsAppLauncherSelected])
 
   return (
     <div className={className}>

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
@@ -87,8 +87,14 @@ export const Content: FC<
 > = ({ domRef, children, setIsOpen, tenantSelector }) => {
   const { selectedNavigationGroup, setSelectedNavigationGroup } = useContext(NavigationContext)
   const { isReleaseNoteSelected, setIsReleaseNoteSelected } = useContext(ReleaseNoteContext)
-  const { features, isAppLauncherSelected, setIsAppLauncherSelected } =
-    useContext(AppLauncherContext)
+  const {
+    features,
+    isAppLauncherAvailable,
+    featuresLoading,
+    featuresError,
+    isAppLauncherSelected,
+    setIsAppLauncherSelected,
+  } = useContext(AppLauncherContext)
 
   const translated = useLocalize({
     launcherListText: {
@@ -173,8 +179,8 @@ export const Content: FC<
         </Cluster>
       </div>
 
-      {isAppLauncherSelected && features && features.length > 0 ? (
-        <AppLauncher features={features} />
+      {isAppLauncherSelected && isAppLauncherAvailable ? (
+        <AppLauncher features={features} loading={featuresLoading} error={featuresError} />
       ) : (
         <Scroller direction="vertical" className={CLASS_NAMES.content}>
           {isReleaseNoteSelected ? (

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MobileHeader.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MobileHeader.tsx
@@ -10,11 +10,15 @@ import { ReleaseNoteContext } from './ReleaseNoteContext'
 import { TenantSelector } from './TenantSelector'
 import { UserInfo } from './UserInfo'
 
-import type { HeaderProps, NavigationGroup } from '../../types'
+import type { InternalHeaderProps, NavigationGroup } from '../../types'
 
-export const MobileHeader: FC<HeaderProps> = ({
+export const MobileHeader: FC<InternalHeaderProps> = ({
   navigations,
   features,
+  isAppLauncherAvailable,
+  featuresLoading,
+  featuresError,
+  handleOpenAppLauncher,
   releaseNote,
   className = '',
   tenants,
@@ -42,6 +46,10 @@ export const MobileHeader: FC<HeaderProps> = ({
     <AppLauncherContext.Provider
       value={{
         features,
+        isAppLauncherAvailable,
+        featuresLoading,
+        featuresError,
+        handleOpenAppLauncher,
         isAppLauncherSelected,
         setIsAppLauncherSelected,
       }}

--- a/packages/smarthr-ui/src/components/AppHeader/stories/AppHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/stories/AppHeader.stories.tsx
@@ -15,3 +15,12 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Playground: Story = {}
+
+export const LazyFeatures: Story = {
+  args: {
+    fetchFeatures: () =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve(args.features ?? []), 1000)
+      }),
+  },
+}

--- a/packages/smarthr-ui/src/components/AppHeader/stories/VRTAppHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/stories/VRTAppHeader.stories.tsx
@@ -102,6 +102,28 @@ export const VRTLauncher: Story = {
   },
 }
 
+export const VRTLauncherLoading: Story = {
+  args: {
+    // HINT: 解決しない Promise を返して loading 状態を固定する
+    fetchFeatures: () => new Promise(() => {}),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    canvas.getByRole('button', { name: 'アプリ' }).click()
+  },
+}
+
+export const VRTLauncherError: Story = {
+  args: {
+    fetchFeatures: () => Promise.reject(new Error('failed')),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    canvas.getByRole('button', { name: 'アプリ' }).click()
+    await canvas.findByText(/アプリ一覧の読み込みに失敗しました/)
+  },
+}
+
 export const VRTReleaseNote: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/packages/smarthr-ui/src/components/AppHeader/stories/VRTAppHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/stories/VRTAppHeader.stories.tsx
@@ -110,6 +110,8 @@ export const VRTLauncherLoading: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     canvas.getByRole('button', { name: 'アプリ' }).click()
+    // HINT: ランチャーは Dropdown のポータル（document.body 直下）に描画されるため body から参照する
+    await within(canvasElement.ownerDocument.body).findByText('処理中')
   },
 }
 
@@ -120,7 +122,7 @@ export const VRTLauncherError: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     canvas.getByRole('button', { name: 'アプリ' }).click()
-    await canvas.findByText(/アプリ一覧の読み込みに失敗しました/)
+    await within(canvasElement.ownerDocument.body).findByText(/アプリ一覧の読み込みに失敗しました/)
   },
 }
 

--- a/packages/smarthr-ui/src/components/AppHeader/types.ts
+++ b/packages/smarthr-ui/src/components/AppHeader/types.ts
@@ -28,7 +28,21 @@ export type HeaderProps = ComponentProps<typeof Header> & {
   desktopNavigationAdditionalContent?: ReactNode
   releaseNote?: ReleaseNoteProps | null
   features?: Array<Launcher['feature']>
+  /**
+   * 指定するとアプリランチャーを開いたタイミングでアプリ一覧を取得します（遅延ロード）。
+   * 指定した場合、features は無視されます。
+   */
+  fetchFeatures?: () => Promise<Array<Launcher['feature']>>
   mobileAdditionalContent?: ReactNode
+}
+
+/** AppHeader が内部の DesktopHeader・MobileHeader へ渡す props */
+export type InternalHeaderProps = Omit<HeaderProps, 'features' | 'fetchFeatures'> & {
+  features: Array<Launcher['feature']>
+  isAppLauncherAvailable: boolean
+  featuresLoading: boolean
+  featuresError: boolean
+  handleOpenAppLauncher: () => void
 }
 
 export type Navigation = NavigationLink | NavigationCustomTag | NavigationButton | NavigationGroup

--- a/packages/smarthr-ui/src/intl/locales/ja.json
+++ b/packages/smarthr-ui/src/intl/locales/ja.json
@@ -24,6 +24,7 @@
   "smarthr-ui/AppHeader/Launcher/helpText": "よく使うアプリとは",
   "smarthr-ui/AppHeader/Launcher/searchResultText": "検索結果",
   "smarthr-ui/AppHeader/Launcher/emptyText": "該当するアプリが見つかりませんでした。",
+  "smarthr-ui/AppHeader/Launcher/loadError": "アプリ一覧の読み込みに失敗しました。\n時間をおいて、やり直してください。",
   "smarthr-ui/AppHeader/Launcher/sortDropdownLabel": "表示順",
   "smarthr-ui/AppHeader/Launcher/sortDropdownSelected": "選択中",
   "smarthr-ui/AppHeader/Launcher/sortDropdownOrderDefault": "デフォルト",

--- a/packages/smarthr-ui/src/intl/locales/ja.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja.ts
@@ -26,6 +26,7 @@ export const locale = {
   'smarthr-ui/AppHeader/Launcher/helpText': 'よく使うアプリとは',
   'smarthr-ui/AppHeader/Launcher/searchResultText': '検索結果',
   'smarthr-ui/AppHeader/Launcher/emptyText': '該当するアプリが見つかりませんでした。',
+  'smarthr-ui/AppHeader/Launcher/loadError': 'アプリ一覧の読み込みに失敗しました。\n時間をおいて、やり直してください。',
   'smarthr-ui/AppHeader/Launcher/sortDropdownLabel': '表示順',
   'smarthr-ui/AppHeader/Launcher/sortDropdownSelected': '選択中',
   'smarthr-ui/AppHeader/Launcher/sortDropdownOrderDefault': 'デフォルト',


### PR DESCRIPTION
## 概要

`AppHeader` のアプリランチャー表示のために、ページ描画のたびにをバックエンドで呼び出し、Propsとして渡している。
しかしランチャーは「アプリ」ボタンを押して初めて開く UI で、開かれないセッションではこのリクエストが丸ごと無駄になっている。

`AppHeader` に遅延ロードオプション `fetchFeatures` を追加し、取得タイミングを「ページ描画時」から「ランチャーを開いたとき」に移すことで、各プラスアプリが段階的にリクエスト量を削減できるようにする。

## 変更内容

- `HeaderProps` に `fetchFeatures?: () => Promise<Array<Launcher['feature']>>` を追加
  - 指定すると、アプリランチャーを開いたタイミング（デスクトップの「アプリ」ボタン押下 / モバイルの「アプリ一覧」タップ）で呼び出してアプリ一覧を取得する
  - 指定した場合、既存の `features` prop は無視される
- 取得状態（loading・data・error）は `AppHeader.tsx` にホイストし、Desktop/Mobile のどちらから開いても `fetchFeatures` の呼び出しが1回だけになるようにした（両ヘッダーは常時マウントされる構造のため）
- 取得中は Loader、失敗時はエラーメッセージを表示し、失敗時は次にランチャーを開いたときに再試行できるようにした
- 初回取得に成功した結果は同一マウント中キャッシュし、再取得しない
- 既存の `features` prop の挙動は変更していない（後方互換）
- i18n: `smarthr-ui/AppHeader/Launcher/loadError` を追加
  - `ja.ts` / `ja.json` のみ更新。他言語は Crowdin の定期更新で反映

### スコープ外（未対応）

- `enableNew`（新デザイン）側の `Header/AppLauncher`（prop は `apps: Category[]`）への同等対応
  - 現状 desktop は `enableNew` 有効時にランチャー自体を描画しないため、今回の `fetchFeatures` は「旧デザインの desktop + 全デザインの mobile」にのみ適用している

## プロダクト側で対応が必要な事項

既存の `features` prop はそのまま動作するため、破壊的変更はない。
`fetchFeatures` への移行は各アプリの任意タイミングで行う。

## 確認方法

- `pnpm ui lint` / `pnpm ui test` がグリーンであることを確認済み
- Storybook (`pnpm ui dev`) の `Components/AppHeader` → `LazyFeatures` で、初期表示・クリック後の Loader・成功後の一覧表示・再オープン時にキャッシュされることを確認できる
- Storybook VRT の `VRTLauncherLoading` / `VRTLauncherError` で、ローディング中・失敗時（検索窓やサイドナビは維持したままリスト領域のみエラー文言に差し替わる）の見た目を確認できる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アプリランチャーの一覧を遅延読み込みできるようになりました。
  * 読み込み中、一覧が空の場合、読み込み失敗時に適切な表示を行います。
  * 読み込み失敗後は、アプリランチャーを再度開いて再試行できます。
  * デスクトップとモバイルの両方で利用できます。
  * 一度取得した一覧は、同じ画面表示中に再利用されます。

* **ドキュメント**
  * 遅延読み込みの設定方法と動作仕様を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->