### PR TITLE
refactor(RemoteDialogTrigger): useRef+useEffectをcallback refに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/RemoteDialogTrigger.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { type FC, type PropsWithChildren, useEffect, useRef } from 'react'
+import { type FC, type PropsWithChildren, useCallback } from 'react'
 
+import { useCallbackRefCleanupForReact18 } from '../../../hooks/client/useCallbackRefCleanupForReact18'
 import { useLatest } from '../../../hooks/useLatest'
 
 import { TRIGGER_EVENT } from './useRemoteTrigger'
@@ -24,86 +25,91 @@ export const RemoteDialogTrigger: FC<
     onClick?: (open: () => void) => void
   }>
 > = ({ targetId, children, onClick }) => {
-  const ref = useRef<HTMLSpanElement | null>(null)
   const latest = useLatest({ onClick })
 
-  useEffect(() => {
-    const currentRef = ref.current
-    if (!currentRef) {
-      return
-    }
+  const callbackRef = useCallbackRefCleanupForReact18(
+    useCallback(
+      (node: HTMLElement | null) => {
+        if (!node) {
+          return
+        }
 
-    const handleClick = (e: Event) => {
-      // HINT: onClick内で非同期処理される場合、e.currentTargetがnullになってしまう可能性があるため
-      // 先にariaControlsを取得しておく
-      const ariaControls = (e.currentTarget as HTMLElement).getAttribute('aria-controls') as string
+        const handleClick = (e: Event) => {
+          // HINT: onClick内で非同期処理される場合、e.currentTargetがnullになってしまう可能性があるため
+          // 先にariaControlsを取得しておく
+          const ariaControls = (e.currentTarget as HTMLElement).getAttribute(
+            'aria-controls',
+          ) as string
 
-      if (latest.onClick) {
-        return latest.onClick(() => {
+          if (latest.onClick) {
+            return latest.onClick(() => {
+              dispatchRemoteDialogTrigger(ariaControls)
+            })
+          }
+
           dispatchRemoteDialogTrigger(ariaControls)
+        }
+
+        const getClickableElement = () =>
+          node.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
+
+        // 現在の子要素に対して処理を実行
+        const setupElement = () => {
+          const element = getClickableElement()
+          if (!element) {
+            return
+          }
+
+          element.setAttribute('aria-haspopup', 'dialog')
+          element.setAttribute('aria-controls', targetId)
+
+          // Button は native disabled ではなく aria-disabled を使うため、
+          // 無効時はリスナーを貼らず Dialog が開かないようにする（DropdownTrigger と同じ）
+          if (
+            !('disabled' in element && element.disabled) &&
+            element.getAttribute('aria-disabled') !== 'true'
+          ) {
+            // HINT: DropdownCloser のonClickより先に実行するため、キャプチャフェーズで処理する
+            element.addEventListener('click', handleClick, CAPTURE_OPTION)
+          }
+        }
+
+        const clearEventListener = () => {
+          // 既存のイベントリスナーをクリーンアップ
+          const element = getClickableElement()
+          if (element) {
+            element.removeEventListener('click', handleClick, CAPTURE_OPTION)
+          }
+        }
+
+        // 初回セットアップ
+        setupElement()
+
+        // MutationObserverでDOM変更を監視
+        const observer = new MutationObserver(() => {
+          clearEventListener()
+          setupElement()
         })
-      }
 
-      dispatchRemoteDialogTrigger(ariaControls)
-    }
+        observer.observe(node, {
+          childList: true,
+          subtree: true,
+          // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
+          attributes: true,
+          attributeFilter: ['disabled', 'aria-disabled'],
+        })
 
-    const getClickableElement = () =>
-      currentRef.querySelector<HTMLButtonElement | HTMLAnchorElement>('button, a')
-
-    // 現在の子要素に対して処理を実行
-    const setupElement = () => {
-      const element = getClickableElement()
-      if (!element) {
-        return
-      }
-
-      element.setAttribute('aria-haspopup', 'dialog')
-      element.setAttribute('aria-controls', targetId)
-
-      // Button は native disabled ではなく aria-disabled を使うため、
-      // 無効時はリスナーを貼らず Dialog が開かないようにする（DropdownTrigger と同じ）
-      if (
-        !('disabled' in element && element.disabled) &&
-        element.getAttribute('aria-disabled') !== 'true'
-      ) {
-        // HINT: DropdownCloser のonClickより先に実行するため、キャプチャフェーズで処理する
-        element.addEventListener('click', handleClick, CAPTURE_OPTION)
-      }
-    }
-
-    const clearEventListener = () => {
-      // 既存のイベントリスナーをクリーンアップ
-      const element = getClickableElement()
-      if (element) {
-        element.removeEventListener('click', handleClick, CAPTURE_OPTION)
-      }
-    }
-
-    // 初回セットアップ
-    setupElement()
-
-    // MutationObserverでDOM変更を監視
-    const observer = new MutationObserver(() => {
-      clearEventListener()
-      setupElement()
-    })
-
-    observer.observe(currentRef, {
-      childList: true,
-      subtree: true,
-      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
-      attributes: true,
-      attributeFilter: ['disabled', 'aria-disabled'],
-    })
-
-    return () => {
-      observer.disconnect()
-      clearEventListener()
-    }
-  }, [targetId, latest])
+        return () => {
+          observer.disconnect()
+          clearEventListener()
+        }
+      },
+      [targetId, latest],
+    ),
+  )
 
   return (
-    <span ref={ref} className="smarthr-ui-RemoteDialogTrigger shr-contents">
+    <span ref={callbackRef} className="smarthr-ui-RemoteDialogTrigger shr-contents">
       {children}
     </span>
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

`RemoteDialogTrigger`はuseRef+useEffectでDOM要素（子要素のbutton/a）にMutationObserverとclickイベントリスナーをセットアップしていたが、これはDOM要素のmount/unmountに直接連動する処理であり、CLAUDE.mdの方針に沿ってcallback ref化する。

## 変更内容

- `useRef` + `useEffect`を、`useCallbackRefCleanupForReact18`でラップしたcallback refに置き換えた
- ラップが必要な理由: React 19ではcallback refが返すcleanup関数をReactが自動実行するが、React 18にはその仕組みがなく戻り値は無視される。smarthr-uiは`react: "^18.0.0 || ^19.0.0"`を対象とするため、ラップしないとReact 18環境で`targetId`/`onClick`変化のたびにMutationObserverとclickイベントリスナーが解放されずに重複登録されてしまう
- ロジック自体（子要素の検出、`aria-haspopup`/`aria-controls`付与、disabled時のリスナー抑制、MutationObserverによる再セットアップ）は変更していない

## プロダクト側で対応が必要な事項

なし

## 確認方法

- `tsc --noEmit` / `eslint` / `prettier --check` / 既存の`vitest`（RemoteDialogTrigger配下、3ファイル10件）が通過することを確認済み
- `onClick`変更によるrerenderでclickイベントリスナーが重複登録されないことを一時テストで確認済み
- Storybookで`Components/Dialog/RemoteDialogTrigger`の見た目・挙動に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ダイアログを開くトリガーの内部処理を更新し、React 18環境での安定性を向上しました。
  * クリック操作、無効状態の判定、属性設定、変更監視など、既存の動作は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->