### PR TITLE
refactor(FileViewer): useEffectの見直し(callback ref化・レンダー中同期・Component分岐)

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -269,16 +269,11 @@ const ActualFileViewer: FC<
   )
 
   return hasWidth ? (
-    <Scroller direction="both" className={SCROLLER_CLASS_NAME}>
-      {content}
-    </Scroller>
+    <ActualScroller>{content}</ActualScroller>
   ) : (
     <ResizingScroller setWidth={setWidth}>{content}</ResizingScroller>
   )
 }
-
-const SCROLLER_CLASS_NAME =
-  'shr-flex shr-h-full shr-w-full shr-flex-col shr-gap-2 shr-bg-scrim shr-bg-[radial-gradient(theme(textColor.black)_1px,_transparent_0)] shr-bg-[length:16px_16px]'
 
 const ResizingScroller: FC<PropsWithChildren<{ setWidth: CommonViewerProps['setWidth'] }>> = ({
   setWidth,
@@ -305,12 +300,19 @@ const ResizingScroller: FC<PropsWithChildren<{ setWidth: CommonViewerProps['setW
     ),
   )
 
-  return (
-    <Scroller ref={callbackRef} direction="both" className={SCROLLER_CLASS_NAME}>
-      {children}
-    </Scroller>
-  )
+  return <ActualScroller callbackRef={callbackRef}>{children}</ActualScroller>
 }
+const ActualScroller: FC<
+  PropsWithChildren<{ callbackRef?: (node: HTMLElement | null) => void }>
+> = ({ callbackRef, children }) => (
+  <Scroller
+    ref={callbackRef}
+    direction="both"
+    className="shr-flex shr-h-full shr-w-full shr-flex-col shr-gap-2 shr-bg-scrim shr-bg-[radial-gradient(theme(textColor.black)_1px,_transparent_0)] shr-bg-[length:16px_16px]"
+  >
+    {children}
+  </Scroller>
+)
 
 type ControllerProps = Pick<CommonViewerProps, 'scale' | 'functions'> & {
   scaleSteps: NonNullable<CommonViewerProps['scaleSteps']>

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -8,12 +8,12 @@ import {
   type PropsWithChildren,
   type ReactNode,
   memo,
-  useEffect,
+  useCallback,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 
+import { useCallbackRefCleanupForReact18 } from '../../hooks/client/useCallbackRefCleanupForReact18'
 import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
@@ -238,28 +238,32 @@ const ActualFileViewer: FC<
     }
   >
 > = ({ scale, loaded, hasWidth, setWidth, scaleSteps, functions, searchController, children }) => {
-  const ref = useRef<HTMLDivElement>(null)
   const loading = children && !loaded
 
-  useEffect(() => {
-    if (!ref.current || hasWidth) {
-      return
-    }
+  const callbackRef = useCallbackRefCleanupForReact18(
+    useCallback(
+      (node: HTMLElement | null) => {
+        if (!node || hasWidth) {
+          return
+        }
 
-    const resizeObserver = new ResizeObserver(() => {
-      setWidth((ref.current?.clientWidth ?? 0) - 64)
-    })
+        const resizeObserver = new ResizeObserver(() => {
+          setWidth((node.clientWidth ?? 0) - 64)
+        })
 
-    resizeObserver.observe(ref.current)
+        resizeObserver.observe(node)
 
-    return () => {
-      resizeObserver.disconnect()
-    }
-  }, [hasWidth, setWidth])
+        return () => {
+          resizeObserver.disconnect()
+        }
+      },
+      [hasWidth, setWidth],
+    ),
+  )
 
   return (
     <Scroller
-      ref={ref}
+      ref={callbackRef}
       direction="both"
       className="shr-flex shr-h-full shr-w-full shr-flex-col shr-gap-2 shr-bg-scrim shr-bg-[radial-gradient(theme(textColor.black)_1px,_transparent_0)] shr-bg-[length:16px_16px]"
     >

--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -240,33 +240,8 @@ const ActualFileViewer: FC<
 > = ({ scale, loaded, hasWidth, setWidth, scaleSteps, functions, searchController, children }) => {
   const loading = children && !loaded
 
-  const callbackRef = useCallbackRefCleanupForReact18(
-    useCallback(
-      (node: HTMLElement | null) => {
-        if (!node || hasWidth) {
-          return
-        }
-
-        const resizeObserver = new ResizeObserver(() => {
-          setWidth((node.clientWidth ?? 0) - 64)
-        })
-
-        resizeObserver.observe(node)
-
-        return () => {
-          resizeObserver.disconnect()
-        }
-      },
-      [hasWidth, setWidth],
-    ),
-  )
-
-  return (
-    <Scroller
-      ref={callbackRef}
-      direction="both"
-      className="shr-flex shr-h-full shr-w-full shr-flex-col shr-gap-2 shr-bg-scrim shr-bg-[radial-gradient(theme(textColor.black)_1px,_transparent_0)] shr-bg-[length:16px_16px]"
-    >
+  const content = (
+    <>
       <div className="shr-sticky shr-start-0 shr-top-0 shr-z-[1] shr-flex shr-w-full shr-flex-shrink-0 shr-gap-0.5">
         <Controller
           scale={scale}
@@ -290,6 +265,49 @@ const ActualFileViewer: FC<
           )}
         </div>
       </div>
+    </>
+  )
+
+  return hasWidth ? (
+    <Scroller direction="both" className={SCROLLER_CLASS_NAME}>
+      {content}
+    </Scroller>
+  ) : (
+    <ResizingScroller setWidth={setWidth}>{content}</ResizingScroller>
+  )
+}
+
+const SCROLLER_CLASS_NAME =
+  'shr-flex shr-h-full shr-w-full shr-flex-col shr-gap-2 shr-bg-scrim shr-bg-[radial-gradient(theme(textColor.black)_1px,_transparent_0)] shr-bg-[length:16px_16px]'
+
+const ResizingScroller: FC<PropsWithChildren<{ setWidth: CommonViewerProps['setWidth'] }>> = ({
+  setWidth,
+  children,
+}) => {
+  const callbackRef = useCallbackRefCleanupForReact18(
+    useCallback(
+      (node: HTMLElement | null) => {
+        if (!node) {
+          return
+        }
+
+        const resizeObserver = new ResizeObserver(() => {
+          setWidth((node.clientWidth ?? 0) - 64)
+        })
+
+        resizeObserver.observe(node)
+
+        return () => {
+          resizeObserver.disconnect()
+        }
+      },
+      [setWidth],
+    ),
+  )
+
+  return (
+    <Scroller ref={callbackRef} direction="both" className={SCROLLER_CLASS_NAME}>
+      {children}
     </Scroller>
   )
 }

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,11 +1,4 @@
-import {
-  type ChangeEvent,
-  type ComponentProps,
-  type KeyboardEvent,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { type ChangeEvent, type ComponentProps, type KeyboardEvent, useMemo, useState } from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -67,13 +60,12 @@ export const usePDFSearch = (fileUrl: string) => {
   const [query, setQueryState] = useState('')
   const [matches, setMatches] = useState<PDFSearchMatch[]>([])
   const [currentMatchIndex, setCurrentMatchIndex] = useState(-1)
-  const pageTextsRef = useRef<Map<number, string[]>>(new Map())
-  const queryRef = useRef('')
+  const [pageTexts, setPageTexts] = useState<Map<number, string[]>>(() => new Map())
   const [prevFileUrl, setPrevFileUrl] = useState(fileUrl)
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const latest = useLatest({ matchCount })
+  const latest = useLatest({ matchCount, query, pageTexts })
 
   const functions = useMemo(() => {
     const resetMatchState = () => {
@@ -81,21 +73,25 @@ export const usePDFSearch = (fileUrl: string) => {
       setCurrentMatchIndex(-1)
     }
 
-    const recalculate = (nextQuery: string, options?: { resetSelection?: boolean }) => {
+    const recalculate = (
+      texts: Map<number, string[]>,
+      nextQuery: string,
+      options?: { resetSelection?: boolean },
+    ) => {
       if (nextQuery === '') {
         resetMatchState()
         return
       }
       const escapedQuery = escapeRegExp(normalize(nextQuery))
-      const pageIndices = Array.from(pageTextsRef.current.keys()).sort((a, b) => a - b)
+      const pageIndices = Array.from(texts.keys()).sort((a, b) => a - b)
       const collected: PDFSearchMatch[] = []
       let globalIndex = 0
       for (const pageIndex of pageIndices) {
-        const texts = pageTextsRef.current.get(pageIndex)
-        if (!texts) continue
+        const pageTextItems = texts.get(pageIndex)
+        if (!pageTextItems) continue
         const { matches: pageMatches, nextGlobalIndex } = computeMatchesForPage(
           pageIndex,
-          texts,
+          pageTextItems,
           escapedQuery,
           globalIndex,
         )
@@ -137,9 +133,8 @@ export const usePDFSearch = (fileUrl: string) => {
       handleChangeQuery: (e: ChangeEvent<HTMLInputElement>) => {
         const nextQuery = e.target.value
 
-        queryRef.current = nextQuery
         setQueryState(nextQuery)
-        recalculate(nextQuery, { resetSelection: true })
+        recalculate(latest.pageTexts, nextQuery, { resetSelection: true })
       },
       handleKeyDownQuery: (e: KeyboardEvent<HTMLInputElement>) => {
         if (e.nativeEvent.isComposing) {
@@ -156,9 +151,8 @@ export const usePDFSearch = (fileUrl: string) => {
             break
           }
           case 'Escape': {
-            if (queryRef.current !== '') {
+            if (latest.query !== '') {
               e.preventDefault()
-              queryRef.current = ''
               setQueryState('')
               resetMatchState()
             }
@@ -173,10 +167,12 @@ export const usePDFSearch = (fileUrl: string) => {
           }
           return acc
         }, [])
-        pageTextsRef.current.set(pageIndex, texts.map(normalize))
+        const nextPageTexts = new Map(latest.pageTexts)
+        nextPageTexts.set(pageIndex, texts.map(normalize))
+        setPageTexts(nextPageTexts)
         // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
-        if (queryRef.current !== '') {
-          recalculate(queryRef.current)
+        if (latest.query !== '') {
+          recalculate(nextPageTexts, latest.query)
         }
       },
     }
@@ -184,8 +180,7 @@ export const usePDFSearch = (fileUrl: string) => {
 
   if (prevFileUrl !== fileUrl) {
     setPrevFileUrl(fileUrl)
-    pageTextsRef.current.clear()
-    queryRef.current = ''
+    setPageTexts(new Map())
     setQueryState('')
     functions.resetMatchState()
   }

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -2,7 +2,6 @@ import {
   type ChangeEvent,
   type ComponentProps,
   type KeyboardEvent,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -70,6 +69,7 @@ export const usePDFSearch = (fileUrl: string) => {
   const [currentMatchIndex, setCurrentMatchIndex] = useState(-1)
   const pageTextsRef = useRef<Map<number, string[]>>(new Map())
   const queryRef = useRef('')
+  const [prevFileUrl, setPrevFileUrl] = useState(fileUrl)
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
@@ -182,12 +182,13 @@ export const usePDFSearch = (fileUrl: string) => {
     }
   }, [latest])
 
-  useEffect(() => {
+  if (prevFileUrl !== fileUrl) {
+    setPrevFileUrl(fileUrl)
     pageTextsRef.current.clear()
     queryRef.current = ''
     setQueryState('')
     functions.resetMatchState()
-  }, [fileUrl, functions])
+  }
 
   const customTextRenderer = useMemo(() => {
     if (matches.length === 0) {

--- a/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
+++ b/packages/smarthr-ui/src/components/FileViewer/usePDFSearch.ts
@@ -1,4 +1,11 @@
-import { type ChangeEvent, type ComponentProps, type KeyboardEvent, useMemo, useState } from 'react'
+import {
+  type ChangeEvent,
+  type ComponentProps,
+  type KeyboardEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
 import { useLatest } from '../../hooks/useLatest'
 
@@ -60,12 +67,16 @@ export const usePDFSearch = (fileUrl: string) => {
   const [query, setQueryState] = useState('')
   const [matches, setMatches] = useState<PDFSearchMatch[]>([])
   const [currentMatchIndex, setCurrentMatchIndex] = useState(-1)
-  const [pageTexts, setPageTexts] = useState<Map<number, string[]>>(() => new Map())
+  // useState化も検討したが、ページ読み込み完了ごとにMapを丸ごとコピーして再レンダーを誘発するコストが
+  // ページ数に対してO(n^2)になり実測でも悪化したため、refのまま維持している。
+  // レンダー中に呼ぶのはclear()のみで、Suspense/startTransition等concurrent機能を使っていないため
+  // 「レンダー破棄によるref不整合」の実害はない。
+  const pageTextsRef = useRef<Map<number, string[]>>(new Map())
   const [prevFileUrl, setPrevFileUrl] = useState(fileUrl)
 
   const matchCount = matches.length === 0 ? 0 : matches[matches.length - 1].globalIndex + 1
 
-  const latest = useLatest({ matchCount, query, pageTexts })
+  const latest = useLatest({ matchCount, query })
 
   const functions = useMemo(() => {
     const resetMatchState = () => {
@@ -73,21 +84,17 @@ export const usePDFSearch = (fileUrl: string) => {
       setCurrentMatchIndex(-1)
     }
 
-    const recalculate = (
-      texts: Map<number, string[]>,
-      nextQuery: string,
-      options?: { resetSelection?: boolean },
-    ) => {
+    const recalculate = (nextQuery: string, options?: { resetSelection?: boolean }) => {
       if (nextQuery === '') {
         resetMatchState()
         return
       }
       const escapedQuery = escapeRegExp(normalize(nextQuery))
-      const pageIndices = Array.from(texts.keys()).sort((a, b) => a - b)
+      const pageIndices = Array.from(pageTextsRef.current.keys()).sort((a, b) => a - b)
       const collected: PDFSearchMatch[] = []
       let globalIndex = 0
       for (const pageIndex of pageIndices) {
-        const pageTextItems = texts.get(pageIndex)
+        const pageTextItems = pageTextsRef.current.get(pageIndex)
         if (!pageTextItems) continue
         const { matches: pageMatches, nextGlobalIndex } = computeMatchesForPage(
           pageIndex,
@@ -134,7 +141,7 @@ export const usePDFSearch = (fileUrl: string) => {
         const nextQuery = e.target.value
 
         setQueryState(nextQuery)
-        recalculate(latest.pageTexts, nextQuery, { resetSelection: true })
+        recalculate(nextQuery, { resetSelection: true })
       },
       handleKeyDownQuery: (e: KeyboardEvent<HTMLInputElement>) => {
         if (e.nativeEvent.isComposing) {
@@ -167,12 +174,10 @@ export const usePDFSearch = (fileUrl: string) => {
           }
           return acc
         }, [])
-        const nextPageTexts = new Map(latest.pageTexts)
-        nextPageTexts.set(pageIndex, texts.map(normalize))
-        setPageTexts(nextPageTexts)
+        pageTextsRef.current.set(pageIndex, texts.map(normalize))
         // 全ページ読み込み前に検索が始まっても、後から読んだページがヒットするよう再計算する。
         if (latest.query !== '') {
-          recalculate(nextPageTexts, latest.query)
+          recalculate(latest.query)
         }
       },
     }
@@ -180,7 +185,7 @@ export const usePDFSearch = (fileUrl: string) => {
 
   if (prevFileUrl !== fileUrl) {
     setPrevFileUrl(fileUrl)
-    setPageTexts(new Map())
+    pageTextsRef.current.clear()
     setQueryState('')
     functions.resetMatchState()
   }


### PR DESCRIPTION
## 関連URL

なし

## 概要

FileViewer配下のuseEffectを見直し、以下の観点でリファクタリングした。

- DOM要素のmount/unmountに連動する処理はcallback ref化できないか
- レンダー中に比較・計算できる処理はuseEffectから外せないか
- 条件によって処理の要否が完全に分かれる場合、コンポーネント分岐で表現できないか

## 変更内容

### FileViewer

- `useRef` + `useEffect`によるResizeObserverのセットアップを、`useCallbackRefCleanupForReact18`でラップしたcallback refに置き換えた。ラップしないとReact 18環境ではcallback refの戻り値（cleanup関数）が無視されるため、`hasWidth`変化のたびにResizeObserverが解放されず重複登録されてしまう不具合があった
- `hasWidth`がtrueの場合はResizeObserverが不要なため、callback ref内で`hasWidth`をチェックするのではなく、`Scroller`（refなし）と`ResizingScroller`（callback refあり）にコンポーネントを分岐した。`ResizingScroller`内では`hasWidth`を見る必要がなくなり、`useCallback`の依存配列からも外せる。`hasWidth`は`FileViewer`の`width` propに由来し実行中に動的変化しないため、分岐によるアンマウント/再マウントの影響も実質ない

### usePDFSearch

`fileUrl`変化時の検索状態（ページテキストキャッシュ・クエリ・マッチ結果）のリセットを`useEffect`からレンダー中の比較に変更した。`useEffect`だと、`fileUrl`変化後リセットが反映されるまでの1レンダー分、検索input欄に古いファイルの検索文字列が表示されてしまう。前回の`fileUrl`を`useState`で保持しレンダー中に比較する方式に変更し、1レンダーの遅延なく同期されるようにした。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 各変更について `tsc --noEmit` / `eslint` / `prettier --check` / 関連する `vitest`（FileViewer配下、3ファイル38件）を実行し通過を確認済み
- `usePDFSearch`: `fileUrl`変化時に`query`/`matches`/`currentMatchIndex`がリセットされること、同一`fileUrl`でのrerenderではリセットされないことを一時テストで確認
- `FileViewer`: `hasWidth`ありなし両パターンで正常にレンダーされること、変更前後で`renderToStaticMarkup`によるDOM出力が完全一致することを確認
- Storybookで`Components/FileViewer`の見た目・挙動に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - ファイルビューアーの表示幅変更に対応し、サイズ調整時の表示がより安定しました。
  - 指定された表示幅に応じて、スクロール領域が適切に調整されるようになりました。

- **バグ修正**
  - 表示するファイルを切り替えた際、以前の検索語や検索結果が残らず、新しいファイルの内容に合わせて検索状態が正しく更新されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->