### PR TITLE
chore: Storybookのbackgrounds設定をv10のAPIに追従させる

### DIFF
--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -83,9 +83,15 @@ const preview: Preview = {
       forcedColors: 'none',
     },
     backgrounds: {
-      default: 'light',
-      values: [{ name: 'light', value: backgroundColor.background }],
+      options: {
+        white: { name: 'white', value: backgroundColor.white },
+        background: { name: 'background', value: backgroundColor.background },
+        brand: { name: 'brand', value: backgroundColor.brand },
+      },
     },
+  },
+  initialGlobals: {
+    backgrounds: { value: 'white' },
   },
   globalTypes: {
     locale: {

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviAnchor.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviAnchor.stories.tsx
@@ -1,4 +1,3 @@
-import { backgroundColor } from '../../../tailwind'
 import { FaGearIcon } from '../../Icon'
 import { AppNaviAnchor } from '../AppNaviAnchor'
 
@@ -47,9 +46,6 @@ export default {
     children: 'アンカーボタン',
   },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
     chromatic: { disableSnapshot: true },
   },
   excludeStories: ['Template'],

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviButton.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from 'storybook/actions'
 
-import { backgroundColor } from '../../../tailwind'
 import { FaGearIcon } from '../../Icon'
 import { AppNaviButton } from '../AppNaviButton'
 
@@ -26,9 +25,6 @@ export default {
     children: 'ボタン',
   },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
     chromatic: { disableSnapshot: true },
   },
   excludeStories: ['Template'],

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviCustomTag.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviCustomTag.stories.tsx
@@ -1,4 +1,3 @@
-import { backgroundColor } from '../../../tailwind'
 import { FaGearIcon } from '../../Icon'
 import { AppNaviCustomTag } from '../AppNaviCustomTag'
 
@@ -37,9 +36,6 @@ export default {
     children: 'カスタムタグ',
   },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
     chromatic: { disableSnapshot: true },
   },
   excludeStories: ['Template'],

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
@@ -1,4 +1,3 @@
-import { backgroundColor } from '../../../tailwind'
 import { AnchorButton, Button } from '../../Button'
 import { AppNaviDropdownMenuButton } from '../AppNaviDropdownMenuButton'
 
@@ -17,9 +16,6 @@ export default {
     label: 'ボタン',
   },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
     chromatic: { disableSnapshot: true },
   },
   excludeStories: ['Template'],

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/SingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/SingleCombobox.stories.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useArgs } from 'storybook/preview-api'
 
-import { backgroundColor } from '../../../../tailwind'
 import { FaCirclePlusIcon } from '../../../Icon'
 import { Stack } from '../../../Layout'
 import { SingleCombobox } from '../SingleCombobox'
@@ -168,9 +167,6 @@ export const ReadOnly: StoryObj<typeof SingleCombobox> = {
   name: 'readOnly',
   args: {
     readOnly: true,
-  },
-  parameters: {
-    backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
   },
 }
 

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/VRTSingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/VRTSingleCombobox.stories.tsx
@@ -1,6 +1,5 @@
 import { userEvent, within } from 'storybook/test'
 
-import { backgroundColor } from '../../../../tailwind'
 import { Cluster, Stack } from '../../../Layout'
 import { SingleCombobox } from '../SingleCombobox'
 
@@ -146,17 +145,12 @@ export default {
   tags: ['!autodocs'],
 } as Meta<typeof SingleCombobox>
 
-export const VRT: StoryObj<typeof SingleCombobox> = {
-  parameters: {
-    backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
-  },
-}
+export const VRT: StoryObj<typeof SingleCombobox> = {}
 
 export const VRTForcedColors: StoryObj<typeof SingleCombobox> = {
   ...VRT,
   parameters: {
     chromatic: { forcedColors: 'active' },
-    backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
   },
 }
 
@@ -188,7 +182,4 @@ export const VRTOnRightEdge: StoryObj<typeof SingleCombobox> = {
     </div>
   ),
   play: playOnRightEdge,
-  parameters: {
-    backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
-  },
 }

--- a/packages/smarthr-ui/src/components/Header/stories/AppLauncher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/AppLauncher.stories.tsx
@@ -1,4 +1,3 @@
-import { backgroundColor } from '../../../tailwind'
 import { AppLauncher } from '../AppLauncher'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
@@ -61,10 +60,8 @@ export default {
   args: {
     apps,
   },
+  globals: { backgrounds: { value: 'brand' } },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.brand }],
-    },
     chromatic: { disableSnapshot: true },
   },
 } satisfies Meta<typeof AppLauncher>
@@ -83,9 +80,5 @@ export const EnableNew: StoryObj<typeof AppLauncher> = {
   args: {
     enableNew: true,
   },
-  parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
-  },
+  globals: { backgrounds: { value: 'white' } },
 }

