### PR TITLE
refactor(RadioButtonPanel): クリック委譲ロジックをClickablePanelへ切り出しuse clientを削除

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -5,7 +5,6 @@ import {
   type ComponentType,
   type FC,
   type ReactNode,
-  useCallback,
   useId,
   useMemo,
 } from 'react'
@@ -126,28 +125,26 @@ const DescriptionRadioButtonPanel: FC<LowerProps> = ({
   )
 }
 
-const ActualRadioButtonPanel: FC<LowerProps> = ({ as, classNames, children, label, ...rest }) => {
-  // 外側の装飾を押しても内側のラジオボタンが押せるようにする
-  const handleDelegateClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    // RadioButtonの要素（labelまたはinput）以外がクリックされた場合（description や Base の余白）
-    if (!isRadioButtonElementClicked(e.nativeEvent.composedPath(), e.currentTarget)) {
-      // Base要素のclickイベントは止める（実装の詳細を隠蔽し、input要素のclickのみを親に伝える）
-      e.stopPropagation()
-      // 手動でinputをクリック
-      e.currentTarget
-        .querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"][type="radio"]')
-        ?.click()
-    }
-    // RadioButtonの要素（labelまたはinput）がクリックされた場合は何もしない
-    // （ブラウザの標準動作でinputがクリックされ、そのイベントが親に伝わる）
-  }, [])
-
-  return (
-    <Panel as={as} padding={1} className={classNames.base} onClick={handleDelegateClick}>
-      <RadioButton {...rest} className={classNames.radio}>
-        {label}
-      </RadioButton>
-      {children}
-    </Panel>
-  )
+// 外側の装飾を押しても内側のラジオボタンが押せるようにする
+const handleDelegateClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  // RadioButtonの要素（labelまたはinput）以外がクリックされた場合（description や Base の余白）
+  if (!isRadioButtonElementClicked(e.nativeEvent.composedPath(), e.currentTarget)) {
+    // Base要素のclickイベントは止める（実装の詳細を隠蔽し、input要素のclickのみを親に伝える）
+    e.stopPropagation()
+    // 手動でinputをクリック
+    e.currentTarget
+      .querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"][type="radio"]')
+      ?.click()
+  }
+  // RadioButtonの要素（labelまたはinput）がクリックされた場合は何もしない
+  // （ブラウザの標準動作でinputがクリックされ、そのイベントが親に伝わる）
 }
+
+const ActualRadioButtonPanel: FC<LowerProps> = ({ as, classNames, children, label, ...rest }) => (
+  <Panel as={as} padding={1} className={classNames.base} onClick={handleDelegateClick}>
+    <RadioButton {...rest} className={classNames.radio}>
+      {label}
+    </RadioButton>
+    {children}
+  </Panel>
+)

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/RadioButtonPanel.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentProps,
   type ComponentType,
@@ -10,8 +8,9 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { Panel } from '../Panel'
 import { RadioButton } from '../RadioButton'
+
+import { ClickablePanel } from './client/components'
 
 type Props = ComponentProps<typeof RadioButton> & {
   as?: string | ComponentType<any>
@@ -44,36 +43,6 @@ const classNameGenerator = tv({
     },
   },
 })
