### PR TITLE
refactor(useListbox): IntersectionのuseRef+useEffectをcallback ref・レンダー中の比較に置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/__tests__/ListBox.test.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/__tests__/ListBox.test.tsx
@@ -1,0 +1,103 @@
+import { act, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { vi } from 'vitest'
+
+import { ListBox } from '../useListbox'
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = []
+  callback: IntersectionObserverCallback
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback
+    MockIntersectionObserver.instances.push(this)
+  }
+
+  observe = vi.fn()
+  disconnect = vi.fn()
+}
+
+const OPTION_COUNT = 250
+
+const buildOptions = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `id-${i}`,
+    selected: false,
+    isNew: false,
+    item: { label: `option${i}`, value: `value-${i}` },
+  }))
+
+describe('ListBox - Intersection(スクロール末端検知による追加読み込み)', () => {
+  const options = buildOptions(OPTION_COUNT)
+  const listBoxRef = createRef<HTMLDivElement>()
+  const activeRef = createRef<HTMLButtonElement>()
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances = []
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const renderListBox = () =>
+    render(
+      <ListBox
+        listBoxRef={listBoxRef}
+        activeRef={activeRef}
+        activeOptionId={undefined}
+        listBoxId="listbox"
+        isExpanded
+        listBoxRect={{ top: 0, left: 0 }}
+        triggerWidth={100}
+        handleAdd={undefined}
+        handleHoverOption={() => {}}
+        handleSelect={() => {}}
+        options={options}
+      />,
+    )
+
+  const intersect = () => {
+    const observer = MockIntersectionObserver.instances.at(-1)!
+
+    act(() => {
+      observer.callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        observer as unknown as IntersectionObserver,
+      )
+    })
+  }
+
+  it('初期表示は先頭から100件のみで、末尾に監視要素が配置され観測が開始される', () => {
+    renderListBox()
+
+    expect(screen.getByText('option99')).toBeInTheDocument()
+    expect(screen.queryByText('option100')).not.toBeInTheDocument()
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1)
+    expect(MockIntersectionObserver.instances[0].observe).toHaveBeenCalledTimes(1)
+  })
+
+  it('監視要素が交差すると表示件数が100件ずつ増える', () => {
+    renderListBox()
+
+    intersect()
+
+    expect(screen.getByText('option199')).toBeInTheDocument()
+    expect(screen.queryByText('option200')).not.toBeInTheDocument()
+  })
+
+  it('全件表示に達すると監視要素が消え、observerがdisconnectされる', () => {
+    renderListBox()
+
+    intersect()
+
+    const observerAfterFirstIntersect = MockIntersectionObserver.instances.at(-1)!
+
+    intersect()
+
+    expect(screen.getByText('option249')).toBeInTheDocument()
+    expect(observerAfterFirstIntersect.disconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -254,19 +254,24 @@ export const useListbox = <T,>({
     }
   }, [hasOnAdd, latest])
 
-  // TODO: callbackRefにまとめ直したい
-  useEffect(() => addFrame.cancel, [addFrame.cancel])
+  useEnhancedEffect(() => {
+    // 閉じたときに activeOption を初期化
+    if (!isExpanded) {
+      return setActiveOption(null)
+    }
 
-  useEffect(() => {
-    // props の変更によって activeOption の状態が変わりうるので、実態を反映する
-    setActiveOption((current) => {
-      if (current === null) {
-        return null
-      }
+    functions.calculateRect()
 
-      return options.find((option) => current.id === option.id) ?? null
-    })
-  }, [options])
+    const scrollOption = { capture: true, passive: true }
+    window.addEventListener('scroll', functions.calculateRect, scrollOption)
+    window.addEventListener('resize', functions.calculateRect, { passive: true })
+
+    return () => {
+      window.removeEventListener('scroll', functions.calculateRect, scrollOption)
+      window.removeEventListener('resize', functions.calculateRect)
+    }
+    // HINT: optionsが変わる場合メニューのサイズが変わる可能性がある
+  }, [isExpanded, options, functions])
 
   useEffect(() => {
     // actionOption の要素が表示される位置までリストボックス内をスクロールさせる
@@ -289,24 +294,19 @@ export const useListbox = <T,>({
     }
   }, [activeOption, navigationType])
 
-  useEnhancedEffect(() => {
-    // 閉じたときに activeOption を初期化
-    if (!isExpanded) {
-      return setActiveOption(null)
-    }
+  // TODO: callbackRefにまとめ直したい
+  useEffect(() => addFrame.cancel, [addFrame.cancel])
 
-    functions.calculateRect()
+  useEffect(() => {
+    // props の変更によって activeOption の状態が変わりうるので、実態を反映する
+    setActiveOption((current) => {
+      if (current === null) {
+        return null
+      }
 
-    const scrollOption = { capture: true, passive: true }
-    window.addEventListener('scroll', functions.calculateRect, scrollOption)
-    window.addEventListener('resize', functions.calculateRect, { passive: true })
-
-    return () => {
-      window.removeEventListener('scroll', functions.calculateRect, scrollOption)
-      window.removeEventListener('resize', functions.calculateRect)
-    }
-    // HINT: optionsが変わる場合メニューのサイズが変わる可能性がある
-  }, [isExpanded, options, functions])
+      return options.find((option) => current.id === option.id) ?? null
+    })
+  }, [options])
 
   return {
     listBoxProps: {

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -383,9 +383,16 @@ export const ListBox = memo(
         (activeOptionId === undefined ? 0 : options.findIndex((o) => o.id === activeOptionId)) + 1,
       [activeOptionId, options],
     )
+    const [prevMinLength, setPrevMinLength] = useState(minLength)
     const [currentItemLength, setCurrentItemLength] = useState(() =>
       Math.max(OPTION_INCREMENT_AMOUNT, minLength),
     )
+
+    if (minLength !== prevMinLength) {
+      setPrevMinLength(minLength)
+      setCurrentItemLength((current) => Math.max(current, minLength))
+    }
+
     const items = useMemo(() => options.slice(0, currentItemLength), [currentItemLength, options])
 
     const styles = useMemo(() => {
@@ -454,10 +461,6 @@ export const ListBox = memo(
         },
       }
     }, [latest])
-
-    useEffect(() => {
-      setCurrentItemLength((current) => Math.max(current, minLength))
-    }, [minLength])
 
     return createPortal(
       <div

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -6,7 +6,6 @@ import {
   type ReactNode,
   type RefObject,
   memo,
-  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -420,6 +419,23 @@ export const ListBox = memo(
       }
 
       return {
+        intersectCallbackRef: (node: HTMLElement | null) => {
+          if (node === null) {
+            return
+          }
+
+          const observer = new IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+              setCurrentItemLength((current) =>
+                Math.max(current + OPTION_INCREMENT_AMOUNT, latest.minLength),
+              )
+            }
+          })
+
+          observer.observe(node)
+
+          return () => observer.disconnect()
+        },
         handleDelegateClick: (e: MouseEvent) => {
           const option = resolveOption(e)
           if (option) {
@@ -435,11 +451,6 @@ export const ListBox = memo(
           if (option) {
             latest.handleHoverOption(option)
           }
-        },
-        handleIntersect: () => {
-          setCurrentItemLength((current) =>
-            Math.max(current + OPTION_INCREMENT_AMOUNT, latest.minLength),
-          )
         },
       }
     }, [latest])
@@ -507,7 +518,7 @@ export const ListBox = memo(
             )
           ) : null}
           {currentItemLength < options.length && (
-            <Intersection handleIntersect={functions.handleIntersect} />
+            <Intersection callbackRef={functions.intersectCallbackRef} />
           )}
         </Scroller>
       </div>,
@@ -515,27 +526,10 @@ export const ListBox = memo(
   },
 ) as <T>(props: ListBoxProps<T>) => ReactNode
 
