### PR TITLE
refactor(createShadow)!: styled-componentsに依存しないようにする

### DIFF
--- a/packages/smarthr-ui/src/themes/__tests__/createShadow.ts
+++ b/packages/smarthr-ui/src/themes/__tests__/createShadow.ts
@@ -1,8 +1,6 @@
-import { type FlattenSimpleInterpolation, css } from 'styled-components'
-
 import { createShadow } from '../createShadow'
 
-const replaceSpaces = (str: FlattenSimpleInterpolation) => String(str).replace(/\s/g, '')
+const replaceSpaces = (str: string) => str.replace(/\s/g, '')
 
 describe('createShadow', () => {
   it('ユーザー指定の OUTLINE がフォーカススタイルに反映されること', () => {
@@ -13,7 +11,7 @@ describe('createShadow', () => {
     expect(actual.OUTLINE).toBe(expectedOutline)
 
     const actualFocusIndicator = replaceSpaces(actual.focusIndicatorStyles)
-    const expectedFocusIndicator = replaceSpaces(css`
+    const expectedFocusIndicator = replaceSpaces(`
       /* stylelint-disable no-invalid-position-declaration */
       isolation: isolate;
       box-shadow: 0 0 0 2px white;

--- a/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
+++ b/packages/smarthr-ui/src/themes/createShadow/createShadow.ts
@@ -1,9 +1,3 @@
-// HINT: styled-componentsがRSCに対応するのはv6.3.0以降。peerは^5.0.1のため、
-// モジュールスコープでcreateContextを呼びガードが無いバージョンが解決されうる。
-// ただしこのモジュールはcreateTheme経由でuseThemeから使われ、useThemeが'use client'を
-// 持つためサーバ側では評価されない。
-import { type FlattenSimpleInterpolation, css } from 'styled-components'
-
 import { merge } from '../../libs/lodash'
 import { type ColorProperty, defaultColor } from '../createColor'
 
@@ -29,13 +23,13 @@ export type CreatedShadowTheme = {
   OUTLINE: string
   OUTLINE_MARGIN: string
   UNDERLINE: string
-  focusIndicatorStyles: FlattenSimpleInterpolation
+  focusIndicatorStyles: string
 }
 
 const createOutline = (color: string) => `0 0 0 2px white, 0 0 0 4px ${color}`
 
 // 将来的になんらか別のデザイントークンに移行したい
-const createFocusIndicatorStyles = (outlineColor: string) => css`
+const createFocusIndicatorStyles = (outlineColor: string) => `
   /* stylelint-disable no-invalid-position-declaration */
   isolation: isolate;
   box-shadow: 0 0 0 2px white;


### PR DESCRIPTION
## 関連URL

なし

## 概要

`createShadow.ts` が `focusIndicatorStyles` の生成に styled-components の `css` タグ関数を使用していた。styled-components への依存を減らし Tailwind への移行を進める方針（CLAUDE.md）に沿って、`css` を使わない実装に変更する。

styled-components のテンプレートリテラルに `${theme.shadow.focusIndicatorStyles}` として埋め込んで使う分には、`css()` が返すトークン配列とプレーンな文字列とで最終的に生成される CSS が完全に一致することを実測で確認済み。

```
css() version:    {isolation:isolate;box-shadow:0 0 0 2px white;outline:2px solid black;outline-offset:2px;}
string version:    {isolation:isolate;box-shadow:0 0 0 2px white;outline:2px solid black;outline-offset:2px;}
EQUAL: true
```

## 変更内容

- `createFocusIndicatorStyles` の実装を `css` タグ関数呼び出しから、プレーンな文字列を返すテンプレートリテラルに変更
- `import { css, type FlattenSimpleInterpolation } from 'styled-components'` を削除
- `CreatedShadowTheme.focusIndicatorStyles` の型を `FlattenSimpleInterpolation` → `string` に変更
- 該当しなくなった styled-components v5 の RSC 非対応に関する HINT コメントを削除
- `__tests__/createShadow.ts` のテストを `css` を使った比較からプレーン文字列比較に変更

## プロダクト側で対応が必要な事項

`theme.shadow.focusIndicatorStyles` の型が `FlattenSimpleInterpolation` から `string` に変わります。実利用箇所を調査した限り、いずれも styled-components のテンプレートリテラルに `${theme.shadow.focusIndicatorStyles}` として埋め込むだけの使い方で、変数の型注釈などに `FlattenSimpleInterpolation` を明示的に使っている箇所は見当たりませんでした。動作は変わりませんが、型を明示的に注釈している場合は `string` への更新が必要です。

## 確認方法

```sh
pnpm ui lint
pnpm ui test -- --run src/themes
pnpm ui build
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * フォーカスインジケーターのスタイル生成を簡素化し、より安定して扱えるようにしました。
  * テーマのフォーカスインジケータースタイルを文字列として扱うよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->