### PR TITLE
feat(ResponseMessage): LiveRegionを内部で使用する

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentResponseStatusMessage.tsx
@@ -7,22 +7,26 @@ export const DialogContentResponseStatusMessage: FC<{
   responseStatus: ReturnType<typeof useResponseStatus>
   className?: string
 }> = ({ responseStatus, className }) => {
-  const isError = responseStatus.message && responseStatus.status === 'error'
-  const isSuccess = responseStatus.message && responseStatus.status === 'success'
+  if (responseStatus.message) {
+    let attrs: { role: 'status' | 'alert'; status: 'success' | 'error' } | null = null
 
-  return (
-    /**
-     * ライブリージョンを条件付きでDOMに追加すると、支援技術に通知が正しく行われないことがあるため、常にDOM上に存在するようにしています
-     *
-     * @see https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/#make-sure-the-live-region-container-is-in-the-dom-as-early-as-possible
-     */
-    <>
-      <div role="alert" className={isError ? `${className} shr-mt-0.5` : className}>
-        {isError && <ResponseMessage status="error">{responseStatus.message}</ResponseMessage>}
-      </div>
-      <div role="status" className={isSuccess ? `${className} shr-mt-0.5` : className}>
-        {isSuccess && <ResponseMessage status="success">{responseStatus.message}</ResponseMessage>}
-      </div>
-    </>
-  )
+    switch (responseStatus.status) {
+      case 'error':
+        attrs = { role: 'alert', status: 'error' }
+        break
+      case 'success':
+        attrs = { role: 'status', status: 'success' }
+        break
+    }
+
+    if (attrs) {
+      return (
+        <ResponseMessage {...attrs} className={`${className} shr-mt-0.5`}>
+          {responseStatus.message}
+        </ResponseMessage>
+      )
+    }
+  }
+
+  return null
 }

--- a/packages/smarthr-ui/src/components/Dialog/dialogInnerStyle.ts
+++ b/packages/smarthr-ui/src/components/Dialog/dialogInnerStyle.ts
@@ -8,6 +8,6 @@ export const dialogContentInner = tv({
       'shr-border-t-shorthand shr-sticky shr-bottom-0 shr-z-1 shr-flex-[0_0_auto] shr-rounded-b-m shr-bg-white shr-px-1.5 shr-py-1',
     ],
     buttonArea: ['smarthr-ui-Dialog-buttonArea', 'shr-ms-auto'],
-    message: 'shr-text-right',
+    message: 'shr-block shr-text-right',
   },
 })

--- a/packages/smarthr-ui/src/components/ResponseMessage/ResponseMessage.tsx
+++ b/packages/smarthr-ui/src/components/ResponseMessage/ResponseMessage.tsx
@@ -9,11 +9,13 @@ import {
   type ComponentProps as IconProps,
   WarningIcon,
 } from '../Icon'
+import { LiveRegion } from '../LiveRegion'
 import { Text } from '../Text'
 
 type Props = PropsWithChildren<Omit<IconProps, 'size' | 'alt'>> & {
   size?: Extract<ComponentPropsWithoutRef<typeof Text>['size'], 'XS' | 'S' | 'M'>
   status?: keyof typeof STATUS_ICON_MAPPER
+  htmlFor?: string
 }
 
 export const classNameGenerator = tv({
@@ -37,15 +39,23 @@ const STATUS_ICON_MAPPER = {
   sync: FaRotateIcon,
 } as const
 
-// TODO: LiveRegionを内部で呼び出すように修正する
-// 利用している他コンポーネントで調整が必要なため、専用PRで対応
-export const ResponseMessage: FC<Props> = ({ status = 'info', size, children, ...rest }) => {
-  const className = useMemo(() => classNameGenerator({ status }), [status])
+export const ResponseMessage: FC<Props> = ({
+  status = 'info',
+  size,
+  role,
+  htmlFor,
+  className,
+  children,
+  ...rest
+}) => {
+  const iconClassName = useMemo(() => classNameGenerator({ status }), [status])
   const TextIcon = STATUS_ICON_MAPPER[status]
 
   return (
-    <Text size={size} icon={<TextIcon {...rest} className={className} />}>
-      {children}
+    <Text size={size} className={className} icon={<TextIcon {...rest} className={iconClassName} />}>
+      <LiveRegion role={role} htmlFor={htmlFor} className="shr-contents">
+        {children}
+      </LiveRegion>
     </Text>
   )
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

#6960 でLiveRegionコンポーネントを追加した際、ResponseMessageへの適用は他コンポーネントとの調整が必要だったため見送り、TODOコメントのみ残していた。今回、ResponseMessage内部でLiveRegionを使用するよう対応した。

## 変更内容

- `ResponseMessage`の内部で`LiveRegion`を呼び出すよう修正
  - `role`はアイコンではなく`LiveRegion`へ渡すようにした（アイコンには本来role属性を渡す意味がない）
  - `className`・`htmlFor`が`Text`・`LiveRegion`へ正しく配線されるようにした（従来は`className`が`rest`経由でアイコンに渡り、アイコン用の`classNameGenerator`の出力で上書きされ実質適用されていなかった）
  - `LiveRegion`の外側要素には`display: contents`相当のクラスを指定し、アイコン付き`Text`のレイアウトに影響を与えないようにしている
- `DialogContentResponseStatusMessage`の実装を整理
  - 従来は`role="alert"`/`role="status"`を持つ空のコンテナを常にDOMに配置しておく実装だった（スクリーンリーダーへの通知が正しく行われるよう、要素を先にDOMへ配置しておく手法）
  - `ResponseMessage`が内部で`LiveRegion`を使うようになったことで、この対応が不要になった。`LiveRegion`はマウント時に空の状態から遅延してテキストを設定する仕組みを持ち、動的に追加される場合でも同様の効果が得られるため
  - `switch`文で`role`/`status`をまとめて算出し、条件付きで`ResponseMessage`を1つだけレンダーする形に簡略化した

## プロダクト側で対応が必要な事項

なし。`ResponseMessage`・`DialogContentResponseStatusMessage`の公開インターフェース（props）に変更はない。

## 確認方法

`ResponseMessage`・`FormDialog`等（`DialogContentResponseStatusMessage`利用箇所）のStorybookで、見た目・`className`指定（マージン等）に問題がないことを確認する。