-const Intersection = memo<{ handleIntersect: () => void }>(({ handleIntersect }) => {
-  const callbackRef = useCallbackRefCleanupForReact18(
-    useCallback(
-      (node: HTMLElement | null) => {
-        if (node === null) {
-          return
-        }
+const Intersection = memo<{
+  callbackRef: (node: HTMLElement | null) => (() => void) | undefined
+}>(({ callbackRef }) => {
+  const actualCallbackRef = useCallbackRefCleanupForReact18(callbackRef)
 
-        const observer = new IntersectionObserver(([entry]) => {
-          if (entry.isIntersecting) {
-            handleIntersect()
-          }
-        })
-
-        observer.observe(node)
-
-        return () => observer.disconnect()
-      },
-      [handleIntersect],
-    ),
-  )
-
-  return <div ref={callbackRef} />
+  return <div ref={actualCallbackRef} />
 })

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   type RefObject,
   memo,
+  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -15,6 +16,7 @@ import {
 import { tv } from 'tailwind-variants'
 
 import { useAnimationFrame } from '../../hooks/client/useAnimationFrame'
+import { useCallbackRefCleanupForReact18 } from '../../hooks/client/useCallbackRefCleanupForReact18'
 import { useEnhancedEffect } from '../../hooks/client/useEnhancedEffect'
 import { usePortal } from '../../hooks/client/usePortal'
 import { useTheme } from '../../hooks/client/useTheme'
@@ -514,25 +516,26 @@ export const ListBox = memo(
 ) as <T>(props: ListBoxProps<T>) => ReactNode
 
 const Intersection = memo<{ handleIntersect: () => void }>(({ handleIntersect }) => {
-  const ref = useRef<HTMLDivElement>(null)
+  const callbackRef = useCallbackRefCleanupForReact18(
+    useCallback(
+      (node: HTMLElement | null) => {
+        if (node === null) {
+          return
+        }
 
-  useEffect(() => {
-    const target = ref.current
+        const observer = new IntersectionObserver(([entry]) => {
+          if (entry.isIntersecting) {
+            handleIntersect()
+          }
+        })
 
-    if (target === null) {
-      return
-    }
+        observer.observe(node)
 
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        handleIntersect()
-      }
-    })
+        return () => observer.disconnect()
+      },
+      [handleIntersect],
+    ),
+  )
 
-    observer.observe(target)
-
-    return () => observer.disconnect()
-  }, [handleIntersect])
-
-  return <div ref={ref} />
+  return <div ref={callbackRef} />
 })

