### PR TITLE
refactor(SectioningContent): isStyledComponentを使わずtargetの有無で判定する

### DIFF
--- a/packages/smarthr-ui/src/components/SectioningContent/client/hooks/index.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/client/hooks/index.ts
@@ -1,1 +1,0 @@
-export { useSectionWrapper } from './useSectioningWrapper'

--- a/packages/smarthr-ui/src/components/SectioningContent/client/hooks/useSectioningWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/client/hooks/useSectioningWrapper.test.tsx
@@ -38,4 +38,43 @@ describe('useSectionWrapper', () => {
       expect(result.current).toBe(null)
     })
   })
+
+  it('StyledComponent を extend した場合も、元の要素で判定されること', () => {
+    // eslint-disable-next-line smarthr/a11y-heading-in-sectioning-content -- 判定対象を作るためのテストコードのため
+    const StyledSection = styled.section``
+    const ExtendedSection = styled(StyledSection)``
+
+    const { result } = renderHook(() => useSectionWrapper(ExtendedSection))
+    expect(result.current).toBe(SectioningFragment)
+
+    const StyledDiv = styled.div``
+    const ExtendedDiv = styled(StyledDiv)``
+
+    const { result: notSectioning } = renderHook(() => useSectionWrapper(ExtendedDiv))
+    expect(notSectioning.current).toBe(null)
+  })
+
+  it('attrs・withConfig を挟んだ StyledComponent でも判定できること', () => {
+    const { result: attrs } = renderHook(() => useSectionWrapper(styled.section.attrs({})``))
+    expect(attrs.current).toBe(SectioningFragment)
+
+    const { result: withConfig } = renderHook(() =>
+      useSectionWrapper(styled.section.withConfig({ displayName: 'Foo' })``),
+    )
+    expect(withConfig.current).toBe(SectioningFragment)
+  })
+
+  it('コンポーネントを styled 化した場合は、要素名ではないため null が返ること', () => {
+    const Component = () => null
+
+    const { result } = renderHook(() => useSectionWrapper(styled(Component)``))
+    expect(result.current).toBe(null)
+  })
+
+  it('StyledComponent ではないコンポーネントの場合、null が返ること', () => {
+    const Component = () => null
+
+    const { result } = renderHook(() => useSectionWrapper(Component))
+    expect(result.current).toBe(null)
+  })
 })

