### PR TITLE
fix(FormControl): describedbyIdsがDOM要素に漏れる問題を修正

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -78,7 +78,7 @@ const useFormControlProps = ({
     id: baseLabel.id || `${baseId}-label`,
   }
 
-  const calculatedDescribedByIds = useDescribedByIds({
+  const { describedbyIds: _describedbyIds, ...describedByIdsRest } = useDescribedByIds({
     wrapperRef,
     htmlFor: label.htmlFor,
     errorMessages: orgErrorMessages,
@@ -122,7 +122,7 @@ const useFormControlProps = ({
 
   return {
     ...rest,
-    ...calculatedDescribedByIds,
+    ...describedByIdsRest,
     wrapperRef,
     label,
     helpMessage,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`FormControl` を使用すると、ブラウザコンソールに以下の警告が出る不具合があった。

```
React does not recognize the `describedbyIds` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `describedbyids` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

原因は #6779（AppHeaderでプラットフォーム固有のpropsがDOM要素に渡っていた不具合）と同じパターンで、`FormControl` 内部の `useFormControlProps` が `useDescribedByIds` の戻り値をそのまま `FormGroup` に spread しており、`describedbyIds` が `FormGroup` の `...rest` → `Stack` の `...rest` を経由してDOM要素までそのまま渡ってしまっていた。

なお `Fieldset` 側は `describedbyIds` を明示的に分離した上で `aria-describedby` として再利用しており、この不具合は発生していなかった。

## 変更内容

`FormControl.tsx` の `useFormControlProps` で `useDescribedByIds` の戻り値から `describedbyIds` を分離し、`FormGroup` に渡す props に含まれないよう修正した。

`describedbyIds` は `useDescribedByIds` 内の `useEffect` で子の input 要素へ `aria-describedby` として付与する処理が既に完結しており、`FormGroup` 側で改めて受け取る必要はない（`Fieldset` と異なり `FormControl` はwrapper要素に `aria-describedby` を設定する仕様ではないため）。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`helpMessage` / `exampleMessage` / `errorMessages` / `supplementaryMessage` のいずれかを指定した `FormControl`（例: `TextField` など）をブラウザで表示し、コンソールに `describedbyIds` に関する警告が出ないことを確認する。

既存のテスト（`FormGroup`, `Textarea`, `InputFile`, `DatePicker`, `WarekiPicker` など）はすべてパスすることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * フォームコントロールにおける説明情報の内部処理を整理しました。
  * ユーザー向けの機能や表示に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->