### PR TITLE
fix(AppHeader/DatePicker): usePortalを使うコンポーネントに'use client'を追加

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/Menu.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   type FC,
   type PropsWithChildren,

--- a/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type PropsWithChildren, forwardRef, useImperativeHandle, useRef, useState } from 'react'
 
 import { useEnhancedEffect } from '../../hooks/useEnhancedEffect'


### PR DESCRIPTION
## 関連URL

- #6911 / #6912 — `'use client'` を見直す一連の作業

## 概要

`usePortal` はモジュールスコープで `createContext` を呼んでいます。

```tsx
const ParentContext = createContext<ParentContextValue>({ seqs: [] })
```

`react-server` ビルドでは `createContext` が `undefined` のため、このモジュールが評価されると例外になります。実測で確認しました。

```
TypeError - React.createContext is not a function
```

`usePortal` の利用元のうち、`Button` / `Dropdown` / `Combobox/useListbox` には `'use client'` がありますが、**`AppHeader/components/mobile/Menu` と `DatePicker/Portal` には無い**状態でした。client 境界が無いまま Server Component から到達すると評価されてしまいます。

## 変更内容

2ファイルに `'use client'` を追加します。

- `components/AppHeader/components/mobile/Menu.tsx`
- `components/DatePicker/Portal.tsx`

### なぜ `usePortal` 側ではなく利用側か

`usePortal` は `src/index.ts` から export しておらず、内部専用です。

`'use client'` は client 境界を宣言するもので、**client module が import するモジュールは client グラフに含まれ、サーバ側では評価されません**。そのため利用側に境界を置けば、`usePortal` のモジュールスコープの処理はサーバで評価されなくなります。

境界はコンポーネント側に置くのが適切です。hook は単独でレンダリングされず、呼び出すコンポーネントが client でなければ動きません。

### 両ファイルは元から `'use client'` が必要だった

`usePortal` の件とは別に、どちらも client 専用 API を直接使っています。

- `Menu.tsx` — `useContext` / `useEffect` / `useState` / `useCallback`
- `DatePicker/Portal.tsx` — `useImperativeHandle` / `useRef` / `useState`

## プロダクト側で対応が必要な事項

なし。ディレクティブの追加のみで、DOM や挙動に変更はありません。

Server Component から smarthr-ui を利用する場合に、これらのモジュールが評価されて例外になる問題が解消されます。

## 確認方法

- CI（lint / tsc / test）がパスしていること

### ビルド出力の確認

rollup は `preserveModules: true` を使っており、ディレクティブがモジュール単位で出力に保持されます。ビルドして確認しました。

```
lib/components/AppHeader/components/mobile/Menu.js   "use client";
lib/components/DatePicker/Portal.js                  "use client";
lib/hooks/usePortal.js                               （無し。利用側が境界のため不要）
```

`lib/index.js` にディレクティブが無いことも確認済みです。バレルに付けるとライブラリ全体が client 扱いになるため、付けてはいけません。

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `DatePicker` / `AppHeader` のテスト — 4ファイル 20件パス

## 補足

同じくモジュールスコープで `createContext` を呼ぶ `useTheme.tsx` と `useEnvironment/useEnvironment.ts` には `'use client'` があります。ただしこの2つは `ThemeProvider` / `EnvironmentProvider` として公開しているため、利用者側の Server Component から直接レンダリングできる必要があり、ディレクティブを持つのが適切です。

`usePortal` のみが非公開かつ境界を持たない状態でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)