### PR TITLE
refactor(Dropdown): useEffectの見直し(callback ref化・依存配列整理・重大な回帰バグ修正)

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.test.tsx
@@ -9,6 +9,9 @@ import { Dropdown } from './Dropdown'
 import { DropdownContent } from './DropdownContent'
 import { DropdownTrigger } from './DropdownTrigger'
 
+const waitForAnimationFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
 describe('Dropdown', () => {
   const template = (
     <Dropdown>
@@ -37,6 +40,9 @@ describe('Dropdown', () => {
     render(template)
 
     act(() => screen.getByRole('button', { name: 'Trigger' }).click())
+    await act(async () => {
+      await waitForAnimationFrame()
+    })
 
     expect(screen.getByRole('button', { name: 'Button1' })).not.toHaveFocus()
     await userEvent.tab()
@@ -62,6 +68,9 @@ describe('Dropdown', () => {
   it('ドロップダウン展開後にShift+Tabでトリガーにフォーカスが戻るとドロップダウンが閉じること', async () => {
     render(template)
     act(() => screen.getByRole('button', { name: 'Trigger', expanded: false }).click())
+    await act(async () => {
+      await waitForAnimationFrame()
+    })
     expect(screen.getByRole('button', { name: 'Button1' })).toBeVisible()
 
     await userEvent.tab()
@@ -76,6 +85,9 @@ describe('Dropdown', () => {
     render(template)
 
     act(() => screen.getByRole('button', { name: 'Trigger', expanded: false }).click())
+    await act(async () => {
+      await waitForAnimationFrame()
+    })
     expect(screen.getByRole('button', { name: 'Button1' })).toBeVisible()
 
     await userEvent.tab()

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -30,7 +30,7 @@ type DropdownContextType = {
   triggerRect: Rect
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
-  contentInnerCallbackRef: () => () => void
+  contentInnerCallbackRef: (node: HTMLElement | null) => (() => void) | undefined
   cleanupFrame: () => void
   handleClickTrigger: (rect: Rect) => void
   handleDelegateClickCloser: () => void
@@ -46,7 +46,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   triggerRect: initialRect,
   triggerElementRef: createRef(),
   rootTriggerRef: null,
-  contentInnerCallbackRef: () => NOOP,
+  contentInnerCallbackRef: () => undefined,
   cleanupFrame: NOOP,
   handleClickTrigger: NOOP,
   handleDelegateClickCloser: NOOP,
@@ -114,7 +114,11 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
         latest.openFrame.cancel()
         latest.closeFrame.cancel()
       },
-      contentInnerCallbackRef: () => {
+      contentInnerCallbackRef: (node: HTMLElement | null) => {
+        if (!node) {
+          return
+        }
+
         document.body.addEventListener('click', handleClickBody, false)
         window.addEventListener('scroll', updateTriggerRect, { passive: true })
         window.addEventListener('resize', updateTriggerRect, { passive: true })

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -8,7 +8,6 @@ import {
   createContext,
   createRef,
   useContext,
-  useEffect,
   useId,
   useMemo,
   useRef,
@@ -32,6 +31,7 @@ type DropdownContextType = {
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
   contentInnerCallbackRef: () => () => void
+  cleanupFrame: () => void
   handleClickTrigger: (rect: Rect) => void
   handleDelegateClickCloser: () => void
   DropdownContentRoot: FC<{ children: ReactNode }>
@@ -47,6 +47,7 @@ export const DropdownContext = createContext<DropdownContextType>({
   triggerElementRef: createRef(),
   rootTriggerRef: null,
   contentInnerCallbackRef: () => NOOP,
+  cleanupFrame: NOOP,
   handleClickTrigger: NOOP,
   handleDelegateClickCloser: NOOP,
   DropdownContentRoot: NOOP,
@@ -109,6 +110,10 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
 
     return {
       DropdownContentRoot,
+      cleanupFrame: () => {
+        latest.openFrame.cancel()
+        latest.closeFrame.cancel()
+      },
       contentInnerCallbackRef: () => {
         document.body.addEventListener('click', handleClickBody, false)
         window.addEventListener('scroll', updateTriggerRect, { passive: true })
@@ -143,16 +148,6 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     }
   }, [latest])
 
-  // openFrame/closeFrameのキャンセルは、DropdownContentInnerのmount/unmount(=Dropdownの開閉)
-  // とは発火条件が異なる(Dropdown自体のアンマウント時にのみキャンセルすればよい)ため分離する
-  useEffect(
-    () => () => {
-      latest.openFrame.cancel()
-      latest.closeFrame.cancel()
-    },
-    [latest],
-  )
-
   return (
     <PortalParentProvider>
       <DropdownContext.Provider
@@ -162,6 +157,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
           contentInnerCallbackRef: functions.contentInnerCallbackRef,
+          cleanupFrame: functions.cleanupFrame,
           handleClickTrigger: functions.handleClickTrigger,
           handleDelegateClickCloser: functions.handleDelegateClickCloser,
           DropdownContentRoot: functions.DropdownContentRoot,

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -31,6 +31,7 @@ type DropdownContextType = {
   triggerRect: Rect
   triggerElementRef: MutableRefObject<HTMLDivElement | null>
   rootTriggerRef: MutableRefObject<HTMLDivElement | null> | null
+  contentInnerCallbackRef: () => () => void
   handleClickTrigger: (rect: Rect) => void
   handleDelegateClickCloser: () => void
   DropdownContentRoot: FC<{ children: ReactNode }>
@@ -39,18 +40,16 @@ type DropdownContextType = {
 
 const initialRect = { top: 0, right: 0, bottom: 0, left: 0 }
 
+const NOOP = () => null
 export const DropdownContext = createContext<DropdownContextType>({
   active: false,
   triggerRect: initialRect,
   triggerElementRef: createRef(),
   rootTriggerRef: null,
-  handleClickTrigger: () => {
-    /* noop */
-  },
-  handleDelegateClickCloser: () => {
-    /* noop */
-  },
-  DropdownContentRoot: () => null,
+  contentInnerCallbackRef: () => NOOP,
+  handleClickTrigger: NOOP,
+  handleDelegateClickCloser: NOOP,
+  DropdownContentRoot: NOOP,
   contentId: '',
 })
 
@@ -92,6 +91,17 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
 
     return {
       DropdownContentRoot,
+      contentInnerCallbackRef: () => {
+        document.body.addEventListener('click', functions.handleClickBody, false)
+        window.addEventListener('scroll', functions.updateTriggerRect, { passive: true })
+        window.addEventListener('resize', functions.updateTriggerRect, { passive: true })
+
+        return () => {
+          document.body.removeEventListener('click', functions.handleClickBody, false)
+          window.removeEventListener('scroll', functions.updateTriggerRect)
+          window.removeEventListener('resize', functions.updateTriggerRect)
+        }
+      },
       handleClickTrigger: (rect: Rect) => {
         if (latest.active) {
           setActive(false)
@@ -131,6 +141,8 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     }
   }, [latest])
 
+  // openFrame/closeFrameのキャンセルは、DropdownContentInnerのmount/unmount(=Dropdownの開閉)
+  // とは発火条件が異なる(Dropdown自体のアンマウント時にのみキャンセルすればよい)ため分離する
   useEffect(
     () => () => {
       latest.openFrame.cancel()
@@ -138,20 +150,6 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
     },
     [latest],
   )
-
-  useEffect(() => {
-    if (!active) return
-
-    document.body.addEventListener('click', functions.handleClickBody, false)
-    window.addEventListener('scroll', functions.updateTriggerRect, { passive: true })
-    window.addEventListener('resize', functions.updateTriggerRect, { passive: true })
-
-    return () => {
-      document.body.removeEventListener('click', functions.handleClickBody, false)
-      window.removeEventListener('scroll', functions.updateTriggerRect)
-      window.removeEventListener('resize', functions.updateTriggerRect)
-    }
-  }, [active, functions])
 
   return (
     <PortalParentProvider>
@@ -161,6 +159,7 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
           triggerRect,
           triggerElementRef,
           rootTriggerRef: rootTriggerRef || triggerElementRef || null,
+          contentInnerCallbackRef: functions.contentInnerCallbackRef,
           handleClickTrigger: functions.handleClickTrigger,
           handleDelegateClickCloser: functions.handleDelegateClickCloser,
           DropdownContentRoot: functions.DropdownContentRoot,

--- a/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/Dropdown.tsx
@@ -89,17 +89,35 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
       }
     }
 
+    const handleClickBody = (e: any) => {
+      // ignore events from events within DropdownTrigger and DropdownContent
+      if (
+        latest.active &&
+        !isEventFromChild(e, triggerElementRef.current) &&
+        !latest.isChildPortal(e.target)
+      ) {
+        setActive(false)
+        actualClose()
+      }
+    }
+
+    const updateTriggerRect = () => {
+      if (triggerElementRef.current) {
+        setTriggerRect(triggerElementRef.current.getBoundingClientRect())
+      }
+    }
+
     return {
       DropdownContentRoot,
       contentInnerCallbackRef: () => {
-        document.body.addEventListener('click', functions.handleClickBody, false)
-        window.addEventListener('scroll', functions.updateTriggerRect, { passive: true })
-        window.addEventListener('resize', functions.updateTriggerRect, { passive: true })
+        document.body.addEventListener('click', handleClickBody, false)
+        window.addEventListener('scroll', updateTriggerRect, { passive: true })
+        window.addEventListener('resize', updateTriggerRect, { passive: true })
 
         return () => {
-          document.body.removeEventListener('click', functions.handleClickBody, false)
-          window.removeEventListener('scroll', functions.updateTriggerRect)
-          window.removeEventListener('resize', functions.updateTriggerRect)
+          document.body.removeEventListener('click', handleClickBody, false)
+          window.removeEventListener('scroll', updateTriggerRect)
+          window.removeEventListener('resize', updateTriggerRect)
         }
       },
       handleClickTrigger: (rect: Rect) => {
@@ -121,22 +139,6 @@ export const Dropdown: FC<Props> = ({ onOpen, onClose, children }) => {
 
         // return focus to the Trigger
         getFirstTabbable(triggerElementRef)?.focus()
-      },
-      handleClickBody: (e: any) => {
-        // ignore events from events within DropdownTrigger and DropdownContent
-        if (
-          latest.active &&
-          !isEventFromChild(e, triggerElementRef.current) &&
-          !latest.isChildPortal(e.target)
-        ) {
-          setActive(false)
-          actualClose()
-        }
-      },
-      updateTriggerRect: () => {
-        if (triggerElementRef.current) {
-          setTriggerRect(triggerElementRef.current.getBoundingClientRect())
-        }
       },
     }
   }, [latest])

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../hooks/client/useAnimationFrame'
 import { useTheme } from '../../hooks/client/useTheme'
 import { useLatest } from '../../hooks/useLatest'
 import { tabbable } from '../../libs/tabbable'
@@ -91,44 +92,40 @@ export const DropdownContentInner: FC<Props> = ({
     }
   })()
 
-  useEffect(() => {
-    if (wrapperRef.current) {
-      setContentBox(
-        getContentBoxStyle(
-          triggerRect,
-          {
-            width: wrapperRef.current.offsetWidth,
-            height: wrapperRef.current.offsetHeight,
-          },
-          {
-            width: document.body.clientWidth,
-            height: innerHeight,
-          },
-          {
-            top: scrollY,
-            left: scrollX,
-          },
-        ),
-      )
-      setIsActive(true)
-    }
-  }, [triggerRect])
+  const focusFrame = useAnimationFrame()
 
-  // setIsActive(true) と同じ useEffect 内で直接 focus() を呼ぶことはできない。
-  // このコンポーネントは Dropdown が開かれた時のみマウントされるが、マウント直後は
-  // 位置計算が完了していないためコンテンツが誤った位置にちらつくのを防ぐために
-  // shr-invisible (visibility: hidden) でレンダリングされる。
-  // ちらつき防止には実寸法を保持したまま視覚的に隠せる visibility: hidden が唯一の手段となる。
-  // visibility: hidden の要素はフォーカスを受け付けないため、setIsActive(true) の直後に
-  // focus() を呼んでも DOM がまだ更新されておらず無効になる。
-  //
-  // useEffect([isActive]) であれば、isActive=true になった後の render commit 後に
-  // 必ず実行されることが保証されるため、この実装が最も信頼性が高い。
   useEffect(() => {
-    if (isActive) {
-      focusTargetRef.current?.focus()
+    if (!wrapperRef.current) {
+      return
     }
-  }, [isActive])
+
+    setContentBox(
+      getContentBoxStyle(
+        triggerRect,
+        {
+          width: wrapperRef.current.offsetWidth,
+          height: wrapperRef.current.offsetHeight,
+        },
+        {
+          width: document.body.clientWidth,
+          height: innerHeight,
+        },
+        {
+          top: scrollY,
+          left: scrollX,
+        },
+      ),
+    )
+    setIsActive(true)
+
+    focusFrame.request(() => {
+      focusTargetRef.current?.focus()
+    })
+
+    return () => {
+      focusFrame.cancel()
+    }
+  }, [triggerRect, focusFrame])
 
   const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser, contentInnerCallbackRef } =
     useContext(DropdownContext)

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -101,7 +101,6 @@ export const DropdownContentInner: FC<Props> = ({
     triggerElementRef,
     rootTriggerRef,
     handleDelegateClickCloser,
-    contentInnerCallbackRef,
   })
 
   const callbackRef = useCallback(
@@ -110,7 +109,6 @@ export const DropdownContentInner: FC<Props> = ({
         return
       }
 
-      const callbackRefCleanup = latest.contentInnerCallbackRef()
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === 'Tab') {
           if (!latest.triggerElementRef.current || !latest.rootTriggerRef?.current) {
@@ -183,14 +181,13 @@ export const DropdownContentInner: FC<Props> = ({
       window.addEventListener('keydown', handleKeyDown)
 
       return () => {
-        callbackRefCleanup()
         window.removeEventListener('keydown', handleKeyDown)
       }
     },
     [latest],
   )
 
-  const mergedRef = useMergeRefs(wrapperRef, callbackRef)
+  const mergedRef = useMergeRefs(contentInnerCallbackRef, wrapperRef, callbackRef)
 
   const focusFrame = useAnimationFrame()
 

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -5,6 +5,7 @@ import {
   type FC,
   type PropsWithChildren,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -14,6 +15,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useAnimationFrame } from '../../hooks/client/useAnimationFrame'
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useTheme } from '../../hooks/client/useTheme'
 import { useLatest } from '../../hooks/useLatest'
 import { tabbable } from '../../libs/tabbable'
@@ -92,6 +94,104 @@ export const DropdownContentInner: FC<Props> = ({
     }
   })()
 
+  const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser, contentInnerCallbackRef } =
+    useContext(DropdownContext)
+
+  const latest = useLatest({
+    triggerElementRef,
+    rootTriggerRef,
+    handleDelegateClickCloser,
+    contentInnerCallbackRef,
+  })
+
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) {
+        return
+      }
+
+      const callbackRefCleanup = latest.contentInnerCallbackRef()
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Tab') {
+          if (!latest.triggerElementRef.current || !latest.rootTriggerRef?.current) {
+            return
+          }
+
+          const tabbablesInContent = tabbable(node)
+
+          if (tabbablesInContent.length === 0) {
+            return
+          }
+
+          const trigger = tabbable(latest.triggerElementRef.current).at(-1)
+          const firstTabbable = tabbablesInContent[0]
+
+          if (e.target === trigger) {
+            if (e.shiftKey) {
+              // move focus previous of the Trigger
+              return
+            }
+
+            // focus a first tabbable element in the dropdown content
+            e.preventDefault()
+            firstTabbable.focus()
+
+            return
+          } else if (e.shiftKey) {
+            if (e.target === firstTabbable || e.target === focusTargetRef.current) {
+              // focus the Trigger
+              e.preventDefault()
+              trigger!.focus()
+              latest.handleDelegateClickCloser()
+            }
+          } else if (e.target === tabbablesInContent.at(-1)) {
+            // move focus next of the Trigger
+            const rootTrigger = tabbable(latest.rootTriggerRef.current).at(-1)
+
+            if (rootTrigger) {
+              rootTrigger.focus()
+              latest.handleDelegateClickCloser()
+            }
+          }
+        } else if (KEY_ESCAPE.test(e.key)) {
+          if (e.target && e.target === focusTargetRef.current) {
+            latest.handleDelegateClickCloser()
+
+            return
+          }
+
+          const trigger = getFirstTabbable(latest.triggerElementRef)
+
+          if (trigger && e.target === trigger) {
+            // close the dropdown when the Trigger is focused and Esc key is pressed
+            latest.handleDelegateClickCloser()
+
+            return
+          }
+
+          for (const inner of tabbable(node)) {
+            if (inner === e.target) {
+              // close the dropdown when an element that is included in dropdown content is focused and Esc key is pressed
+              latest.handleDelegateClickCloser()
+
+              break
+            }
+          }
+        }
+      }
+
+      window.addEventListener('keydown', handleKeyDown)
+
+      return () => {
+        callbackRefCleanup()
+        window.removeEventListener('keydown', handleKeyDown)
+      }
+    },
+    [latest],
+  )
+
+  const mergedRef = useMergeRefs(wrapperRef, callbackRef)
+
   const focusFrame = useAnimationFrame()
 
   useEffect(() => {
@@ -127,103 +227,8 @@ export const DropdownContentInner: FC<Props> = ({
     }
   }, [triggerRect, focusFrame])
 
-  const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser, contentInnerCallbackRef } =
-    useContext(DropdownContext)
-
-  const latest = useLatest({
-    triggerElementRef,
-    rootTriggerRef,
-    handleDelegateClickCloser,
-    contentInnerCallbackRef,
-  })
-
-  useEffect(() => {
-    const callbackRefCleanup = latest.contentInnerCallbackRef()
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Tab') {
-        if (
-          !wrapperRef.current ||
-          !latest.triggerElementRef.current ||
-          !latest.rootTriggerRef?.current
-        ) {
-          return
-        }
-
-        const tabbablesInContent = tabbable(wrapperRef.current)
-
-        if (tabbablesInContent.length === 0) {
-          return
-        }
-
-        const trigger = tabbable(latest.triggerElementRef.current).at(-1)
-        const firstTabbable = tabbablesInContent[0]
-
-        if (e.target === trigger) {
-          if (e.shiftKey) {
-            // move focus previous of the Trigger
-            return
-          }
-
-          // focus a first tabbable element in the dropdown content
-          e.preventDefault()
-          firstTabbable.focus()
-
-          return
-        } else if (e.shiftKey) {
-          if (e.target === firstTabbable || e.target === focusTargetRef.current) {
-            // focus the Trigger
-            e.preventDefault()
-            trigger!.focus()
-            latest.handleDelegateClickCloser()
-          }
-        } else if (e.target === tabbablesInContent.at(-1)) {
-          // move focus next of the Trigger
-          const rootTrigger = tabbable(latest.rootTriggerRef.current).at(-1)
-
-          if (rootTrigger) {
-            rootTrigger.focus()
-            latest.handleDelegateClickCloser()
-          }
-        }
-      } else if (KEY_ESCAPE.test(e.key)) {
-        if (e.target && e.target === focusTargetRef.current) {
-          latest.handleDelegateClickCloser()
-
-          return
-        }
-
-        const trigger = getFirstTabbable(latest.triggerElementRef)
-
-        if (trigger && e.target === trigger) {
-          // close the dropdown when the Trigger is focused and Esc key is pressed
-          latest.handleDelegateClickCloser()
-
-          return
-        }
-
-        if (wrapperRef.current) {
-          for (const inner of tabbable(wrapperRef.current)) {
-            if (inner === e.target) {
-              // close the dropdown when an element that is included in dropdown content is focused and Esc key is pressed
-              latest.handleDelegateClickCloser()
-
-              break
-            }
-          }
-        }
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-
-    return () => {
-      callbackRefCleanup()
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [latest])
-
   return (
-    <div {...rest} ref={wrapperRef} className={actualClassName} style={style}>
+    <div {...rest} ref={mergedRef} className={actualClassName} style={style}>
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex -- dummy element for focus management. */}
       <div ref={focusTargetRef} tabIndex={-1} />
       {controllable ? (

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -130,16 +130,18 @@ export const DropdownContentInner: FC<Props> = ({
     }
   }, [isActive])
 
-  const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser } =
+  const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser, contentInnerCallbackRef } =
     useContext(DropdownContext)
 
   const latest = useLatest({
     triggerElementRef,
     rootTriggerRef,
     handleDelegateClickCloser,
+    contentInnerCallbackRef,
   })
 
   useEffect(() => {
+    const callbackRefCleanup = latest.contentInnerCallbackRef()
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Tab') {
         if (
@@ -218,6 +220,7 @@ export const DropdownContentInner: FC<Props> = ({
     window.addEventListener('keydown', handleKeyDown)
 
     return () => {
+      callbackRefCleanup()
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [latest])

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -5,12 +5,14 @@ import {
   type FC,
   type PropsWithChildren,
   type ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useLatest } from '../../hooks/useLatest'
 import { tabbable } from '../../libs/tabbable'
 import { Tooltip } from '../Tooltip'
@@ -50,8 +52,64 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
 
   const latest = useLatest({ triggerElementRef, contentId, handleClickTrigger, cleanupFrame })
 
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) {
+        return
+      }
+
+      let currentCleanup: (() => void) | undefined
+
+      const setupButton = () => {
+        // 既存のクリーンアップを実行
+        currentCleanup?.()
+        currentCleanup = undefined
+
+        const button = node.querySelector<HTMLButtonElement>('button')
+
+        // 引き金となる要素が disabled な場合、処理を差し込む必要がないため、そのまま出力する
+        if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
+          return
+        }
+
+        // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
+        // そのためcaptureで開く処理を実行する
+        const callback = (e: MouseEvent) => {
+          latest.handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
+        }
+
+        button.addEventListener('click', callback, CAPTURE_OPTION)
+
+        currentCleanup = () => {
+          button.removeEventListener('click', callback, CAPTURE_OPTION)
+        }
+      }
+
+      setupButton()
+
+      const observer = new MutationObserver(setupButton)
+
+      observer.observe(node, {
+        childList: true,
+        subtree: true,
+        // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
+        attributes: true,
+        attributeFilter: ['disabled', 'aria-disabled'],
+      })
+
+      return () => {
+        currentCleanup?.()
+        observer.disconnect()
+        latest.cleanupFrame()
+      }
+    },
+    [latest],
+  )
+
+  const mergedRef = useMergeRefs(triggerElementRef, callbackRef)
+
   // aria-expandedはactiveの変化と同期して更新する必要があるため、
-  // 下記のMutationObserverベースのeffect(非同期に発火しうる)とは分離する
+  // MutationObserverベースのcallbackRef(非同期に発火しうる)とは分離する
   useEffect(() => {
     if (!latest.triggerElementRef.current) {
       return
@@ -65,60 +123,8 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     })
   }, [active, latest])
 
-  useEffect(() => {
-    const triggerElement = latest.triggerElementRef.current
-    if (!triggerElement) {
-      return
-    }
-
-    let currentCleanup: (() => void) | undefined
-
-    const setupButton = () => {
-      // 既存のクリーンアップを実行
-      currentCleanup?.()
-      currentCleanup = undefined
-
-      const button = triggerElement.querySelector<HTMLButtonElement>('button')
-
-      // 引き金となる要素が disabled な場合、処理を差し込む必要がないため、そのまま出力する
-      if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
-        return
-      }
-
-      // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
-      // そのためcaptureで開く処理を実行する
-      const callback = (e: MouseEvent) => {
-        latest.handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
-      }
-
-      button.addEventListener('click', callback, CAPTURE_OPTION)
-
-      currentCleanup = () => {
-        button.removeEventListener('click', callback, CAPTURE_OPTION)
-      }
-    }
-
-    setupButton()
-
-    const observer = new MutationObserver(setupButton)
-
-    observer.observe(triggerElement, {
-      childList: true,
-      subtree: true,
-      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
-      attributes: true,
-      attributeFilter: ['disabled', 'aria-disabled'],
-    })
-
-    return () => {
-      currentCleanup?.()
-      observer.disconnect()
-      latest.cleanupFrame()
-    }
-  }, [latest])
-
   return (
-    <div ref={triggerElementRef} className={actualClassName}>
+    <div ref={mergedRef} className={actualClassName}>
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex */}
       <ConditionalWrapper
         shouldWrapContent={tooltip?.show}

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useLatest } from '../../hooks/useLatest'
 import { tabbable } from '../../libs/tabbable'
 import { Tooltip } from '../Tooltip'
 
@@ -43,26 +44,28 @@ const classNameGenerator = tv({
 })
 
 export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => {
+  const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
   const { active, handleClickTrigger, contentId, triggerElementRef, cleanupFrame } =
     useContext(DropdownContext)
-  const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
+
+  const latest = useLatest({ triggerElementRef, contentId, handleClickTrigger, cleanupFrame })
 
   useEffect(() => {
-    if (!triggerElementRef.current) {
+    if (!latest.triggerElementRef.current) {
       return
     }
 
     // apply ARIA to all focusable elements in trigger
-    const triggers = tabbable(triggerElementRef.current, { shouldIgnoreVisibility: true })
+    const triggers = tabbable(latest.triggerElementRef.current, { shouldIgnoreVisibility: true })
 
     triggers.forEach((trigger) => {
       trigger.setAttribute('aria-expanded', active.toString())
-      trigger.setAttribute('aria-controls', contentId)
+      trigger.setAttribute('aria-controls', latest.contentId)
     })
-  }, [active, triggerElementRef, contentId])
+  }, [active, latest])
 
   useEffect(() => {
-    const triggerElement = triggerElementRef.current
+    const triggerElement = latest.triggerElementRef.current
     if (!triggerElement) {
       return
     }
@@ -84,7 +87,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
       // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
       // そのためcaptureで開く処理を実行する
       const callback = (e: MouseEvent) => {
-        handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
+        latest.handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
       }
 
       button.addEventListener('click', callback, CAPTURE_OPTION)
@@ -109,9 +112,9 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     return () => {
       currentCleanup?.()
       observer.disconnect()
-      cleanupFrame()
+      latest.cleanupFrame()
     }
-  }, [handleClickTrigger, triggerElementRef, cleanupFrame])
+  }, [latest])
 
   return (
     <div ref={triggerElementRef} className={actualClassName}>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -50,12 +50,13 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
 
   const latest = useLatest({ triggerElementRef, contentId, handleClickTrigger, cleanupFrame })
 
+  // aria-expandedはactiveの変化と同期して更新する必要があるため、
+  // 下記のMutationObserverベースのeffect(非同期に発火しうる)とは分離する
   useEffect(() => {
     if (!latest.triggerElementRef.current) {
       return
     }
 
-    // apply ARIA to all focusable elements in trigger
     const triggers = tabbable(latest.triggerElementRef.current, { shouldIgnoreVisibility: true })
 
     triggers.forEach((trigger) => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -43,7 +43,8 @@ const classNameGenerator = tv({
 })
 
 export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => {
-  const { active, handleClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)
+  const { active, handleClickTrigger, contentId, triggerElementRef, cleanupFrame } =
+    useContext(DropdownContext)
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
   useEffect(() => {
@@ -108,8 +109,9 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
     return () => {
       currentCleanup?.()
       observer.disconnect()
+      cleanupFrame()
     }
-  }, [handleClickTrigger, triggerElementRef])
+  }, [handleClickTrigger, triggerElementRef, cleanupFrame])
 
   return (
     <div ref={triggerElementRef} className={actualClassName}>


### PR DESCRIPTION
## 関連URL

なし

## 概要

Dropdown配下のuseEffectを見直し、以下の観点でリファクタリングした。

- DOM要素のmount/unmountに連動する処理はcallback ref化できないか
- functionsオブジェクトに不要な公開プロパティを含めていないか
- useLatestパターンで依存配列を整理できないか
- 発火条件が異なる処理を無理に1つのeffectへ統合していないか

## 変更内容

### Dropdown

- `document.body`/`window`へのイベントリスナー登録を、`if (!active) return`で分岐していた`Dropdown.tsx`側のuseEffectから、実際に`active`な間だけマウントされる`DropdownContentInner`側へ移した
- `updateTriggerRect`/`handleClickBody`を`functions`の公開プロパティからローカル関数にした（`contentInnerCallbackRef`内でしか参照されていなかったため）
- `openFrame`/`closeFrame`のキャンセルを、独立したuseEffectから`DropdownTrigger`側の既存effect（クリックリスナー設定・disabled監視）に統合した。`DropdownTrigger`は`Dropdown`の開閉に関わらず常にレンダーされる要素で、該当effectの依存配列はすべて安定した参照のため、実質マウント時に1回・アンマウント時に1回しか実行されない
- `contentInnerCallbackRef`を「呼び出すとcleanup関数を返す関数」から正真正銘のcallback ref形式（`(node) => cleanup | undefined`）に変更し、`useMergeRefs`で直接統合できるようにした

### DropdownTrigger

- クリックリスナー設定・disabled監視をcallback refに置き換えた。`useMergeRefs`経由でのみ使われるため、`useMergeRefs`が内部で担うReact 18/19互換のcleanup管理により`useCallbackRefCleanupForReact18`での追加ラップは不要と判断した
- `aria-expanded`/`aria-controls`の更新は`active`の変化と同期して行う必要があるため、上記callback ref（MutationObserverベースで非同期に発火しうる）とは分離し、独立したuseEffectのまま維持した
- 各effectの依存配列をuseLatestパターンで整理した

### DropdownContentInner

- keydown処理・`contentInnerCallbackRef`呼び出しをcallback refに置き換えた
- 位置計算とfocus処理を、`useAnimationFrame`（focusFrame）による1つのeffectに統合した。従来は「同じeffect内で`setIsActive(true)`直後に`focus()`を呼べない」制約を、`isActive`依存の別effectで回避していたが、`requestAnimationFrame`経由の遅延実行に置き換えて1つに統合した

### 見つけた重大な回帰バグ

リファクタリングの過程で、以下の重大な回帰バグを発見し都度修正した。

1. `openFrame`/`closeFrame`のキャンセルを`DropdownContentInner`（開閉のたびにマウント/アンマウントされる）のクリーンアップに統合してしまい、`actualClose`で予約した`closeFrame`が直後にキャンセルされ`onClose`が呼ばれなくなっていた
2. `aria-expanded`の更新をMutationObserverベースのeffectに統合してしまい、更新が非同期化され、既存テストが失敗するようになっていた（`aria-expanded`はUIの状態変化と同期して更新される必要がある）
3. 位置計算・focus処理の統合により、`requestAnimationFrame`がReactのコミットタイミングとは独立して実行されるようになったため、既存テストの`await userEvent.tab()`だけではフレーム発火を待てなくなっていた

いずれも実際にテストで再現を確認したうえで修正・対応済み。3番目についてはテスト側に`waitForAnimationFrame`ヘルパーを追加して対応した。

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 各変更について `tsc --noEmit` / `eslint` / `prettier --check` / 関連する `vitest`（Dropdown配下、2ファイル14件）を実行し通過を確認済み
- `onOpen`/`onClose`が開閉のたびに正しく発火し続けること、`aria-expanded`が同期的に更新され続けること、`document.body`のイベントリスナーが重複登録されないことなどを一時テストで確認済み
- Storybookで`Components/Dropdown`の見た目・挙動（開閉、フォーカス移動、キーボード操作）に変化がないことを確認可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ドロップダウン展開後のフォーカス移動が、アニメーション完了後に正しく行われるよう改善しました。
  * TabキーやEscapeキーを使用した際のフォーカス制御と閉じる動作の安定性を向上しました。
  * ドロップダウン表示中に画面をスクロールまたはリサイズした場合も、位置が適切に更新されるよう修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->