### PR TITLE
refactor(DefinitionListItem): client専用処理をclient/ItemWrapperに切り出す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,24 @@ import 'styled-components';    // ← hooks 側の依存が転記される
 
 **例外: `Table` パターンのようにフラット配置する場合**
 
-前述のとおり hook が `client/` 内の component からしか呼ばれない場合は `components/` `hooks/` に分けず `client/index.ts` を一つだけ置きます。これは「componentsとhooksの合流点を作らない」という目的に反しません。この `client/index.ts` が re-export するのは**公開する component のみ**で、`useTableHeadCellCount` のような非公開の内部 hook は re-export しないためです。結果として `client/index.ts` は実質「component 用バレル」としてのみ機能し、hook 側の依存が別経路から迷い込む合流点にはなりません。hook は同じ `client/` 内から相対 import で直接参照します。
+前述のとおり hook が `client/` 内の component からしか呼ばれない場合は `components/` `hooks/` に分けず `client/index.ts` を一つだけ置きます。これは「componentsとhooksの合流点を作らない」という目的に反しません。`client/` 内で宣言した hook は client 内の component から相対 import で直接参照されるだけで、`client/` の外から参照されることは原則ありません。したがって `client/index.ts` から hook が re-export されることはなく（例外は次項の `useSectioningWrapper` のように hook が Server Component からも直接 import されうる場合のみ）、`client/index.ts` は実質「component 用バレル」としてのみ機能します。
+
+**例外: `client/index.ts` が component のみを re-export する場合**
+
+`client/index.ts` が re-export する対象は component のみです。`client/` 内で宣言した hook は client 専用の内部実装であり、同じ `client/` 内の component から相対 import で直接参照されるだけで、`client/` の外から参照されることは原則ありません（例外は `useSectioningWrapper` のように、hook が `client/` 内の component を経由せず Server Component からも直接 import されうる場合のみ）。`client/` 配下にある component は前述の原則（そのファイル自身が client 専用 API を使っているかで判断する）に従い `'use client'` を持つため、`'use client'` を持つモジュールは react-server グラフでは実体を評価されずクライアント参照に変換されます。したがって複数の component を一つの `client/index.ts` で re-export しても、ある component の依存が別の component 側へ転記されることはありません。対象が公開 component か非公開 component かは無関係です。
+
+`DefinitionListItem` の `client/ItemWrapper.tsx`（非公開 component、`useTheme` を使うため `'use client'` あり）が実例です。
+
+```text
+DefinitionList/
+├── index.ts                      公開バレル
+├── DefinitionListItem.tsx         'use client' 無し。client/ItemWrapper を使う
+└── client/
+    ├── index.ts                  componentのみre-export（ItemWrapper）
+    └── ItemWrapper.tsx            'use client' 有。非公開component
+```
+
+rollup ビルド出力で `DefinitionListItem.js` が `client/index.js` を経由せず `client/ItemWrapper.js` に直リンクされること、`node --conditions react-server` での評価が成功することを実測済みです。
 
 **この転記は Next.js 実利用では顕在化しないが、それでも作らない**
 

--- a/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/DefinitionListItem.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithoutRef,
   type FC,
@@ -10,10 +8,10 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useTheme } from '../../hooks/client/useTheme'
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
-import { Stack } from '../Layout'
 import { Text } from '../Text'
