### PR TITLE
feat(InputFile): ファイルプレビューに別タブで開くリンクを追加

### DIFF
--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -62,6 +62,11 @@ export const FilePreviewDialog: FC<Props> = memo(
           <Loader size="M" />
         </Center>
       )
+    const actionAreaButtons = (
+      <Button onClick={handleDownload}>
+        <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
+      </Button>
+    )
 
     if (mobile) {
       return (
@@ -92,9 +97,7 @@ export const FilePreviewDialog: FC<Props> = memo(
               justify="end"
               className="shr-border-t-shorthand shr-shrink-0 shr-px-1.5 shr-py-1"
             >
-              <Button onClick={handleDownload}>
-                <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
-              </Button>
+              {actionAreaButtons}
             </Cluster>
           </div>
         </Dialog>
@@ -112,9 +115,7 @@ export const FilePreviewDialog: FC<Props> = memo(
         heading={file?.name ?? ''}
         footer={
           <Cluster justify="end" className="shr-px-1.5 shr-py-1">
-            <Button onClick={handleDownload}>
-              <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
-            </Button>
+            {actionAreaButtons}
           </Cluster>
         }
       >

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -119,7 +119,7 @@ export const FilePreviewDialog: FC<Props> = memo(
         onClickClose={handleClose}
         heading={file?.name ?? ''}
         footer={
-          <Cluster justify="end" className="shr-px-1.5 shr-py-1">
+          <Cluster gap={1} justify="end" className="shr-px-1.5 shr-py-1">
             {actionAreaButtons}
           </Cluster>
         }

--- a/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/FilePreviewDialog.tsx
@@ -4,7 +4,7 @@ import { type FC, memo, useEffect, useState } from 'react'
 
 import { useEnvironment } from '../../hooks/client/useEnvironment'
 import { Localizer } from '../../intl'
-import { Button } from '../Button'
+import { AnchorButton, Button } from '../Button'
 import { Dialog, ModelessDialog } from '../Dialog'
 import { FileViewer } from '../FileViewer'
 import { Heading } from '../Heading'
@@ -63,9 +63,14 @@ export const FilePreviewDialog: FC<Props> = memo(
         </Center>
       )
     const actionAreaButtons = (
-      <Button onClick={handleDownload}>
-        <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
-      </Button>
+      <>
+        <AnchorButton href={blobUrl} target="_blank">
+          <Localizer id="smarthr-ui/InputFile/targetBlank" defaultText="別タブで開く" />
+        </AnchorButton>
+        <Button onClick={handleDownload}>
+          <Localizer id="smarthr-ui/InputFile/download" defaultText="ダウンロード" />
+        </Button>
+      </>
     )
 
     if (mobile) {

--- a/packages/smarthr-ui/src/intl/locales/ja.json
+++ b/packages/smarthr-ui/src/intl/locales/ja.json
@@ -62,6 +62,7 @@
   "smarthr-ui/InformationPanel/closeButtonLabel": "閉じる",
   "smarthr-ui/InformationPanel/openButtonLabel": "開く",
   "smarthr-ui/InputFile/destroy": "削除",
+  "smarthr-ui/InputFile/targetBlank": "別タブで開く",
   "smarthr-ui/InputFile/download": "ダウンロード",
   "smarthr-ui/InputFile/previewLabel": "{fileName}のプレビューを開く",
   "smarthr-ui/InputFile/downloadLabel": "{fileName}をダウンロード",

--- a/packages/smarthr-ui/src/intl/locales/ja.ts
+++ b/packages/smarthr-ui/src/intl/locales/ja.ts
@@ -64,6 +64,7 @@ export const locale = {
   'smarthr-ui/InformationPanel/closeButtonLabel': '閉じる',
   'smarthr-ui/InformationPanel/openButtonLabel': '開く',
   'smarthr-ui/InputFile/destroy': '削除',
+  'smarthr-ui/InputFile/targetBlank': '別タブで開く',
   'smarthr-ui/InputFile/download': 'ダウンロード',
   'smarthr-ui/InputFile/previewLabel': '{fileName}のプレビューを開く',
   'smarthr-ui/InputFile/downloadLabel': '{fileName}をダウンロード',


### PR DESCRIPTION
## 関連URL

なし

## 概要

`InputFile` のファイルプレビュー（`FilePreviewDialog`）は、ダイアログ内に収まるサイズでファイルが表示されるため、画像などの細部を確認しづらい状態でした。

ブラウザの別タブでファイルそのものを開けるようにし、拡大表示や既定のビューアでの閲覧をできるようにします。

## 変更内容

- `FilePreviewDialog` のアクション領域に「別タブで開く」リンク（`AnchorButton`）を追加しました。
  - `href` にはプレビューで使用している blob URL を渡しています。
  - `AnchorButton` に `target="_blank"` を指定しているため、外部リンクアイコンと `rel="noopener noreferrer"` は自動で付与されます。
- モバイル表示（`Dialog`）とデスクトップ表示（`ModelessDialog`）で同じボタン群を出し分けていたため、`actionAreaButtons` として共通化しました。
- 翻訳キー `smarthr-ui/InputFile/targetBlank`（`別タブで開く`）を `ja` のロケールに追加しました。

### 表示イメージ

（キャプチャ添付予定）

## プロダクト側で対応が必要な事項

なし

既存のインタフェースに変更はありません。プレビューダイアログに「別タブで開く」リンクが増えるのみです。

## 確認方法

Storybook の `InputFile` のストーリーから、ファイルを選択してプレビューを開いてください。

- ダイアログのアクション領域に「別タブで開く」が表示されること
- クリックすると別タブでファイルが開くこと
- デスクトップ表示・モバイル表示の双方で表示されること

Chromatic の VRT でも差分を確認できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ファイルプレビュー画面に「別タブで開く」リンクを追加しました。
  * モバイル・デスクトップのファイルプレビュー画面で利用できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->