--- a/packages/smarthr-ui/src/components/Header/stories/HeaderLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/HeaderLink.stories.tsx
@@ -1,4 +1,3 @@
-import { backgroundColor } from '../../../tailwind'
 import { FaRegCircleQuestionIcon } from '../../Icon'
 import { HeaderLink } from '../HeaderLink'
 
@@ -11,10 +10,8 @@ export default {
   args: {
     href: '#',
   },
+  globals: { backgrounds: { value: 'brand' } },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.brand }],
-    },
     chromatic: { disableSnapshot: true },
   },
 } satisfies Meta<typeof HeaderLink>
@@ -37,9 +34,5 @@ export const EnableNew: StoryObj<typeof HeaderLink> = {
     prefix: <FaRegCircleQuestionIcon />,
     enableNew: true,
   },
-  parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
-  },
+  globals: { backgrounds: { value: 'white' } },
 }

--- a/packages/smarthr-ui/src/components/Header/stories/LanguageSwitcher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/LanguageSwitcher.stories.tsx
@@ -1,7 +1,6 @@
 import { action } from 'storybook/actions'
 
 import { localeMap } from '../../../intl'
-import { defaultBackgroundColor as backgroundColor } from '../../../themes'
 import { LanguageSwitcher } from '../LanguageSwitcher'
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5'
@@ -13,10 +12,8 @@ export default {
   args: {
     localeMap,
   },
+  globals: { backgrounds: { value: 'brand' } },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.brand }],
-    },
     chromatic: { disableSnapshot: true },
   },
 } satisfies Meta<typeof LanguageSwitcher>
@@ -63,11 +60,7 @@ export const Invert: StoryObj<typeof LanguageSwitcher> = {
   args: {
     invert: true,
   },
-  parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.background }],
-    },
-  },
+  globals: { backgrounds: { value: 'background' } },
 }
 
 export const EnableNew: StoryObj<typeof LanguageSwitcher> = {
@@ -76,9 +69,5 @@ export const EnableNew: StoryObj<typeof LanguageSwitcher> = {
   args: {
     enableNew: true,
   },
-  parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.white }],
-    },
-  },
+  globals: { backgrounds: { value: 'white' } },
 }

--- a/packages/smarthr-ui/src/components/Input/stories/Input.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/stories/Input.stories.tsx
@@ -122,9 +122,6 @@ export const ReadOnly: StoryObj<typeof Input> = {
     readOnly: true,
     value: '読み取り専用',
   },
-  parameters: {
-    backgrounds: { values: [{ name: 'light', value: backgroundColor.white }] },
-  },
 }
 
 export const Handlers: StoryObj<typeof Input> = {

--- a/packages/smarthr-ui/src/components/Panel/stories/Groupbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Panel/stories/Groupbox.stories.tsx
@@ -1,5 +1,4 @@
 import { backgroundColor } from '../../../tailwind'
-import { defaultBackgroundColor as backgroundColorValue } from '../../../themes'
 import { Stack } from '../../Layout'
 import { Groupbox } from '../Groupbox'
 import { panelClassNameGenerator } from '../Panel'
@@ -27,9 +26,6 @@ export default {
     children: 'ベースカラム',
   },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColorValue.white }],
-    },
     chromatic: { disableSnapshot: true },
   },
 } as Meta<typeof Groupbox>

--- a/packages/smarthr-ui/src/components/SmartHRLogo/stories/SmartHrLogo.stories.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRLogo/stories/SmartHrLogo.stories.tsx
@@ -1,4 +1,3 @@
-import { backgroundColor } from '../../../tailwind'
 import { Stack } from '../../Layout'
 import { SmartHRLogo } from '../SmartHRLogo'
 
@@ -9,10 +8,8 @@ export default {
   component: SmartHRLogo,
   render: (args) => <SmartHRLogo {...args} />,
   args: {},
+  globals: { backgrounds: { value: 'brand' } },
   parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.brand }],
-    },
     chromatic: { disableSnapshot: true },
   },
 } satisfies Meta<typeof SmartHRLogo>
@@ -49,9 +46,5 @@ export const Fill: StoryObj<typeof SmartHRLogo> = {
       ))}
     </Stack>
   ),
-  parameters: {
-    backgrounds: {
-      values: [{ name: 'light', value: backgroundColor.background }],
-    },
-  },
+  globals: { backgrounds: { value: 'background' } },
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

