### PR TITLE
docs(storybook): react-docgenでBabel 7を使用する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   tar@<=7.5.15: '>=7.5.22'
   js-yaml@>=4.0.0 <=5.2.1: '>=5.2.3'
   '@babel/core@<=7.29.0': '>=8.0.1'
+  react-docgen@8.0.0>@babel/core: ^7.28.0
   sharp@<0.35.0: '>=0.35.3'
   nanoid@<3.3.18: '>=3.3.18 <7'
 
@@ -117,19 +118,19 @@ importers:
         version: 12.1.4(rollup@4.62.3)(tslib@2.8.1)(typescript@5.9.3)
       '@storybook/addon-a11y':
         specifier: 9.1.20
-        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
+        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
       '@storybook/addon-docs':
         specifier: 9.1.20
-        version: 9.1.20(@types/react@18.3.31)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
+        version: 9.1.20(@types/react@18.3.31)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
       '@storybook/cli':
         specifier: 9.1.20
-        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@storybook/react':
         specifier: 9.1.20
-        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
+        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 9.1.20
-        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@types/node':
         specifier: ^20.19.43
         version: 20.19.43
@@ -150,7 +151,7 @@ importers:
         version: 13.0.6
       jsdom:
         specifier: ^26.1.0
-        version: 26.1.0(canvas@3.1.0)(supports-color@10.2.2)
+        version: 26.1.0(canvas@3.1.0)(supports-color@5.5.0)
       npm-run-all2:
         specifier: ^9.0.2
         version: 9.0.2
@@ -177,7 +178,7 @@ importers:
         version: link:../smarthr-ui
       storybook:
         specifier: 9.1.20
-        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       styled-components:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@19.2.8(react@19.2.8))(react-is@19.2.0)(react@19.2.8)
@@ -195,7 +196,7 @@ importers:
         version: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@20.19.43)(jsdom@26.1.0(canvas@3.1.0)(supports-color@10.2.2))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@20.19.43)(jsdom@26.1.0(canvas@3.1.0)(supports-color@5.5.0))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/smarthr-ui:
     dependencies:
@@ -271,16 +272,16 @@ importers:
         version: 12.1.4(rollup@4.62.3)(tslib@2.8.1)(typescript@5.9.3)
       '@storybook/addon-docs':
         specifier: 9.1.20
-        version: 9.1.20(@types/react@18.3.31)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
+        version: 9.1.20(@types/react@18.3.31)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
       '@storybook/cli':
         specifier: 9.1.20
-        version: 9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@storybook/react':
         specifier: 9.1.20
-        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
+        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 9.1.20
-        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 9.1.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.3)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@swc/core':
         specifier: ^1.15.46
         version: 1.15.46(@swc/helpers@0.5.23)
@@ -331,16 +332,16 @@ importers:
         version: 18.1.0
       eslint-plugin-storybook:
         specifier: 9.1.20
-        version: 9.1.20(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@5.9.3)
+        version: 9.1.20(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@5.9.3)
       glob:
         specifier: 13.0.6
         version: 13.0.6
       http-server:
         specifier: ^14.1.1
-        version: 14.1.1(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
+        version: 14.1.1(debug@4.4.3(supports-color@10.2.2))(supports-color@5.5.0)
       jsdom:
         specifier: ^26.1.0
-        version: 26.1.0(canvas@3.1.0)(supports-color@5.5.0)
+        version: 26.1.0(canvas@3.1.0)(supports-color@10.2.2)
       npm-run-all2:
         specifier: ^9.0.2
         version: 9.0.2
@@ -388,10 +389,10 @@ importers:
         version: 1.3.1(rollup@4.62.3)
       storybook:
         specifier: 9.1.20
-        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       storybook-addon-pseudo-states:
         specifier: 9.1.20
-        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
+        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))
       styled-components:
         specifier: ^5.3.11
         version: 5.3.11(react-dom@19.2.8(react@19.2.8))(react-is@19.2.0)(react@19.2.8)
