### PR TITLE
refactor(Stepper): variant名をstatusTypeに統一しStatusType型を集約する

### DIFF
--- a/packages/smarthr-ui/src/components/Badge/Badge.tsx
+++ b/packages/smarthr-ui/src/components/Badge/Badge.tsx
@@ -60,7 +60,7 @@ const classNameGenerator = tv({
         pill: 'shr-bg-danger shr-text-white shr-shadow-[0_0_0_1px_theme(colors.white)]',
         dotElement: 'shr-bg-danger shr-shadow-[0_0_0_1px_theme(colors.white)]',
       },
-    },
+    } satisfies Record<Color, object>,
     withChildren: {
       // HINT: pill・dotElementで同一の指定になるためcompoundSlotsで扱う
       true: '',

--- a/packages/smarthr-ui/src/components/Stepper/HorizontalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/HorizontalStepItem.tsx
@@ -81,19 +81,18 @@ export const HorizontalStepItem = memo<Props>(
         beforeLine,
         afterLine,
         label: labelText,
-      } = classNameGenerator({
-        statusType,
-        current,
-        isPrevStepCompleted,
-      })
+      } = classNameGenerator()
 
       return {
         wrapper: wrapper(),
         labelWrapper: labelWrapper(),
         stepCounterWrapper: stepCounterWrapper(),
-        beforeLine: beforeLine(),
-        afterLine: afterLine(),
-        label: labelText(),
+        beforeLine: beforeLine({ isPrevStepCompleted }),
+        afterLine: afterLine({ statusType }),
+        label: labelText({
+          statusType,
+          current,
+        }),
       }
     }, [statusType, current, isPrevStepCompleted])
 

--- a/packages/smarthr-ui/src/components/Stepper/HorizontalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/HorizontalStepItem.tsx
@@ -5,10 +5,10 @@ import { Text } from '../Text'
 
 import { StepCounter } from './StepCounter'
 
