### PR TITLE
fix(WarekiPicker): client境界を張る

### DIFF
--- a/packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type ComponentProps, type FC, useCallback } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`WarekiPicker` に `'use client'` が付いておらず、Server Component のグラフに含まれた状態になっていました。`src/index.ts` から公開しているため利用者の Server Component から直接レンダリングされ得ますが、実際には Server Component として成立しないため境界を張ります。

同種の欠落を1コンポーネントずつ対応していく方針で、本PRは `WarekiPicker` のみを扱います。

## 変更内容

`packages/smarthr-ui/src/components/WarekiPicker/WarekiPicker.tsx` の先頭に `'use client'` を追加しました。差分は2行です。

```diff
+'use client'
+
 import { type ComponentProps, type FC, useCallback } from 'react'
```

### Server Component として成立しない理由

```tsx
export const WarekiPicker: FC<Props> = (props) => {
  const { locale } = useIntl()          // ①
  const latest = useLatest({ locale })  // ②
  const showAlternative = useCallback(...)
  return <DatePicker {...props} showAlternative={showAlternative} />  // ③
}
```

**① `useIntl`** — `intl/useIntl.ts` は `'use client'` を持つため、Server Component 側では client reference になり関数として呼び出せません。実行順としてはここで最初に失敗します。

**② `useLatest`** — 内部で `useRef` を使います。react 19.2.8 の `react-server` ビルドは `useRef` を export しません（実測で確認）。

```
useRef: なし / useState: なし / useContext: なし
useCallback: あり / useMemo: あり
```

**③ `showAlternative`** — ①②を取り除いたとしても、生成した関数を client component である `DatePicker` へ渡す構造のため Server Component にはできません。`Props` は `Omit<..., 'showAlternative'>` で利用者から受け取らず、必ず内部で生成するため `undefined` になる余地もありません。

### 境界の位置について

CLAUDE.md の `#### 'use client' を付けるべきかの判定` に記載の原則どおり、公開コンポーネントは利用者の Server Component から直接レンダリングされるため、そのファイル自身に境界を置きます。

## プロダクト側で対応が必要な事項

なし。公開インターフェースと描画結果に変更はありません。

## 確認方法

### サーバグラフからの除外

`src/index.ts` から `'use client'` を跨がずに到達できるモジュール集合を比較しました。

```
変更前: 212モジュール（WarekiPicker.tsx を含む）
変更後: 208モジュール（WarekiPicker.tsx が除外される）
```

### ビルド出力

rollup は `preserveModules: true` のためディレクティブがモジュール単位で保持されます。

```sh
cd packages/smarthr-ui && npx rollup --config rollup.esm.config.js
head -1 lib/components/WarekiPicker/WarekiPicker.js
# "use client";
```

### テスト

WarekiPicker・DatePicker のテスト 12件がパスすることを確認しました。tsc / eslint も通過しています。`'use client'` の追加は DOM に影響しません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 和暦選択コンポーネントをクライアント環境で正しく利用できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->