### PR TITLE
feat(charts): 棒グラフに同系色の濃淡で配色するオプションを追加

### DIFF
--- a/packages/charts/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.stories.tsx
@@ -47,6 +47,9 @@ export const Playground: Story = {
     disablePatterns: {
       control: 'boolean',
     },
+    singleTone: {
+      control: 'object',
+    },
   },
 }
 
@@ -67,6 +70,35 @@ export const WithoutPattern: Story = {
   args: {
     data: multiSmall,
     disablePatterns: true,
+  },
+}
+
+export const SingleTone: Story = {
+  name: 'singleTone',
+  args: {
+    data: multiSmall,
+    disablePatterns: true,
+    singleTone: { from: 0, to: 5 },
+  },
+}
+
+// 範囲を狭めると濃淡差が小さくなり、系列が多くても色が重複しやすくなる
+export const ToneRange: Story = {
+  name: 'singleTone（範囲を狭める）',
+  args: {
+    data: multiSmall,
+    disablePatterns: true,
+    singleTone: { from: 0, to: 2 },
+  },
+}
+
+// from を to より大きくすると、第一系列がいちばん濃くなる
+export const DescendingTone: Story = {
+  name: 'singleTone（from > to）',
+  args: {
+    data: multiSmall,
+    disablePatterns: true,
+    singleTone: { from: 5, to: 0 },
   },
 }
 

--- a/packages/charts/src/components/BarChart/BarChart.test.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.test.tsx
@@ -1,0 +1,74 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SINGLE_CHART_COLORS } from '../../helper'
+
+import { BarChart } from './BarChart'
+
+import type { ChartData, ChartDataset } from 'chart.js'
+
+// jsdomにCanvasがないため、柄の生成をモックする
+vi.mock('@smarthr/patternomaly', () => ({
+  draw: vi.fn(() => ({ type: 'pattern' }) as unknown as CanvasPattern),
+}))
+
+let renderedData: ChartData<'bar'> | undefined
+
+vi.mock('react-chartjs-2', () => ({
+  Bar: (props: { data: ChartData<'bar'> }) => {
+    renderedData = props.data
+    return null
+  },
+}))
+
+const defaultProps = {
+  data: {
+    labels: ['レベル1'],
+    datasets: [
+      { label: '1年前', data: [1] },
+      { label: '現在', data: [3] },
+    ],
+  },
+  disablePatterns: true,
+  singleTone: { from: 0, to: 5 },
+} satisfies React.ComponentProps<typeof BarChart>
+
+const render = (props: Partial<React.ComponentProps<typeof BarChart>> = {}) => {
+  renderedData = undefined
+  renderToStaticMarkup(<BarChart {...defaultProps} {...props} />)
+
+  return renderedData!.datasets as Array<ChartDataset<'bar'> & { borderColor: string }>
+}
+
+describe('BarChart', () => {
+  it('datasetsの順にそのまま描画する', () => {
+    const datasets = render()
+    expect(datasets.map((dataset) => dataset.label)).toStrictEqual(['1年前', '現在'])
+  })
+
+  it('指定した範囲の両端を第一系列と最終系列に割り当てる', () => {
+    const datasets = render()
+    expect(datasets.map((dataset) => [dataset.label, dataset.borderColor])).toStrictEqual([
+      ['1年前', SINGLE_CHART_COLORS[0]],
+      ['現在', SINGLE_CHART_COLORS[5]],
+    ])
+  })
+
+  it('singleToneに範囲を渡すと濃淡を狭められる', () => {
+    const datasets = render({ singleTone: { from: 0, to: 2 } })
+    expect(datasets.map((dataset) => [dataset.label, dataset.borderColor])).toStrictEqual([
+      ['1年前', SINGLE_CHART_COLORS[0]],
+      ['現在', SINGLE_CHART_COLORS[2]],
+    ])
+  })
+
+  it('系列が1つのときも濃い側の端の色になり、比較時と変わらない', () => {
+    const datasets = render({
+      data: { labels: ['レベル1'], datasets: [{ label: '現在', data: [3] }] },
+      singleTone: { from: 0, to: 5 },
+    })
+    expect(datasets.map((dataset) => [dataset.label, dataset.borderColor])).toStrictEqual([
+      ['現在', SINGLE_CHART_COLORS[5]],
+    ])
+  })
+})

