### PR TITLE
refactor(HeaderLink): enableNewの型をVariantPropsから明示的な型に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Header/HeaderLink.tsx
+++ b/packages/smarthr-ui/src/components/Header/HeaderLink.tsx
@@ -1,13 +1,12 @@
 import { type ComponentProps, memo, useMemo } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { AnchorButton } from '../Button'
 
 type Props = Omit<
   ComponentProps<typeof AnchorButton>,
   'variant' | 'size' | 'wide' | 'loading' | 'inactiveReason'
-> &
-  VariantProps<typeof classNameGenerator>
+> & { enableNew?: boolean }
 
 const classNameGenerator = tv({
   base: [


### PR DESCRIPTION
## 関連URL

- #6901（`VariantProps` 廃止の1件目。方針の詳細はこちら）

## 概要

props の型生成に `tailwind-variants` の `VariantProps` を使うのをやめていく取り組みの2件目として、`HeaderLink` を対応します。

`VariantProps` には以下の問題があります。

**必須かどうかが宣言から読み取れない** — `VariantProps` は全 variant を optional にします。`defaultVariants` を指定していても optional のままです。

**props 型が tv の定義に依存する** — 外部に公開する型が内部のスタイル定義に紐づくため、依存関係が増えます。結果として、スタイルを生成しない variant を「型のためだけに」tv 側へ残す必要が生じます。

## 変更内容

`HeaderLink` の props 型から `VariantProps` を外し、`enableNew` を `boolean` として明示的に宣言しました。

```tsx
// Before
import { type VariantProps, tv } from 'tailwind-variants'

type Props = Omit<
  ComponentProps<typeof AnchorButton>,
  'variant' | 'size' | 'wide' | 'loading' | 'inactiveReason'
> &
  VariantProps<typeof classNameGenerator>

// After
import { tv } from 'tailwind-variants'

type Props = Omit<
  ComponentProps<typeof AnchorButton>,
  'variant' | 'size' | 'wide' | 'loading' | 'inactiveReason'
> & { enableNew?: boolean }
```

tv 側の `variants.enableNew` は `true` / `false` ともに実際にクラスを生成しているため、定義はそのまま残しています。

なお #6901 の `Badge` では variant 定義に `satisfies Record<Color, object>` を付けて型と tv 定義の同期を担保しましたが、今回は boolean variant でキーが `true` / `false` に固定されるため、同等の記述は付けていません。

## プロダクト側で対応が必要な事項

なし。`enableNew` prop の型は変更前と完全に一致します。

## 確認方法

- CI（lint / tsc / test）がパスしていること
- Chromatic で `Components/Header/HeaderLink` の `EnableNew` ストーリーに差分がないこと

### 型の同一性について

`HeaderLink.tsx` の `classNameGenerator` と同一の tv 定義を再現して旧型を復元し、公開されている `HeaderLink` の props 型と相互代入可能性で比較しました。

```ts
type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
const expectExact = <T extends true>(_v?: T) => undefined

type OldType = VariantProps<typeof classNameGenerator>['enableNew']
type NewType = ComponentProps<typeof HeaderLink>['enableNew']

expectExact<Exact<OldType, NewType>>()

// ネガティブコントロール（検査が機能していることの確認。ここは意図的に落ちる）
expectExact<Exact<OldType, string | undefined>>()
expectExact<Exact<OldType, boolean>>()
```

本命の比較はエラーなし、ネガティブコントロール2件は期待どおり `Type 'false' does not satisfy the constraint 'true'` で失敗しました。どちらの型も `boolean | undefined` として一致しています。

<details>
<summary>ネガティブコントロールを入れた理由</summary>

当初 `ComponentProps<typeof HeaderLink>['className']` を不一致側の対照に使っていましたが、これは `any` に解決されるため `Exact` が常に `true` になり、検査として機能しませんでした。対照を具体的な型に置き換えたうえで、検査が実際に失敗しうることを確認しています。

</details>

### ローカルでの確認結果

- `npx eslint --fix` — エラーなし
- `npx prettier --check` — 差分なし
- `npx stylelint` — エラーなし
- `npx tsc --noEmit` — `HeaderLink.tsx` に対する指摘なし

型のみの変更であり、実行時の挙動には影響しません。`Header` 配下にテストファイルは存在せず、リポジトリ内の利用箇所は `AppHeader/components/desktop/DesktopHeader.tsx` とストーリー2件です。

## 今後の対応

`VariantProps` は他に30コンポーネント（＋ `src/hooks/client/useSV`）で使われています。影響範囲を確認しやすくするため、引き続き1ファイルずつ別PRで対応していく予定です。

うち以下は `Omit`・`Pick`・インデックスアクセスで加工していたり、値の型としても使っているため、個別に判断が必要です。

`Cluster` `Sidebar` `Container` `ModelessDialog` `DialogBody` `ThSortButton` `Text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ヘッダーリンクのプロパティ定義を整理し、`enableNew` の指定を明確化しました。
  * 型情報の扱いを見直し、型チェックの安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->