### PR TITLE
refactor(Panel): 'use client'を削除する

### DIFF
--- a/packages/smarthr-ui/src/components/Panel/Panel.tsx
+++ b/packages/smarthr-ui/src/components/Panel/Panel.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithRef,
   type ComponentType,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Panel`自身は`createContext`/`useContext`などのclient専用APIを使っておらず、`react-server`条件で問題なく評価できる状態だったため、`'use client'`を削除した。

## 変更内容

- `Panel.tsx`から`'use client'`を削除

### 検証内容

- 素の`node --conditions react-server`での実測では、`themes`バレル（`themes/index.ts`の`export { defaultShadow } from './createShadow'`経由）に`styled-components`依存（モジュールスコープで`createContext`を呼びガードが無い）が含まれており、バレルの平坦化（rollupの`preserveModules`）でPanelのビルド出力に副作用importとして転記され`TypeError`になることを確認した
- しかし実際の`sandbox/next`でのNext.js（Turbopack）ビルドでは、`package.json`の`sideEffects`宣言によりこの未使用importがtree-shakingで除去され、`Panel`がServer Componentとして問題なく動作することを実測確認した（`RSCChecker`で"This is server component"と表示され、正常にレンダリングされることを確認）
- これは既存の`SectioningContent`（`client/index.ts`を作らない方針）と同種の「素のNode実行では顕在化するが、実際のバンドラ利用では顕在化しない」パターンであり、CLAUDE.mdに記載の既存の考え方に沿っている

## プロダクト側で対応が必要な事項

なし。`Panel`の公開インターフェース（props）に変更はない。

## 確認方法

Storybookで`Panel`・`Groupbox`（`Panel`を内部で使用）の見た目に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Panelのクライアントコンポーネント指定を見直しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->