### PR TITLE
refactor(Badge): typeの型をVariantPropsから明示的な型に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Badge/Badge.tsx
+++ b/packages/smarthr-ui/src/components/Badge/Badge.tsx
@@ -5,7 +5,7 @@ import {
   memo,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { Text } from '../Text'
 
@@ -17,7 +17,7 @@ type BaseProps = PropsWithChildren<{
   /** 0値を表示するかどうか */
   showZero?: boolean
   /** 色の種類 */
-  type?: VariantProps<typeof classNameGenerator>['color']
+  type?: 'grey' | 'blue' | 'yellow' | 'red'
   /** ドット表示するかどうか */
   dot?: boolean
 }>

--- a/packages/smarthr-ui/src/components/Badge/Badge.tsx
+++ b/packages/smarthr-ui/src/components/Badge/Badge.tsx
@@ -9,6 +9,8 @@ import { tv } from 'tailwind-variants'
 
 import { Text } from '../Text'
 
+type Color = 'grey' | 'blue' | 'yellow' | 'red'
+
 type BaseProps = PropsWithChildren<{
   /** 件数 */
   count?: number
@@ -17,7 +19,7 @@ type BaseProps = PropsWithChildren<{
   /** 0値を表示するかどうか */
   showZero?: boolean
   /** 色の種類 */
-  type?: 'grey' | 'blue' | 'yellow' | 'red'
+  type?: Color
   /** ドット表示するかどうか */
   dot?: boolean
 }>
@@ -37,7 +39,7 @@ const classNameGenerator = tv({
       blue: {},
       yellow: {},
       red: {},
-    },
+    } satisfies Record<Color, object>,
     withChildren: {
       true: {},
     },

--- a/packages/smarthr-ui/src/components/Badge/Badge.tsx
+++ b/packages/smarthr-ui/src/components/Badge/Badge.tsx
@@ -18,7 +18,12 @@ type BaseProps = PropsWithChildren<{
   overflowCount?: number
   /** 0値を表示するかどうか */
   showZero?: boolean
-  /** 色の種類 */
+  /**
+   * 色の種類
+   *
+   * TODO: HTMLのtype属性と紛れやすく、tv側のvariant名もcolorであるため、
+   * 破壊的変更を伴うタイミングでcolorへリネームする
+   */
   type?: Color
   /** ドット表示するかどうか */
   dot?: boolean


### PR DESCRIPTION
## 関連URL

なし

## 概要

props の型生成に `tailwind-variants` の `VariantProps` を使うのをやめていきたいと考えています。その1件目として `Badge` を対応します。

`VariantProps` には以下の問題があります。

**必須かどうかが宣言から読み取れない** — `VariantProps` は全 variant を optional にします。`defaultVariants` を指定していても optional のままです。

**props 型が tv の定義に依存する** — 外部に公開する型が内部のスタイル定義に紐づくため、依存関係が増えます。結果として、スタイルを生成しない variant を「型のためだけに」tv 側へ残す必要が生じます。

## 変更内容

```tsx
// Before
import { type VariantProps, tv } from 'tailwind-variants'

type BaseProps = PropsWithChildren<{
  // ...
  /** 色の種類 */
  type?: VariantProps<typeof classNameGenerator>['color']
  // ...
}>

// After
import { tv } from 'tailwind-variants'

type BaseProps = PropsWithChildren<{
  // ...
  /** 色の種類 */
  type?: 'grey' | 'blue' | 'yellow' | 'red'
  // ...
}>
```

`Badge` では prop 名（`type`）と variant 名（`color`）が異なり、インデックスアクセスで取り出す形になっていました。直接型を書くことで、外部インターフェースを tv の内部命名から切り離しています。

### `color` variant を残している理由

`color` の4値はいずれも空オブジェクトでクラスを生成しませんが、`compoundVariants` から参照されているため定義自体は残しています。

```ts
color: {
  grey: {},
  blue: {},
  yellow: {},
  red: {},
},
```

## プロダクト側で対応が必要な事項

なし。`type` prop の型は変更前と完全に一致します。

## 確認方法

- CI（lint / tsc / test）がパスしていること

### 型の同一性について

`Badge.tsx` の `classNameGenerator` と同一の tv 定義を再現して旧型を復元し、公開されている `Badge` の props 型と相互代入可能性で比較しました。

```ts
type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
const expectExact = <T extends true>(_v?: T) => undefined

type OldType = VariantProps<typeof classNameGenerator>['color']
type NewType = React.ComponentProps<typeof Badge>['type']

expectExact<Exact<OldType, NewType>>()
```

不一致の場合は `Type 'false' does not satisfy the constraint 'true'` で tsc が失敗しますが、エラーは出ませんでした。どちらも `'grey' | 'blue' | 'yellow' | 'red' | undefined` として一致しています。

なお `VariantProps` が生成する型の規則は、以下7ケースを同じ方法で実測して確認済みです。

| tv の variants 定義 | 生成される型 |
|---|---|
| `size: { S: 'a', M: 'b' }` | `size?: 'S' \| 'M'` |
| `disabled: { true: 'a', false: 'b' }` | `disabled?: boolean` |
| `active: { true: 'a' }`（true のみ） | `active?: boolean` |
| `level: { 1: 'a', 2: 'b' }` | `level?: 1 \| 2` |
| `defaultVariants` あり | optional のまま |
| `slots` 利用時 | スロットに関係なく variant キーのみ |
| `extend` したもの | 継承元の variant も同じ規則で合成 |

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし

型のみの変更であり、実行時の挙動には影響しません。`Badge` にテストファイルはなく、リポジトリ内の利用箇所は `TabBar` のストーリー3件のみで、いずれも `type` prop を使っていません。

## 今後の対応

`VariantProps` は他に31ファイルで使われています。影響範囲を確認しやすくするため、1ファイルずつ別PRで対応していく予定です。

うち以下は `Omit`・`Pick`・インデックスアクセスで加工していたり、値の型としても使っているため、個別に判断が必要です。

`Cluster` `Sidebar` `Container` `ModelessDialog` `DialogBody` `ThSortButton` `Text`

また `VariantProps` を外すことで「型のためだけに残っている variant 定義」を削除できる箇所が出てきますが、`compoundVariants` からの参照有無を確認する必要があるため、型の置き換えとは分けて扱う予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - Badgeの色指定を明確化し、利用可能な色（グレー、ブルー、イエロー、レッド）を一貫して選択できるようにしました。
  - 既存の表示や色味に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->