-
-/** RadioButtonのクリック可能な要素（labelまたはinput）を判定するための正規表現 */
-const REGEX_RADIO_CLICKABLE_ELEMENT = /^(label|input)$/
-
-/**
- * イベントパス内にRadioButtonの要素（LABELまたはINPUT）が含まれているか判定
- *
- * NOTE: ReactのSyntheticEventは非同期処理内でnullになる可能性があるため、
- * イベントオブジェクトではなく、事前に取得したpathとcurrentTargetを受け取る
- *
- * @param path イベントのcomposedPath（事前に取得したもの）
- * @param currentTarget イベントのcurrentTarget（事前に取得したもの）
- * @returns RadioButtonの要素がクリックされた場合true
- */
-const isRadioButtonElementClicked = (path: EventTarget[], currentTarget: EventTarget): boolean => {
-  for (const node of path) {
-    // 先にLABELまたはINPUTをチェック（高頻度ケース）
-    if (
-      node instanceof HTMLElement &&
-      REGEX_RADIO_CLICKABLE_ELEMENT.test(node.tagName.toLowerCase())
-    ) {
-      return true
-    } else if (node === currentTarget) {
-      // Base要素に到達したらfalse（低頻度ケース）
-      return false
-    }
-  }
-
-  return false
-}
 
 export const RadioButtonPanel: FC<Props> = ({ children, className, ...rest }) => {
   const hasDescription = !!children
@@ -125,26 +94,11 @@ const DescriptionRadioButtonPanel: FC<LowerProps> = ({
   )
 }
 
-// 外側の装飾を押しても内側のラジオボタンが押せるようにする
-const handleDelegateClick = (e: React.MouseEvent<HTMLDivElement>) => {
-  // RadioButtonの要素（labelまたはinput）以外がクリックされた場合（description や Base の余白）
-  if (!isRadioButtonElementClicked(e.nativeEvent.composedPath(), e.currentTarget)) {
-    // Base要素のclickイベントは止める（実装の詳細を隠蔽し、input要素のclickのみを親に伝える）
-    e.stopPropagation()
-    // 手動でinputをクリック
-    e.currentTarget
-      .querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"][type="radio"]')
-      ?.click()
-  }
-  // RadioButtonの要素（labelまたはinput）がクリックされた場合は何もしない
-  // （ブラウザの標準動作でinputがクリックされ、そのイベントが親に伝わる）
-}
-
 const ActualRadioButtonPanel: FC<LowerProps> = ({ as, classNames, children, label, ...rest }) => (
-  <Panel as={as} padding={1} className={classNames.base} onClick={handleDelegateClick}>
+  <ClickablePanel as={as} className={classNames.base}>
     <RadioButton {...rest} className={classNames.radio}>
       {label}
     </RadioButton>
     {children}
-  </Panel>
+  </ClickablePanel>
 )

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/client/components/ClickablePanel.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/client/components/ClickablePanel.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { Panel } from '../../../Panel'
+
+import type { ComponentType, FC, ReactNode } from 'react'
+
+type Props = {
+  as?: string | ComponentType<any>
+  children: ReactNode
+  className: string
+}
+
+export const ClickablePanel: FC<Props> = ({ as, className, children }) => (
+  <Panel as={as} padding={1} className={className} onClick={handleDelegateClick}>
+    {children}
+  </Panel>
+)
+
+/** RadioButtonのクリック可能な要素（labelまたはinput）を判定するための正規表現 */
+const REGEX_RADIO_CLICKABLE_ELEMENT = /^(label|input)$/
+
+/**
+ * イベントパス内にRadioButtonの要素（LABELまたはINPUT）が含まれているか判定
+ *
+ * NOTE: ReactのSyntheticEventは非同期処理内でnullになる可能性があるため、
+ * イベントオブジェクトではなく、事前に取得したpathとcurrentTargetを受け取る
+ *
+ * @param path イベントのcomposedPath（事前に取得したもの）
+ * @param currentTarget イベントのcurrentTarget（事前に取得したもの）
+ * @returns RadioButtonの要素がクリックされた場合true
+ */
+const isRadioButtonElementClicked = (path: EventTarget[], currentTarget: EventTarget): boolean => {
+  for (const node of path) {
+    // 先にLABELまたはINPUTをチェック（高頻度ケース）
+    if (
+      node instanceof HTMLElement &&
+      REGEX_RADIO_CLICKABLE_ELEMENT.test(node.tagName.toLowerCase())
+    ) {
+      return true
+    } else if (node === currentTarget) {
+      // Base要素に到達したらfalse（低頻度ケース）
+      return false
+    }
+  }
+
+  return false
+}
+
+// 外側の装飾を押しても内側のラジオボタンが押せるようにする
+const handleDelegateClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  // RadioButtonの要素（labelまたはinput）以外がクリックされた場合（description や Base の余白）
+  if (!isRadioButtonElementClicked(e.nativeEvent.composedPath(), e.currentTarget)) {
+    // Base要素のclickイベントは止める（実装の詳細を隠蔽し、input要素のclickのみを親に伝える）
+    e.stopPropagation()
+    // 手動でinputをクリック
+    e.currentTarget
+      .querySelector<HTMLInputElement>('[data-smarthr-ui-input="true"][type="radio"]')
+      ?.click()
+  }
+  // RadioButtonの要素（labelまたはinput）がクリックされた場合は何もしない
+  // （ブラウザの標準動作でinputがクリックされ、そのイベントが親に伝わる）
+}

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/client/components/index.ts
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/client/components/index.ts
@@ -1,0 +1,1 @@
+export { ClickablePanel } from './ClickablePanel'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`'use client'` 削除の取り組みの一環。RadioButtonPanelは、外側の装飾部分をクリックしても内側のラジオボタンが選択されるようにクリック委譲ハンドラを`Panel`にアタッチしていた。このハンドラ自体はサーバ・クライアント双方で評価可能な純粋な処理だが、`Panel`へのアタッチ（イベントハンドラをpropsとして渡す）はサーバ・クライアント境界を越えられない処理のため、コンポーネント全体が`'use client'`を要求していた。

## 変更内容

- クリックハンドラをアタッチする箇所のみ`RadioButtonPanel/client/components/ClickablePanel.tsx`として独立したクライアント境界に切り出した
- `RadioButtonPanel.tsx`本体から`'use client'`を削除。`ClickablePanel`をJSXとしてレンダーする形に変更したことで、境界を跨ぐ関数propsの受け渡しが発生しなくなった
- これにより`RadioButtonPanel`はServer Component・Client Componentの両方から利用できるようになる

### 検証

- `next build`による実Next.js RSC環境での動作確認
  - `RadioButtonPanel`はclient reference symbolを持たず、Server/Clientどちらのグラフからも利用可能な状態になっていることを確認
  - `ClickablePanel`と`RadioButton`のみが独立したクライアント参照として遅延ロードされ、生成HTMLにも意図通りradio要素が出力されることを確認
- description/label/radio本体のいずれをクリックしても`onChange`が1回だけ発火し、二重発火が起きないことをテストで確認（マスターと同一挙動）

## プロダクト側で対応が必要な事項

なし。propsのインタフェースに変更はない

## 確認方法

Storybookで既存のRadioButtonPanelストーリーを操作し、外側クリック・ラジオ直接クリック・labelクリックいずれも正しく選択されることを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ラジオボタンパネルの余白や説明部分をクリックしても、対応するラジオボタンを選択できるようになりました。
  * ラベルやラジオボタン本体をクリックした際は、従来どおり標準の動作が維持されます。
  * パネル全体のクリック操作がより一貫して機能するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->