### PR TITLE
refactor(Checkbox): useRef+useEffectをcallback refに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
@@ -5,10 +5,9 @@ import {
   type PropsWithChildren,
   forwardRef,
   memo,
-  useEffect,
+  useCallback,
   useId,
   useMemo,
-  useRef,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
@@ -79,18 +78,36 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
       }
     }, [className])
 
-    const inputRef = useRef<HTMLInputElement>(null)
-
     const defaultId = useId()
     const checkBoxId = id || defaultId
 
-    const mergedRef = useMergeRefs(inputRef, ref)
-
-    useEffect(() => {
-      if (inputRef.current) {
-        inputRef.current.indeterminate = !!(checked && mixed)
+    const callbackRef = useCallback((node: HTMLInputElement | null) => {
+      if (!node) {
+        return
       }
-    }, [checked, mixed])
+
+      // checkedはcontrolled propとしてinput.checkedプロパティにのみ反映され、
+      // HTML属性としては反映されないため、data-checked属性で代替判定する
+      const action = () => {
+        node.indeterminate =
+          node.getAttribute('data-checked') === 'true' && node.getAttribute('data-mixed') === 'true'
+      }
+
+      action()
+
+      const observer = new MutationObserver(action)
+
+      observer.observe(node, {
+        attributes: true,
+        attributeFilter: ['data-checked', 'data-mixed'],
+      })
+
+      return () => {
+        observer.disconnect()
+      }
+    }, [])
+
+    const mergedRef = useMergeRefs(callbackRef, ref)
 
     return (
       <span className={classNames.wrapper} data-disabled={disabled}>
@@ -105,6 +122,9 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
             className={classNames.input}
             aria-invalid={error || undefined}
             data-smarthr-ui-input="true"
+            // checkedはDOM属性ではなくプロパティとしてのみ反映されるため、data-checkedをMutationObserverで監視
+            data-checked={checked || undefined}
+            data-mixed={mixed || undefined}
           />
           <AriaHiddenBox className={classNames.box} />
           <CheckIconArea mixed={mixed} classNames={classNames} />

--- a/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
@@ -5,7 +5,6 @@ import {
   type PropsWithChildren,
   forwardRef,
   memo,
-  useCallback,
   useId,
   useMemo,
 } from 'react'
@@ -62,6 +61,32 @@ const classNameGenerator = tv({
   },
 })
 
+const callbackRef = (node: HTMLInputElement | null) => {
+  if (!node) {
+    return
+  }
+
+  // checkedはcontrolled propとしてinput.checkedプロパティにのみ反映され、
+  // HTML属性としては反映されないため、data-checked属性で代替判定する
+  const action = () => {
+    node.indeterminate =
+      node.getAttribute('data-checked') === 'true' && node.getAttribute('data-mixed') === 'true'
+  }
+
+  action()
+
+  const observer = new MutationObserver(action)
+
+  observer.observe(node, {
+    attributes: true,
+    attributeFilter: ['data-checked', 'data-mixed'],
+  })
+
+  return () => {
+    observer.disconnect()
+  }
+}
+
 export const Checkbox = forwardRef<HTMLInputElement, Props>(
   ({ checked, mixed, error, className, children, disabled, id, ...rest }, ref) => {
     const classNames = useMemo(() => {
@@ -80,32 +105,6 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
 
     const defaultId = useId()
     const checkBoxId = id || defaultId
-
-    const callbackRef = useCallback((node: HTMLInputElement | null) => {
-      if (!node) {
-        return
-      }
-
-      // checkedはcontrolled propとしてinput.checkedプロパティにのみ反映され、
-      // HTML属性としては反映されないため、data-checked属性で代替判定する
-      const action = () => {
-        node.indeterminate =
-          node.getAttribute('data-checked') === 'true' && node.getAttribute('data-mixed') === 'true'
-      }
-
-      action()
-
-      const observer = new MutationObserver(action)
-
-      observer.observe(node, {
-        attributes: true,
-        attributeFilter: ['data-checked', 'data-mixed'],
-      })
-
-      return () => {
-        observer.disconnect()
-      }
-    }, [])
 
     const mergedRef = useMergeRefs(callbackRef, ref)
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`indeterminate`状態の設定は`checked`/`mixed`というDOM要素のmount/unmountに連動する処理のため、CLAUDE.mdの方針に沿ってcallback ref化する。

## 変更内容

- `useRef` + `useEffect`（`[checked, mixed]`依存）を、callback refに置き換えた
- `checked`propはcontrolled propとして`input.checked`プロパティにのみ反映され、HTML属性としては反映されない（`getAttribute('checked')`は常に`null`のまま）ため、MutationObserverの`attributes`監視では検知できない。`data-checked`属性を追加してこれを代替判定に使うことで、属性の変化として検知できるようにした
- `callback ref`は既存の`useMergeRefs(callbackRef, ref)`経由でのみ使われている。`useMergeRefs`は内部で「callback refが返したcleanup関数を自前で保持し、`node = null`で呼ばれた際に手動実行する」という仕組みを持っており（`useMergeRefs.test.ts`の「アンマウント時はマウント時と逆順でcleanupされる」で検証済み）、React 18/19どちらでも正しく動作する。そのため`useCallbackRefCleanupForReact18`での追加ラップは不要と判断した

## プロダクト側で対応が必要な事項

なし

## 確認方法

- `tsc --noEmit` / `eslint` / `prettier --check` を実行し通過を確認済み
- 以下のシナリオを一時テストで確認済み
  - `mixed=true`固定で`checked`をtoggleすると`indeterminate`も正しく追従すること
  - `checked=true`固定で`mixed`をtoggleすると`indeterminate`も正しく追従すること
  - 外部から渡された`ref`が`checked`変化のたびに不要に再実行されないこと
- Storybookで`Components/Checkbox`の見た目・挙動（indeterminate表示含む）に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * チェックボックスの状態監視処理を整理しました。
  * 選択状態・混在状態に応じた中間状態の反映動作は従来どおりです。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->