+
+import { ItemWrapper } from './client'
 
 type ObjectTermType = {
   text: ReactNode
@@ -54,7 +52,6 @@ export const DefinitionListItem: FC<Props> = ({
   fullWidth,
   className,
 }) => {
-  const theme = useTheme()
   const term = useObjectAttributes<ReactNode | ObjectTermType, ObjectTermType>(
     orgTerm,
     termObjectConverter,
@@ -68,27 +65,17 @@ export const DefinitionListItem: FC<Props> = ({
       term: cs.term(),
       description: cs.description(),
     }
-  }, [className, fullWidth])
+  }, [fullWidth, className])
 
   return (
-    <Stack
-      gap={0.25}
-      className={classNames.wrapper}
-      style={{
-        flexBasis:
-          // fullWidth の方が強い
-          !fullWidth && maxColumns
-            ? `calc((100% - ${theme.spacingByChar(1.5)} * ${maxColumns - 1}) / ${maxColumns})`
-            : undefined,
-      }}
-    >
+    <ItemWrapper maxColumns={maxColumns} fullWidth={fullWidth} className={classNames.wrapper}>
       <DefinitionTerm styleType={term.styleType} className={classNames.term}>
         {term.text}
       </DefinitionTerm>
       <Text as="dd" size="M" color="TEXT_BLACK" leading="NORMAL" className={classNames.description}>
         {children}
       </Text>
-    </Stack>
+    </ItemWrapper>
   )
 }
 

--- a/packages/smarthr-ui/src/components/DefinitionList/client/ItemWrapper.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/client/ItemWrapper.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useTheme } from '../../../hooks/client/useTheme'
+import { Stack } from '../../Layout'
+
+import type { FC, PropsWithChildren } from 'react'
+
+type Props = PropsWithChildren<{
+  className?: string
+  fullWidth?: boolean
+  maxColumns?: number
+}>
+
+export const ItemWrapper: FC<Props> = ({ children, className, maxColumns, fullWidth }) => {
+  const theme = useTheme()
+
+  return (
+    <Stack
+      gap={0.25}
+      className={className}
+      style={{
+        flexBasis:
+          // fullWidth の方が強い
+          !fullWidth && maxColumns
+            ? `calc((100% - ${theme.spacingByChar(1.5)} * ${maxColumns - 1}) / ${maxColumns})`
+            : undefined,
+      }}
+    >
+      {children}
+    </Stack>
+  )
+}

--- a/packages/smarthr-ui/src/components/DefinitionList/client/index.ts
+++ b/packages/smarthr-ui/src/components/DefinitionList/client/index.ts
@@ -1,0 +1,1 @@
+export { ItemWrapper } from './ItemWrapper'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DefinitionListItem`（公開コンポーネント）が `useTheme`（client専用hook）を使っていたため `'use client'` を持っていた。`'use client'` の境界判断を「公開しているかどうか」ではなく「そのファイル自身が client 専用 API を使っているか」で個別に判断する方針に変更したのに合わせ、`useTheme` を使う部分だけを `client/ItemWrapper.tsx` に切り出し、`DefinitionListItem.tsx` 自体から `'use client'` を削除する。

あわせて、`client/index.ts`（re-export対象がcomponentのみのバレル）が安全に作れる条件について、CLAUDE.mdの記述を実測に基づいて修正する。

## 変更内容

- `DefinitionListItem.tsx`: `useTheme` を使っていた `flexBasis` 計算とラッパー部分を `client/ItemWrapper.tsx` に切り出し、`'use client'` を削除
- `client/ItemWrapper.tsx`: 新規作成。`useTheme` を使う非公開component
- `client/index.ts`: `ItemWrapper` のみをre-exportするバレル
- `CLAUDE.md`: `client/index.ts` を作ってよい条件を「re-exportする対象が公開componentのみ」から「re-exportする対象が全てcomponent（`'use client'`を持つ）かどうか」に修正。hookは`client/`の外から参照されることを前提としない（`useSectioningWrapper`のような例外を除く）ことを明記

## プロダクト側で対応が必要な事項

なし

## 確認方法

rollupビルド出力で `DefinitionListItem.js` が `client/index.js` を経由せず `client/ItemWrapper.js` に直リンクされること、`node --conditions react-server` での評価が成功することを実測済み。Storybookの `Components/DefinitionList` で表示・レイアウトに変化がないことを目視確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - DefinitionList の項目レイアウト処理を整理し、`maxColumns` や `fullWidth` 指定時の表示をより安定して扱えるようにしました。
  - クライアント側のレイアウト構成を分離し、テーマに基づくスペーシングや列幅の計算を適切に適用します。
- **ドキュメント**
  - コンポーネントの公開方法に関するガイドラインと、各実行環境での確認例を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->