### PR TITLE
refactor(Layout): Center/Cluster/Reel/Sidebar/Stackから'use client'を削除する

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Center/Center.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Center/Center.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithRef,
   type ComponentType,

--- a/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithoutRef,
   type ElementType,

--- a/packages/smarthr-ui/src/components/Layout/Reel/Reel.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Reel/Reel.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithRef,
   type ComponentType,

--- a/packages/smarthr-ui/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Sidebar/Sidebar.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type CSSProperties,
   Children,

--- a/packages/smarthr-ui/src/components/Layout/Stack/Stack.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Stack/Stack.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithRef,
   type ComponentType,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Layout`配下の`Center`/`Cluster`/`Reel`/`Sidebar`/`Stack`はいずれも`useMemo`/`forwardRef`/`useSectionWrapper`のみを使用しており、`createContext`/`useContext`/`useState`などのclient専用APIを呼んでいなかったため、`'use client'`を削除した。

`Container`のみ`useEnvironment`（client専用）に依存しているため、今回の対象から除外している。

## 変更内容

- `Center.tsx`/`Cluster.tsx`/`Reel.tsx`/`Sidebar.tsx`/`Stack.tsx`から`'use client'`を削除

### 検証内容

- `sandbox/next`で各コンポーネントをServer Componentとしてレンダリングするページを使い、`RSCChecker`で"This is server component"と表示されること、実際に正しくレンダリングされることを実測確認した
- `pnpm ui lint`・`vitest run`（全体）が通ることを確認

## プロダクト側で対応が必要な事項

なし。各コンポーネントの公開インターフェース（props）に変更はない。

## 確認方法

Storybookで`Center`/`Cluster`/`Reel`/`Sidebar`/`Stack`の見た目に変化がないことを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * レイアウトコンポーネントのクライアントコンポーネント指定を見直しました。
  * 表示や利用方法など、コンポーネントの動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->