### PR TITLE
refactor(Calendar): useEffectをレンダー中の比較に変更、YearPickerにuse clientを追加

### DIFF
--- a/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/Calendar.tsx
@@ -7,7 +7,6 @@ import {
   type PropsWithChildren,
   forwardRef,
   memo,
-  useEffect,
   useId,
   useMemo,
   useState,
@@ -69,6 +68,8 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
       }
     }, [className])
 
+    const yearPickerId = useId()
+
     const formattedFrom = useMemo(() => {
       const date = getFromDate(from)
       const day = dayjs(date)
@@ -94,6 +95,8 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
       () => value && isBetween(value, formattedFrom.date, formattedTo.date),
       [value, formattedFrom.date, formattedTo.date],
     )
+    const [prevIsValidValue, setPrevIsValidValue] = useState(isValidValue)
+    const [prevValue, setPrevValue] = useState(value)
 
     const [currentMonth, setCurrentMonth] = useState(() => {
       if (isValidValue) {
@@ -108,15 +111,15 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
           ? formattedFrom.day
           : today
     })
-    const [isSelectingYear, setIsSelectingYear] = useState(false)
 
-    const yearPickerId = useId()
+    if (isValidValue !== prevIsValidValue || value !== prevValue) {
+      setPrevIsValidValue(isValidValue)
+      setPrevValue(value)
 
-    useEffect(() => {
       if (isValidValue) {
         setCurrentMonth(dayjs(value))
       }
-    }, [value, isValidValue])
+    }
 
     const calculatedCurrentMonth = useMemo(() => {
       const d = currentMonth.toDate()
@@ -137,6 +140,8 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(
         selectedText: currentMonth.toString(),
       }
     }, [currentMonth, formatDate, getWeekStartDay])
+
+    const [isSelectingYear, setIsSelectingYear] = useState(false)
 
     const functions = useMemo(
       () => ({

--- a/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/YearPicker.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { type ComponentProps, type FC, type MouseEvent, memo, useMemo, useState } from 'react'
 import { tv } from 'tailwind-variants'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useEffect` の見直しプロジェクトの一環。`Calendar` で `value`/`isValidValue` 変化時に `currentMonth` を同期する処理が `useEffect` で実装されていたため、レンダー中の比較で実現できないか検証した。あわせて `YearPicker`（`useState` を使う非公開コンポーネント）に `'use client'` を追加する。

## 変更内容

- `Calendar.tsx`: `value`/`isValidValue` が変化した際に `currentMonth` を同期する処理を `useEffect` からレンダー中の比較パターン（前回の値を `useState` で保持し、変化していたら同一レンダー内で `setCurrentMonth` する）に変更した
- `YearPicker.tsx`: `useState` を使うため `'use client'` を追加（呼び出し元の `Calendar.tsx` は既に `'use client'` を持つため動作上は冗長だが、公開/非公開に関わらずファイル自身の必要性で `'use client'` を判断する方針に沿った変更）

`value` が外部から変化した際に表示月が正しく追従することをテストで再現・確認済み。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm ui test -- --run src/components/Calendar` で既存テスト（24件）が通ることを確認済み。Storybookの `Components/Calendar` で日付選択・月切り替え・年選択の挙動に変化がないことを目視確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * カレンダーで値や有効性が変更された際、表示中の月が適切に同期されるよう改善しました。
  * 年選択機能がクライアント環境で正しく動作するよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->