### PR TITLE
docs: 'use client'の要否が読み取れない箇所にHINTコメントを追加

### DIFF
--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncherContext.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/AppLauncherContext.tsx
@@ -1,3 +1,6 @@
+// HINT: モジュールスコープでcreateContextを呼ぶため、react-server条件で評価されると
+// TypeErrorになる。上位のAppHeaderが'use client'を持つことで
+// clientグラフに入り、サーバ側では評価されない。
 import { type Dispatch, type SetStateAction, createContext } from 'react'
 
 import type { Launcher } from '../../types'

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/NavigationContext.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/NavigationContext.tsx
@@ -1,3 +1,6 @@
+// HINT: モジュールスコープでcreateContextを呼ぶため、react-server条件で評価されると
+// TypeErrorになる。上位のAppHeaderが'use client'を持つことで
+// clientグラフに入り、サーバ側では評価されない。
 import { type Dispatch, type SetStateAction, createContext } from 'react'
 
 import type { Navigation, NavigationGroup } from '../../types'

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/ReleaseNoteContext.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/ReleaseNoteContext.tsx
@@ -1,3 +1,6 @@
+// HINT: モジュールスコープでcreateContextを呼ぶため、react-server条件で評価されると
+// TypeErrorになる。上位のAppHeaderが'use client'を持つことで
+// clientグラフに入り、サーバ側では評価されない。
 import { type Dispatch, type SetStateAction, createContext } from 'react'
 
 import type { HeaderProps } from '../../types'

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
@@ -1,4 +1,7 @@
 import { type ComponentType, useMemo } from 'react'
+// HINT: styled-components@5はRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// react-server条件でimportするとTypeErrorになるため、このモジュールを使うコンポーネントは
+// 'use client'を外せない（Layout配下・Panelが該当）。
 import { isStyledComponent } from 'styled-components'
 
 import { SectioningFragment } from './SectioningContent'

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
@@ -1,5 +1,6 @@
 import { type ComponentType, useMemo } from 'react'
-// HINT: styled-components@5はRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// HINT: styled-componentsがRSCに対応するのはv6.3.0以降。peerは^5.0.1のため、
+// モジュールスコープでcreateContextを呼びガードが無いバージョンが解決されうる。
 // react-server条件でimportするとTypeErrorになるため、このモジュールを使うコンポーネントは
 // 'use client'を外せない（Layout配下・Panelが該当）。
 import { isStyledComponent } from 'styled-components'

--- a/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNavContext.tsx
@@ -1,3 +1,6 @@
+// HINT: モジュールスコープでcreateContextを呼ぶため、react-server条件で評価されると
+// TypeErrorになる。利用側のコンポーネント（SideNav・SideNavItemButton）が'use client'を持つことで
+// clientグラフに入り、サーバ側では評価されない。
 import { createContext, useContext } from 'react'
 
 import type { SideNavSizeType } from './SideNavItemButton'