@@ -406,13 +407,13 @@ importers:
         version: 4.23.1
       typescript-eslint:
         specifier: ^8.64.0
-        version: 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+        version: 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       vite:
         specifier: 7.3.6
         version: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@20.19.43)(jsdom@26.1.0(canvas@3.1.0)(supports-color@5.5.0))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@types/node@20.19.43)(jsdom@26.1.0(canvas@3.1.0)(supports-color@10.2.2))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   sandbox/next:
     dependencies:
@@ -475,9 +476,17 @@ packages:
     resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@8.0.0':
     resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/core@8.0.1':
     resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
@@ -501,6 +510,10 @@ packages:
 
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@8.0.0':
@@ -556,12 +569,22 @@ packages:
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@8.0.0':
     resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': '>=8.0.1'
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': '>=8.0.1'
@@ -636,6 +659,10 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@8.0.0':
     resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -643,6 +670,10 @@ packages:
   '@babel/helper-wrap-function@8.0.0':
     resolution: {integrity: sha512-Qpm8+wi5xfDkBfollanwriCcKniFfBmMmaKB01GVM6VGzKXo1fdxosZp04qEr5HM+LKhwr3hG1yRy8+ORsficA==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helpers@8.0.0':
     resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
@@ -1808,6 +1839,9 @@ packages:
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -6246,7 +6280,49 @@ snapshots:
 
   '@babel/compat-data@7.28.6': {}
 
+  '@babel/compat-data@7.29.7': {}
+
   '@babel/compat-data@8.0.0': {}
+
+  '@babel/core@7.29.7(supports-color@10.2.2)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/core@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@5.5.0))(supports-color@5.5.0)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@8.0.1':
     dependencies:
@@ -6296,6 +6372,14 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.6
       '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.6
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       browserslist: 4.28.6
       lru-cache: 5.1.1
       semver: 6.3.1
@@ -6407,6 +6491,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
+    dependencies:
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@8.0.0':
     dependencies:
       '@babel/traverse': 8.0.4
@@ -6425,6 +6523,24 @@ snapshots:
     dependencies:
       '@babel/core': 8.0.1
       '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@5.5.0))(supports-color@5.5.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@5.5.0)
     transitivePeerDependencies:
@@ -6512,6 +6628,8 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
+  '@babel/helper-validator-option@7.29.7': {}
+
   '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helper-wrap-function@8.0.0':
@@ -6519,6 +6637,11 @@ snapshots:
       '@babel/template': 8.0.0
       '@babel/traverse': 8.0.4
       '@babel/types': 8.0.4
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/helpers@8.0.0':
     dependencies:
@@ -7517,25 +7640,12 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))':
-    dependencies:
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.2(supports-color@10.2.2)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 3.1.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/config-array@0.21.2(supports-color@5.5.0)':
-    dependencies:
-      '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -7552,20 +7662,6 @@ snapshots:
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@10.2.2)
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 5.2.3
-      minimatch: 3.1.5
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eslint/eslintrc@3.3.6(supports-color@5.5.0)':
-    dependencies:
-      ajv: 6.15.0
-      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -7764,6 +7860,11 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -8129,11 +8230,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))':
+  '@storybook/addon-a11y@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.12.1
-      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@storybook/addon-docs@9.1.20(@types/react@18.3.31)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))':
     dependencies:
@@ -8175,34 +8276,14 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
-  '@storybook/cli@9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@storybook/cli@9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
-      '@storybook/codemod': 9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@types/semver': 7.5.0
-      commander: 12.1.0
-      create-storybook: 9.1.20
-      giget: 1.1.2(supports-color@5.5.0)
-      jscodeshift: 0.15.1(@babel/preset-env@8.0.2(@babel/core@8.0.1))(supports-color@5.5.0)
-      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - '@testing-library/dom'
-      - bufferutil
-      - msw
-      - prettier
-      - supports-color
-      - utf-8-validate
-      - vite
-
-  '@storybook/cli@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@storybook/codemod': 9.1.20(@testing-library/dom@10.4.0)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@storybook/codemod': 9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@types/semver': 7.5.0
       commander: 12.1.0
       create-storybook: 9.1.20
       giget: 1.1.2(supports-color@10.2.2)
