### PR TITLE
fix(ModelessDialog): ヘッダーの文字列が長いときの表示崩れを修正する

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -411,7 +411,7 @@ export const ModelessDialog: FC<Props> = ({
               handleArrowKeyDown={functions.handleArrowKeyDown}
               className={classNames.dialogHandler}
             />
-            <div id={labelId} className="shr-my-1 shr-me-1 shr-min-w-0 shr-break-all">
+            <div id={labelId} className="shr-my-1 shr-me-1 shr-min-w-0">
               {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
               <Heading>{heading}</Heading>
             </div>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -411,7 +411,7 @@ export const ModelessDialog: FC<Props> = ({
               handleArrowKeyDown={functions.handleArrowKeyDown}
               className={classNames.dialogHandler}
             />
-            <div id={labelId} className="shr-my-1 shr-me-1">
+            <div id={labelId} className="shr-my-1 shr-me-1 shr-min-w-0 shr-break-all">
               {/* eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content */}
               <Heading>{heading}</Heading>
             </div>

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/stories/VRTModelessDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/stories/VRTModelessDialog.stories.tsx
@@ -38,3 +38,10 @@ export const VRTForcedColors: StoryObj<typeof ModelessDialog> = {
     chromatic: { forcedColors: 'active' },
   },
 }
+
+export const VRTLongHeading: StoryObj<typeof ModelessDialog> = {
+  args: {
+    heading:
+      'ModelessDialog?%20%20%20%20%20%20%20%20%20%20&amp;%20%20%20%20%20%20=%20%20%20%20%20%20%20%20-%20%20%20%20%20%20%20%20--%20%20%20%20%20%20%20%20_%20%20%20%20%20%20%20%20__%20%20%20%20%20%20%20%20',
+  },
+}


### PR DESCRIPTION
## 概要

ModelessDialogのヘッダーに長い文字列が入ってくると、ヘッダーのコンテナが広がって閉じるボタンが横スクロールしないと見えない位置に行ってしまうのを修正しました。

| Before | After |
|---|---|
| <img width="646" height="459" alt="スクリーンショット 2026-08-28 17 24 36" src="https://github.com/user-attachments/assets/8f4abcdd-c732-4498-8116-350e31fb9774" /><br><img width="669" height="470" alt="スクリーンショット 2026-08-28 17 24 31" src="https://github.com/user-attachments/assets/99385b5c-64df-4cf1-a5eb-a09d13459ab0" /> | <img width="644" height="458" alt="スクリーンショット 2026-08-28 17 24 44" src="https://github.com/user-attachments/assets/68d79735-852a-4409-943a-552983ae8a41" /> |

## 変更内容

- タイトルが入るフレックスアイテムに `shr-min-w-0` を追加した
- 長いタイトルのVRTストーリーを追加した

## プロダクト側で対応が必要な事項

基本的にはないはずですが、ModelessDialog のタイトルにテキスト以外も入れてる場合はレイアウトが崩れる可能性はあります。

## 確認方法

storybook の VRT に `Long Heading` を追加しているので、それで確認してください。