### PR TITLE
fix(ModelessDialog): 中央寄せが不要になった際にcenteringをリセットする

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -352,6 +352,11 @@ export const ModelessDialog: FC<Props> = ({
               : tempCentering
 
           setCentering(nextCentering)
+        } else if (latest.centering.top !== undefined || latest.centering.left !== undefined) {
+          // HINT: 中央寄せが不要になった場合、以前の値が残るとdefaultPositionより優先されてしまう
+          nextCentering = {}
+
+          setCentering(nextCentering)
         }
 
         // HINT: 中央寄せの有無に関わらずdraggableBoundsは更新する必要がある


### PR DESCRIPTION
## 関連URL

- #6909 のレビュー指摘（https://github.com/kufu/smarthr-ui/pull/6909#discussion_r3878308768）から切り出し
- #6858 — 分割元

## 概要

`centering` の state は中央寄せが必要な場合にのみ更新されており、不要になっても以前の値が残り続けていました。

`style` は `centering.top ?? defaultPosition.top` を参照するため、残った `centering` が指定位置より優先されます。結果として **中央寄せで開いたあと閉じ、`top`/`left` を指定して開き直すと、指定した位置ではなく中央寄せの座標が使われる** 状態でした。

## 変更内容

縦横どちらも中央寄せでない場合に `centering` を空にします。

```tsx
if (isXCenter || isYCenter) {
  // ...中央寄せの座標を算出
  setCentering(nextCentering)
} else if (latest.centering.top !== undefined || latest.centering.left !== undefined) {
  // HINT: 中央寄せが不要になった場合、以前の値が残るとdefaultPositionより優先されてしまう
  nextCentering = {}

  setCentering(nextCentering)
}
```

`nextCentering` は直後の `setDraggableBounds` でも参照されるため、そちらにも反映されます。

すでに空の場合は `setCentering` を呼ばず、不要な再レンダリングを避けています。

## いつからの不具合か

`61f7d303e`（一連の切り出し開始前）・`824797ad4`（#6906 マージ前）・`e1e2ff468`（#6907 マージ後）・`f86076349`（#6909 マージ後）の4リビジョンで同じ検証を行い、結果が完全に一致することを確認しました。

**一連のリファクタリングによる回帰ではなく、それ以前から存在する不具合です。**

## プロダクト側で対応が必要な事項

**中央寄せで表示したあと、位置を指定して開き直した場合の表示位置が変わります。**

これまでは中央寄せの座標が使われ続けていましたが、指定した `top` / `left` / `right` / `bottom` が反映されるようになります。

`right` / `bottom` のみを指定するケースでは、これまで `top` / `left` に中央寄せの値が残っていたため縦横ともに位置が固定されていましたが、今後は `right` / `bottom` のみが効きます。

## 確認方法

- Chromatic で `ModelessDialog` に差分が出ていないこと（既存ストーリーは開き直しを行わないため差分が出ない想定）
- CI（lint / tsc / test）がパスしていること

### 挙動の比較

ダイアログの `style`（`top`/`left`/`right`/`bottom`/`transform`）、`role="status"` のテキスト、`document.activeElement` を記録して比較しました。

**修正対象（3ケース）**

| ケース | 修正前 | 修正後 |
|---|---|---|
| 中央寄せ → 閉 → `top=30` `left=40` | `384px` / `512px` | **`30px` / `40px`** |
| 中央寄せ → 閉 → 四辺すべて指定 | `384px` / `512px` | **`1px` / `2px`** |
| 中央寄せ → 閉 → `right`/`bottom` 指定 | `384px` / `512px` 残留 | **解除** |

`384` / `512` は jsdom の window サイズ（768 × 1024）の中央値です。

**変更前と一致（11ケース）**

中央寄せ / 最初から `top`+`left` / `top` のみ / `left` のみ / 四辺すべて / `right`+`bottom` / 閉じた状態 / 閉→開 / `top`+`left` → 閉 → 中央寄せで開く / 中央寄せで開閉3回 / `top`+`left` で開閉3回 / ライブリージョン / 矢印キー移動 / unmount

中央寄せ → 閉 → `top`+`bottom` 指定（横は中央寄せ継続）のケースも一致しています。片方だけ中央寄せが継続する場合は従来どおりです。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Dialog` のテスト — 10ファイル 23件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * モードレスダイアログで中央寄せが不要になった際、保持されていた位置情報をクリアし、既定の位置に正しく戻るよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->