### PR TITLE
fix(TextLink): Server Componentとして描画できない問題を修正する

### DIFF
--- a/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/TextLink.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
-import { useLatest } from '../../hooks/useLatest'
 import { OpenInNewTabIcon } from '../Icon'
 
 import type { ElementRef, ElementRefProps } from '../../types'
@@ -92,32 +91,32 @@ const ActualTextLink: TextLinkComponent = forwardRef(
       }
     }, [size, className])
 
-    const latest = useLatest({ onClick, href })
-
-    const hasOnClick = !!onClick
-
-    const functions = useMemo(
-      () => ({
-        handleClick: hasOnClick
-          ? (e: MouseEvent) => {
-              if (!latest.href) {
-                e.preventDefault()
-              }
-              latest.onClick?.(e)
-            }
-          : undefined,
-      }),
-      [hasOnClick, latest],
-    )
-
     return (
       <Anchor
         {...rest}
         ref={ref}
+        // HINT: a要素でhrefが存在しない === button[disabled]のように無効化されていることを表す
+        // そのためhrefが存在せず、かつonClickが設定されている場合、hrefを擬似的に設定することで
+        // disabledではない状態にする (TODO: a11y的にはhrefをoptionalではなく必須属性としたい)
         href={href ? href : onClick ? '' : undefined}
         target={target}
         rel={rel === undefined && target === '_blank' ? 'noopener noreferrer' : rel}
-        onClick={functions.handleClick}
+        // HINT: このコンポーネントは `use client` をつけなくても動作する状態にしたい
+        //  - TextLinkにonClickが設定されるパターンは少ない
+        //  - elementAsが設定されるパターンはさらに少ないため基本的にa要素になっている
+        //  - useLatestを利用すると内部でuseRefを利用しているためclient componentが強制される
+        // 以上からmemo化せずに直接設定しています。
+        // 今後の修正でclient componentになった場合はmemo化を検討する
+        onClick={
+          onClick
+            ? (e: MouseEvent) => {
+                if (!href) {
+                  e.preventDefault()
+                }
+                onClick(e)
+              }
+            : undefined
+        }
         className={classNames.anchor}
       >
         {prefix && <span className={classNames.prefixWrapper}>{prefix}</span>}


### PR DESCRIPTION
## 関連URL

なし

## 概要（`refactor` から `fix` へ変更）

**`TextLink` は `'use client'` を持たないにもかかわらず `useLatest`（内部で `useRef`）を呼んでおり、Server Component として描画すると例外になる状態でした。**

バレル（`src/index.ts`）から `'use client'` を跨がずに到達できるモジュール（サーバグラフ）を算出したところ、`TextLink.tsx` と `hooks/useLatest.ts` の双方が含まれていました。既存の不具合にあたるため、PR の種別を `refactor` から `fix` に変更しています。

## 変更の詳細

`TextLink` を Server Component として利用できる状態に近づけます。

`useLatest` は内部で `useRef` を使っていますが、React の `react-server` ビルドは `useRef` を export していないため、Server Component では利用できません。`TextLink` から `useLatest` を外すことで、この制約を取り除きます。

## 変更内容

```tsx
// Before
const latest = useLatest({ onClick, href })
const hasOnClick = !!onClick

const functions = useMemo(
  () => ({
    handleClick: hasOnClick
      ? (e: MouseEvent) => {
          if (!latest.href) {
            e.preventDefault()
          }
          latest.onClick?.(e)
        }
      : undefined,
  }),
  [hasOnClick, latest],
)

// ...
<Anchor onClick={functions.handleClick} />
```

```tsx
// After
<Anchor
  onClick={
    onClick
      ? (e: MouseEvent) => {
          if (!href) {
            e.preventDefault()
          }
          onClick(e)
        }
      : undefined
  }
/>
```

`latest.href` / `latest.onClick` が直接の `href` / `onClick` になりますが、`useLatest` は常に最新値を返すため参照先の値は同じです。

### memo化していない理由

コード内にコメントとして記録しています。

```tsx
// HINT: このコンポーネントは `use client` をつけなくても動作する状態にしたい
//  - TextLinkにonClickが設定されるパターンは少ない
//  - elementAsが設定されるパターンはさらに少ないため基本的にa要素になっている
//  - useLatestを利用すると内部でuseRefを利用しているためclient componentが強制される
// 以上からmemo化せずに直接設定しています。
// 今後の修正でclient componentになった場合はmemo化を検討する
```

補足すると、親から渡される `onClick` が memo 化されていなければ、`useLatest` を使っていても `TextLink` 自体の `memo` は効きません。そのため実質的な差は小さいと判断しています。

### 残っているhookについて

同ファイルでは `useMemo`・`forwardRef`・`memo` を引き続き使っていますが、これらは Server Component でも利用できます。React 19.2.8 の `react-server` ビルドが export しているものは以下のとおりです。

```
Children Fragment Profiler StrictMode Suspense cache cacheSignal
captureOwnerStack cloneElement createElement createRef forwardRef
isValidElement lazy memo use useCallback useDebugValue useId useMemo version
```

`useMemo` は `create` を即時実行する実装になっています。一方 `useRef`・`useState`・`useEffect` は export されていません。

## プロダクト側で対応が必要な事項

なし。公開インターフェースおよび挙動に変更はありません。

## 確認方法

- Chromatic で `TextLink` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 挙動の同一性について

要素のタグ・`class` 以外の全属性・クラス・`innerHTML` を記録し、あわせてクリック時の `onClick` 呼び出し回数と `defaultPrevented` を比較しました。

以下15パターンで検証しています。

1. `href` のみ
2. `href` なし・`onClick` なし（無効状態）
3. `href` なし・`onClick` あり（`href=""` が付く）
4. `href` あり・`onClick` あり
5. `target="_blank"`（`rel` と `OpenInNewTabIcon`）
6. `target="_blank"` + `suffix={null}`
7. `prefix` / `suffix` / `size` / `className`
8. `elementAs` で別要素
9. `ref` が渡る
10. `href` なし・`onClick` ありをクリック → `defaultPrevented: true`
11. `href` あり・`onClick` ありをクリック → `defaultPrevented: false`
12. `onClick` なしをクリック
13. `href` を後から外す（rerender）→ `defaultPrevented: true`
14. `onClick` を差し替える（rerender）→ 新しい方だけが呼ばれる
15. `onClick` を後から追加する（rerender）

結果は master と**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし

## 補足

本PRだけでは `TextLink` は Server Component になりません。`'use client'` は元から付いていませんが、Server Component として動作させるには利用側の構成も含めた確認が必要です。本PRはその障害を1つ取り除くものと位置づけています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * テキストリンクのクリック処理を整理し、クリック時の動作をより一貫して処理できるようにしました。
  * リンク先が未指定の場合も、不要なページ遷移を防ぎながらクリックイベントを適切に処理します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
