### PR TITLE
chore: sizeストーリーに存在しないバリアント値が指定されていたのを修正

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/stories/InputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/stories/InputFile.stories.tsx
@@ -34,8 +34,8 @@ export const Size: StoryObj<typeof InputFile> = {
   name: 'size',
   render: (args) => (
     <Stack>
-      {[undefined, 'default', 's'].map((size) => (
-        <InputFile {...args} key={size} size={size as any} />
+      {([undefined, 'M', 'S'] as const).map((size) => (
+        <InputFile {...args} key={String(size)} size={size} />
       ))}
     </Stack>
   ),

--- a/packages/smarthr-ui/src/components/Select/stories/Select.stories.tsx
+++ b/packages/smarthr-ui/src/components/Select/stories/Select.stories.tsx
@@ -72,8 +72,8 @@ export const Size: StoryObj<typeof Select> = {
   name: 'size',
   render: (args) => (
     <Stack align="flex-start">
-      {[undefined, 'default', 's'].map((size) => (
-        <Select {...args} key={size} size={size as any} />
+      {([undefined, 'M', 'S'] as const).map((size) => (
+        <Select {...args} key={String(size)} size={size} />
       ))}
     </Stack>
   ),

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
@@ -4,7 +4,7 @@ import { FaGearIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { StatusLabel } from '../../StatusLabel'
 import { SideNav } from '../SideNav'
-import { SideNavItemAnchor, SideNavItemButton, type SideNavSizeType } from '../SideNavItemButton'
+import { SideNavItemAnchor, SideNavItemButton } from '../SideNavItemButton'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 
@@ -70,8 +70,8 @@ export const Size: StoryObj<typeof SideNav> = {
   name: 'size',
   render: (args) => (
     <Stack>
-      {[undefined, 'default', 's'].map((size, i) => (
-        <SideNav {...args} key={i} size={size as SideNavSizeType}>
+      {([undefined, 'M', 'S'] as const).map((size, i) => (
+        <SideNav {...args} key={i} size={size}>
           {_sideNavItems.map((item) => (
             <SideNavItemButton
               key={item.id + i}


### PR DESCRIPTION
## 関連URL

- 原因となった PR: https://github.com/kufu/smarthr-ui/pull/6239
- 同種の取りこぼしを Chip について修正した PR: https://github.com/kufu/smarthr-ui/pull/6360

## 概要

InputFile・Select・SideNav の size ストーリーが、存在しないバリアント値 `'default'` / `'s'` を指定していたため、Storybook 上で2番目・3番目の表示が崩れていました。

tailwind-variants は未定義のバリアント値を渡されると、該当スロットのクラスを一切付けず、`defaultVariants` へのフォールバックも行いません（`size` が `undefined` のときだけ `defaultVariants` が効きます）。そのため `padding` と `font-size` が抜け落ちます。実際の `tv()` の出力は以下の通りです。

```
undefined => shr-border-shorthand shr-inline-flex shr-px-1 shr-py-0.75 shr-text-base
"default"  => shr-border-shorthand shr-inline-flex                      ← padding / font-size が付かない
"s"        => shr-border-shorthand shr-inline-flex                      ← 同上
"M"        => shr-border-shorthand shr-inline-flex shr-px-1 shr-py-0.75 shr-text-base
"S"        => shr-border-shorthand shr-inline-flex shr-p-0.5 shr-text-sm
```

#6239 でコンポーネントサイズ指定を大文字に統一した際、VRT ストーリー（`VRTInputFile` / `VRTSelect` / `VRTSideNav`）は更新されましたが、通常のストーリー3ファイルが取り残されていたことが原因です。通常のストーリーは `chromatic: { disableSnapshot: true }` を指定しているため、Chromatic でも検出されませんでした。


<img width="2324" height="534" alt="compare-InputFile" src="https://github.com/user-attachments/assets/9b7bb75f-42d4-444d-a607-4a66a83cdb06" />

<img width="2324" height="554" alt="compare-Select" src="https://github.com/user-attachments/assets/54cc114e-5b9c-4bc6-ac97-a1e43670b33c" />


<img width="2324" height="1360" alt="compare-SideNav" src="https://github.com/user-attachments/assets/c5d22b97-b51d-4550-83c0-9dc1bf445fff" />


## 変更内容



- `size` の指定を `'default'` / `'s'` → `'M'` / `'S'` に修正
- 型エラーを潰していた `as any`（InputFile・Select）と `as SideNavSizeType`（SideNav）のキャストを撤去し、配列を `as const` にすることで、以後同じ誤りが型で検出されるようにしました
- SideNav で未使用になった `SideNavSizeType` の import を削除
- `key={size}` が `undefined` になっていたため `key={String(size)}` に修正（Chip の size ストーリーと同じ書き方に揃えました）

### 変更例

```tsx
// Before
{[undefined, 'default', 's'].map((size) => (
  <InputFile {...args} key={size} size={size as any} />
))}

// After
{([undefined, 'M', 'S'] as const).map((size) => (
  <InputFile {...args} key={String(size)} size={size} />
))}
```

### ローカル Storybook での実測値（getComputedStyle）

| コンポーネント | 表示順 | Before | After |
| --- | --- | --- | --- |
| InputFile | 1番目（`undefined`） | `padding: 12px 16px` / `16px` | `padding: 12px 16px` / `16px` |
| InputFile | 2番目 | **`padding: 0px`** / `16px` | `padding: 12px 16px` / `16px`（M） |
| InputFile | 3番目 | **`padding: 0px`** / `16px` | `padding: 8px` / `13.7px`（S） |
| Select | 1番目（`undefined`） | `padding: 8px 32px 8px 8px` / `16px` | 同じ |
| Select | 2番目 | **`padding: 0px`** / `16px` | `padding: 8px 32px 8px 8px` / `16px`（M） |
| Select | 3番目 | **`padding: 0px`** / `16px` | `padding: 4px 24px 4px 8px` / `13.7px`（S） |
| SideNav | 1セット目（`undefined`） | `padding: 16px` / `16px` | 同じ |
| SideNav | 2セット目 | **`padding: 0px`** / `16px` | `padding: 16px` / `16px`（M） |
| SideNav | 3セット目 | **`padding: 0px`** / `16px` | `padding: 8px 16px` / `13.7px`（S） |

### 補足: なぜ型チェックで防げなかったか

上記のキャストに加えて、以下2点により型チェックが機能していませんでした。本 PR のスコープ外なので、別途対応したいと考えています。

- ストーリー211ファイルが `@storybook/react-webpack5` から型を import していますが、#6116 で Storybook が vite ベースへ移行し依存は `@storybook/react-vite` のみになっているため、`TS2307` で `Meta` / `StoryObj` が `any` に落ちています
- `packages/smarthr-ui/tsconfig.build.json` が `src/**/*.stories.tsx` と `src/**/stories/*.tsx` を exclude しているため、`lint:tsc` の対象外です

## プロダクト側で対応が必要な事項

なし（Storybook のストーリーのみの変更で、パッケージの挙動は変わりません）

## 確認方法

Storybook で以下を開き、2番目が M・3番目が S として `padding` と `font-size` が効いていることを確認してください。

- `Components/InputFile` → `size`
- `Components/Select` → `size`
- `Components/SideNav` → `size`

修正前は2番目・3番目の `padding` が `0px` になり、枠に文字が密着した状態（Select は矢印アイコンが枠外にはみ出した状態）で表示されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - InputFile、Select、SideNavのサイズバリエーション表示を、現行の`M`／`S`表記に更新しました。
  - サイズ未指定のケースもストーリーで確認できるようになりました。
  - 型指定を整理し、不要な型変換を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->