### PR TITLE
fix(SideNav): client境界を張る

### DIFF
--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type ComponentPropsWithoutRef, type FC, type PropsWithChildren, useMemo } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 

--- a/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavItemButton.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   type ComponentPropsWithoutRef,
   type ElementType,


### PR DESCRIPTION
## 関連URL

- #6913 — 当初 `usePortal` の件として起票したが不要と判明。調査過程で本件を発見したためクローズ
- #6911 / #6912 — `'use client'` を見直す一連の作業

## 概要

`SideNavContext` はモジュールスコープで `createContext` を呼んでいます。

```tsx
const SideNavContext = createContext<SideNavContextValue>({ size: 'M' })
```

`react-server` ビルドでは `createContext` が `undefined` のため、このモジュールが評価された時点で例外になります。実測で確認しました。

```
TypeError - React.createContext is not a function
```

`SideNav` 配下はいずれも `'use client'` を持たず、`src/index.ts` から公開している `SideNav` / `SideNavItemButton` / `SideNavItemAnchor` のどこにも境界がありませんでした。バレル経由で到達し評価されます。

## 変更内容

2ファイルに `'use client'` を追加します。

- `components/SideNav/SideNav.tsx` — `SideNavProvider` を使う
- `components/SideNav/SideNavItemButton.tsx` — `useSideNavContext` を呼ぶ

### なぜ `SideNavContext` 側ではなく利用側か

`SideNavContext` は `src/index.ts` から export しておらず、内部専用です。

`'use client'` は client 境界を宣言するもので、client module が import するモジュールは client グラフに含まれ、サーバ側では評価されません。そのため利用側に境界を置けば、`SideNavContext` のモジュールスコープの処理はサーバで評価されなくなります。

## プロダクト側で対応が必要な事項

なし。ディレクティブの追加のみで、DOM や挙動に変更はありません。

Server Component から smarthr-ui を利用する場合に、このモジュールが評価されて例外になる問題が解消されます。

## 確認方法

- CI（lint / tsc / test）がパスしていること

### サーバグラフによる検証

バレル（`src/index.ts`）から `'use client'` を跨がずに到達できるモジュール＝サーバグラフを算出し、その中で client 専用 API を使うものを列挙しました。

**修正前**

- サーバグラフ: 210モジュール / client 境界: 93モジュール
- モジュールスコープでの違反: **`components/SideNav/SideNavContext.tsx` の1件**

**修正後**

- サーバグラフ: 207モジュール
- モジュールスコープでの違反: **0件**

### 残るもの（いずれも問題なし）

サーバグラフから到達可能で client 専用 API を import しているものが3件残りますが、実行される文脈は client 側です。

| ファイル | 理由 |
|---|---|
| `hooks/useLatest.ts` | hook。モジュールスコープでは何も実行しない。呼び出し元が client グラフ内 |
| `hooks/useMergeRefs.ts` | 同上 |
| `components/Dialog/FocusTrap.tsx` | 実利用元の `DialogContentInner` / `ControlledStepFormDialog` がいずれも `'use client'` を持つ。`Dialog/index.ts` は再エクスポートのみ |

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし

## 補足: 境界は直近の親である必要はない

#6913 では `Menu.tsx` / `DatePicker/Portal.tsx` に `'use client'` が無いことを欠落と判断しましたが、上位に境界があるかを辿っていませんでした。

```
DatePicker/Portal.tsx  ← DatePicker.tsx（'use client' 有）
Menu.tsx  ← MobileHeader.tsx  ← AppHeader.tsx（'use client' 有）
```

個別ファイルの有無ではなく、**バレルからのグラフとして評価する**必要があります。本PRの検証方法はそれに沿ったものです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * サイドナビゲーションがクライアント環境で適切に動作するようになりました。
  * サイドナビゲーション項目のボタン操作における互換性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->