### PR TITLE
fix(TabItem): Server Componentから使うとエラーになる不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/TabBar/client/TabItem.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/client/TabItem.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
   type ComponentProps,
   type FC,
@@ -9,10 +11,10 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useLatest } from '../../hooks/useLatest'
-import { UnstyledButton } from '../Button'
-import { FaCircleInfoIcon } from '../Icon'
-import { Tooltip } from '../Tooltip'
+import { useLatest } from '../../../hooks/useLatest'
+import { UnstyledButton } from '../../Button'
+import { FaCircleInfoIcon } from '../../Icon'
+import { Tooltip } from '../../Tooltip'
 
 const classNameGenerator = tv({
   slots: {

--- a/packages/smarthr-ui/src/components/TabBar/client/index.ts
+++ b/packages/smarthr-ui/src/components/TabBar/client/index.ts
@@ -1,0 +1,1 @@
+export { TabItem } from './TabItem'

--- a/packages/smarthr-ui/src/components/TabBar/index.ts
+++ b/packages/smarthr-ui/src/components/TabBar/index.ts
@@ -1,2 +1,2 @@
 export { TabBar } from './TabBar'
-export { TabItem } from './TabItem'
+export { TabItem } from './client'

--- a/packages/smarthr-ui/src/components/TabBar/stories/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/TabBar.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from 'storybook/actions'
 
 import { TabBar } from '../TabBar'
-import { TabItem } from '../TabItem'
+import { TabItem } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 

--- a/packages/smarthr-ui/src/components/TabBar/stories/TabItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/TabItem.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from 'storybook/actions'
 
 import { Badge } from '../../Badge'
-import { TabItem } from '../TabItem'
+import { TabItem } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 

--- a/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
@@ -5,7 +5,7 @@ import { Badge } from '../../Badge'
 import { FaCircleExclamationIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { TabBar } from '../TabBar'
-import { TabItem } from '../TabItem'
+import { TabItem } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`TabItem` は内部で `onClick` を新しい関数（`handleClick`）にラップし、最終的に `'use client'` を持つ `UnstyledButton` の `onClick` に渡している。`TabItem` 自体は `'use client'` を持っていなかったため、Server Component から利用すると実行時エラーになっていた。

`sandbox/next` の `rsc_test/TabItem` ページ（既存の検証用ページ）で `next dev` から実際にアクセスし、以下のエラーが再現することを確認した。

```
Error: Event handlers cannot be passed to Client Component props.
  <button role="tab" ... onClick={function handleClick} ...>
If you need interactivity, consider converting part of this to a Client Component.
```

## 変更内容

- `TabItem.tsx` に `'use client'` を追加
- `TabBar/client/` へ移動（hook が存在しないため `client/` 直下にフラット配置。CLAUDE.md の判断基準に基づく）
- `TabBar/index.ts` および Storybook の import パスを更新
- 公開エクスポート内容・パスは変更なし

## プロダクト側で対応が必要な事項

なし。`TabItem` は元々クラッシュしていたケース（Server Component から直接利用）を除き、通常の利用（Client Component 配下でのレンダリング）には影響しません。

## 確認方法

```sh
pnpm ui lint
pnpm ui test -- --run src/components/TabBar
```

Storybook で `TabBar` / `TabItem` が従来どおり動作することを確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * TabBarのタブ項目がクライアント環境で正しく動作するようになりました。
  * TabItemの公開エントリーポイントを整理し、利用時の互換性を維持しました。

* **テスト**
  * Storybook上のTabItemおよびTabBarの参照を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->