### PR TITLE
refactor(Scroller): tabIndexの管理をuseStateからcallback ref内の直接DOM操作に変更する

### DIFF
--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -7,7 +7,6 @@ import {
   forwardRef,
   useCallback,
   useMemo,
-  useState,
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
 
@@ -80,8 +79,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
     },
     ref,
   ) => {
-    const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
-
     const actualClassName = useMemo(
       () =>
         classNameGenerator({
@@ -97,24 +94,28 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
         if (!node) return
 
         const autoTabIndex = () => {
-          let nextTabIndex: 0 | undefined = undefined
+          let nextTabIndex: '0' | undefined = undefined
 
           switch (direction) {
             case 'vertical':
-              nextTabIndex = node.scrollHeight > node.clientHeight ? 0 : undefined
+              nextTabIndex = node.scrollHeight > node.clientHeight ? '0' : undefined
               break
             case 'horizontal':
-              nextTabIndex = node.scrollWidth > node.clientWidth ? 0 : undefined
+              nextTabIndex = node.scrollWidth > node.clientWidth ? '0' : undefined
               break
             case 'both':
               nextTabIndex =
                 node.scrollHeight > node.clientHeight || node.scrollWidth > node.clientWidth
-                  ? 0
+                  ? '0'
                   : undefined
               break
           }
 
-          setTabIndex(nextTabIndex)
+          if (nextTabIndex === undefined) {
+            node.removeAttribute('tabIndex')
+          } else {
+            node.setAttribute('tabIndex', nextTabIndex)
+          }
         }
 
         autoTabIndex()
@@ -125,6 +126,7 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
         // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
         // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
         return () => {
+          node.removeAttribute('tabIndex')
           resizeObserver.disconnect()
         }
       },
@@ -137,7 +139,7 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
 
     const Wrapper = useSectionWrapper(Component)
     const body = (
-      <Component {...rest} ref={mergedRef} tabIndex={tabIndex} className={actualClassName}>
+      <Component {...rest} ref={mergedRef} className={actualClassName}>
         {children}
       </Component>
     )

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+// HINT: libs/uaはtypeof window !== 'undefined'でガードされているためRSCで例外にはならないが、
+// isIOS・isMobileSafariは実機のUAをブラウザ側で検出する必要がある。Server Componentのままだと
+// navigatorが存在しないサーバ上で1回だけ評価され常にfalseに固定されるため、'use client'が必要
+
 import {
   type ChangeEvent,
   type ComponentPropsWithoutRef,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Scroller` の `tabIndex` 自動制御を `useState` から callback ref 内での直接 DOM 操作に変更しました。

`useState` によるタイミングは、`ResizeObserver` のコールバックやマウント時の callback ref 内で `setTabIndex` を呼ぶ形になっており、commit フェーズ中に追加の再レンダリングを引き起こしていました。`setAttribute` / `removeAttribute` による直接操作に置き換えることで、この再レンダリングをなくします。

なお、この変更は当初 `Scroller` から `'use client'` を削除することを意図していましたが、調査の結果削除できないことが判明しました（詳細は下記）。

## 変更内容

### `Scroller.tsx`

```diff
-    const [tabIndex, setTabIndex] = useState<0 | undefined>(undefined)
-
     ...
-          setTabIndex(nextTabIndex)
+          if (nextTabIndex === undefined) {
+            node.removeAttribute('tabIndex')
+          } else {
+            node.setAttribute('tabIndex', nextTabIndex)
+          }
     ...
         return () => {
+          node.removeAttribute('tabIndex')
           resizeObserver.disconnect()
         }
     ...
-      <Component {...rest} ref={mergedRef} tabIndex={tabIndex} className={actualClassName}>
+      <Component {...rest} ref={mergedRef} className={actualClassName}>
```

`nextTabIndex` の型はリテラル文字列 `'0' | undefined` に変更しています（`setAttribute` の第2引数が文字列を要求するため）。

cleanup にも `removeAttribute('tabIndex')` を追加しました。`autoTabIndex` は再アタッチ時に必ず set/remove のどちらかを行うため厳密には冗長ですが、副作用を明示的に打ち消す防御的な記述として残しています。

### `Select.tsx`

`'use client'` が必要な理由を説明する既存コメントを修正しました。

```diff
-// HINT: isIOS, isMobileSafariなどUAを判定しているため、'use client'が必要
+// HINT: libs/uaはtypeof window !== 'undefined'でガードされているためRSCで例外にはならないが、
+// isIOS・isMobileSafariは実機のUAをブラウザ側で検出する必要がある。Server Componentのままだと
+// navigatorが存在しないサーバ上で1回だけ評価され常にfalseに固定されるため、'use client'が必要
```

`libs/ua.ts` は `typeof window !== 'undefined'` でガードされているため RSC で例外にはなりません。本当の理由は、Server Component のままだと `navigator` が存在しないサーバ上で1回だけ評価され、実機の UA に関わらず常に `false` に固定されてしまう点です。iOS 実機でアクセスしても `required={isIOS ? undefined : required}` の a11y ワークアラウンドが発火しなくなるため、`'use client'` が必要です。

## `'use client'` を削除できなかった理由

`useState` を除去しても、`Scroller` には独立した2つの client 依存が残っています。

**1. `useSectionWrapper`（styled-components v5 依存）**

```tsx
const Wrapper = useSectionWrapper(Component)
```

`useSectionWrapper` は `isStyledComponent` の判定に styled-components を使っており、peer が `^5.0.1` のため v5 が解決されうる状態です。v5 はモジュールスコープで `createContext` を呼びガードが無いため、`react-server` 条件で import すると `TypeError` になります。これは Layout 系（`Center` `Cluster` `Reel` `Sidebar` `Stack` `Panel` `Container`）で既知の制約でしたが、`Scroller` も同じ hook を呼んでおり対象漏れしていました。

**2. `useMergeRefs`（内部で `useRef` を使用）**

```tsx
const mergedRef = useMergeRefs(callbackRef, ref)
```

`useMergeRefs` は `import { useCallback, useRef } from 'react'` としており、`react-server` ビルドは `useRef` を export しません。`'use client'` を外してビルドし、`node --conditions react-server` で実際に評価したところ、この import 文自体で失敗することを確認しました。

```
SyntaxError: Named export 'useRef' not found. The requested module 'react' is a CommonJS module...
```

どちらか一方だけでも `'use client'` を外せないため、本 PR では `'use client'` を維持します。

## プロダクト側で対応が必要な事項

なし。公開インターフェースと描画結果に変更はありません。

## 確認方法

### DOM 等価性

`overflow` の有無・`direction` 変更の3パターンで master と比較し、`tabindex` 属性の有無・値が完全一致することを確認しました。

### 静的チェック

tsc / eslint とも通過しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アクセシビリティ改善**
  * スクロール可能な領域だけがキーボード操作の対象となり、不要な場合はフォーカス対象から自動的に除外されるようになりました。
  * コンポーネントの終了時にも不要なフォーカス属性が残らなくなりました。
* **互換性改善**
  * iOSおよびモバイルSafariでのセレクト操作に関するブラウザ対応を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->