--- a/packages/smarthr-ui/src/hooks/usePortal.tsx
+++ b/packages/smarthr-ui/src/hooks/usePortal.tsx
@@ -1,3 +1,6 @@
+// HINT: モジュールスコープでcreateContextを呼ぶため、react-server条件で評価されると
+// TypeErrorになる。利用側のコンポーネント（Button・Dropdown・useListbox・Menu・DatePicker/Portal）が'use client'を持つことで
+// clientグラフに入り、サーバ側では評価されない。
 import { type FC, type ReactNode, createContext, useContext, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 

--- a/packages/smarthr-ui/src/intl/DateFormatter.tsx
+++ b/packages/smarthr-ui/src/intl/DateFormatter.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: useDateFormat経由でreact-intlに到達する。react-intlはRSC非対応のため、
+// 利用側へ境界を移せない。
 import dayjs from 'dayjs'
 
 import { type FormatDateProps, useDateFormat } from './useDateFormat'

--- a/packages/smarthr-ui/src/intl/IntlProvider.tsx
+++ b/packages/smarthr-ui/src/intl/IntlProvider.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: react-intlはRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// react-server条件でimportするとTypeErrorになるため、利用側へ境界を移せない。
 import { type FC, type PropsWithChildren, createContext, useContext, useMemo } from 'react'
 import { IntlContext, IntlProvider as ReactIntlProvider } from 'react-intl'
 

--- a/packages/smarthr-ui/src/intl/Localizer.tsx
+++ b/packages/smarthr-ui/src/intl/Localizer.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: react-intlはRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// react-server条件でimportするとTypeErrorになるため、利用側へ境界を移せない。
 import { type ComponentProps, memo } from 'react'
 import { FormattedMessage as ReactIntlFormattedMessage } from 'react-intl'
 

--- a/packages/smarthr-ui/src/intl/TimeFormatter.tsx
+++ b/packages/smarthr-ui/src/intl/TimeFormatter.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: useDateFormat経由でreact-intlに到達する。react-intlはRSC非対応のため、
+// 利用側へ境界を移せない。
 import dayjs from 'dayjs'
 import { memo } from 'react'
 

--- a/packages/smarthr-ui/src/intl/TimestampFormatter.tsx
+++ b/packages/smarthr-ui/src/intl/TimestampFormatter.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: useDateFormat経由でreact-intlに到達する。react-intlはRSC非対応のため、
+// 利用側へ境界を移せない。
 import dayjs from 'dayjs'
 
 import { type FormatTimestampProps, useDateFormat } from './useDateFormat'

--- a/packages/smarthr-ui/src/intl/useDateFormat.ts
+++ b/packages/smarthr-ui/src/intl/useDateFormat.ts
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: react-intlはRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// react-server条件でimportするとTypeErrorになるため、利用側へ境界を移せない。
 import { useMemo } from 'react'
 import { useIntl as useReactIntl } from 'react-intl'
 

--- a/packages/smarthr-ui/src/intl/useIntl.ts
+++ b/packages/smarthr-ui/src/intl/useIntl.ts
@@ -1,5 +1,7 @@
 'use client'
 
+// HINT: react-intlはRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// react-server条件でimportするとTypeErrorになるため、利用側へ境界を移せない。
 import { useMemo } from 'react'
 import {
   type PrimitiveType,

--- a/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
+++ b/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
@@ -1,3 +1,6 @@
+// HINT: styled-components@5はRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
+// このモジュールはcreateTheme経由でuseThemeから使われ、useThemeが'use client'を持つため
+// サーバ側では評価されない。
 import { type FlattenSimpleInterpolation, css } from 'styled-components'
 
 import { merge } from '../../libs/lodash'

--- a/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
+++ b/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
@@ -1,6 +1,7 @@
-// HINT: styled-components@5はRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
-// このモジュールはcreateTheme経由でuseThemeから使われ、useThemeが'use client'を持つため
-// サーバ側では評価されない。
+// HINT: styled-componentsがRSCに対応するのはv6.3.0以降。peerは^5.0.1のため、
+// モジュールスコープでcreateContextを呼びガードが無いバージョンが解決されうる。
+// ただしこのモジュールはcreateTheme経由でuseThemeから使われ、useThemeが'use client'を
+// 持つためサーバ側では評価されない。
 import { type FlattenSimpleInterpolation, css } from 'styled-components'
 
 import { merge } from '../../libs/lodash'


### PR DESCRIPTION
## 関連URL

- #6912 — `'use client'` の判定手順を CLAUDE.md に追加

## 概要

`'use client'` の要否がコードから読み取れない箇所にコメントを追加します。実装の変更はありません。

`'use client'` を削除できるか検討する際、以下が毎回調べ直しになっていました。

- なぜこのファイルに `'use client'` が必要なのか
- なぜこのファイルには不要なのか（どこに境界があるのか）

## 変更内容

### 1. RSC 非対応パッケージに依存する箇所（9件）

`react-intl` と `styled-components` はいずれもモジュールスコープで `createContext` を呼びガードが無いため、`react-server` 条件で import した時点で例外になります。実測で確認済みです。

```
TypeError: React.createContext is not a function
```

そのため、これらに到達するモジュールは**利用側へ境界を移せません**。`'use client'` を外すと、サーバグラフから到達する経路が1つでもあれば落ちます。

**react-intl に直接到達（4件）**

`intl/useIntl.ts` / `intl/useDateFormat.ts` / `intl/Localizer.tsx` / `intl/IntlProvider.tsx`

```tsx
'use client'

// HINT: react-intlはRSC非対応（モジュールスコープでcreateContextを呼びガードが無い）。
// react-server条件でimportするとTypeErrorになるため、利用側へ境界を移せない。
```

**`useDateFormat` 経由で到達（3件）**

`intl/DateFormatter.tsx` / `intl/TimeFormatter.tsx` / `intl/TimestampFormatter.tsx`

**styled-components（2件）**

`components/SectioningContent/useSectioningWrapper.ts` は境界を持たず、**Layout 配下と Panel が `'use client'` を外せない原因**になっています。

`themes/createShadow/createShadow.ts` は `createTheme` 経由で `useTheme` から使われ、`useTheme` が境界を持つためサーバ側では評価されません。この違いも記載しています。

RSC に対応するのは v6.3.0 以降です。実測で `v6.2.0` は `TypeError`、`v6.3.0` は成功することを確認しました。peer は `^5.0.1` のため、未対応バージョンが解決されうる状態です。

### 2. client 境界に依存している箇所（5件）

モジュールスコープで `createContext` を呼びながら `'use client'` を持たないファイルです。いずれも**上位に境界があるため安全**ですが、その依存関係がコードから読み取れませんでした。

`hooks/usePortal.tsx` / `components/SideNav/SideNavContext.tsx` / `components/AppHeader/components/mobile/` 配下3件

```tsx
// HINT: モジュールスコープでcreateContextを呼ぶため、react-server条件で評価されると
// TypeErrorになる。利用側のコンポーネント（Button・Dropdown・useListbox・Menu・
// DatePicker/Portal）が'use client'を持つことでclientグラフに入り、
// サーバ側では評価されない。
```

## 調査方法

モジュールスコープで `createContext` / `useState` / `useRef` を呼ぶファイルを全件洗い出したところ **17件**ありました。うち `'use client'` を持たないのが5件です。

バレル（`src/index.ts`）から `'use client'` を跨がずに到達できるモジュール（サーバグラフ）を算出し、5件すべてが境界の内側にあることを確認しました。**現時点で違反はありません。**

## プロダクト側で対応が必要な事項

なし。コメントの追加のみで、DOM や挙動に変更はありません。

## 確認方法

- CI（lint / tsc / test）がパスしていること

### ローカルでの確認結果

- `npx eslint` — エラーなし
- `npx tsc --noEmit -p tsconfig.build.json` — エラーなし
- `npx prettier --check` — 差分なし
- `SideNav` / `AppHeader` / `Dropdown` / `intl` のテスト — 5ファイル 83件パス

## 今後

`'use client'` の判定手順は #6912 で CLAUDE.md に記載しました。本PRのコメントはその判定を個別ファイルで繰り返さずに済むようにするものです。

将来的には lint ルールで機械的に検出する形が望ましいと考えていますが、まずはコメントで判別できる状態にします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)