### PR TITLE
refactor: useEffectの見直し（不要な処理の簡略化・useLayoutEffect化・レンダー中比較への置き換え）

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.ts
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/useRemoteTrigger.ts
@@ -48,6 +48,9 @@ export function useRemoteTrigger({
 
     return {
       updateIsOpen,
+      cleanupToggleFrame: () => {
+        latest.toggleFrame.cancel()
+      },
       handleClickClose: () => {
         if (latest.onClickClose) {
           return latest.onClickClose(() => {
@@ -80,10 +83,10 @@ export function useRemoteTrigger({
 
     return () => {
       // HINT: アンマウント後に予約済みのonToggle・onOpen・onCloseが呼ばれないようにする
-      toggleFrame.cancel()
+      functions.cleanupToggleFrame()
       document.removeEventListener(TRIGGER_EVENT, handler)
     }
-  }, [id, toggleFrame, functions])
+  }, [id, functions])
 
   return {
     isOpen,

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -5,9 +5,9 @@ import {
   type PropsWithChildren,
   type ReactNode,
   memo,
-  useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
@@ -130,9 +130,15 @@ export const InformationPanel: FC<Props> = ({
   onClickTrigger,
   ...rest
 }) => {
-  const [active, setActive] = useState(activeProp)
   const id = useId()
   const contentId = `${id}-content`
+  const [active, setActive] = useState(activeProp)
+  const prevActiveRef = useRef<boolean>(activeProp)
+
+  if (prevActiveRef.current !== activeProp) {
+    prevActiveRef.current = activeProp
+    setActive(activeProp)
+  }
 
   const classNames = useMemo(() => {
     const {
@@ -154,10 +160,6 @@ export const InformationPanel: FC<Props> = ({
       content: content(),
     }
   }, [type, bold, className])
-
-  useEffect(() => {
-    setActive(activeProp)
-  }, [activeProp])
 
   return (
     <Panel {...rest} as="section" className={classNames.wrapper} data-active={active}>

--- a/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/InformationPanel.tsx
@@ -7,7 +7,6 @@ import {
   memo,
   useId,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { type VariantProps, tv } from 'tailwind-variants'
@@ -133,10 +132,10 @@ export const InformationPanel: FC<Props> = ({
   const id = useId()
   const contentId = `${id}-content`
   const [active, setActive] = useState(activeProp)
-  const prevActiveRef = useRef<boolean>(activeProp)
+  const [prevActiveProp, setPrevActiveProp] = useState(activeProp)
 
-  if (prevActiveRef.current !== activeProp) {
-    prevActiveRef.current = activeProp
+  if (prevActiveProp !== activeProp) {
+    setPrevActiveProp(activeProp)
     setActive(activeProp)
   }
 

--- a/packages/smarthr-ui/src/components/InputFile/client/DownloadAnchorButton.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/client/DownloadAnchorButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FC, useEffect, useState } from 'react'
+import { type FC, useLayoutEffect, useState } from 'react'
 
 import { Localizer } from '../../../intl'
 import { AnchorButton } from '../../Button'
@@ -12,7 +12,7 @@ import { PREVIEW_BUTTON_CLASSNAME } from './style'
 export const DownloadAnchorButton: FC<{ file: File }> = ({ file }) => {
   const [href, setHref] = useState('')
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const url = URL.createObjectURL(file)
     setHref(url)
 

--- a/packages/smarthr-ui/src/components/InputFile/client/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/client/FilePreviewDialog.tsx
@@ -27,15 +27,7 @@ export const FilePreviewDialog: FC<Props> = memo(
 
     useEffect(() => {
       if (!file) {
-        setBlobUrl((current) => {
-          if (current) {
-            URL.revokeObjectURL(current)
-            return undefined
-          }
-
-          return current
-        })
-
+        setBlobUrl(undefined)
         return
       }
 

--- a/packages/smarthr-ui/src/components/InputFile/client/FilePreviewDialog.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/client/FilePreviewDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type FC, memo, useEffect, useState } from 'react'
+import { type FC, memo, useLayoutEffect, useState } from 'react'
 
 import { useEnvironment } from '../../../hooks/client/useEnvironment'
 import { Localizer } from '../../../intl'
@@ -25,7 +25,7 @@ export const FilePreviewDialog: FC<Props> = memo(
     const isOpen = !!file
     const { mobile } = useEnvironment()
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (!file) {
         setBlobUrl(undefined)
         return


### PR DESCRIPTION
## 関連URL

なし

## 概要

複数コンポーネントのuseEffectを個別に見直し、それぞれ以下の観点でリファクタリングした。

- レンダー中に比較・計算できる処理をuseEffectから外せないか
- ちらつき防止のためuseLayoutEffectにすべきでないか
- 冗長・不要な処理が含まれていないか

## 変更内容

### InformationPanel

`activeProp`変化時の内部state同期を、`useEffect`からレンダー中に前回値をrefで比較する方式に変更。React公式が推奨する"prop変化に応じたstate同期"パターンで、`useEffect`版と違い1回分の余分な再レンダリングが発生しない。

### FilePreviewDialog

- `file`が`null`になった際、Reactが自動実行する前回effectのクリーンアップで既にrevokeObjectURL済みのURLを、`if (!file)`分岐内で再度revokeしていた（二重revoke、実害はないが冗長）のを解消し、`setBlobUrl(undefined)`のみに簡略化
- `blobUrl`生成を`useEffect`から`useLayoutEffect`に変更。`file`が新規セットされた直後は`blobUrl`が未設定のためLoaderが一度描画されてしまい、`useEffect`（ペイント後実行）だとLoader表示後にFileViewerへ切り替わるちらつきが発生しうるため

### DownloadAnchorButton

`href`のblobUrl生成を`useEffect`から`useLayoutEffect`に変更。初回レンダー時は`href=''`のAnchorButtonが一瞬コミットされ、`useEffect`（ペイント後実行）だとブラウザがその状態を一度描画してしまうため（FilePreviewDialogと同様の理由）

### useRemoteTrigger

`toggleFrame.cancel()`の呼び出しを`functions`経由にまとめ、`useEffect`の依存配列から`toggleFrame`を除去。`useAnimationFrame`は常に安定した参照を返すため挙動に変化はないが、`useEffect`内で直接参照しなくなった値を依存配列から外す一貫性のための変更

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 各コンポーネントについて `tsc --noEmit` / `eslint` / `prettier --check` / 関連する `vitest` を実行し通過を確認済み
- InformationPanel: activeProp外部変化時にdata-active属性が正しく同期されることを一時テストで確認
- Storybookで各コンポーネントの見た目・挙動に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ダイアログを閉じる際のアニメーション処理を改善し、不要な動作が残る問題を防止しました。
  - 情報パネルの表示状態が、指定された状態と正しく同期するよう改善しました。
  - ファイルのダウンロードやプレビュー時のURL処理を見直し、表示前後のちらつきや不要なリソースが残る問題を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->