[AppLauncher のドキュメントページ](https://story.smarthr-ui.dev/?path=/docs/components-header-applauncher--docs)で、コンポーネントが何も表示されていない状態になっていました。

原因は Storybook の backgrounds 設定が v7 時代の API のままだったことです。v9 で `parameters.backgrounds.default` が削除され、`values` も v8 で `options` へ改称されたため、`chore: update storybook monorepo to v9 (major) (#5646)`（2025-06-10）以降、**Storybook 全体でどのストーリーにも背景色が適用されていませんでした**。

AppLauncher のトリガーボタンは `shr-text-white`（白文字・背景透明）なので、背景が塗られなくなった結果、白地に白文字で溶けて見えなくなっていました。DOM 上はレンダリングされており、JS エラーも出ていません。

`storybook@10.5.10` の backgrounds デコレータが読むのは以下の2つだけです。

```js
let { options = DEFAULT_BACKGROUNDS, disable, grid } = parameters[PARAM_KEY] || {}
let data = globals[PARAM_KEY] || {}
let backgroundName = typeof data == "string" ? data : data?.value
let item = backgroundName ? options[backgroundName] : void 0
```

`globals.backgrounds.value` が未設定だと `shownBackground` が false になり、style 要素自体が注入されません。ツールバーの選択肢もアドオン組み込みの fallback（`light` / `dark`）が出ている状態でした。

## 変更内容

### `.storybook/preview.tsx`

読まれなくなっていた `default` / `values` を、現行 API の `options`（Record 形式）と `initialGlobals` に置き換えました。

```tsx
// Before
backgrounds: {
  default: 'light',
  values: [{ name: 'light', value: backgroundColor.background }],
},

// After
backgrounds: {
  options: {
    white: { name: 'white', value: backgroundColor.white },
    background: { name: 'background', value: backgroundColor.background },
    brand: { name: 'brand', value: backgroundColor.brand },
  },
},
initialGlobals: {
  backgrounds: { value: 'white' },
},
```

**グローバル既定を `white` にしています。** 現状は何も塗られずブラウザの地色（`#fff`）が見えている状態なので、背景指定のないストーリーは表示が変わりません。旧既定の `background`（`#f8f7f6`）に戻すと、背景色を指定していない全ストーリーに差分が出てしまうためです。

ツールバーの選択肢も SmartHR のトークンに戻ります。

```
Before: Reset background / light / dark      ← アドオン組み込みの fallback
After:  Reset background / white / background / brand
```

### 各ストーリー（12ファイル）

`parameters.backgrounds.values` を `globals` へ移行しました。背景色の定義は `preview.tsx` に集約し、各ストーリーはキー名だけを指定します。

```tsx
// Before
parameters: {
  backgrounds: {
    values: [{ name: 'light', value: backgroundColor.brand }],
  },
  chromatic: { disableSnapshot: true },
},

// After
globals: { backgrounds: { value: 'brand' } },
parameters: {
  chromatic: { disableSnapshot: true },
},
```

既定が `white` になったことで不要になった指定は削除しました（AppNavi 4種、BaseColumn、Input readOnly、SingleCombobox readOnly、VRTSingleCombobox 3種の計10箇所）。

ただし **meta が `brand` を宣言しているファイルの `enableNew` 系 3件は残しています。** これらの `white` は「既定と同じ値の重複」ではなく、meta から継承する `brand` を打ち消す上書きだからです。実際に削除して測定したところ、3件ともブランドカラーに落ちることを確認しました。

不要になった `backgroundColor` の import も 11ファイルから削除しています。

## プロダクト側で対応が必要な事項

なし

`.storybook/` と `*.stories.tsx` のみの変更で、npm に公開される成果物（`package.json` の `files`: `esm` / `lib` / `smarthr-ui.css` / `metadata.json`）は一切変わりません。

## 確認方法

Storybook で確認できます。[AppLauncher の Docs](https://story.smarthr-ui.dev/?path=/docs/components-header-applauncher--docs) でブランドカラー背景に「アプリ」ボタンが表示されれば OK です。

ローカルで Storybook を起動し、`.sb-show-main` に注入されるスタイルを 20 ストーリーで実測して全件パスしています。

| 分類 | ストーリー | 背景 |
|---|---|---|
| meta の brand | AppLauncher / HeaderLink / LanguageSwitcher / SmartHRLogo の Playground、AppLauncher urlToShowAll | `#00c4cc` |
| brand を上書き | AppLauncher / HeaderLink / LanguageSwitcher の enableNew | `#fff` |
| background 指定 | LanguageSwitcher invert、SmartHRLogo fill | `#f8f7f6` |
| 既定に委譲 | AppNavi 4種、BaseColumn、Input readOnly、SingleCombobox readOnly | `#fff` |
| 元から無指定 | Button variant、Chip、Dialog | `#fff` |

### Chromatic について

差分が出るのは brand / background を指定している 9 ストーリーのみです（多くは `chromatic: { disableSnapshot: true }` 付き）。背景指定のないストーリーは既定の `white` がブラウザ地色と同じ `#fff` のため、差分は出ない想定です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Storybookの背景設定を整理し、`white`、`background`、`brand`から選択できるようにしました。
  * 各コンポーネントのストーリーで、用途に応じた背景色が一貫して表示されるようになりました。
  * 不要な背景設定を見直し、ストーリー表示とビジュアルテストの設定を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->