### PR TITLE
refactor(Disclosure): useEffectの見直し(レンダー中同期・callback ref最適化)

### DIFF
--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.test.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.test.tsx
@@ -129,6 +129,45 @@ describe('Disclosure', () => {
     })
   })
 
+  describe('isOpenの制御を再開する場合', () => {
+    test('isOpen={true}→undefined(外部操作でfalseに)→isOpen={true}で再度開く', async () => {
+      const Wrapper = ({ isOpen }: { isOpen: boolean | undefined }) => (
+        <div className="App">
+          <DisclosureTrigger targetId="dc">
+            <Button>押してね</Button>
+          </DisclosureTrigger>
+
+          <DisclosureContent id="dc" isOpen={isOpen}>
+            <p>これは詳細です</p>
+          </DisclosureContent>
+        </div>
+      )
+
+      const { rerender } = render(<Wrapper isOpen={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('これは詳細です')).toBeInTheDocument()
+      })
+
+      // isOpenをundefinedにする(非制御化)
+      rerender(<Wrapper isOpen={undefined} />)
+
+      // 外部操作(トリガークリック)でexpandedをfalseにする
+      await userEvent.click(screen.getByRole('button', { name: '押してね', expanded: true }))
+
+      await waitFor(() => {
+        expect(screen.queryByText('これは詳細です')).toBeNull()
+      })
+
+      // 再度isOpen={true}に戻す
+      rerender(<Wrapper isOpen={true} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('これは詳細です')).toBeInTheDocument()
+      })
+    })
+  })
+
   describe('SHRUI-1324: DisclosureContentよりもあとにDisclosureTriggerがある場合', () => {
     beforeEach(() => {
       render(

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ComponentProps, type FC, type PropsWithChildren, useState } from 'react'
+import { type ComponentProps, type FC, type PropsWithChildren, useEffect, useState } from 'react'
 
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
@@ -24,13 +24,15 @@ export const DisclosureContent: FC<DisclosureContentProps> = ({
   children,
   ...rest
 }) => {
-  const [expanded, setExpanded] = useDisclosure(id)
+  const [expanded, setExpanded, addDisclosureChangeListener] = useDisclosure(id)
   const [prevIsOpen, setPrevIsOpen] = useState(expanded)
 
   if (isOpen !== undefined && isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen)
     setExpanded(isOpen)
   }
+
+  useEffect(() => addDisclosureChangeListener(), [addDisclosureChangeListener])
 
   if (expanded) {
     return (

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
@@ -25,11 +25,14 @@ export const DisclosureContent: FC<DisclosureContentProps> = ({
   ...rest
 }) => {
   const [expanded, setExpanded, addDisclosureChangeListener] = useDisclosure(id)
-  const [prevIsOpen, setPrevIsOpen] = useState(expanded)
+  const [prevIsOpen, setPrevIsOpen] = useState<boolean | undefined>(undefined)
 
-  if (isOpen !== undefined && isOpen !== prevIsOpen) {
+  if (isOpen !== prevIsOpen) {
     setPrevIsOpen(isOpen)
-    setExpanded(isOpen)
+
+    if (isOpen !== undefined) {
+      setExpanded(isOpen)
+    }
   }
 
   useEffect(() => addDisclosureChangeListener(), [addDisclosureChangeListener])

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ComponentProps, type FC, type PropsWithChildren, useEffect } from 'react'
+import { type ComponentProps, type FC, type PropsWithChildren, useState } from 'react'
 
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
@@ -25,12 +25,12 @@ export const DisclosureContent: FC<DisclosureContentProps> = ({
   ...rest
 }) => {
   const [expanded, setExpanded] = useDisclosure(id)
+  const [prevIsOpen, setPrevIsOpen] = useState(expanded)
 
-  useEffect(() => {
-    if (isOpen !== undefined) {
-      setExpanded(isOpen)
-    }
-  }, [isOpen, setExpanded])
+  if (isOpen !== undefined && isOpen !== prevIsOpen) {
+    setPrevIsOpen(isOpen)
+    setExpanded(isOpen)
+  }
 
   if (expanded) {
     return (

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
@@ -22,9 +22,9 @@ type DisclosureTriggerProps = {
 }
 
 export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, children, onClick }) => {
-  const [expanded, setExpanded] = useDisclosure(targetId)
+  const [expanded, setExpanded, addDisclosureChangeListener] = useDisclosure(targetId)
 
-  const latest = useLatest({ onClick, setExpanded })
+  const latest = useLatest({ onClick, setExpanded, addDisclosureChangeListener })
 
   // HINT: callbackRefで実装しているが、外部からrefを受け取る様になったらuseEffect化が必要
   const callbackRef = useCallbackRefCleanupForReact18(
@@ -33,6 +33,8 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
         if (!node) {
           return
         }
+
+        const removeDisclosureChangeListener = latest.addDisclosureChangeListener()
 
         let currentCleanup: (() => void) | undefined
 
@@ -85,6 +87,7 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
 
         return () => {
           currentCleanup?.()
+          removeDisclosureChangeListener()
           observer.disconnect()
         }
       },

--- a/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/DisclosureTrigger.tsx
@@ -26,7 +26,6 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
 
   const latest = useLatest({ onClick, setExpanded, addDisclosureChangeListener })
 
-  // HINT: callbackRefで実装しているが、外部からrefを受け取る様になったらuseEffect化が必要
   const callbackRef = useCallbackRefCleanupForReact18(
     useCallback(
       (node: HTMLElement | null) => {
@@ -48,8 +47,11 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
             throw new Error('DisclosureTriggerのchildrenにbutton要素を設置してください')
           }
 
-          button.setAttribute('aria-expanded', expanded.toString())
-          button.setAttribute('aria-controls', targetId)
+          button.setAttribute(
+            'aria-expanded',
+            (node.getAttribute('data-disclosure-expanded') === 'true').toString(),
+          )
+          button.setAttribute('aria-controls', node.getAttribute('data-disclosure-target-id') ?? '')
 
           // Button は native disabled ではなく aria-disabled を使うため、
           // 無効時はリスナーを貼らず開閉しないようにする（DropdownTrigger と同じ）
@@ -82,7 +84,12 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
           subtree: true,
           // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
           attributes: true,
-          attributeFilter: ['disabled', 'aria-disabled'],
+          attributeFilter: [
+            'data-disclosure-expanded',
+            'aria-disabled',
+            'disabled',
+            'data-disclosure-target-id',
+          ],
         })
 
         return () => {
@@ -91,7 +98,7 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
           observer.disconnect()
         }
       },
-      [expanded, targetId, latest],
+      [latest],
     ),
   )
 
@@ -99,7 +106,12 @@ export const DisclosureTrigger: FC<DisclosureTriggerProps> = ({ targetId, childr
   // Fragmentにrefが渡せるようになったタイミングでclassNameも不要になる
   // TODO: 将来的にspan -> Fragmentに変更する
   return (
-    <span ref={callbackRef} className="smarthr-ui-DisclosureTriggerWrapper shr-contents">
+    <span
+      ref={callbackRef}
+      className="smarthr-ui-DisclosureTriggerWrapper shr-contents"
+      data-disclosure-target-id={targetId}
+      data-disclosure-expanded={expanded}
+    >
       {children instanceof Function ? children({ expanded }) : children}
     </span>
   )

--- a/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureTrigger.stories.tsx
@@ -63,3 +63,15 @@ export const Disabled: StoryObj<typeof DisclosureTrigger> = {
     </>
   ),
 }
+
+export const Loading: StoryObj<typeof DisclosureTrigger> = {
+  name: 'loading',
+  render: () => (
+    <>
+      <DisclosureTrigger targetId="disclosure_loading">
+        <Button loading>ディスクロージャートリガー（loading）</Button>
+      </DisclosureTrigger>
+      <DisclosureContent id="disclosure_loading">ディスクロージャーコンテンツ</DisclosureContent>
+    </>
+  ),
+}

--- a/packages/smarthr-ui/src/components/Disclosure/stories/VRTDisclosure.stories.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/stories/VRTDisclosure.stories.tsx
@@ -18,6 +18,17 @@ export default {
           </DisclosureContent>
         </>
       ))}
+      {/* DisclosureContentがDisclosureTriggerより先にレンダリングされても、レンダリング順序に関わらずisOpenが反映されることを確認する */}
+      {[{ isOpen: true }].map((args, index) => (
+        <>
+          <DisclosureContent {...args} id={`disclosure_reverse_${index}`}>
+            ディスクロージャーコンテンツ
+          </DisclosureContent>
+          <DisclosureTrigger targetId={`disclosure_reverse_${index}`}>
+            {({ expanded }) => <Button>ディスクロージャーを{expanded ? '閉じる' : '開く'}</Button>}
+          </DisclosureTrigger>
+        </>
+      ))}
     </>
   ),
   parameters: {

--- a/packages/smarthr-ui/src/components/Disclosure/useDisclosure.test.ts
+++ b/packages/smarthr-ui/src/components/Disclosure/useDisclosure.test.ts
@@ -10,6 +10,10 @@ describe('useDisclosure', () => {
     const c4 = renderHook(useDisclosure, { initialProps: 'disclosure-1' })
     const c5 = renderHook(useDisclosure, { initialProps: 'disclosure-1' })
 
+    act(() => {
+      ;[c1, c2, c3, c4, c5].forEach((c) => c.result.current[2]())
+    })
+
     expect(c1.result.current[0]).toBe(false)
     expect(c2.result.current[0]).toBe(false)
     expect(c3.result.current[0]).toBe(false)

--- a/packages/smarthr-ui/src/components/Disclosure/useDisclosure.test.ts
+++ b/packages/smarthr-ui/src/components/Disclosure/useDisclosure.test.ts
@@ -10,38 +10,46 @@ describe('useDisclosure', () => {
     const c4 = renderHook(useDisclosure, { initialProps: 'disclosure-1' })
     const c5 = renderHook(useDisclosure, { initialProps: 'disclosure-1' })
 
-    act(() => {
-      ;[c1, c2, c3, c4, c5].forEach((c) => c.result.current[2]())
-    })
-
-    expect(c1.result.current[0]).toBe(false)
-    expect(c2.result.current[0]).toBe(false)
-    expect(c3.result.current[0]).toBe(false)
-    expect(c4.result.current[0]).toBe(false)
-    expect(c5.result.current[0]).toBe(false)
+    let cleanups: Array<() => void> = []
 
     act(() => {
-      c3.result.current[1](true)
+      cleanups = [c1, c2, c3, c4, c5].map((c) => c.result.current[2]())
     })
 
-    await waitFor(() => {
-      expect(c1.result.current[0]).toBe(true)
-      expect(c2.result.current[0]).toBe(true)
-      expect(c3.result.current[0]).toBe(true)
-      expect(c4.result.current[0]).toBe(true)
-      expect(c5.result.current[0]).toBe(true)
-    })
-
-    act(() => {
-      c3.result.current[1](false)
-    })
-
-    await waitFor(() => {
+    try {
       expect(c1.result.current[0]).toBe(false)
       expect(c2.result.current[0]).toBe(false)
       expect(c3.result.current[0]).toBe(false)
       expect(c4.result.current[0]).toBe(false)
       expect(c5.result.current[0]).toBe(false)
-    })
+
+      act(() => {
+        c3.result.current[1](true)
+      })
+
+      await waitFor(() => {
+        expect(c1.result.current[0]).toBe(true)
+        expect(c2.result.current[0]).toBe(true)
+        expect(c3.result.current[0]).toBe(true)
+        expect(c4.result.current[0]).toBe(true)
+        expect(c5.result.current[0]).toBe(true)
+      })
+
+      act(() => {
+        c3.result.current[1](false)
+      })
+
+      await waitFor(() => {
+        expect(c1.result.current[0]).toBe(false)
+        expect(c2.result.current[0]).toBe(false)
+        expect(c3.result.current[0]).toBe(false)
+        expect(c4.result.current[0]).toBe(false)
+        expect(c5.result.current[0]).toBe(false)
+      })
+    } finally {
+      act(() => {
+        cleanups.forEach((cleanup) => cleanup())
+      })
+    }
   })
 })

--- a/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
+++ b/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
@@ -27,6 +27,7 @@ export const useDisclosure = (id: string): UseDisclosureResult => {
 
   const functions = useMemo(
     () => ({
+      cleanupFrame: () => latest.frame.cancel(),
       safeSetExpanded: (value: boolean | ((prev: boolean) => boolean)) => {
         // DisclosureTrigger と DisclosureContent のレンダリング順序に影響しないように animation frame を待ってから state を更新する
         latest.frame.request(() => {
@@ -55,10 +56,10 @@ export const useDisclosure = (id: string): UseDisclosureResult => {
     document.addEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
 
     return () => {
-      frame.cancel()
+      functions.cleanupFrame()
       document.removeEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
     }
-  }, [frame, functions])
+  }, [functions])
 
   return [expanded, functions.safeSetExpanded]
 }

--- a/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
+++ b/packages/smarthr-ui/src/components/Disclosure/useDisclosure.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useAnimationFrame } from '../../hooks/client/useAnimationFrame'
 import { useLatest } from '../../hooks/useLatest'
@@ -15,7 +15,11 @@ declare global {
 
 type Setter = (value: boolean | ((prev: boolean) => boolean)) => void
 
-type UseDisclosureResult = [expanded: boolean, setExpanded: Setter]
+type UseDisclosureResult = [
+  expanded: boolean,
+  setExpanded: Setter,
+  addDisclosureChangeListener: () => () => void,
+]
 
 /**
  * 同じ `id` で呼ぶとイベント経由で状態が同期される custom hook
@@ -27,7 +31,14 @@ export const useDisclosure = (id: string): UseDisclosureResult => {
 
   const functions = useMemo(
     () => ({
-      cleanupFrame: () => latest.frame.cancel(),
+      addDisclosureChangeListener: () => {
+        document.addEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
+
+        return () => {
+          latest.frame.cancel()
+          document.removeEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
+        }
+      },
       safeSetExpanded: (value: boolean | ((prev: boolean) => boolean)) => {
         // DisclosureTrigger と DisclosureContent のレンダリング順序に影響しないように animation frame を待ってから state を更新する
         latest.frame.request(() => {
@@ -52,14 +63,5 @@ export const useDisclosure = (id: string): UseDisclosureResult => {
     [latest],
   )
 
-  useEffect(() => {
-    document.addEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
-
-    return () => {
-      functions.cleanupFrame()
-      document.removeEventListener(DISCLOSURE_CHANGE_EVENT, functions.handleDisclosureChange)
-    }
-  }, [functions])
-
-  return [expanded, functions.safeSetExpanded]
+  return [expanded, functions.safeSetExpanded, functions.addDisclosureChangeListener]
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

Disclosure配下のuseEffectを見直し、以下の観点でリファクタリングした。

- レンダー中に比較・計算できる処理はuseEffectから外せないか
- documentへのイベントリスナー登録は、DOM要素のmount/unmountに連動する既存のcallback refに統合できないか
- callback refの依存配列に含まれる値の変化頻度が高い場合、data属性+MutationObserver監視に置き換えられないか

## 変更内容

### DisclosureContent

`isOpen`変化時の内部state同期を、`useEffect`からレンダー中に前回値をuseStateで比較する方式に変更。`useEffect`版と違い1回分の余分な再レンダリングが発生しない。

### useDisclosure

- `frame.cancel()`の呼び出しを`functions`経由にまとめ、`useEffect`の依存配列から`frame`を除去（`useAnimationFrame`は常に安定した参照を返すため挙動に変化はない）
- `document`へのイベントリスナー登録をフック自身の`useEffect`から切り離し、`addDisclosureChangeListener`という関数を公開する形に変更。いつ・どう発火させるかを呼び出し側に委ねられるようにした

### DisclosureTrigger

- `addDisclosureChangeListener`を既存のcallback ref内から呼び出すことで、DOM要素のmount/unmountとdocumentイベントリスナーの登録タイミングを一致させた
- callback refの依存配列に含めていた`expanded`/`targetId`を、`data-disclosure-expanded`/`data-disclosure-target-id`属性+MutationObserver監視に置き換えた。これにより開閉のたびにcallback refが再アタッチされ、documentイベントリスナーの解除・再登録やMutationObserverの再構築が無駄に発生していた問題を解消した

### Storybook

`DisclosureTrigger`の`loading`状態パターン（既存テストにはあったがStorybookに無かった）と、`DisclosureContent`が`DisclosureTrigger`より先にレンダリングされてもレンダリング順序に関わらず`isOpen`が反映されることを確認するVRTパターンを追加した。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 各変更について `tsc --noEmit` / `eslint` / `prettier --check` / 関連する `vitest`（Disclosure配下、2ファイル8件）を実行し通過を確認済み
- `isOpen`変化直後にフレーム発火前の再レンダーが挟まっても、短時間で複数回反転しても最終的に正しく同期されることを一時テストで確認
- 同じidを共有する複数のtrigger/contentペアで開閉を繰り返しても、documentイベントリスナーの同期が壊れないことを確認
- 開閉を繰り返してもdocumentイベントリスナーが再登録されないこと、`aria-expanded`がMutationObserver経由で正しく更新されることを確認
- Storybookで`Components/Disclosure`の見た目・挙動に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 開閉式コンテンツの状態が、表示順序にかかわらず正しく同期されるようになりました。
  - 外部から開閉状態が変更された場合も、トリガーの表示やアクセシビリティ情報が正しく更新されます。
  - 開閉状態の切り替えや再開時の動作が安定し、不要な重複更新を抑制しました。

- **テスト**
  - ローディング中のボタン表示や、コンテンツを先に表示するケースを追加検証しました。
  - 開閉状態の切り替えと外部操作後の再開動作を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->