### PR TITLE
refactor(ModelessDialog): 中央寄せとdraggableBoundsの算出をdefaultPosition確定と同じeffectに統合

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -203,6 +203,7 @@ export const ModelessDialog: FC<Props> = ({
     right,
     bottom,
     defaultPosition,
+    centering,
     localize,
     liveRegionFrame,
   })
@@ -313,28 +314,6 @@ export const ModelessDialog: FC<Props> = ({
 
   useEffect(() => {
     if (isOpen) {
-      setDraggableBounds((current: DraggableBounds | string | false) => {
-        if (centering.top) {
-          const nextTop = centering.top * -1
-
-          if ((typeof current === 'object' ? current.top : undefined) !== nextTop) {
-            return { top: nextTop }
-          }
-        } else if (wrapperRef.current) {
-          const nextTop = wrapperRef.current.getBoundingClientRect().top * -1
-
-          if ((typeof current === 'object' ? current.top : undefined) !== nextTop) {
-            return { top: nextTop }
-          }
-        }
-
-        return current
-      })
-    }
-  }, [isOpen, centering.top])
-
-  useEffect(() => {
-    if (isOpen) {
       const oldDefaultPosition = latest.defaultPosition
       const nextDefaultPosition =
         oldDefaultPosition.top === latest.top &&
@@ -357,19 +336,42 @@ export const ModelessDialog: FC<Props> = ({
           nextDefaultPosition.left === undefined && nextDefaultPosition.right === undefined
         const isYCenter =
           nextDefaultPosition.top === undefined && nextDefaultPosition.bottom === undefined
+        let nextCentering = latest.centering
 
         if (isXCenter || isYCenter) {
           const rect = wrapperRef.current.getBoundingClientRect()
+          const tempCentering = {
+            top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
+            left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
+          }
 
-          setCentering((current) => {
-            const temp = {
-              top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
-              left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
-            }
+          nextCentering =
+            latest.centering.top === tempCentering.top &&
+            latest.centering.left === tempCentering.left
+              ? latest.centering
+              : tempCentering
 
-            return current.top === temp.top && current.left === temp.left ? current : temp
-          })
+          setCentering(nextCentering)
         }
+
+        // HINT: 中央寄せの有無に関わらずdraggableBoundsは更新する必要がある
+        setDraggableBounds((current: DraggableBounds | string | false) => {
+          if (nextCentering.top) {
+            const nextTop = nextCentering.top * -1
+
+            if ((typeof current === 'object' ? current.top : undefined) !== nextTop) {
+              return { top: nextTop }
+            }
+          } else if (wrapperRef.current) {
+            const nextTop = wrapperRef.current.getBoundingClientRect().top * -1
+
+            if ((typeof current === 'object' ? current.top : undefined) !== nextTop) {
+              return { top: nextTop }
+            }
+          }
+
+          return current
+        })
       }
 
       functions.setActualPosition({ x: 0, y: 0 })

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -193,7 +193,7 @@ export const ModelessDialog: FC<Props> = ({
   })
   const [draggableBounds, setDraggableBounds] = useState(Draggable.defaultProps.bounds)
 
-  const positionFrame = useAnimationFrame()
+  const liveRegionFrame = useAnimationFrame()
   const latest = useLatest({
     isOpen,
     onClickClose,
@@ -202,8 +202,9 @@ export const ModelessDialog: FC<Props> = ({
     left,
     right,
     bottom,
+    defaultPosition,
     localize,
-    positionFrame,
+    liveRegionFrame,
   })
 
   const functions = useMemo(() => {
@@ -211,7 +212,7 @@ export const ModelessDialog: FC<Props> = ({
     const setActualPosition = (pos: SetStateAction<{ x: number; y: number }>) => {
       setPosition(pos)
 
-      latest.positionFrame.request(() => {
+      latest.liveRegionFrame.request(() => {
         const wrapperPosition = wrapperRef.current
           ? wrapperRef.current.getBoundingClientRect()
           : undefined
@@ -249,8 +250,8 @@ export const ModelessDialog: FC<Props> = ({
     }
 
     return {
-      cleanup: () => {
-        latest.positionFrame.cancel()
+      cleanupLiveRegion: () => {
+        latest.liveRegionFrame.cancel()
         debounceLiveRegionText.cancel()
       },
       setActualPosition,
@@ -310,31 +311,6 @@ export const ModelessDialog: FC<Props> = ({
     }
   }, [latest])
 
-  useEffect(() => functions.cleanup, [functions])
-
-  useEffect(() => {
-    // 中央寄せの座標計算を行う
-    if (!wrapperRef.current || !isOpen) {
-      return
-    }
-
-    const isXCenter = defaultPosition.left === undefined && defaultPosition.right === undefined
-    const isYCenter = defaultPosition.top === undefined && defaultPosition.bottom === undefined
-
-    if (isXCenter || isYCenter) {
-      const rect = wrapperRef.current.getBoundingClientRect()
-
-      setCentering((current) => {
-        const temp = {
-          top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
-          left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
-        }
-
-        return current.top === temp.top && current.left === temp.left ? current : temp
-      })
-    }
-  }, [isOpen, defaultPosition])
-
   useEffect(() => {
     if (isOpen) {
       setDraggableBounds((current: DraggableBounds | string | false) => {
@@ -359,23 +335,43 @@ export const ModelessDialog: FC<Props> = ({
 
   useEffect(() => {
     if (isOpen) {
-      setDefaultPosition((current) => {
-        if (
-          current.top === latest.top &&
-          current.left === latest.left &&
-          current.right === latest.right &&
-          current.bottom === latest.bottom
-        ) {
-          return current
-        }
+      const oldDefaultPosition = latest.defaultPosition
+      const nextDefaultPosition =
+        oldDefaultPosition.top === latest.top &&
+        oldDefaultPosition.left === latest.left &&
+        oldDefaultPosition.right === latest.right &&
+        oldDefaultPosition.bottom === latest.bottom
+          ? oldDefaultPosition
+          : {
+              top: latest.top,
+              left: latest.left,
+              right: latest.right,
+              bottom: latest.bottom,
+            }
 
-        return {
-          top: latest.top,
-          left: latest.left,
-          right: latest.right,
-          bottom: latest.bottom,
+      setDefaultPosition(nextDefaultPosition)
+
+      // 中央寄せの座標計算を行う
+      if (wrapperRef.current) {
+        const isXCenter =
+          nextDefaultPosition.left === undefined && nextDefaultPosition.right === undefined
+        const isYCenter =
+          nextDefaultPosition.top === undefined && nextDefaultPosition.bottom === undefined
+
+        if (isXCenter || isYCenter) {
+          const rect = wrapperRef.current.getBoundingClientRect()
+
+          setCentering((current) => {
+            const temp = {
+              top: isYCenter ? Math.max(0, window.innerHeight / 2 - rect.height / 2) : undefined,
+              left: isXCenter ? Math.max(0, window.innerWidth / 2 - rect.width / 2) : undefined,
+            }
+
+            return current.top === temp.top && current.left === temp.left ? current : temp
+          })
         }
-      })
+      }
+
       functions.setActualPosition({ x: 0, y: 0 })
       focusTargetRef.current?.focus()
     }
@@ -389,7 +385,10 @@ export const ModelessDialog: FC<Props> = ({
 
     document.addEventListener('focus', focusHandler, true)
 
-    return () => document.removeEventListener('focus', focusHandler, true)
+    return () => {
+      functions.cleanupLiveRegion()
+      document.removeEventListener('focus', focusHandler, true)
+    }
   }, [isOpen, functions, latest])
 
   useHandleEscape(isOpen ? functions.handlePressEscape : undefined)


### PR DESCRIPTION
## 関連URL

- #6858 — 本PRの切り出し元
- #6905 / #6906 / #6907 — 先行してマージ済みの切り出し

## 概要

`ModelessDialog` が持つ3つの `useEffect` を1つに統合します。

これまでは `defaultPosition` の state 更新 → 再レンダリング → 中央寄せ計算 → 再レンダリング → `draggableBounds` 更新、という多段構成でした。`isOpen` の effect 内で `defaultPosition` を先に確定させ、その値を使って中央寄せと `draggableBounds` をまとめて算出します。

## 変更内容

### 1. 中央寄せ計算を `defaultPosition` 確定と同じ effect に統合

`setDefaultPosition` の更新関数形式をやめ、次の値を `latest.defaultPosition` から算出する形にします。値が変わらない場合に同じ参照を返す点は変わりません。

あわせて以下も行っています。

- ライブリージョン関連の識別子を `positionFrame` → `liveRegionFrame`、`cleanup` → `cleanupLiveRegion` にリネームし、用途を名前で示す
- 独立していた cleanup 用の `useEffect` をやめ、`isOpen` の effect の cleanup にまとめる

### 2. `draggableBounds` の算出を統合

`centering` を確定させた直後に、同じ effect 内で更新します。

**元コミットからの変更点があります。** `#6858` の該当コミットでは `setDraggableBounds` を中央寄せ計算の `if` ブロック内へ移していましたが、それでは縦横どちらも中央寄せでない場合に `bounds` が初期値の `false` のままになります。

```tsx
const isXCenter = nextDefaultPosition.left === undefined && nextDefaultPosition.right === undefined
const isYCenter = nextDefaultPosition.top === undefined && nextDefaultPosition.bottom === undefined

if (isXCenter || isYCenter) {
  // ← ここに setDraggableBounds を入れると top+left 指定時に呼ばれない
}
```

`if` ブロックの外に置き、中央寄せの有無に関わらず更新するようにしました。意図はコード内のコメントにも記録しています。

```tsx
// HINT: 中央寄せの有無に関わらずdraggableBoundsは更新する必要がある
setDraggableBounds((current: DraggableBounds | string | false) => { ... })
```

## プロダクト側で対応が必要な事項

なし。公開インターフェース・DOM・挙動のいずれにも変更はありません。

## 確認方法

- Chromatic で `ModelessDialog` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### `draggableBounds` の同一性について

`react-draggable` をモックして `bounds` prop を直接捕捉し、8パターンで比較しました。

位置指定なし（中央寄せ）/ `top`+`left` / 四辺すべて / `top` のみ / `left` のみ / `right`+`bottom` / `top`+`bottom` / `left`+`right`

結果は master と**完全一致**でした。

なお当初はハンドルへの `mouseDown`/`mouseMove` でドラッグを再現しようとしましたが、jsdom では `react-draggable` が反応せず全ケースで `translate(0px,0px)` のままでした。その状態での一致は無意味なため、`bounds` を直接捕捉する方法に切り替えています。

上記の元コミットからの変更点は、この計測で回帰を検出したことによるものです。修正前は `top`+`left` / 四辺すべて / `right`+`bottom` の3ケースで `{top:0}` が `false` になっていました。

### 位置・フォーカス・ライブリージョンの同一性について

ダイアログの `style`（`top`/`left`/`right`/`bottom`/`transform`）、`role="status"` のテキスト、`document.activeElement` を記録して比較しました。debounce（600ms）を挟む項目はフェイクタイマーで経過させています。

中央寄せ / `top`+`left` / `top` のみ / `left` のみ / `right`+`bottom` / 四辺すべて / 閉→開 / 位置指定あり→なしで開き直す / なし→ありで開き直す / 開閉を3回繰り返す / ライブリージョン / 矢印キー移動 / 移動後の unmount / 閉じたときのクリア

いずれも master と**完全一致**でした。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Dialog` のテスト — 10ファイル 23件パス

## 今後

`#6858` に残るのは以下2件です。本PRの時点ではまだ cherry-pick が通りません。

`defaultPosition初期化用effectをcallback refに変換` / `初期フォーカス対象要素をrefからquerySelectorに変更`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - モードレスダイアログを開いた際、指定した位置が正しく反映されるよう改善しました。
  - ダイアログの中央寄せや画面内のドラッグ範囲が、最新の位置情報に基づいて適切に計算されるようになりました。
  - ライブリージョンの更新処理を安定化し、支援技術への通知がより確実に行われるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->