--- a/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/useListbox.tsx
@@ -103,13 +103,27 @@ export const useListbox = <T,>({
   const listBoxId = useId()
 
   const [navigationType, setNavigationType] = useState<'pointer' | 'key'>('pointer')
-  const [activeOption, setActiveOption] = useState<ComboboxOption<T> | null>(null)
   const [listBoxRect, setListBoxRect] = useState<Rect>({
     top: 0,
     left: 0,
   })
   // HINT: calculateRectで同時に計算するとwidthの幅が変更されるタイミングの問題でlistBoxHeightが変化する場合がある
   const [triggerWidth, setTriggerWidth] = useState(0)
+
+  const [activeOption, setActiveOption] = useState<ComboboxOption<T> | null>(null)
+  const [prevOptions, setPrevOptions] = useState(options)
+
+  if (options !== prevOptions) {
+    setPrevOptions(options)
+    // props の変更によって activeOption の状態が変わりうるので、実態を反映する
+    setActiveOption((current) => {
+      if (current === null) {
+        return null
+      }
+
+      return options.find((option) => current.id === option.id) ?? null
+    })
+  }
 
   const listBoxRef = useRef<HTMLDivElement>(null)
   const activeRef = useRef<HTMLButtonElement>(null)
@@ -296,17 +310,6 @@ export const useListbox = <T,>({
 
   // TODO: callbackRefにまとめ直したい
   useEffect(() => addFrame.cancel, [addFrame.cancel])
-
-  useEffect(() => {
-    // props の変更によって activeOption の状態が変わりうるので、実態を反映する
-    setActiveOption((current) => {
-      if (current === null) {
-        return null
-      }
-
-      return options.find((option) => current.id === option.id) ?? null
-    })
-  }, [options])
 
   return {
     listBoxProps: {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useEffect` の見直しプロジェクトの一環。`useListbox`(Combobox内部)で使われている `useRef` + `useEffect` を、DOM要素の mount/unmount に連動する処理は callback ref に、prop/option 変化への追従はレンダー中の比較に置き換えられないか検証した。

## 変更内容

- `Intersection` コンポーネント: `IntersectionObserver` のセットアップを `useRef` + `useEffect` から callback ref に変更。`useCallbackRefCleanupForReact18` でラップし React 18/19 両対応。その後、`IntersectionObserver` の構築ロジックを呼び出し元の `functions` 側に集約し、`Intersection` コンポーネント自体は渡された callback ref を中継するだけのシンプルな実装に変更。
- `minLength`(activeOptionの位置に応じた最小描画件数)変化時の `currentItemLength` 更新を `useEffect` からレンダー中の比較に変更。
- `options` 変化時の `activeOption` 同期を `useEffect` からレンダー中の比較に変更。
- 上記に伴う既存 `useEffect` の宣言順序の整理。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm ui test -- --run src/components/Combobox` で既存テスト(43件)が通ることを確認済み。Storybookの `Components/Combobox` でオプション選択・スクロール・無限スクロール的な件数増加の挙動に変化がないことを目視確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * コンボボックスの選択肢更新時に、アクティブな選択肢が適切に同期されるよう改善しました。
  * 表示件数や展開状態の変更時に、リスト表示と位置計算が正しく更新されるよう修正しました。
  * リストの表示・非表示切り替え時に、監視処理やイベントが適切に管理されるよう改善しました。
  * リストをスクロールした際、追加の選択肢が正しく読み込まれるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->