--- a/packages/charts/src/components/BarChart/BarChart.tsx
+++ b/packages/charts/src/components/BarChart/BarChart.tsx
@@ -7,10 +7,37 @@ import { VisuallyHiddenText } from 'smarthr-ui'
 import { createBarChartOptions, registerChartComponents } from '../../config'
 import { getChartColors } from '../../helper'
 
+import type { SingleToneLevel } from '../../helper'
 import type { Chart, ChartData, ChartOptions } from 'chart.js'
 
 // Chart.jsのコンポーネントをモジュールレベルで登録
 registerChartComponents()
+
+/** 棒グラフ固有の配色オプション。Chart から type="bar" のときだけ生やすために切り出している */
+export type BarChartColorProps = {
+  /**
+   * 棒グラフの柄を無効化するか
+   */
+  disablePatterns?: boolean
+  /**
+   * 指定すると、系列の色をカテゴリ配色ではなく同系色の濃淡
+   * （SINGLE_CHART_COLORS）にする。値は濃淡の範囲
+   */
+  singleTone?: SingleToneRange
+}
+
+/**
+ * 濃淡の範囲。第一系列を from、最終系列を to の濃さにして、間を均等に配分する。
+ * from > to にすれば第一系列を濃くでき、範囲を狭めれば濃淡差を抑えられる。
+ * 範囲の段数より系列が多いと色が重複するので、そのときは柄で見分ける。
+ * 系列が1つのときは from と to の濃い側を使う。系列数が変わっても強調される系列の
+ * 色が変わらないようにするためで、1系列のときの色を確定させたい場合は
+ * from と to を同じ値にする
+ */
+export type SingleToneRange = {
+  from: SingleToneLevel
+  to: SingleToneLevel
+}
 
 type Props = {
   // 色などはpropsで渡せないようにする
@@ -18,23 +45,28 @@ type Props = {
   data: ChartData<'bar'>
   title?: string
   options?: Partial<ChartOptions<'bar'>>
-  /**
-   * 棒グラフの柄を無効化するか
-   */
-  disablePatterns?: boolean
-}
+} & BarChartColorProps
 
 export const BarChart: React.FC<Props> = ({
   data,
   title,
   options: externalOptions,
   disablePatterns,
+  singleTone,
 }) => {
   const chartId = useId()
   const chartRef = useRef<Chart<'bar'>>(null)
+  // 依存配列をプリミティブに保つため、オブジェクトのまま useMemo に渡さない。
+  // 呼び出し側が singleTone={{ … }} と書くと毎回別参照になり、柄の再生成が走ってしまう
   const chartColors = useMemo(
-    () => getChartColors(data.datasets.length, disablePatterns),
-    [data.datasets.length, disablePatterns],
+    () =>
+      getChartColors(data.datasets.length, {
+        disablePatterns,
+        singleTone: Boolean(singleTone),
+        toneFrom: singleTone?.from,
+        toneTo: singleTone?.to,
+      }),
+    [data.datasets.length, disablePatterns, singleTone?.from, singleTone?.to],
   )
 
   const ariaLabel = useMemo(() => {

--- a/packages/charts/src/components/BarChart/index.ts
+++ b/packages/charts/src/components/BarChart/index.ts
@@ -1,1 +1,2 @@
 export { BarChart } from './BarChart'
+export type { BarChartColorProps, SingleToneRange } from './BarChart'

--- a/packages/charts/src/components/Chart/Chart.stories.tsx
+++ b/packages/charts/src/components/Chart/Chart.stories.tsx
@@ -85,6 +85,16 @@ export const DisablePatterns: Story = {
   },
 }
 
+export const ToneRange: Story = {
+  name: 'singleTone（範囲を指定）',
+  args: {
+    type: 'bar',
+    data: multiSmall,
+    disablePatterns: true,
+    singleTone: { from: 0, to: 2 },
+  },
+}
+
 export const WithChartJsOptions: Story = {
   name: 'with Chart.js options',
   args: {

--- a/packages/charts/src/components/Chart/Chart.tsx
+++ b/packages/charts/src/components/Chart/Chart.tsx
@@ -8,6 +8,7 @@ import { BarChart } from '../BarChart'
 import { LineChart } from '../LineChart'
 import { RadarChart } from '../RadarChart'
 
+import type { BarChartColorProps } from '../BarChart'
 import type { ChartData, ChartOptions } from 'chart.js'
 
 registerChartComponents()
@@ -21,11 +22,7 @@ type Props = {
     title?: string
     className?: string
     options?: Partial<ChartOptions<K>>
-    /**
-     * 棒グラフの柄を無効化するか（type="bar" のときのみ有効）
-     */
-    disablePatterns?: boolean
-  }
+  } & (K extends 'bar' ? BarChartColorProps : object)
 }[ChartType]
 
 const classNameGenerator = tv({
@@ -48,6 +45,7 @@ const InnerChart: React.FC<Props> = (props) => {
         <BarChart
           data={props.data}
           disablePatterns={props.disablePatterns}
+          singleTone={props.singleTone}
           title={props.title}
           options={props.options}
         />

--- a/packages/charts/src/components/DoughnutChart/DoughnutChart.tsx
+++ b/packages/charts/src/components/DoughnutChart/DoughnutChart.tsx
@@ -47,7 +47,7 @@ export const DoughnutChart: React.FC<Props> = ({
   const chartRef = useRef<Chart<'doughnut'>>(null)
   const segmentCount = data.labels?.length ?? data.datasets[0]?.data.length ?? 0
   const chartColors = useMemo(
-    () => getChartColors<'doughnut'>(segmentCount, disablePatterns),
+    () => getChartColors<'doughnut'>(segmentCount, { disablePatterns }),
     [segmentCount, disablePatterns],
   )
   const { chartArea, chartAreaPlugin } = useChartAreaTracker()

--- a/packages/charts/src/helper/data.test.ts
+++ b/packages/charts/src/helper/data.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { OTHER_CHART_COLOR, SINGLE_CHART_COLORS } from './constants'
-import { getProgressDoughnutColors } from './data'
+import { CHART_COLORS, OTHER_CHART_COLOR, SINGLE_CHART_COLORS } from './constants'
+import { getChartColors, getProgressDoughnutColors } from './data'
 
 // Mock patternomaly's draw function since jsdom doesn't support Canvas
 vi.mock('@smarthr/patternomaly', () => ({
@@ -37,5 +37,92 @@ describe('getProgressDoughnutColors', () => {
   it('最濃色のときhover色は同色になる', () => {
     const last = SINGLE_CHART_COLORS.length - 1
     expect(getProgressDoughnutColors(last).progressHover).toBe(SINGLE_CHART_COLORS[last])
+  })
+})
+
+describe('getChartColors', () => {
+  it('系列のindex順に色を割り当てる', () => {
+    const result = getChartColors(3, { disablePatterns: true })
+    expect(result.map((color) => color.borderColor)).toStrictEqual([
+      CHART_COLORS[0],
+      CHART_COLORS[1],
+      CHART_COLORS[2],
+    ])
+  })
+
+  it('singleToneのときは既定でパレットの全段を使う', () => {
+    const result = getChartColors(2, { disablePatterns: true, singleTone: true })
+    expect(result.map((color) => color.borderColor)).toStrictEqual([
+      SINGLE_CHART_COLORS[0],
+      SINGLE_CHART_COLORS[SINGLE_CHART_COLORS.length - 1],
+    ])
+  })
+
+  it('toneFromからtoneToの範囲に濃淡を均等配分する', () => {
+    const result = getChartColors(3, {
+      disablePatterns: true,
+      singleTone: true,
+      toneFrom: 0,
+      toneTo: 4,
+    })
+    expect(result.map((color) => color.borderColor)).toStrictEqual([
+      SINGLE_CHART_COLORS[0],
+      SINGLE_CHART_COLORS[2],
+      SINGLE_CHART_COLORS[4],
+    ])
+  })
+
+  it('範囲を狭めれば濃淡差を抑えられる', () => {
+    const result = getChartColors(3, {
+      disablePatterns: true,
+      singleTone: true,
+      toneFrom: 0,
+      toneTo: 2,
+    })
+    expect(result.map((color) => color.borderColor)).toStrictEqual([
+      SINGLE_CHART_COLORS[0],
+      SINGLE_CHART_COLORS[1],
+      SINGLE_CHART_COLORS[2],
+    ])
+  })
+
+  it('toneFromがtoneToより大きいときは第一系列が最も濃くなる', () => {
+    const result = getChartColors(3, {
+      disablePatterns: true,
+      singleTone: true,
+      toneFrom: 5,
+      toneTo: 0,
+    })
+    expect(result.map((color) => color.borderColor)).toStrictEqual([
+      SINGLE_CHART_COLORS[5],
+      SINGLE_CHART_COLORS[3],
+      SINGLE_CHART_COLORS[0],
+    ])
+  })
+
+  it('系列が1つのときは濃い側の端を使い、系列数によらず色が変わらない', () => {
+    const options = { disablePatterns: true, singleTone: true, toneFrom: 0, toneTo: 5 } as const
+    expect(getChartColors(1, options)[0].borderColor).toBe(SINGLE_CHART_COLORS[5])
+    // 向きが逆でも「濃い側の端」は変わらない
+    expect(getChartColors(1, { ...options, toneFrom: 5, toneTo: 0 })[0].borderColor).toBe(
+      SINGLE_CHART_COLORS[5],
+    )
+  })
+
+  it('singleToneでないときはtoneFrom / toneToを無視する', () => {
+    const result = getChartColors(2, { disablePatterns: true, toneFrom: 5, toneTo: 0 })
+    expect(result.map((color) => color.borderColor)).toStrictEqual([
+      CHART_COLORS[0],
+      CHART_COLORS[1],
+    ])
+  })
+
+  it('柄は第一系列以外に付く', () => {
+    const result = getChartColors(2, { singleTone: true })
+    expect(result[0].backgroundColor).toBe(SINGLE_CHART_COLORS[0])
+    expect(result[1].backgroundColor).toMatchObject({
+      type: 'pattern',
+      backgroundColor: SINGLE_CHART_COLORS[SINGLE_CHART_COLORS.length - 1],
+    })
   })
 })

--- a/packages/charts/src/helper/data.ts
+++ b/packages/charts/src/helper/data.ts
@@ -105,10 +105,45 @@ export const getRadarChartColors = (dataLength: number): RadarChartColorConfig[]
   return colors
 }
 
-// TODO: SINGLE_CHART_COLORS を使うオプションを追加する
+/** 濃淡の段階。SINGLE_CHART_COLORS の index に対応し、0が最も淡く5が最も濃い */
+export type SingleToneLevel = 0 | 1 | 2 | 3 | 4 | 5
+
+/**
+ * 同系色の濃淡を toneFrom から toneTo の範囲に均等配分する。
+ * position は第一系列を0とした系列の位置。toneFrom > toneTo なら濃い側から始まる。
+ * 範囲の段数より系列が多いと色は重複するので、その場合は柄で見分ける
+ */
+const getSingleToneColor = (
+  position: number,
+  dataLength: number,
+  toneFrom: SingleToneLevel,
+  toneTo: SingleToneLevel,
+) => {
+  // 系列が1つだと第一系列と最終系列が同じになり式では決まらないため、濃い側を選ぶ。
+  // こうすると系列数が変わっても強調する系列の色が変わらない
+  if (dataLength === 1) {
+    return SINGLE_CHART_COLORS[Math.max(toneFrom, toneTo)]
+  }
+
+  // 第一系列を0、最終系列を1とした進み具合
+  const ratio = position / (dataLength - 1)
+  // 濃淡の幅。符号が向きを表す
+  const toneRange = toneTo - toneFrom
+  const toneIndex = Math.round(toneFrom + toneRange * ratio)
+
+  return SINGLE_CHART_COLORS[toneIndex]
+}
+
+type ChartColorOptions = {
+  disablePatterns?: boolean
+  singleTone?: boolean
+  toneFrom?: SingleToneLevel
+  toneTo?: SingleToneLevel
+}
+
 export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
   dataLength: number,
-  disablePatterns = false,
+  { disablePatterns = false, singleTone = false, toneFrom = 0, toneTo = 5 }: ChartColorOptions = {},
 ): Array<
   Pick<ChartDataset<T>, 'backgroundColor' | 'borderColor' | 'hoverBorderColor' | 'hoverBorderWidth'>
 > => {
@@ -120,7 +155,7 @@ export const getChartColors = <T extends Exclude<ChartType, 'line'> = 'bar'>(
   > = []
 
   for (let i = 0; i < dataLength; i++) {
-    const color = getColor(i)
+    const color = singleTone ? getSingleToneColor(i, dataLength, toneFrom, toneTo) : getColor(i)
     colors.push({
       backgroundColor:
         !disablePatterns && i > 0

--- a/packages/charts/src/helper/index.ts
+++ b/packages/charts/src/helper/index.ts
@@ -1,3 +1,4 @@
+export type { SingleToneLevel } from './data'
 export {
   getChartColors,
   getLineChartColors,


### PR DESCRIPTION
## 関連URL

なし

## 概要

katanaの「現在 / 1年前」のように順序のある系列を比較する棒グラフで、系列をカテゴリ配色ではなく**同系色の濃淡**で表せるようにします。

## 変更内容

### `singleTone` props の追加（`type="bar"` のみ）

```tsx
<Chart type="bar" data={data} singleTone={{ from: 0, to: 5 }} />
```

`from` を第一系列、`to` を最終系列の濃さ（`SINGLE_CHART_COLORS` の index）として、間を均等に配分します。

| 系列数 | 割り当てられる index |
|---|---|
| 1 | `[5]` |
| 2 | `[0, 5]` |
| 3 | `[0, 3, 5]` |
| 4 | `[0, 2, 3, 5]` |

**両端を固定しているのがポイントです。** 単純に `0, 1, 2…` と連番にすると最終系列の色が系列数によって変わり、「現在のみ表示」と「過去と比較」を切り替えたときに、同じ「現在」の棒の色が変わってしまいます。両端を固定すれば系列数によらず同じ色になります。

また `SINGLE_CHART_COLORS` は隣接する段の差が小さいため、連番だと3系列以上で濃淡がほとんど見分けられませんでした。

`from > to` にすれば第一系列を最も濃くできます。系列が1つのときは `from` と `to` の濃い側を使います（強調される系列の色を系列数によらず一定にするため）。

### `type="bar"` 専用 props を型で限定

`disablePatterns` と `singleTone` を `BarChartColorProps` にまとめ、`type="bar"` のときだけ生えるようにしました。

```ts
type Props = {
  [K in ChartType]: {
    type: K
    // ...
  } & (K extends 'bar' ? BarChartColorProps : object)
}[ChartType]
```

### `getChartColors` の引数をオプションオブジェクトに変更

真偽値の位置引数が増えて呼び出し側で意味が読めなくなるため、オブジェクトに変更しました。`src/index.ts` から export していない内部ヘルパーです。

```diff
- getChartColors(dataLength, disablePatterns)
+ getChartColors(dataLength, { disablePatterns, singleTone, toneFrom, toneTo })
```

### テストの追加

`BarChart` に、実際に Chart.js へ渡るデータを検証するテストを追加しました（`react-chartjs-2` をモックして `data` を取り出す方式）。

## プロダクト側で対応が必要な事項

`disablePatterns` が `type="bar"` 以外では**型エラーになります**。これまでは `type="line"` などにも渡せて無視されていましたが、bar 専用であることを型で表現したためです。渡していた箇所があれば削除してください（挙動は変わりません）。

それ以外は追加のみで、破壊的変更はありません。

## 確認方法

Storybook の以下のストーリーで確認できます。

- `Charts/BarChart` → `singleTone` / `singleTone（範囲を狭める）` / `singleTone（from > to）`
- `Charts/Chart` → `singleTone（範囲を指定）`

色の決まり方はテストが仕様になっています。

```
✓ toneFromからtoneToの範囲に濃淡を均等配分する
✓ 系列が1つのときは濃い側の端を使い、系列数によらず色が変わらない
✓ 範囲を狭めれば濃淡差を抑えられる
✓ toneFromがtoneToより大きいときは第一系列が最も濃くなる
✓ singleToneでないときはtoneFrom / toneToを無視する
✓ 柄は第一系列以外に付く
```

## 補足

`src/helper/data.ts` の `withAlpha` に eslint エラー（`best-practice-for-no-unnecessary-variable`）、`LineChart.stories.tsx` に prettier の失敗が出ますが、**どちらも本 PR で変更していない行**で、master 時点から存在します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 棒グラフとチャートで、単一トーンの配色を指定できるようになりました。
  - 濃淡の範囲を指定でき、通常・狭い範囲・逆順の設定に対応しました。
  - パターン表示の無効化と、系列数に応じた色分けを利用できます。
- **テスト**
  - 単一系列や複数系列、色の割り当て、各種濃淡範囲の動作確認を追加しました。
- **ドキュメント**
  - Storybookに単一トーン配色の確認用サンプルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->