-      jscodeshift: 0.15.1(supports-color@10.2.2)
+      jscodeshift: 0.15.1(@babel/preset-env@8.0.2(@babel/core@8.0.1))(supports-color@10.2.2)
       storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -8215,15 +8296,35 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@storybook/codemod@9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@storybook/cli@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@storybook/codemod': 9.1.20(@testing-library/dom@10.4.0)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@types/semver': 7.5.0
+      commander: 12.1.0
+      create-storybook: 9.1.20
+      giget: 1.1.2(supports-color@5.5.0)
+      jscodeshift: 0.15.1(supports-color@5.5.0)
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - '@testing-library/dom'
+      - bufferutil
+      - msw
+      - prettier
+      - supports-color
+      - utf-8-validate
+      - vite
+
+  '@storybook/codemod@9.1.20(@babel/preset-env@8.0.2(@babel/core@8.0.1))(@testing-library/dom@10.4.0)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.6
       es-toolkit: 1.49.0
       globby: 14.1.0
-      jscodeshift: 0.15.1(@babel/preset-env@8.0.2(@babel/core@8.0.1))(supports-color@5.5.0)
+      jscodeshift: 0.15.1(@babel/preset-env@8.0.2(@babel/core@8.0.1))(supports-color@10.2.2)
       prettier: 3.9.6
-      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -8234,15 +8335,15 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@storybook/codemod@9.1.20(@testing-library/dom@10.4.0)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@storybook/codemod@9.1.20(@testing-library/dom@10.4.0)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.6
       es-toolkit: 1.49.0
       globby: 14.1.0
-      jscodeshift: 0.15.1(supports-color@10.2.2)
+      jscodeshift: 0.15.1(supports-color@5.5.0)
       prettier: 3.9.6
-      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -8596,22 +8697,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
-      ignore: 7.0.6
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
@@ -8624,32 +8709,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/project-service@8.64.0(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3(supports-color@10.2.2)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/project-service@8.64.0(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.64.0
-      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8693,18 +8757,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/types@8.64.0': {}
 
   '@typescript-eslint/types@8.67.0': {}
@@ -8716,21 +8768,6 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 10.2.5
-      semver: 7.8.5
-      tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.64.0(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.64.0(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/visitor-keys': 8.64.0
-      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -8761,17 +8798,6 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/typescript-estree': 8.64.0(supports-color@10.2.2)(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))
-      '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@5.5.0)(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9817,20 +9843,20 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
       json5: 2.2.3
 
+  eslint-plugin-storybook@9.1.20(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-plugin-storybook@9.1.20(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.9.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@10.2.2)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
       storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@22.9.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-storybook@9.1.20(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)))(supports-color@5.5.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
-      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9864,47 +9890,6 @@ snapshots:
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@10.2.2)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.7.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.6(supports-color@5.5.0)
-      '@eslint/js': 9.39.5
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -10062,9 +10047,9 @@ snapshots:
 
   flow-parser@0.154.0: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@5.5.0)):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
     optionalDependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.2.2)
 
   for-each@0.3.5:
     dependencies:
@@ -10362,22 +10347,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.4.3(supports-color@5.5.0)):
+  http-proxy@1.18.1(debug@4.4.3(supports-color@10.2.2)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@5.5.0))
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
 
