### PR TITLE
refactor(useLatest): useRefの依存を排除し、RSCでも動作する状態にする

### DIFF
--- a/packages/smarthr-ui/src/hooks/useLatest.ts
+++ b/packages/smarthr-ui/src/hooks/useLatest.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 
 /**
  * 常に最新の値を参照するためのフック。
@@ -19,14 +19,18 @@ import { useMemo, useRef } from 'react'
  * if (latest.selectedItem) { ... }
  */
 export function useLatest<T extends object>(values: T): Readonly<T> {
-  const ref = useRef<T>(values)
-  ref.current = values
+  const stableValues = useMemo(() => ({}), [])
 
-  return useMemo(
-    () =>
-      new Proxy({} as T, {
-        get: (_target, prop) => ref.current[prop as keyof T],
-      }) as Readonly<T>,
-    [],
-  )
+  // TODO: 必要に応じて下記ロジックを導入する。
+  // 通常の利用方法では削除する必要性はないためコメントアウトしている
+  // // 古いプロパティをすべて削除してから assign する（キーの増減に対応）
+  // for (const key in stableValues) {
+  //   if (!(key in values)) {
+  //     delete (stableValues as any)[key]
+  //   }
+  // }
+
+  Object.assign(stableValues, values)
+
+  return stableValues as Readonly<T>
 }


### PR DESCRIPTION
<!--
PRのタイトルは、PRによる変更内容が利用者にも伝わるようにお願いします。
通常、PRをスカッシュマージした場合のコミットメッセージがそのままリリースノートやCHANGELOGに反映されるためです。
-->

## 関連URL

<!--
PRに関連するURLなどを記載してください。

e.g.
- JIRA チケットURL (社内向け)
- Slack URL (社内向け)
- GitHub Issues URL (社外向け)
-->

## 概要

<!--
PRを作成した目的や解決したい課題を簡潔に記載してください。
-->

- useRefを利用していることでRSCから利用した場合動作しない状態になっていた
- useMemoだけに絞ることで動作するように修正

## 変更内容

<!--
PRではどのような変更を加えたのか、マージ後にどう変わるかなどを具体的に記載してください。
コンポーネントの新規追加やスタイル変更などがある場合、キャプチャを添付してください。
コンポーネントのインタフェースが変更(特に破壊的変更)がある場合、変更前後での使用例を記載してください。
-->

- useMemoで作ったobjectに対してObject.assignする構造に変更することで同じ参照を維持しつつ、RSCでも利用可能な状態にした(useMemoのmemo化は動作しないがコード上問題なく動作する状態になる)

## プロダクト側で対応が必要な事項

<!--
このPRの変更によりプロダクト側で対応しないとならないことがある場合は記載してください。
特に破壊的変更になる場合はなるべく記載してください。
ここに書いた内容がそのままリリースノートに転機されます。
例：
`isHoge` propsが削除されました。fugaeの場合は `isFuga` propsで、piypの場合は `isPiyo` で置き換えてください。
-->

## 確認方法

<!--
PRの変更内容を確認する方法について記載してください。
Storybook や Chromatic での確認で十分な場合、そのURLを記載してください。
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 値の参照処理を見直し、最新の値がより安定して反映されるよう改善しました。
  * 一部のプロパティが削除された場合、以前の値が残る可能性があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->