### PR TITLE
refactor(Dialog): useEffectの見直し(useLayoutEffect化・callback ref化・不具合修正)

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/DialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentInner.tsx
@@ -6,7 +6,7 @@ import {
   type PropsWithChildren,
   type RefObject,
   memo,
-  useEffect,
+  useLayoutEffect,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
@@ -138,7 +138,7 @@ export const DialogContentInner: FC<Props> = ({
 
   const callbackRef = useEscapeCallbackRef(functions.handlePressEscape)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isOpen) return
 
     const body = document.body

--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -3,13 +3,15 @@ import {
   type FC,
   type PropsWithChildren,
   type ReactNode,
-  useEffect,
+  useCallback,
   useMemo,
   useRef,
 } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { tv } from 'tailwind-variants'
 
+import { useCallbackRefCleanupForReact18 } from '../../hooks/client/useCallbackRefCleanupForReact18'
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { Center } from '../Layout'
 
 type Props = PropsWithChildren<
@@ -38,38 +40,46 @@ const classNameGenerator = tv({
 })
 
 export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) => {
-  const childrenBufferRef = useRef<ReactNode>(null)
-  const nodeRef = useRef<HTMLDivElement>(null)
-
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
   // childrenをrefに保存（毎レンダリング時に最新の値を設定）
   const childrenRef = useRef(children)
   childrenRef.current = children
+  const childrenBufferRef = useRef<ReactNode>(null)
 
-  useEffect(() => {
-    if (!isOpen || !nodeRef.current) {
-      return
-    }
+  const nodeRef = useRef<HTMLElement>(null)
 
-    // isOpen が true になった時に初期値を設定
-    childrenBufferRef.current = childrenRef.current
+  const callbackRef = useCallbackRefCleanupForReact18(
+    useCallback((node: HTMLElement | null) => {
+      if (!node) {
+        return
+      }
 
-    // MutationObserver で DOM の変更を監視
-    const observer = new MutationObserver(() => {
-      childrenBufferRef.current = childrenRef.current
-    })
+      const syncChildrenBuffer = () => {
+        if (node.getAttribute('data-dialog-open') === 'true') {
+          childrenBufferRef.current = childrenRef.current
+        }
+      }
 
-    observer.observe(nodeRef.current, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    })
+      // マウント時点のdata-dialog-open状態を反映
+      syncChildrenBuffer()
 
-    return () => {
-      observer.disconnect()
-    }
-  }, [isOpen])
+      // MutationObserver で DOM の変更を監視
+      const observer = new MutationObserver(syncChildrenBuffer)
+
+      observer.observe(node, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      })
+
+      return () => {
+        observer.disconnect()
+      }
+    }, []),
+  )
+
+  const mergedRef = useMergeRefs(nodeRef, callbackRef)
 
   return (
     <CSSTransition
@@ -79,7 +89,13 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
       unmountOnExit
       classNames="shr-dialog-transition"
     >
-      <Center as={as} ref={nodeRef} verticalCentering className={actualClassName}>
+      <Center
+        as={as}
+        ref={mergedRef}
+        verticalCentering
+        className={actualClassName}
+        data-dialog-open={isOpen || undefined}
+      >
         {isOpen ? children : childrenBufferRef.current}
       </Center>
     </CSSTransition>

--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -2,10 +2,10 @@ import {
   type ComponentProps,
   type FC,
   type PropsWithChildren,
-  type ReactNode,
   useCallback,
   useMemo,
   useRef,
+  useState,
 } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import { tv } from 'tailwind-variants'
@@ -45,7 +45,7 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
   // childrenをrefに保存（毎レンダリング時に最新の値を設定）
   const childrenRef = useRef(children)
   childrenRef.current = children
-  const childrenBufferRef = useRef<ReactNode>(null)
+  const [childrenBuffer, setChildrenBuffer] = useState(children)
 
   const nodeRef = useRef<HTMLElement>(null)
 
@@ -56,8 +56,8 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
       }
 
       const syncChildrenBuffer = () => {
-        if (node.getAttribute('data-dialog-open') === 'true') {
-          childrenBufferRef.current = childrenRef.current
+        if (node.getAttribute('data-dialog-open') !== 'true') {
+          setChildrenBuffer(childrenRef.current)
         }
       }
 
@@ -68,10 +68,8 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
       const observer = new MutationObserver(syncChildrenBuffer)
 
       observer.observe(node, {
-        childList: true,
-        subtree: true,
-        characterData: true,
         attributes: true,
+        attributeFilter: ['data-dialog-open'],
       })
 
       return () => {
@@ -97,7 +95,7 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
         className={actualClassName}
         data-dialog-open={isOpen || undefined}
       >
-        {isOpen ? children : childrenBufferRef.current}
+        {isOpen ? children : childrenBuffer}
       </Center>
     </CSSTransition>
   )

--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -71,6 +71,7 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
         childList: true,
         subtree: true,
         characterData: true,
+        attributes: true,
       })
 
       return () => {

--- a/packages/smarthr-ui/src/components/Dialog/useDialogPortal.ts
+++ b/packages/smarthr-ui/src/components/Dialog/useDialogPortal.ts
@@ -18,7 +18,7 @@ export function useDialogPortal(parent?: HTMLElement | RefObject<HTMLElement>, i
     }
 
     const parentElement = parent && 'current' in parent ? parent.current : parent
-    // SSR を考慮し、useEffect 内で初期値 document.body を指定
+    // SSR を考慮し、useLayoutEffect 内で初期値 document.body を指定
     const actualParent = parentElement || document.body
 
     actualParent.appendChild(portalContainer)


### PR DESCRIPTION
## 関連URL

なし

## 概要

Dialog配下のuseEffectを個別に見直し、それぞれ以下の観点でリファクタリングした。

- ちらつき防止のためuseLayoutEffectにすべきでないか
- DOM要素のmount/unmountに連動する処理はcallback ref化できないか
- 見直しの過程で見つかった既存の不具合の修正

## 変更内容

### useDialogPortal

コメントの文言を調整（実装と一致させた）。

### DialogContentInner

body scroll lock（`overflow:hidden`・スクロールバー幅補正のpadding付与）を`useEffect`から`useLayoutEffect`に変更。`isOpen`がtrueになった最初のフレームでロックが未適用のままDialogが描画されると、レイアウトシフトや一瞬だけ背景がスクロール可能な状態が発生しうるため、ペイント前に同期適用するようにした。

### DialogOverlap

- `useRef` + `useEffect`によるMutationObserverのセットアップを、`useCallbackRefCleanupForReact18`でラップしたcallback refに置き換えた。ラップしないとReact 18環境ではcallback refの戻り値（cleanup関数）が無視されるため、`isOpen`変化のたびにMutationObserverが解放されず重複登録されてしまう不具合があった
- `callbackRef`が`isOpen`に依存し続けると、`isOpen`変化のたびに不要な再アタッチが発生してしまうため、`Center`に`data-dialog-open`属性を追加し、MutationObserverのコールバック内でこの属性を読み取る方式に変更。`callbackRef`自体はマウント時に一度だけセットアップされる
- 監視対象を`data-dialog-open`属性の変化のみに絞った上で、`childrenBufferRef`（`useRef`）を`useState`に変更。refへの代入はReactの再レンダーをトリガーしないため、MutationObserverのコールバック内でbufferを更新してもDOMに反映される保証がなかった不具合を修正した

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 各コンポーネントについて `tsc --noEmit` / `eslint` / `prettier --check` / 関連する `vitest`（Dialog配下、10ファイル23件）を実行し通過を確認済み
- DialogOverlapについては以下のシナリオを一時テストで確認済み
  - 閉じるアニメーション中は閉じる直前の最新の中身が表示され続けること
  - 属性のみの変化（テキスト・DOM構造を変えない）も閉じた際にbufferへ反映されること
  - `isOpen`の変化を繰り返してもcallback refが再アタッチされない（MutationObserverが再セットアップされない）こと
  - 同一イベント内でchildren変更とisOpen=falseを同時に行った場合も最新の内容が表示されること
  - `isOpen=false`になった後（`onClose`コールバック相当のタイミング）にchildrenへ影響する変更が行われた場合は、bufferに反映されない（意図した仕様: Dialogが閉じ始めた後は表示内容を閉じる直前の状態で固定する）ことを確認
- Storybookで各コンポーネントの見た目・挙動に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ダイアログ表示時のスクロール抑制と余白調整のタイミングを改善しました。
  * ダイアログを閉じている間の内容更新を適切に反映し、再表示時に最新の内容が表示されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->