### PR TITLE
refactor(ModelessDialog): ライブリージョン更新をrequestAnimationFrameベースに変更

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -7,6 +7,7 @@ import {
   type PropsWithChildren,
   type ReactNode,
   type RefObject,
+  type SetStateAction,
   memo,
   useEffect,
   useId,
@@ -17,6 +18,7 @@ import {
 import Draggable, { type DraggableBounds } from 'react-draggable'
 import { type VariantProps, tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../../hooks/useAnimationFrame'
 import { useHandleEscape } from '../../../hooks/useHandleEscape'
 import { useLatest } from '../../../hooks/useLatest'
 import { Localizer, useIntl } from '../../../intl'
@@ -191,11 +193,67 @@ export const ModelessDialog: FC<Props> = ({
   })
   const [draggableBounds, setDraggableBounds] = useState(Draggable.defaultProps.bounds)
 
-  const latest = useLatest({ isOpen, onClickClose, onPressEscape, top, left, right, bottom })
+  const positionFrame = useAnimationFrame()
+  const latest = useLatest({
+    isOpen,
+    onClickClose,
+    onPressEscape,
+    top,
+    left,
+    right,
+    bottom,
+    localize,
+    positionFrame,
+  })
 
-  const functions = useMemo(
-    () => ({
-      debounceLiveRegionText: debounce(setDebouncedLiveRegionText, 600),
+  const functions = useMemo(() => {
+    const debounceLiveRegionText = debounce(setDebouncedLiveRegionText, 600)
+    const setActualPosition = (pos: SetStateAction<{ x: number; y: number }>) => {
+      setPosition(pos)
+
+      latest.positionFrame.request(() => {
+        const wrapperPosition = wrapperRef.current
+          ? wrapperRef.current.getBoundingClientRect()
+          : undefined
+
+        if (!wrapperPosition) {
+          setDebouncedLiveRegionText('')
+          return
+        }
+
+        const oldPosition = wrapperPositionRef.current
+
+        wrapperPositionRef.current = wrapperPosition
+
+        if (
+          oldPosition &&
+          wrapperPosition.top === oldPosition.top &&
+          wrapperPosition.left === oldPosition.left
+        ) {
+          return
+        }
+
+        const txt = latest.localize(
+          {
+            id: 'smarthr-ui/ModelessDialog/dialogHandlerLiveRegionText',
+            defaultText: '上から{top}px、左から{left}px',
+          },
+          {
+            top: Math.trunc(wrapperPosition.top).toString(),
+            left: Math.trunc(wrapperPosition.left).toString(),
+          },
+        )
+
+        debounceLiveRegionText(txt)
+      })
+    }
+
+    return {
+      cleanup: () => {
+        latest.positionFrame.cancel()
+        debounceLiveRegionText.cancel()
+      },
+      setActualPosition,
       handleArrowKeyDown: (e: KeyboardEvent) => {
         if (!latest.isOpen || document.activeElement !== e.currentTarget) {
           return
@@ -205,28 +263,28 @@ export const ModelessDialog: FC<Props> = ({
 
         switch (e.key) {
           case 'ArrowUp':
-            setPosition((prev) => ({
+            setActualPosition((prev) => ({
               x: prev.x,
               y: prev.y - movingDistance,
             }))
             e.preventDefault()
             break
           case 'ArrowDown':
-            setPosition((prev) => ({
+            setActualPosition((prev) => ({
               x: prev.x,
               y: prev.y + movingDistance,
             }))
             e.preventDefault()
             break
           case 'ArrowLeft':
-            setPosition((prev) => ({
+            setActualPosition((prev) => ({
               x: prev.x - movingDistance,
               y: prev.y,
             }))
             e.preventDefault()
             break
           case 'ArrowRight':
-            setPosition((prev) => ({
+            setActualPosition((prev) => ({
               x: prev.x + movingDistance,
               y: prev.y,
             }))
@@ -242,54 +300,17 @@ export const ModelessDialog: FC<Props> = ({
         lastFocusElementRef.current?.focus()
         latest.onPressEscape?.()
       },
-      handleDragStart: (_: any, data: { x: number; y: number }) => setPosition(data),
+      handleDragStart: (_: any, data: { x: number; y: number }) => setActualPosition(data),
       handleDrag: (_: any, data: { deltaX: number; deltaY: number }) => {
-        setPosition((prev) => ({
+        setActualPosition((prev) => ({
           x: prev.x + data.deltaX,
           y: prev.y + data.deltaY,
         }))
       },
-    }),
-    [latest],
-  )
-
-  useEffect(() => {
-    const wrapperPosition = wrapperRef.current
-      ? wrapperRef.current.getBoundingClientRect()
-      : undefined
-
-    if (!wrapperPosition) {
-      setDebouncedLiveRegionText('')
-      return functions.debounceLiveRegionText.cancel
     }
+  }, [latest])
 
-    const oldPosition = wrapperPositionRef.current
-
-    wrapperPositionRef.current = wrapperPosition
-
-    if (
-      oldPosition &&
-      wrapperPosition.top === oldPosition.top &&
-      wrapperPosition.left === oldPosition.left
-    ) {
-      return
-    }
-
-    const txt = localize(
-      {
-        id: 'smarthr-ui/ModelessDialog/dialogHandlerLiveRegionText',
-        defaultText: '上から{top}px、左から{left}px',
-      },
-      {
-        top: Math.trunc(wrapperPosition.top).toString(),
-        left: Math.trunc(wrapperPosition.left).toString(),
-      },
-    )
-
-    functions.debounceLiveRegionText(txt)
-
-    return functions.debounceLiveRegionText.cancel
-  }, [position, localize, functions])
+  useEffect(() => functions.cleanup, [functions])
 
   useEffect(() => {
     // 中央寄せの座標計算を行う
@@ -355,7 +376,7 @@ export const ModelessDialog: FC<Props> = ({
           bottom: latest.bottom,
         }
       })
-      setPosition({ x: 0, y: 0 })
+      functions.setActualPosition({ x: 0, y: 0 })
       focusTargetRef.current?.focus()
     }
 
@@ -369,7 +390,7 @@ export const ModelessDialog: FC<Props> = ({
     document.addEventListener('focus', focusHandler, true)
 
     return () => document.removeEventListener('focus', focusHandler, true)
-  }, [isOpen, latest])
+  }, [isOpen, functions, latest])
 
   useHandleEscape(isOpen ? functions.handlePressEscape : undefined)
 

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -179,9 +179,7 @@ export const ModelessDialog: FC<Props> = ({
   const wrapperRef = useRef<HTMLDivElement>(null)
   const focusTargetRef = useRef<HTMLDivElement>(null)
 
-  const [wrapperPosition, setWrapperPosition] = useState<{ top: number; left: number } | undefined>(
-    undefined,
-  )
+  const wrapperPositionRef = useRef<{ top: number; left: number } | undefined>(undefined)
   const [debouncedLiveRegionText, setDebouncedLiveRegionText] = useState<string>('')
   const [centering, setCentering] = useState<{
     top?: number
@@ -256,9 +254,25 @@ export const ModelessDialog: FC<Props> = ({
   )
 
   useEffect(() => {
+    const wrapperPosition = wrapperRef.current
+      ? wrapperRef.current.getBoundingClientRect()
+      : undefined
+
     if (!wrapperPosition) {
       setDebouncedLiveRegionText('')
       return functions.debounceLiveRegionText.cancel
+    }
+
+    const oldPosition = wrapperPositionRef.current
+
+    wrapperPositionRef.current = wrapperPosition
+
+    if (
+      oldPosition &&
+      wrapperPosition.top === oldPosition.top &&
+      wrapperPosition.left === oldPosition.left
+    ) {
+      return
     }
 
     const txt = localize(
@@ -275,21 +289,7 @@ export const ModelessDialog: FC<Props> = ({
     functions.debounceLiveRegionText(txt)
 
     return functions.debounceLiveRegionText.cancel
-  }, [localize, wrapperPosition, functions])
-
-  useEffect(() => {
-    setWrapperPosition((current) => {
-      if (wrapperRef.current instanceof Element) {
-        const temp = wrapperRef.current.getBoundingClientRect()
-
-        if (!current || current.top !== temp.top || current.left !== temp.left) {
-          return temp
-        }
-      }
-
-      return current
-    })
-  }, [position])
+  }, [position, localize, functions])
 
   useEffect(() => {
     // 中央寄せの座標計算を行う


### PR DESCRIPTION
## 関連URL

- #6858 — 本PRの切り出し元
- #6905 / #6906 — 先行してマージ済みの切り出し

## 概要

ダイアログの位置を読み上げるライブリージョンの更新方法を変更します。

これまでは `position` state の変更を `useEffect` で検知して要素の座標を読み取っていましたが、位置を更新する処理から直接 `requestAnimationFrame` で読み取るようにします。

## 変更内容

本PRは2コミットで構成されています。**2つ目のコミットは1つ目が持ち込む問題を解消するものであり、分割してマージできません。**

### 1. `wrapperPosition` を state から ref に変更

座標の保持を `useState` から `useRef` に変え、座標読み取りとライブリージョン更新の2つの `useEffect` を統合します。state 更新による再レンダリングがなくなります。

### 2. ライブリージョン更新を `requestAnimationFrame` ベースに変更

```tsx
const setActualPosition = (pos: SetStateAction<{ x: number; y: number }>) => {
  setPosition(pos)

  latest.positionFrame.request(() => {
    const wrapperPosition = wrapperRef.current?.getBoundingClientRect()
    // ... 座標が変わっていればライブリージョンのテキストを更新
  })
}
```

矢印キーでの移動・ドラッグ・開いたときの位置リセットは、いずれも `setActualPosition` を経由します。`useAnimationFrame` と `debounce` の後片付けは `functions.cleanup` にまとめ、unmount 時に実行します。

### なぜ分割できないか

1つ目のコミットだけを適用すると、**ライブリージョンのテキストが設定されない状態**になります。

統合後の effect は「座標が前回と同じなら早期 return する」という最適化を持ちますが、この early return は cleanup を返しません。一方 effect が再実行される際には前回の cleanup（`debounce.cancel`）が先に走ります。結果として次の順序になります。

```
1回目: 前回座標なし → debounce(txt) をスケジュール、cleanupにcancelを返す
2回目: cleanupでcancelが実行される → 座標が同じなので早期return
       → テキストが設定されないまま終わる
```

実測でも、初期open・開閉の繰り返し・位置指定あり・位置を変えて開き直すの4ケースで、masterが `上から0px、左から0px` を設定するのに対し空文字のままになることを確認しました。

2つ目のコミットで rAF 化すると、位置を更新した箇所からのみ読み取りが走るためこの問題は発生しません。最終形（#6858）でも master と同じ挙動になることを確認済みです。

## プロダクト側で対応が必要な事項

なし。公開インターフェース・DOM・挙動のいずれにも変更はありません。

## 確認方法

- Chromatic で `ModelessDialog` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 挙動の同一性について

`role="status"` のテキスト、ダイアログの `style.cssText`、`document.activeElement`、DOM構造を記録して比較しました。debounce（600ms）を挟む項目はフェイクタイマーで経過させています。

以下15パターンで検証しました。

**ライブリージョンと位置（10パターン）**

初期open（debounce前・経過後）/ 閉じた状態 / 開閉の繰り返し / 位置指定ありでopen / 位置を変えて開き直す / unmount時にタイマーが残らない / フォーカス移動 / `role="status"` のDOM / 中央寄せ時のstyle

**ハンドル操作（5パターン）**

矢印キーでの移動 / 移動後のdebounce経過 / 連続で矢印キー / 移動後のunmount / フォーカスなしでの矢印キー

結果は master と**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Dialog` のテスト — 10ファイル 23件パス

## 今後

本PRがマージされると、#6858 に残る以下のコミットが取り込めるようになる見込みです。

`中央寄せ座標の計算をdefaultPosition更新effectに統合` / `draggableBoundsの算出をcentering確定と同じeffectに統合` / `defaultPosition初期化用effectをcallback refに変換` / `初期フォーカス対象要素をrefからquerySelectorに変更`

🤖 Generated with [Claude Code](https://claude.com/claude-code)