-  http-server@14.1.1(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0):
+  http-server@14.1.1(debug@4.4.3(supports-color@10.2.2))(supports-color@5.5.0):
     dependencies:
       basic-auth: 2.0.1
       chalk: 4.1.2
       corser: 2.0.1
       he: 1.2.0
       html-encoding-sniffer: 3.0.0
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@5.5.0))
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
@@ -10696,17 +10681,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@0.15.1(@babel/preset-env@8.0.2(@babel/core@8.0.1))(supports-color@5.5.0):
+  jscodeshift@0.15.1(@babel/preset-env@8.0.2(@babel/core@8.0.1))(supports-color@10.2.2):
     dependencies:
       '@babel/core': 8.0.1
       '@babel/parser': 7.29.7
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@8.0.1)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
       '@babel/preset-flow': 7.23.3(@babel/core@8.0.1)
-      '@babel/preset-typescript': 7.27.1(@babel/core@8.0.1)(supports-color@5.5.0)
+      '@babel/preset-typescript': 7.27.1(@babel/core@8.0.1)(supports-color@10.2.2)
       '@babel/register': 7.22.15(@babel/core@8.0.1)
       babel-core: 7.0.0-bridge.0(@babel/core@8.0.1)
       chalk: 4.1.2
@@ -10723,17 +10708,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jscodeshift@0.15.1(supports-color@10.2.2):
+  jscodeshift@0.15.1(supports-color@5.5.0):
     dependencies:
       '@babel/core': 8.0.1
       '@babel/parser': 7.29.7
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@8.0.1)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@8.0.1)(supports-color@10.2.2)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@8.0.1)(supports-color@5.5.0)
       '@babel/preset-flow': 7.23.3(@babel/core@8.0.1)
-      '@babel/preset-typescript': 7.27.1(@babel/core@8.0.1)(supports-color@10.2.2)
+      '@babel/preset-typescript': 7.27.1(@babel/core@8.0.1)(supports-color@5.5.0)
       '@babel/register': 7.22.15(@babel/core@8.0.1)
       babel-core: 7.0.0-bridge.0(@babel/core@8.0.1)
       chalk: 4.1.2
@@ -11561,7 +11546,7 @@ snapshots:
 
   react-docgen@8.0.0(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 8.0.1
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
@@ -11576,7 +11561,7 @@ snapshots:
 
   react-docgen@8.0.0(supports-color@5.5.0):
     dependencies:
-      '@babel/core': 8.0.1
+      '@babel/core': 7.29.7(supports-color@5.5.0)
       '@babel/traverse': 7.29.7(supports-color@5.5.0)
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
@@ -12015,9 +12000,9 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-pseudo-states@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))):
+  storybook-addon-pseudo-states@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))):
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@5.5.0)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.9.6)(supports-color@10.2.2)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
@@ -12551,17 +12536,6 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.64.0(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)(supports-color@10.2.2)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  typescript-eslint@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.64.0(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      eslint: 9.39.5(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,5 +20,7 @@ overrides:
   tar@<=7.5.15: '>=7.5.22'
   js-yaml@>=4.0.0 <=5.2.1: '>=5.2.3'
   '@babel/core@<=7.29.0': '>=8.0.1'
+  # react-docgen が Babel 8 に未対応のため、Babel 7 を使用する（reactjs/react-docgen#1102）
+  'react-docgen@8.0.0>@babel/core': '^7.28.0'
   sharp@<0.35.0: '>=0.35.3'
   nanoid@<3.3.18: '>=3.3.18 <7'


### PR DESCRIPTION
## Summary
- `react-docgen@8.0.0` に限定して `@babel/core` 7系を解決するoverrideを追加
- Babel 8との既知の非互換性（reactjs/react-docgen#1102）を回避
- その他の依存では既存のBabel 8 overrideを維持

## Test plan
- [x] `pnpm install`
- [x] `p ui dev`
- [x] Storybookが http://localhost:6006/ で応答することを確認

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Babel 7（^7.28.0）を使用するよう依存関係を調整し、互換性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->