### PR TITLE
refactor(SingleCombobox): selectedItem変化時のinputValue同期をuseEffectからレンダー中の比較に変更する

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 
 import { IntlProvider } from '../../../intl'
 import { FormControl } from '../../FormGroup'
 
 import { SingleCombobox } from './SingleCombobox'
 
+import type { ComboboxItem } from '../types'
 import type { ComponentProps } from 'react'
 
 describe('SingleCombobox', () => {
@@ -118,6 +120,69 @@ describe('SingleCombobox', () => {
     // 新しいアイテムをクリックして、追加イベントの発火を確認
     await userEvent.click(screen.getByRole('option', { name: '「新しいアイテム」を追加' }))
     expect(onAdd).toHaveBeenCalledWith('新しいアイテム')
+  })
+
+  it('creatableで新しく追加したアイテムをselectedItemに指定すると、値・表示が更新されること', async () => {
+    const initialItems: Array<ComboboxItem<string>> = [
+      { label: 'option 1', value: 'value-1' },
+      { label: 'option 2', value: 'value-2' },
+    ]
+
+    // 実際の利用方法を模して、親コンポーネントがitems・selectedItemを状態として管理し、
+    // onAddで追加された値をitemsに加えた上でselectedItemに指定する
+    const CreatableComboboxWrapper = () => {
+      const [items, setItems] = useState(initialItems)
+      const [selectedItem, setSelectedItem] = useState<ComboboxItem<string> | null>(null)
+
+      return (
+        <IntlProvider locale="ja">
+          <form>
+            <FormControl label="コンボボックス">
+              <SingleCombobox
+                name="default"
+                selectedItem={selectedItem}
+                creatable
+                onAdd={(value) => {
+                  const newItem = { label: value, value }
+                  setItems((current) => [...current, newItem])
+                  setSelectedItem(newItem)
+                }}
+                onChangeSelected={setSelectedItem}
+                items={items}
+              />
+            </FormControl>
+            {/* 手入力を経由せず外部からselectedItemを差し替えるための操作(実際のアプリでの「別のUIから選択を変更する」相当) */}
+            <button
+              type="button"
+              onClick={() => setSelectedItem(items.find((item) => item.value === 'value-1')!)}
+            >
+              option 1を外部から選択
+            </button>
+          </form>
+        </IntlProvider>
+      )
+    }
+
+    render(<CreatableComboboxWrapper />)
+
+    await userEvent.click(combobox())
+    await userEvent.type(combobox(), '新しいアイテム')
+    await userEvent.click(screen.getByRole('option', { name: '「新しいアイテム」を追加' }))
+
+    // 追加したアイテムがinputの表示値として反映される
+    expect(combobox()).toHaveValue('新しいアイテム')
+
+    // 再度リストボックスを開くと、追加したアイテムが選択肢として一覧に含まれ、選択中(aria-selected)であること
+    await userEvent.click(combobox())
+    expect(screen.getByRole('option', { name: '新しいアイテム' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+
+    // 手入力を経由せず外部からselectedItemが変わった場合も、inputの表示値が正しく更新されること
+    // (レンダー中の同期処理が効いているかの確認になる)
+    await userEvent.click(screen.getByRole('button', { name: 'option 1を外部から選択' }))
+    expect(combobox()).toHaveValue('option 1')
   })
 
   it('disabled なコンボボックスではアイテムの選択・解除ができないこと', async () => {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -10,7 +10,6 @@ import {
   type RefObject,
   memo,
   useCallback,
-  useEffect,
   useId,
   useMemo,
   useRef,
@@ -198,9 +197,18 @@ const ActualSingleCombobox = <T,>(
   const clearButtonRef = useRef<HTMLButtonElement>(null)
   const [isFocused, setIsFocused] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
-  const [inputValue, setInputValue] = useState('')
   const [isComposing, setIsComposing] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
+
+  const [inputValue, setInputValue] = useState('')
+  const [prevSelectedItemLabelText, setPrevSelectedItemLabelText] = useState('')
+
+  const selectedItemLabelText = selectedItem ? innerText(selectedItem.label) : ''
+
+  if (selectedItemLabelText !== prevSelectedItemLabelText) {
+    setPrevSelectedItemLabelText(selectedItemLabelText)
+    setInputValue(selectedItemLabelText)
+  }
 
   const { options } = useSingleOptions({
     items,
@@ -406,12 +414,6 @@ const ActualSingleCombobox = <T,>(
   const cleanupCallbackRef = useCallback(() => selectFrame.cancel, [selectFrame.cancel])
 
   const mergedRef = useMergeRefs(inputRef, cleanupCallbackRef, ref)
-
-  // selectedItem.label はプリミティブ値でないデータ型の可能性があり、そのまま useEffect の依存配列に入れると意図せぬエフェクトの実行を引き起こしてしまう可能性があるので、プリミティブ値である string 型に変換したものを依存配列に入れています。
-  const selectedItemLabelText = innerText(selectedItem?.label)
-  useEffect(() => {
-    setInputValue(selectedItemLabelText)
-  }, [selectedItemLabelText])
 
   const classNames = useMemo(() => {
     const { wrapper, input, caretDownLayout, caretDownIcon, clearButton, clearButtonIcon } =

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -201,6 +201,8 @@ const ActualSingleCombobox = <T,>(
   const [isEditing, setIsEditing] = useState(false)
 
   const [inputValue, setInputValue] = useState('')
+  // inputValueはユーザーの手入力値も兼ねるため、prevSelectedItemLabelTextの代わりにinputValueと比較すると、
+  // 手入力中に selectedItemLabelText（不変）との不一致を検知して選択中アイテムのラベルへ強制的に戻ってしまう
   const [prevSelectedItemLabelText, setPrevSelectedItemLabelText] = useState('')
 
   const selectedItemLabelText = selectedItem ? innerText(selectedItem.label) : ''


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useEffect` の見直しプロジェクトの一環。`SingleCombobox` で `selectedItem` が変化した際に `inputValue` を同期する処理が `useEffect` で実装されており、prop変化への追従を `useEffect` に頼らずレンダー中の比較で実現できないか検証した。

## 変更内容

`selectedItem` が変化した際の `inputValue` 同期処理を `useEffect` からレンダー中の比較パターン（前回の `selectedItem` のラベルを `useState` で保持し、変化していたら同一レンダー内で `setInputValue` する）に変更した。

これにより、旧実装で `useEffect` の発火（コミット後）を待つ必要があったため理論上生じ得た初期表示時の入力値チラつきが解消され、初回レンダーから即座に正しい値が表示されるようになった。

`isEditing`・`unfocus` 処理との相互作用、`innerText(undefined)` と `selectedItem` が `null` の場合の分岐は挙動が変わらないことを確認済み。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm ui test -- --run src/components/Combobox` で既存テスト（43件）が通ることを確認済み。Storybookの `Components/Combobox/SingleCombobox` で選択アイテムの表示・クリア・手入力時の挙動に変化がないことを目視確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 選択項目のラベル変更時に、入力欄の表示が正しく同期されるよう改善しました。
  * 追加した項目や外部操作による選択項目の変更が、入力欄と選択状態に正しく反映されるよう修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->