### PR TITLE
refactor(InputFile): InputFileNativeのuseImperativeHandleをuseMergeRefsに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/InputFileNative.tsx
@@ -5,12 +5,12 @@ import {
   type MouseEvent,
   forwardRef,
   useId,
-  useImperativeHandle,
   useMemo,
   useRef,
   useState,
 } from 'react'
 
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useLatest } from '../../hooks/useLatest'
 import { Stack } from '../Layout'
 import { Groupbox } from '../Panel'
@@ -53,13 +53,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
     const isUpdatingFilesRef = useRef(false)
 
     const innerRef = useRef<HTMLInputElement>(null)
-
-    // TODO: useMergeRefsが実装されたら修正
-    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
-      ref,
-      () => innerRef.current,
-      [],
-    )
+    const mergedRef = useMergeRefs(innerRef, ref)
 
     const latest = useLatest({ onChange, files, previewFile })
 
@@ -132,7 +126,7 @@ export const InputFileNative = forwardRef<HTMLInputElement, Props>(
         <span className={classNames.inputWrapper}>
           <input
             {...rest}
-            ref={innerRef}
+            ref={mergedRef}
             type="file"
             disabled={disabled}
             className={classNames.input}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InputFileNative` は `useImperativeHandle` を使って `innerRef.current`（DOMノード）をそのまま外部の `ref` に中継していたが、これは CLAUDE.md に定める「DOMノードをそのまま外部refに渡すためだけの中継に `useImperativeHandle` を使うべきではない」アンチパターンに該当する。コード内にも `// TODO: useMergeRefsが実装されたら修正` というコメントが残っていた。

## 変更内容

- `useImperativeHandle` を `useMergeRefs(innerRef, ref)` に置き換え、`innerRef` への代入処理を不要にする
- 外部から渡された `ref` は最後に配置する規約に従っている

公開している props やコンポーネントの見た目・挙動に変更はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

```sh
pnpm ui lint
pnpm ui test -- --run src/components/InputFile src/hooks/client/useMergeRefs
```

Storybook で `InputFile` が従来どおり動作することを確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
  - ファイル選択コンポーネントの参照処理を整理しました。
  - 外部からの参照を引き続き利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->