### PR TITLE
fix(NotificationBar): Successの状態のroleをalertからstatusに変更する

### DIFF
--- a/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
@@ -169,7 +169,7 @@ const ICON_MAPPER = {
   },
 } as const
 
-const ROLE_STATUS_TYPE_REGEX = /^(info|sync)$/
+const ROLE_STATUS_TYPE_REGEX = /^(info|sync|success)$/
 
 export const NotificationBar: FC<Props> = ({
   type,


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

- `NotificationBar`のコンポネントがスクリーンリーダーに読み上げる時で`type`によって、`role`が変わります。`type=success`が今まで `role=alert`になっていましたが、緊急で伝えないと行けない事ではないので `role=status`に変更しました。

| type | role |
| ---- | ---- |
| error | alert |
| warning | alert |
| info | status |
| sync | status |
| success | status |

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- successの場合、roleが`alert`→ `status` に変更しました

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

- 特になし

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->

- NotificationBarのtype=successのコンポネントに読み上げられる時のスクリーンリーダーで確認出来ます、もしくは、accessibility-treeで確認する


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 成功通知に適切な「status」ロールを適用し、スクリーンリーダーなどの支援技術で正しく認識できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->