-import type { HorizontalStep } from './types'
+import type { HorizontalStep, StatusType } from './types'
 
 type Props = Omit<HorizontalStep, 'status'> & {
-  statusType?: 'completed' | 'closed'
+  statusType?: StatusType
   statusText?: string
   /** ステップ数 */
   stepNumber: number
@@ -41,12 +41,12 @@ const classNameGenerator = tv({
     label: 'shr-px-0.25 shr-text-center shr-text-sm',
   },
   variants: {
-    status: {
+    statusType: {
       completed: {
         afterLine: ['shr-bg-main', 'forced-colors:shr-bg-[Highlight]'],
       },
       closed: {},
-    },
+    } satisfies Record<StatusType, object>,
     current: {
       true: {
         label: 'shr-font-bold',
@@ -62,7 +62,7 @@ const classNameGenerator = tv({
   },
   compoundVariants: [
     {
-      status: ['completed', 'closed'],
+      statusType: ['completed', 'closed'],
       current: false,
       className: {
         label: 'shr-text-grey',
@@ -82,7 +82,7 @@ export const HorizontalStepItem = memo<Props>(
         afterLine,
         label: labelText,
       } = classNameGenerator({
-        status: statusType,
+        statusType,
         current,
         isPrevStepCompleted,
       })

--- a/packages/smarthr-ui/src/components/Stepper/StepCounter.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/StepCounter.tsx
@@ -3,8 +3,10 @@ import { tv } from 'tailwind-variants'
 
 import { StepStatusIcon } from './StepStatusIcon'
 
+import type { StatusType } from './types'
+
 type Props = {
-  statusType?: 'completed' | 'closed'
+  statusType?: StatusType
   statusText?: string
   stepNumber?: number
   current: boolean
@@ -19,10 +21,10 @@ const classNameGenerator = tv({
     statusIcon: 'shr-absolute -shr-left-[0.625em] -shr-top-[0.75em]',
   },
   variants: {
-    status: {
+    statusType: {
       completed: { counter: 'shr-border-main' },
       closed: { counter: 'shr-border-grey' },
-    },
+    } satisfies Record<StatusType, object>,
     current: {
       true: {
         counter: [
@@ -30,21 +32,20 @@ const classNameGenerator = tv({
           'forced-colors:shr-border-[Mark] forced-colors:shr-bg-[Mark]',
         ],
       },
-      false: {},
     },
   },
 })
 
 export const StepCounter: FC<Props> = ({ statusType, statusText, current, stepNumber }) => {
   const classNames = useMemo(() => {
-    const { wrapper, counter, statusIcon } = classNameGenerator({
-      status: statusType,
-      current,
-    })
+    const { wrapper, counter, statusIcon } = classNameGenerator()
 
     return {
       wrapper: wrapper(),
-      counter: counter(),
+      counter: counter({
+        statusType,
+        current,
+      }),
       statusIcon: statusIcon(),
     }
   }, [statusType, current])

--- a/packages/smarthr-ui/src/components/Stepper/StepStatusIcon.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/StepStatusIcon.tsx
@@ -4,24 +4,26 @@ import { tv } from 'tailwind-variants'
 import { Localizer } from '../../intl'
 import { FaCircleCheckIcon, FaCircleXmarkIcon } from '../Icon'
 
+import type { StatusType } from './types'
+
 const classNameGenerator = tv({
   base: [
     'shr-rounded-full shr-bg-white shr-shadow-[0_0_0_theme(borderWidth.2)_theme(colors.white)]',
     'forced-colors:shr-bg-[CanvasText] forced-colors:shr-fill-[Canvas] forced-colors:shr-shadow-[0_0_0_theme(borderWidth.2)_Canvas]',
   ],
   variants: {
-    status: {
+    statusType: {
       completed: [
         'shr-text-main',
         'forced-colors:shr-bg-[Canvas] forced-colors:shr-fill-[Highlight]',
       ],
       closed: ['shr-text-grey', 'forced-colors:shr-bg-[Canvas] forced-colors:shr-fill-[GrayText]'],
-    },
+    } satisfies Record<StatusType, object>,
   },
 })
 
 type ActualProps = ComponentProps<typeof FaCircleCheckIcon> & {
-  statusType: 'completed' | 'closed'
+  statusType: StatusType
   statusText?: string
 }
 type Props = Partial<ActualProps>
@@ -45,7 +47,7 @@ const ActualStepStatusIcon: FC<ActualProps> = ({ statusType, statusText, classNa
   const actualAlt = statusText || alt
 
   const actualClassName = useMemo(
-    () => classNameGenerator({ status: statusType, className }),
+    () => classNameGenerator({ statusType, className }),
     [statusType, className],
   )
 

--- a/packages/smarthr-ui/src/components/Stepper/Stepper.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/Stepper.tsx
@@ -8,12 +8,13 @@ import { VerticalStepItem } from './VerticalStepItem'
 
 import type {
   HorizontalStepper as HStepperProps,
+  StatusType,
   Step,
   VerticalStepper as VStepperProps,
 } from './types'
 
-type ObjectStepStatus = { type?: 'completed' | 'closed'; text?: string }
-const statusObjectConverter = (s: 'completed' | 'closed' | undefined): ObjectStepStatus => ({
+type ObjectStepStatus = { type?: StatusType; text?: string }
+const statusObjectConverter = (s: StatusType | undefined): ObjectStepStatus => ({
   type: s,
 })
 

--- a/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
@@ -6,9 +6,8 @@ import { Section } from '../SectioningContent'
 
 import { StepCounter } from './StepCounter'
 
-import type { VerticalStep } from './types'
+import type { StatusType, VerticalStep } from './types'
 
-type StatusType = 'completed' | 'closed'
 type Props = Omit<VerticalStep, 'status'> & {
   statusType?: StatusType
   statusText?: string

--- a/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/VerticalStepItem.tsx
@@ -8,8 +8,9 @@ import { StepCounter } from './StepCounter'
 
 import type { VerticalStep } from './types'
 
+type StatusType = 'completed' | 'closed'
 type Props = Omit<VerticalStep, 'status'> & {
-  statusType?: 'completed' | 'closed'
+  statusType?: StatusType
   statusText?: string
   /** ステップ数 */
   stepNumber: number
@@ -38,12 +39,12 @@ const classNameGenerator = tv({
     ],
   },
   variants: {
-    status: {
+    statusType: {
       completed: {
         stepCounter: ['after:shr-bg-main', 'forced-colors:after:shr-bg-[Highlight]'],
       },
       closed: {},
-    },
+    } satisfies Record<StatusType, object>,
     current: {
       true: {
         heading: 'shr-font-bold',
@@ -53,7 +54,7 @@ const classNameGenerator = tv({
   },
   compoundVariants: [
     {
-      status: ['completed', 'closed'],
+      statusType: ['completed', 'closed'],
       current: false,
       className: {
         heading: 'shr-text-grey',
@@ -72,19 +73,19 @@ export const VerticalStepItem: FC<Props> = ({
 }) => {
   const classNames = useMemo(() => {
     const { wrapper, section, headingWrapper, heading, body, inner, stepCounter } =
-      classNameGenerator({
-        status: statusType,
-        current,
-      })
+      classNameGenerator()
 
     return {
       wrapper: wrapper(),
       section: section(),
       headingWrapper: headingWrapper(),
-      heading: heading(),
+      heading: heading({
+        statusType,
+        current,
+      }),
       body: body(),
       inner: inner(),
-      stepCounter: stepCounter(),
+      stepCounter: stepCounter({ statusType }),
     }
   }, [statusType, current])
 

--- a/packages/smarthr-ui/src/components/Stepper/types.ts
+++ b/packages/smarthr-ui/src/components/Stepper/types.ts
@@ -5,15 +5,16 @@ type BaseProps<P> = P & {
   activeIndex?: number
 } & Omit<ComponentPropsWithoutRef<'ol'>, keyof P>
 
+export type StatusType = 'completed' | 'closed'
+
 export type Step = {
   /** ステップラベル */
   label: ReactNode
   /** 状態 */
   status?:
-    | 'completed'
-    | 'closed'
+    | StatusType
     | {
-        type: 'completed' | 'closed'
+        type: StatusType
         text: string
       }
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Stepper` 配下で以下の不整合があったため整理する。

- tailwind-variants の variant 名が `status`（tv 内部）と `statusType`（Props のフィールド名）で不一致
- `'completed' | 'closed'` というユニオン型が `types.ts` / `VerticalStepItem.tsx` / `StepCounter.tsx` / `HorizontalStepItem.tsx` / `StepStatusIcon.tsx` / `Stepper.tsx` の6箇所に重複定義されていた

## 変更内容

- `Stepper/types.ts` に `StatusType` 型を追加し、`Step.status` を含む重複していたユニオン型を集約
- 各ファイルのインライン型定義を `StatusType` の import に置き換え
- `classNameGenerator` の variant 名を `status` → `statusType` に統一（`HorizontalStepItem` / `StepStatusIcon`。`compoundVariants` のキーも含む）
- 対応する variants に `satisfies Record<StatusType, object>` を追加し、キー漏れを型チェックできるようにする
- `classNameGenerator` の呼び出しを、一括で variants を渡す形から各 slot が実際に依存する variant のみを渡す形に統一（`VerticalStepItem` / `StepCounter` / `HorizontalStepItem`）
  - tailwind-variants で一括呼び出しと個別呼び出しの生成クラス名が完全一致することを実測で確認済み

公開している props やコンポーネントの見た目・挙動に変更はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

```sh
pnpm ui lint
pnpm ui test -- --run src/components/Stepper
```

Storybook で `Stepper` / `HorizontalStepItem` / `VerticalStepItem` が従来どおり動作することを確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ステッパーのステータス型を統一し、コンポーネント間で一貫した状態管理ができるようになりました。
  - ステップの表示状態に関する内部的な整合性を向上しました。

- **互換性**
  - 利用できるステータス値や画面上の表示・動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->