### PR TITLE
refactor(ModelessDialog): useEffectの統合・参照の維持・tv定義の整理

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -98,21 +98,23 @@ const classNameGenerator = tv({
     wrapper:
       'smarthr-ui-ModelessDialog shr-fixed shr-flex shr-max-h-[calc(100svh-theme(spacing[0.5]))] shr-max-w-[calc(100vw-theme(spacing[0.5]))] shr-flex-col',
     headerEl: [
-      'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5',
+      'smarthr-ui-ModelessDialog-header shr-border-b-shorthand shr-relative shr-flex shr-cursor-move shr-items-center',
+      'shr-rounded-tl-l shr-rounded-tr-l shr-pe-1 shr-ps-1.5',
       'hover:shr-bg-white-darken',
       /* DialogHandlerにフォーカスが当たっているときは、headerもフォーカス状態のスタイルにする。 */
-      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-focus-indicator has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-bg-white-darken has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-transition-colors has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-duration-100 has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-ease-in-out',
+      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-focus-indicator',
+      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-bg-white-darken',
+      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-transition-colors',
+      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-duration-100',
+      'has-[.smarthr-ui-ModelessDialog-handle:focus-visible]:shr-ease-in-out',
     ],
     dialogHandler: [
-      'smarthr-ui-ModelessDialog-handle shr-absolute shr-inset-x-0 shr-bottom-0 shr-top-[2px] shr-m-auto shr-flex shr-justify-center shr-rounded-tl-s shr-rounded-tr-s shr-border-none shr-text-grey shr-transition-colors shr-duration-100 shr-ease-in-out',
+      'smarthr-ui-ModelessDialog-handle',
+      'shr-absolute shr-inset-x-0 shr-bottom-0 shr-top-[2px]',
+      'shr-m-auto shr-flex shr-justify-center shr-rounded-tl-s shr-rounded-tr-s shr-border-none',
+      'shr-text-grey shr-transition-colors shr-duration-100 shr-ease-in-out',
       'focus-visible:shr-focus-indicator--none shr-cursor-[inherit] shr-bg-[unset]',
     ],
-    headingEl: ['shr-my-1 shr-me-1'],
-    closeButtonLayout: [
-      'shr-relative' /* DialogHandlerの上に出すためにスタッキングコンテキストを生成 */,
-      'shr-ml-auto shr-shrink-0',
-    ],
-    footerEl: 'smarthr-ui-ModelessDialog-footer shr-border-t-shorthand',
   },
   variants: {
     size: {
@@ -161,17 +163,13 @@ export const ModelessDialog: FC<Props> = ({
   const { localize } = useIntl()
 
   const classNames = useMemo(() => {
-    const { overlap, wrapper, headerEl, headingEl, dialogHandler, closeButtonLayout, footerEl } =
-      classNameGenerator()
+    const { overlap, wrapper, headerEl, dialogHandler } = classNameGenerator()
 
     return {
       overlap: overlap({ className }),
       wrapper: wrapper({ size, resizable }),
       header: headerEl(),
-      heading: headingEl(),
       dialogHandler: dialogHandler(),
-      closeButtonLayout: closeButtonLayout(),
-      footer: footerEl(),
     }
   }, [className, size, resizable])
 
@@ -396,13 +394,14 @@ export const ModelessDialog: FC<Props> = ({
               handleArrowKeyDown={functions.handleArrowKeyDown}
               className={classNames.dialogHandler}
             />
-            <div id={labelId} className={classNames.heading}>
+            <div id={labelId} className="shr-my-1 shr-me-1">
               {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
               <Heading>{heading}</Heading>
             </div>
             <CloseButton
               handleClick={functions.handleClickClose}
-              className={classNames.closeButtonLayout}
+              // DialogHandlerの上に出すためにスタッキングコンテキストを生成
+              className="shr-relative shr-ml-auto shr-shrink-0"
             />
           </div>
           <DialogBody
@@ -412,7 +411,9 @@ export const ModelessDialog: FC<Props> = ({
           >
             {children}
           </DialogBody>
-          {footer && <div className={classNames.footer}>{footer}</div>}
+          {footer && (
+            <div className="smarthr-ui-ModelessDialog-footer shr-border-t-shorthand">{footer}</div>
+          )}
           <LiveRegion regionText={debouncedLiveRegionText} />
         </Panel>
       </Draggable>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -306,9 +306,13 @@ export const ModelessDialog: FC<Props> = ({
     if (isXCenter || isYCenter) {
       const rect = wrapperRef.current.getBoundingClientRect()
 
-      setCentering({
-        top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
-        left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
+      setCentering((current) => {
+        const temp = {
+          top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
+          left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
+        }
+
+        return current.top === temp.top && current.left === temp.left ? current : temp
       })
     }
   }, [bottom, isOpen, left, right, top])

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -14,7 +14,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import Draggable from 'react-draggable'
+import Draggable, { type DraggableBounds } from 'react-draggable'
 import { type VariantProps, tv } from 'tailwind-variants'
 
 import { useHandleEscape } from '../../../hooks/useHandleEscape'
@@ -318,18 +318,24 @@ export const ModelessDialog: FC<Props> = ({
   }, [bottom, isOpen, left, right, top])
 
   useEffect(() => {
-    if (!isOpen) return
+    if (isOpen) {
+      setDraggableBounds((current: DraggableBounds | string | false) => {
+        if (centering.top) {
+          const nextTop = centering.top * -1
 
-    if (centering.top) {
-      setDraggableBounds({ top: centering.top * -1 })
+          if ((typeof current === 'object' ? current.top : undefined) !== nextTop) {
+            return { top: nextTop }
+          }
+        } else if (wrapperRef.current) {
+          const nextTop = wrapperRef.current.getBoundingClientRect().top * -1
 
-      return
-    }
+          if ((typeof current === 'object' ? current.top : undefined) !== nextTop) {
+            return { top: nextTop }
+          }
+        }
 
-    if (wrapperRef.current) {
-      const rect = wrapperRef.current.getBoundingClientRect()
-
-      setDraggableBounds({ top: rect.top * -1 })
+        return current
+      })
     }
   }, [isOpen, centering.top])
 

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -264,6 +264,8 @@ export const ModelessDialog: FC<Props> = ({
     [latest],
   )
 
+  useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
+
   useEffect(() => {
     if (!wrapperPosition) {
       setDebouncedLiveRegionText('')
@@ -332,11 +334,7 @@ export const ModelessDialog: FC<Props> = ({
       setPosition({ x: 0, y: 0 })
       focusTargetRef.current?.focus()
     }
-  }, [isOpen])
 
-  useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
-
-  useEffect(() => {
     const focusHandler = (e: FocusEvent) => {
       // e.target(現在フォーカスがあたっている要素)がModeless dialog外の要素であれば、lastFocusElementRefに代入する
       if (e.target instanceof HTMLElement && !wrapperRef?.current?.contains(e.target)) {
@@ -347,7 +345,7 @@ export const ModelessDialog: FC<Props> = ({
     document.addEventListener('focus', focusHandler, true)
 
     return () => document.removeEventListener('focus', focusHandler, true)
-  }, [])
+  }, [isOpen])
 
   return createPortal(
     <DialogOverlap isOpen={isOpen} className={classNames.overlap} as="section">

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -178,7 +178,9 @@ export const ModelessDialog: FC<Props> = ({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const focusTargetRef = useRef<HTMLDivElement>(null)
 
-  const [wrapperPosition, setWrapperPosition] = useState<DOMRect | undefined>(undefined)
+  const [wrapperPosition, setWrapperPosition] = useState<{ top: number; left: number } | undefined>(
+    undefined,
+  )
   const [debouncedLiveRegionText, setDebouncedLiveRegionText] = useState<string>('')
   const [centering, setCentering] = useState<{
     top?: number
@@ -289,9 +291,17 @@ export const ModelessDialog: FC<Props> = ({
   }, [localize, wrapperPosition, functions])
 
   useEffect(() => {
-    if (wrapperRef.current instanceof Element) {
-      setWrapperPosition(wrapperRef.current.getBoundingClientRect())
-    }
+    setWrapperPosition((current) => {
+      if (wrapperRef.current instanceof Element) {
+        const temp = wrapperRef.current.getBoundingClientRect()
+
+        if (!current || current.top !== temp.top || current.left !== temp.left) {
+          return temp
+        }
+      }
+
+      return current
+    })
   }, [position])
 
   useEffect(() => {


### PR DESCRIPTION
## 関連URL

- #6858 — 本PRの切り出し元

## 概要

`ModelessDialog` に対する大きなリファクタリング（#6858）から、**挙動が変わらないことを確認できた5コミットのみ**を切り出しました。

#6858 は13コミット・187挿入/125削除と規模が大きく、そのままではレビューが困難なため、段階的にmasterへ取り込んでいきます。

## 変更内容

### 1. `isOpen` 変更時の副作用と focus リスナー登録処理の `useEffect` を統合

`isOpen` を見る effect と、focus リスナーを登録する effect（依存配列は `[]`）が別々に存在していました。統合し、依存配列は `[isOpen]` になります。

focus リスナーは開閉のたびに解除・再登録されるようになりますが、ハンドラの内容は同一で、ダイアログ内の要素を無視する実装のため結果は変わりません。

あわせて `useHandleEscape` の呼び出し位置が前方（他の effect より前）へ移動しています。

### 2. 値が変わらない場合に参照を維持する（3コミット）

`centering`・`draggableBounds`・`wrapperPosition` それぞれについて、算出結果が前回と同じ場合は同じ参照を返すようにします。不要な再レンダリングを避けるための最適化で、出力される値は変わりません。

### 3. variant を持たない slot を `tv()` から外す

`headingEl`・`closeButtonLayout`・`footerEl` は variant を持たず、`tv()` に置く必要がありませんでした。利用箇所へ直接 `className` として記述します。

```tsx
// Before
const { overlap, wrapper, headerEl, headingEl, dialogHandler, closeButtonLayout, footerEl } =
  classNameGenerator()

<div id={labelId} className={classNames.heading}>
<CloseButton className={classNames.closeButtonLayout} />

// After
const { overlap, wrapper, headerEl, dialogHandler } = classNameGenerator()

<div id={labelId} className="shr-my-1 shr-me-1">
<CloseButton
  // DialogHandlerの上に出すためにスタッキングコンテキストを生成
  className="shr-relative shr-ml-auto shr-shrink-0"
/>
```

あわせて `headerEl`・`dialogHandler` の長いクラス文字列を意味のまとまりで改行しています。

## プロダクト側で対応が必要な事項

なし。公開インターフェース・生成されるDOM・挙動のいずれにも変更はありません。

## 確認方法

- Chromatic で `ModelessDialog` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 挙動の同一性について

**位置・フォーカス・Escape（15パターン）**

ダイアログの `style`（`top`/`left`/`right`/`bottom`/`width`/`height`/`transform`）とクラス、`document.activeElement`、コールバックの呼び出し回数を記録して比較しました。

閉じた状態 / 初期open / 閉→開 / Escape（open時・close時）/ Escapeによるダイアログ外要素へのフォーカス復帰 / 開閉の繰り返し / unmount後にリスナーが残らないこと / `top`・`left` 指定 / `right`・`bottom` 指定 / 四辺すべて指定 / 位置指定なし（中央寄せ）/ `width`・`height` 指定 / 開いた後の位置props変更 / 閉じてから開き直す

**各パーツのclass（5パターン）**

`tv()` の整理が class に影響しないことを確認するため、header・handle・footer・見出し・閉じるボタンの class と、ダイアログ全体の `innerHTML` を記録しました。

footer なし / footer あり / `size` 指定 / `className` 併用 / `innerHTML` 全体

いずれも master と**完全一致**でした。コミットを積むたびに再確認しています。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Dialog` のテスト — 10ファイル 23件パス

## 切り出していないもの

#6858 の残り8コミットは本PRに含めていません。

**挙動が変わるため別扱いにするもの**

- `defaultPosition` の導入 — 開いた後に位置propsを変更しても初期値が保たれるようになります。実測でも `top` を 10 → 99 に変更したケースで master と差が出ました（master: `99px` / 変更後: `10px`）。意図的な仕様変更のため、単独PRとして説明が必要です

**先行コミットに依存しており、そのままでは適用できないもの**

`positionStyleのuseMemo取りやめ` / `wrapperPositionをstateからrefに変更` / `ライブリージョン更新をrequestAnimationFrameベースに変更` / `中央寄せ座標の計算をdefaultPosition更新effectに統合` / `draggableBoundsの算出をcentering確定と同じeffectに統合` / `defaultPosition初期化用effectをcallback refに変換` / `初期フォーカス対象要素をrefからquerySelectorに変更`

多くは `defaultPosition` の導入を土台にしているため、そちらが入れば順次取り込めるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * モーダレスダイアログのドラッグ操作と位置調整の安定性を向上しました。
  * ダイアログの開閉時にフォーカス管理が適切に更新されるよう改善しました。
  * Escapeキーによるダイアログ終了処理を改善しました。
  * ヘッダー、閉じるボタン、フッターのレイアウトを整理し、表示の一貫性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->