### PR TITLE
refactor(LoaderSpinner): 'use client'を削除する

### DIFF
--- a/packages/smarthr-ui/src/components/Loader/LoaderSpinner.tsx
+++ b/packages/smarthr-ui/src/components/Loader/LoaderSpinner.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../intl'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`LoaderSpinner` は React の hook を一切使っておらず、import しているものもすべて Server Component で扱えます。`'use client'` を削除します。

`'use client'` を削除する取り組みの1件目です。1ファイルずつ import を全件評価して判定していきます。

## 判定根拠

React 19.2.8 の `react-server` ビルドが export する API のみが Server Component で使えます。実測で確認しました。

```
Children Fragment Profiler StrictMode Suspense cache cacheSignal
captureOwnerStack cloneElement createElement createRef forwardRef
isValidElement lazy memo use useCallback useDebugValue useId useMemo version
```

`useRef` / `useState` / `useEffect` / `useContext` / `createContext` などは含まれません。

### `LoaderSpinner` の import 評価

| import | 判定 | 根拠 |
|---|---|---|
| `tailwind-variants` → `tv` | ✅ | パッケージ内を走査し、client専用APIの使用がないことを確認 |
| `../VisuallyHiddenText` | ✅ | `forwardRef` / `memo` / `useMemo` のみ。いずれも `react-server` ビルドが export |
| `../../intl` → `Localizer` | ✅ | 後述 |
| `react` → `FC` / `ReactNode` | ✅ | 型のみ |

### `../../intl` について

import 先はバレル（`intl/index.ts`）であり、こちらは `'use client'` を持ちません。そのため `Localizer` だけでなく `IntlProvider` / `useIntl` / `useDateFormat` なども再エクスポート経由で評価対象になります。

確認したところ、`intl` 配下は `index.ts` と `localeMap.ts`（型のみ）を除き**すべて `'use client'` を持つ**ため、境界で止まります。

`Localizer` 自体は client component ですが、Server Component から**レンダリング**する分には問題ありません。

コンポーネント本体も hook を使わず、即時関数でクラス名を生成しているだけです。

```tsx
// HINT: LoaderSpinnerは一度表示されれば属性が変わる可能性はほぼ無いためuseMemoしない
const classNames = (() => { ... })()
```

### 同ディレクトリとの整合

`Loader.tsx` は元から `'use client'` を持ちません。`LoaderSpinner.tsx` のみに付いている状態が解消されます。

## プロダクト側で対応が必要な事項

なし。公開インターフェース・DOM のいずれにも変更はありません。

## 確認方法

- Chromatic で `Loader` に差分が出ていないこと
- CI（lint / tsc / test）がパスしていること

### 生成DOMの同一性について

`innerHTML` 全体を記録して比較しました。

- `LoaderSpinner` 既定
- `size="S"`
- `type="light"`
- `alt` 指定
- `size="S"` + `type="light"` + `alt`（ReactNode）
- `Loader` 経由（既定）
- `Loader` 経由（`text` / `type` / `size`）

結果は master と**完全一致**でした。

### 依存の追跡

`LoaderSpinner` から `'use client'` に当たるまで再帰的に辿り、サーバ側で評価されるモジュールを列挙しました。

```
components/Loader/LoaderSpinner.tsx
components/VisuallyHiddenText/index.ts   → forwardRef / memo / useMemo
intl/index.ts                            → 配下はすべて 'use client' を持つ
外部: tailwind-variants
```

`tailwind-variants@0.3.1` は `node --conditions react-server` で import できることを確認済みです。

バレル（`src/index.ts`）から `'use client'` を跨がず到達できるモジュール（サーバグラフ）も算出し、本PRによる新規の違反が無いことを確認しました。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `Loader` / `Button` のテスト — 2ファイル 7件パス

## 今後

`'use client'` を持つファイルは115件あり、静的解析では24件が候補として挙がっています。ただしその解析は外部パッケージの内部実装まで見ておらず、精度が不足していました。

そのため1ファイルずつ、import を全件評価して判定していきます。外部パッケージについては、`createContext` などの文字列があるかだけでなく、実装がガードされているかまで確認します。

たとえば `react-icons@5.7.0` は `createContext` を使いますがガードされており、Server Component でも動作します（#6912 で詳述）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ローダーの動作を維持したまま、クライアント専用指定を見直しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