--- a/packages/smarthr-ui/src/components/SectioningContent/client/hooks/useSectioningWrapper.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/client/hooks/useSectioningWrapper.ts
@@ -7,14 +7,21 @@ type AsType = string | ComponentType<any>
 const SECTIONING_CONTENTS_REGEX = /^(article|aside|nav|section)$/
 
 const isSectioningContent = (as: AsType) => {
-  // HINT: styled-componentsは対象の要素をtargetに保持している。
-  // isStyledComponentで判定するとstyled-componentsのimportが必要になり、
-  // v5がreact-server条件でTypeErrorになるためRSCで動作しなくなる。
-  // targetが文字列かどうかだけで判定すればimportが不要になる
-  const target = (as as { target?: unknown }).target
-  const type_ = typeof target === 'string' ? target : as
+  let target: unknown = as
 
-  return typeof type_ === 'string' && SECTIONING_CONTENTS_REGEX.test(type_)
+  if (typeof target !== 'string') {
+    // HINT: styled-componentsは対象の要素をtargetに保持している。
+    // isStyledComponentで判定するとstyled-componentsのimportが必要になり、
+    // v5がreact-server条件でTypeErrorになるためRSCで動作しなくなる。
+    // targetが文字列かどうかだけで判定すればimportが不要になる
+    target = (as as { target?: unknown }).target
+
+    if (typeof target !== 'string') {
+      return false
+    }
+  }
+
+  return SECTIONING_CONTENTS_REGEX.test(target)
 }
 
 /** NOTE: Layout コンポーネントに変更がある場合、必ず [smarthr/a11y-heading-in-sectioning-content](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-heading-in-sectioning-content) を見直すこと

--- a/packages/smarthr-ui/src/components/SectioningContent/client/hooks/useSectioningWrapper.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/client/hooks/useSectioningWrapper.ts
@@ -1,9 +1,4 @@
 import { type ComponentType, useMemo } from 'react'
-// HINT: styled-componentsがRSCに対応するのはv6.3.0以降。peerは^5.0.1のため、
-// モジュールスコープでcreateContextを呼びガードが無いバージョンが解決されうる。
-// react-server条件でimportするとTypeErrorになるため、このモジュールを使うコンポーネントは
-// 'use client'を外せない（Layout配下・Panelが該当）。
-import { isStyledComponent } from 'styled-components'
 
 import { SectioningFragment } from '../components'
 
@@ -12,7 +7,12 @@ type AsType = string | ComponentType<any>
 const SECTIONING_CONTENTS_REGEX = /^(article|aside|nav|section)$/
 
 const isSectioningContent = (as: AsType) => {
-  const type_ = isStyledComponent(as) ? as.target : as
+  // HINT: styled-componentsは対象の要素をtargetに保持している。
+  // isStyledComponentで判定するとstyled-componentsのimportが必要になり、
+  // v5がreact-server条件でTypeErrorになるためRSCで動作しなくなる。
+  // targetが文字列かどうかだけで判定すればimportが不要になる
+  const target = (as as { target?: unknown }).target
+  const type_ = typeof target === 'string' ? target : as
 
   return typeof type_ === 'string' && SECTIONING_CONTENTS_REGEX.test(type_)
 }

--- a/packages/smarthr-ui/src/components/SectioningContent/index.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/index.ts
@@ -1,3 +1,3 @@
 export { Article, Aside, Nav, Section } from './SectioningContent'
 export { LevelContext } from './client/components'
-export { useSectionWrapper } from './client/hooks'
+export { useSectionWrapper } from './useSectioningWrapper'

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.test.tsx
@@ -1,8 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import styled from 'styled-components'
 
-import { SectioningFragment } from '../components'
-
+import { SectioningFragment } from './client/components'
 import { useSectionWrapper } from './useSectioningWrapper'
 
 describe('useSectionWrapper', () => {

--- a/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
+++ b/packages/smarthr-ui/src/components/SectioningContent/useSectioningWrapper.ts
@@ -1,6 +1,6 @@
 import { type ComponentType, useMemo } from 'react'
 
-import { SectioningFragment } from '../components'
+import { SectioningFragment } from './client/components'
 
 type AsType = string | ComponentType<any>
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`'use client'` 削除の取り組みの一環。

`useSectioningWrapper` が styled-components の `isStyledComponent` を import しているため、このモジュールを使うコンポーネント（Layout 配下・`Panel` など）は `'use client'` を外せない状態だった。styled-components v5 はモジュールスコープで `createContext` を呼びガードが無いため、`react-server` 条件で import した時点で `TypeError` になる（peer は `^5.0.1`）。

`isStyledComponent` は `target` を取り出すためだけに使われていたため、`target` が文字列かどうかだけで判定する形に変更し、import 自体を不要にした。

## 変更内容

- `isSectioningContent` から `isStyledComponent` の利用をやめ、`target` が文字列かどうかで判定するようにした
- これにより `useSectioningWrapper.ts` から styled-components の import が消え、ビルド出力にも含まれなくなることを確認済み
- 境界ケース（extend・`attrs`・`withConfig`・コンポーネントの styled 化・StyledComponent 以外）のテストを追加した

### 判定ロジックの変更

```ts
// Before
const type_ = isStyledComponent(as) ? as.target : as

return typeof type_ === 'string' && SECTIONING_CONTENTS_REGEX.test(type_)

// After
let target: unknown = as

if (typeof target !== 'string') {
  target = (as as { target?: unknown }).target

  if (typeof target !== 'string') {
    return false
  }
}

return SECTIONING_CONTENTS_REGEX.test(target)
```

### 検証

- styled-components **v5.3.11 と v6.5.3 の両方**で、以下16ケースの判定結果が変更前と完全に一致することを確認済み
  - 素の文字列（`section` / `article` / `aside` / `nav` / `div`）
  - styled 化した要素（`styled.section` / `styled.div` / `styled.nav`）
  - extend（`styled(styled.section)` / `styled(styled.div)`）
  - `attrs` / `withConfig` を挟んだもの
  - コンポーネントの styled 化（`styled(Component)`）
  - `memo` / `forwardRef` / 素の関数コンポーネント
- 判定が分岐しうるのは「`isStyledComponent` が false かつ `target` が sectioning 名の文字列」というケースのみだが、emotion は `target` 自体を持たない（実測で `undefined`）ため該当しない
- 追加したテストは**変更前の実装でも同じ結果になる**ことを確認しており、等価性の担保として機能する

## プロダクト側で対応が必要な事項

なし。`useSectionWrapper` は内部モジュールであり、判定結果も変わらないため利用者側の対応は不要。

## 確認方法

`useSectioningWrapper.test.tsx` の追加テストケースを参照。`pnpm ui test -- --run src/components/SectioningContent` で実行できる。

なお、このPR単体で Layout 配下・`Panel` から `'use client'` が外せるようになるわけではない。`useSectioningWrapper.ts` は `SectioningContent.tsx`（`'use client'` あり）から `SectioningFragment` を import しているため、実際に外せるかは別途実 Next.js ビルドでの検証が必要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * セクショニングコンテンツの判定処理を改善しました。
  * スタイル付きコンポーネントや属性・設定を組み合わせたコンポーネントでも、適切にラッパーが適用されるようになりました。
  * 通常のコンポーネントが誤ってセクショニングコンテンツとして判定されるケースを防止しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->