### PR TITLE
refactor(Checkbox): input要素をclient/ActualCheckboxに切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {
   type ComponentPropsWithRef,
   type PropsWithChildren,
@@ -10,8 +8,9 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { FaCheckIcon, FaMinusIcon } from '../Icon'
+
+import { ActualCheckbox } from './client'
 
 export type Props = PropsWithChildren<
   ComponentPropsWithRef<'input'> & {
@@ -61,34 +60,8 @@ const classNameGenerator = tv({
   },
 })
 
-const callbackRef = (node: HTMLInputElement | null) => {
-  if (!node) {
-    return
-  }
-
-  // checkedはcontrolled propとしてinput.checkedプロパティにのみ反映され、
-  // HTML属性としては反映されないため、data-checked属性で代替判定する
-  const action = () => {
-    node.indeterminate =
-      node.getAttribute('data-checked') === 'true' && node.getAttribute('data-mixed') === 'true'
-  }
-
-  action()
-
-  const observer = new MutationObserver(action)
-
-  observer.observe(node, {
-    attributes: true,
-    attributeFilter: ['data-checked', 'data-mixed'],
-  })
-
-  return () => {
-    observer.disconnect()
-  }
-}
-
 export const Checkbox = forwardRef<HTMLInputElement, Props>(
-  ({ checked, mixed, error, className, children, disabled, id, ...rest }, ref) => {
+  ({ mixed, className, children, disabled, id, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, innerWrapper, box, input, iconWrap, icon, label } = classNameGenerator()
 
@@ -106,29 +79,20 @@ export const Checkbox = forwardRef<HTMLInputElement, Props>(
     const defaultId = useId()
     const checkBoxId = id || defaultId
 
-    const mergedRef = useMergeRefs(callbackRef, ref)
-
     return (
       <span className={classNames.wrapper} data-disabled={disabled}>
         <span className={classNames.innerWrapper}>
-          <input
+          <ActualCheckbox
             {...rest}
-            ref={mergedRef}
-            type="checkbox"
+            checkboxRef={ref}
             id={checkBoxId}
             disabled={disabled}
-            checked={checked}
+            mixed={mixed}
             className={classNames.input}
-            aria-invalid={error || undefined}
-            data-smarthr-ui-input="true"
-            // checkedはDOM属性ではなくプロパティとしてのみ反映されるため、data-checkedをMutationObserverで監視
-            data-checked={checked || undefined}
-            data-mixed={mixed || undefined}
           />
           <AriaHiddenBox className={classNames.box} />
           <CheckIconArea mixed={mixed} classNames={classNames} />
         </span>
-
         {children && (
           <label htmlFor={checkBoxId} className={classNames.label}>
             {children}

--- a/packages/smarthr-ui/src/components/Checkbox/client/ActualCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/client/ActualCheckbox.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useMergeRefs } from '../../../hooks/client/useMergeRefs'
+
+import type { ComponentPropsWithoutRef, FC, Ref } from 'react'
+
+export type Props = ComponentPropsWithoutRef<'input'> & {
+  checkboxRef?: Ref<HTMLInputElement>
+  /** `true` のとき、チェック状態を `mixed` にする */
+  mixed?: boolean
+  /** チェックボックスにエラーがあるかどうか */
+  error?: boolean
+}
+
+const callbackRef = (node: HTMLInputElement | null) => {
+  if (!node) {
+    return
+  }
+
+  // checkedはcontrolled propとしてinput.checkedプロパティにのみ反映され、
+  // HTML属性としては反映されないため、data-checked属性で代替判定する
+  const action = () => {
+    node.indeterminate =
+      node.getAttribute('data-checked') === 'true' && node.getAttribute('data-mixed') === 'true'
+  }
+
+  action()
+
+  const observer = new MutationObserver(action)
+
+  observer.observe(node, {
+    attributes: true,
+    attributeFilter: ['data-checked', 'data-mixed'],
+  })
+
+  return () => {
+    observer.disconnect()
+  }
+}
+
+export const ActualCheckbox: FC<Props> = ({ checkboxRef, checked, mixed, error, ...rest }) => {
+  const mergedRef = useMergeRefs(callbackRef, checkboxRef)
+
+  return (
+    <input
+      {...rest}
+      ref={mergedRef}
+      type="checkbox"
+      checked={checked}
+      aria-invalid={error || undefined}
+      data-smarthr-ui-input="true"
+      // checkedはDOM属性ではなくプロパティとしてのみ反映されるため、data-checkedをMutationObserverで監視
+      data-checked={checked || undefined}
+      data-mixed={mixed || undefined}
+    />
+  )
+}

--- a/packages/smarthr-ui/src/components/Checkbox/client/index.ts
+++ b/packages/smarthr-ui/src/components/Checkbox/client/index.ts
@@ -1,0 +1,1 @@
+export { ActualCheckbox } from './ActualCheckbox'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`Checkbox`（公開コンポーネント）が `useMergeRefs`（client専用hook）を使っていたため `'use client'` を持っていた。`'use client'` の境界判断を「公開しているかどうか」ではなく「そのファイル自身が client 専用 API を使っているか」で個別に判断する方針に変更したのに合わせ、`useMergeRefs`・`MutationObserver`を使う `<input>` 部分だけを `client/ActualCheckbox.tsx` に切り出し、`Checkbox.tsx` 自体から `'use client'` を削除する。

## 変更内容

- `Checkbox.tsx`: `<input>` 要素とrefのマージ処理（`useMergeRefs`、`data-checked`/`data-mixed` を監視する `MutationObserver`）を `client/ActualCheckbox.tsx` に切り出し、`'use client'` を削除
- `client/ActualCheckbox.tsx`: 新規作成。`useMergeRefs` を使う非公開component
- `client/index.ts`: `ActualCheckbox` のみをre-exportするバレル

## プロダクト側で対応が必要な事項

なし

## 確認方法

`renderToStaticMarkup` で旧実装との出力比較を実施し、属性順序を除き全ケース（checked/mixed/disabled/error/children/id の組み合わせ）で完全一致することを確認済み。

`node --conditions react-server` での素の評価では `Icon`（`FaCheckIcon`/`FaMinusIcon`）経由の間接的な `styled-components` 依存により `TypeError` になるが、実際の Next.js（Turbopack）環境で `next dev` を実測したところ `Checkbox` は正しく Server Component として描画され、問題は顕在化しないことを確認済み（`sideEffects` 宣言によるツリーシェイクのため）。styled-components依存の解消は別PRで対応予定のため、本PRのスコープ外とする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - チェックボックスのチェック状態・混合状態・エラー状態が、表示と入力要素でより安定して同期されるようになりました。
  - 混合状態（「一部選択」）の表示が、状態変更後も正しく反映されるようになりました。
  - チェックボックスの参照（ref）を利用する処理の互換性を維持しながら、状態更新の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->