### PR TITLE
refactor(VisuallyHiddenText): コンポーネント名のclassをtvの引数へ移す

### DIFF
--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.tsx
@@ -34,17 +34,17 @@ const ActualVisuallyHiddenText: VisuallyHiddenTextComponent = forwardRef(
     ref: Ref<ElementRef<T>>,
   ) => {
     const actualClassName = useMemo(
-      () => visuallyHiddenTextClassNameGenerator({ className }),
+      // HINT: smarthr-ui-VisuallyHiddenTextは明示的にこのコンポーネントを利用している場合にのみ設定します
+      // visuallyHiddenTextClassName を利用している場合、他のclassに混ぜられたりする関係上、要素として検索する際
+      // ノイズになる可能性があるため
+      () =>
+        visuallyHiddenTextClassNameGenerator({
+          className: `smarthr-ui-VisuallyHiddenText ${className || ''}`,
+        }),
       [className],
     )
 
-    return (
-      <Component
-        {...rest}
-        ref={ref}
-        className={`smarthr-ui-VisuallyHiddenText ${actualClassName}`}
-      />
-    )
+    return <Component {...rest} ref={ref} className={actualClassName} />
   },
 )
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VisuallyHiddenText` では、コンポーネント名の class をテンプレートリテラルで結合していました。`classNameGenerator` に渡す形へ統一します。

あわせて、`smarthr-ui-VisuallyHiddenText` を `visuallyHiddenTextClassName` に含めていない理由が読み取れないため、HINT コメントを残しました。

## 変更内容

```diff
  const actualClassName = useMemo(
-   () => visuallyHiddenTextClassNameGenerator({ className }),
+   // HINT: smarthr-ui-VisuallyHiddenTextは明示的にこのコンポーネントを利用している場合にのみ設定します
+   // visuallyHiddenTextClassName を利用している場合、他のclassに混ぜられたりする関係上、要素として検索する際
+   // ノイズになる可能性があるため
+   () =>
+     visuallyHiddenTextClassNameGenerator({
+       className: `smarthr-ui-VisuallyHiddenText ${className || ''}`,
+     }),
    [className],
  )

  return (
    <Component
      {...rest}
      ref={ref}
-     className={`smarthr-ui-VisuallyHiddenText ${actualClassName}`}
+     className={actualClassName}
    />
  )
```

### class の並び順が変わります

`smarthr-ui-VisuallyHiddenText` が class 属性の先頭から末尾へ移動します。

```diff
- smarthr-ui-VisuallyHiddenText shr-absolute shr-h-px ... [clip:rect(0_0_0_0)]
+ shr-absolute shr-h-px ... [clip:rect(0_0_0_0)] smarthr-ui-VisuallyHiddenText
```

CSS の適用結果は変わりません。`Fieldset.tsx` が使っている `classList.contains('smarthr-ui-VisuallyHiddenText')` も順序に依存しないため影響ありません。

`VisuallyHiddenText` は17ファイルから利用されているため、DOM スナップショットとしては広い範囲に差分が出ます。

### `visuallyHiddenTextClassName` は変わりません

```
shr-absolute shr-h-px shr-w-px shr-overflow-hidden shr-whitespace-nowrap shr-border-0 shr-p-0 [clip-path:inset(100%)] [clip:rect(0_0_0_0)]
```

引数なしで呼び出しているため base のみで、コンポーネント名 class を含まない点は従来どおりです。`PageHeading.tsx` の `setAttribute('class', visuallyHiddenTextClassName)` にも影響しません。

## プロダクト側で対応が必要な事項

なし。公開インターフェースと描画結果に変更はありません。

## 確認方法

### class 属性の比較

`className` の指定パターンごとに master と比較しました。

| パターン | undefined 混入 | 先頭空白/二重空白 | `classList.contains` |
|---|---|---|---|
| className 未指定 | false | false | true |
| className 指定 | false | false | true |
| className 空文字 | false | false | true |
| as=div | false | false | true |
| as=legend + className | false | false | true |
| Tailwind 衝突する className | false | false | true |

すべて master と一致します。差分は `smarthr-ui-VisuallyHiddenText` の位置のみです。

`className` が optional のため `${className || ''}` としています。

### テスト

VisuallyHiddenText・FormGroup・Heading・Icon のテスト19件がパスすることを確認しました。tsc / eslint も通過しています。

### VRT

class の並び順のみの変更で描画は変わらないため、Chromatic に差分は出ない見込みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 視覚的に非表示のテキストに付与される識別用クラスの適用方法を改善し、表示結果の一貫性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->