### PR TITLE
fix(ModelessDialog): top/left/right/bottomを開いたときの初期位置として扱う

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -264,8 +264,6 @@ export const ModelessDialog: FC<Props> = ({
     [latest],
   )
 
-  useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
-
   useEffect(() => {
     if (!wrapperPosition) {
       setDebouncedLiveRegionText('')
@@ -364,6 +362,8 @@ export const ModelessDialog: FC<Props> = ({
 
     return () => document.removeEventListener('focus', focusHandler, true)
   }, [isOpen])
+
+  useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
 
   return createPortal(
     <DialogOverlap isOpen={isOpen} className={classNames.overlap} as="section">

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -159,6 +159,9 @@ export const ModelessDialog: FC<Props> = ({
 }) => {
   const labelId = useId()
   const lastFocusElementRef = useRef<HTMLElement | null>(null)
+  // HINT: top/left/right/bottomは「開いたときの初期位置」であるため、
+  // 開いている最中のprops変更では追従させず、開くたびに最新の値へ更新する
+  const [defaultPosition, setDefaultPosition] = useState(() => ({ top, left, right, bottom }))
   const { createPortal } = useDialogPortal(portalParent, id)
   const { localize } = useIntl()
 
@@ -190,7 +193,7 @@ export const ModelessDialog: FC<Props> = ({
   })
   const [draggableBounds, setDraggableBounds] = useState(Draggable.defaultProps.bounds)
 
-  const latest = useLatest({ isOpen, onClickClose, onPressEscape })
+  const latest = useLatest({ isOpen, onClickClose, onPressEscape, top, left, right, bottom })
 
   const functions = useMemo(
     () => ({
@@ -294,8 +297,8 @@ export const ModelessDialog: FC<Props> = ({
       return
     }
 
-    const isXCenter = left === undefined && right === undefined
-    const isYCenter = top === undefined && bottom === undefined
+    const isXCenter = defaultPosition.left === undefined && defaultPosition.right === undefined
+    const isYCenter = defaultPosition.top === undefined && defaultPosition.bottom === undefined
 
     if (isXCenter || isYCenter) {
       const rect = wrapperRef.current.getBoundingClientRect()
@@ -309,7 +312,7 @@ export const ModelessDialog: FC<Props> = ({
         return current.top === temp.top && current.left === temp.left ? current : temp
       })
     }
-  }, [bottom, isOpen, left, right, top])
+  }, [isOpen, defaultPosition])
 
   useEffect(() => {
     if (isOpen) {
@@ -335,6 +338,23 @@ export const ModelessDialog: FC<Props> = ({
 
   useEffect(() => {
     if (isOpen) {
+      setDefaultPosition((current) => {
+        if (
+          current.top === latest.top &&
+          current.left === latest.left &&
+          current.right === latest.right &&
+          current.bottom === latest.bottom
+        ) {
+          return current
+        }
+
+        return {
+          top: latest.top,
+          left: latest.left,
+          right: latest.right,
+          bottom: latest.bottom,
+        }
+      })
       setPosition({ x: 0, y: 0 })
       focusTargetRef.current?.focus()
     }
@@ -349,7 +369,7 @@ export const ModelessDialog: FC<Props> = ({
     document.addEventListener('focus', focusHandler, true)
 
     return () => document.removeEventListener('focus', focusHandler, true)
-  }, [isOpen])
+  }, [isOpen, latest])
 
   useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
 
@@ -376,10 +396,10 @@ export const ModelessDialog: FC<Props> = ({
           // HINT: Panelはmemo化されていないため、styleを安定化しても再レンダリングは減らない。
           // 依存する値も多く、memo化の効果が薄いため直接記述している
           style={{
-            top: centering.top ?? top,
-            left: centering.left ?? left,
-            right,
-            bottom,
+            top: centering.top ?? defaultPosition.top,
+            left: centering.left ?? defaultPosition.left,
+            right: defaultPosition.right,
+            bottom: defaultPosition.bottom,
             width: size ? undefined : width,
             height,
           }}

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -190,18 +190,6 @@ export const ModelessDialog: FC<Props> = ({
   })
   const [draggableBounds, setDraggableBounds] = useState(Draggable.defaultProps.bounds)
 
-  const positionStyle = useMemo(
-    () => ({
-      top: centering.top ?? top,
-      left: centering.left ?? left,
-      right,
-      bottom,
-      width: size ? undefined : width,
-      height,
-    }),
-    [centering, top, left, right, bottom, width, height, size],
-  )
-
   const latest = useLatest({ isOpen, onClickClose, onPressEscape })
 
   const functions = useMemo(
@@ -385,7 +373,16 @@ export const ModelessDialog: FC<Props> = ({
           layer={3}
           overflow="auto"
           className={classNames.wrapper}
-          style={positionStyle}
+          // HINT: Panelはmemo化されていないため、styleを安定化しても再レンダリングは減らない。
+          // 依存する値も多く、memo化の効果が薄いため直接記述している
+          style={{
+            top: centering.top ?? top,
+            left: centering.left ?? left,
+            right,
+            bottom,
+            width: size ? undefined : width,
+            height,
+          }}
         >
           {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex -- dummy element for focus management. */}
           <div tabIndex={-1} ref={focusTargetRef} />


### PR DESCRIPTION
## 関連URL

- #6858 — 本PRの切り出し元
- #6905 — 先行してマージ済みの切り出し

## 概要

`ModelessDialog` の `top` / `left` / `right` / `bottom` は、JSDocで「ダイアログを開いたときの初期位置」と説明されています。

```tsx
/**
 * ダイアログを開いたときの初期 top 位置
 */
top?: string | number
```

しかし実装では毎レンダリングで `style` へ反映されており、**ダイアログを開いている最中にこれらのpropsを変更すると即座に位置が動いていました**。ドキュメントされた仕様と実装が一致していないため修正します。

## 変更内容

### `defaultPosition` を state として持つ

```tsx
// HINT: top/left/right/bottomは「開いたときの初期位置」であるため、
// 開いている最中のprops変更では追従させず、開くたびに最新の値へ更新する
const [defaultPosition, setDefaultPosition] = useState(() => ({ top, left, right, bottom }))
```

`style` は `defaultPosition` を参照するようにします。

```tsx
style={{
  top: centering.top ?? defaultPosition.top,
  left: centering.left ?? defaultPosition.left,
  right: defaultPosition.right,
  bottom: defaultPosition.bottom,
  width: size ? undefined : width,
  height,
}}
```

### 開くたびに最新の props へ更新する

`isOpen` の effect 内で更新します。値が変わらない場合は同じ参照を返すため、不要な再計算は発生しません。

```tsx
if (isOpen) {
  setDefaultPosition((current) => {
    if (
      current.top === latest.top &&
      current.left === latest.left &&
      current.right === latest.right &&
      current.bottom === latest.bottom
    ) {
      return current
    }

    return { top: latest.top, left: latest.left, right: latest.right, bottom: latest.bottom }
  })
  setPosition({ x: 0, y: 0 })
  focusTargetRef.current?.focus()
}
```

初期値のみを固定する実装（`const [defaultPosition] = useState(...)`）では、ダイアログは閉じてもアンマウントされないため、**開き直しても位置が更新されない**という別の不具合が生じます。setterを持たせて開くたびに更新することで、これを回避しています。

### 中央寄せの判定も `defaultPosition` を見る

```tsx
const isXCenter = defaultPosition.left === undefined && defaultPosition.right === undefined
const isYCenter = defaultPosition.top === undefined && defaultPosition.bottom === undefined
```

開いている最中のprops変更で中央寄せの有無が切り替わらないよう、位置の扱いを揃えています。

### 本PRに含まれる前段のリファクタリング（2コミット）

`fix` の実装に先立ち、#6858 との差分を縮めるための整理を含めています。いずれも挙動に変更はありません。

- `useHandleEscape` の呼び出しを `return` 直前へ移動（#6905 で前方へ動いていたものを戻す）
- `positionStyle` の `useMemo` を取りやめて `style` に直接記述

後者は CLAUDE.md の「コンポーネントに渡すオブジェクトはmemo化する」規約から意図的に外れています。理由はコード内のコメントに記録しています（`Panel` が `memo` 化されていない / 依存する値が8個あり効果が薄い / ドラッグ中はどのみち再レンダリングされる）。

## プロダクト側で対応が必要な事項

**`top` / `left` / `right` / `bottom` は、ダイアログを開いたときの初期位置として扱われるようになります。**

開いている最中にこれらのpropsを変更しても即座には反映されず、次に開いたときに反映されます。JSDocに記載された仕様どおりの挙動です。

開いたままリアルタイムに位置を変えたい場合、これらのpropsでは実現できなくなります。

## 確認方法

- Chromatic で `ModelessDialog` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 挙動の比較（21パターン）

`style.cssText` とパーツのclass、`document.activeElement`、コールバック呼び出し回数を記録して比較しました。

**変更前と一致する20パターン**

閉じた状態 / 初期open / 閉→開 / Escape（open時・close時）/ Escapeによるフォーカス復帰 / unmount後 / `top`・`left` 指定 / `right`・`bottom` 指定 / 四辺すべて指定 / 中央寄せ / 縦のみ指定 / `width`・`height` 指定 / `size` 指定時に `width` が無視される / パーツのclass

**差が出る1パターン（本PRの修正点）**

| | 変更前 | 変更後 |
|---|---|---|
| 開いたまま `top` を 10 → 99 | `99px` | **`10px`** |

**開き直しで正しく更新されることの確認**

| ケース | 結果 |
|---|---|
| 閉じてから 10→99 に変更し開き直す | `99px` |
| 開いたまま変更 → 閉じて開き直す | `99px` |
| 位置指定あり → なしで開き直す | 中央寄せに戻る |
| 同じ位置propsで開き直す | 維持される |
| 開閉を3回繰り返す | 保たれる |

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Dialog` のテスト — 10ファイル 23件パス

## 今後

本PRがマージされると、#6858 に残る以下のコミットが取り込めるようになる見込みです。

`中央寄せ座標の計算をdefaultPosition更新effectに統合` / `draggableBoundsの算出をcentering確定と同じeffectに統合` / `defaultPosition初期化用effectをcallback refに変換`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * モードレスダイアログを開いている間、位置設定の変更によってダイアログが意図せず移動する問題を修正しました。
  * ダイアログの初期位置と中央揃えの表示が、より安定して反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->