### PR TITLE
refactor(NotificationBar): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/NotificationBar.tsx
@@ -8,7 +8,7 @@ import {
   memo,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
@@ -24,6 +24,31 @@ import {
 import { Cluster } from '../Layout'
 import { Panel } from '../Panel'
 import { Text } from '../Text'
+
+// TODO: base という属性名だとプログラミング文脈に取られかねないためbackgroundなど別の属性名を検討する
+// base="base" も意味が分かりづらい
+type BaseType = 'base' | 'none'
+type TypeType = 'info' | 'success' | 'warning' | 'error' | 'sync'
+
+type BaseProps = PropsWithChildren<{
+  /** コンポーネント右の領域 */
+  subActionArea?: ReactNode
+  /** 閉じるボタン押下時に発火させる関数 */
+  onClose?: () => void
+  /** role 属性 */
+  role?: 'alert' | 'status'
+  /** 下地 */
+  base?: BaseType
+  /** メッセージの種類 */
+  type: TypeType
+  /** 強調するかどうか */
+  bold?: boolean
+  /** スライドインするかどうか */
+  animate?: boolean
+}> &
+  Pick<ComponentProps<typeof Panel>, 'layer'>
+
+type Props = Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps> & BaseProps
 
 const classNameGenerator = tv({
   slots: {
@@ -41,14 +66,12 @@ const classNameGenerator = tv({
       'smarthr-ui-NotificationBar-closeButton -shr-mb-0.5 -shr-mr-0.5 -shr-mt-0.5 shr-flex-shrink-0 shr-text-black',
   },
   variants: {
-    /** 下地 */
     base: {
       none: {},
       base: {
         wrapper: 'shr-py-1 shr-pe-1 shr-ps-1.5',
       },
-    },
-    /** メッセージの種類 */
+    } satisfies Record<BaseType, object>,
     type: {
       info: {
         icon: 'shr-text-grey',
@@ -61,13 +84,11 @@ const classNameGenerator = tv({
       sync: {
         icon: 'shr-text-main',
       },
-    },
-    /** 強調するかどうか */
+    } satisfies Record<TypeType, object>,
     bold: {
       true: '',
       false: '',
     },
-    /** スライドインするかどうか */
     animate: {
       true: {
         wrapper: 'shr-animate-[notification-bar-slide-in_0.2s_ease-out]',
@@ -134,23 +155,6 @@ const classNameGenerator = tv({
     },
   ],
 })
-
-type StyleVariants = VariantProps<typeof classNameGenerator>
-type BaseProps = PropsWithChildren<
-  Omit<StyleVariants, 'type'> &
-    Required<Pick<StyleVariants, 'type'>> & {
-      /** コンポーネント右の領域 */
-      subActionArea?: ReactNode
-      /** 閉じるボタン押下時に発火させる関数 */
-      onClose?: () => void
-      /** role 属性 */
-      role?: 'alert' | 'status'
-    }
->
-type PanelLayerProps = Pick<ComponentProps<typeof Panel>, 'layer'>
-type Props = PanelLayerProps &
-  Omit<ComponentPropsWithoutRef<'div'>, keyof PanelLayerProps> &
-  Omit<BaseProps, keyof PanelLayerProps>
 
 const ABSTRACT_ICON_MAPPER = {
   info: FaCircleInfoIcon,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps<typeof classNameGenerator>` から型を自動導出する方式をやめ、明示的な型定義（`BaseType`/`TypeType`）に置き換えるリファクタリング。

## 変更内容

- `BaseType`（`'base' | 'none'`）・`TypeType`（`'info' | 'success' | 'warning' | 'error' | 'sync'`）を明示的に定義
- `classNameGenerator` の `variants.base`・`variants.type` に `satisfies Record<BaseType, object>` / `satisfies Record<TypeType, object>` を付与し、`tv()` の variants 定義が型定義から漏れなく実装されていることをコンパイル時に検証できるようにした
- `BaseProps` を `VariantProps` 由来の型から明示的なプロパティ定義に変更（`type` は従来通り必須、`base`/`bold`/`animate` は任意のまま）

## プロダクト側で対応が必要な事項

なし

## 確認方法

`renderToStaticMarkup` で旧実装との出力比較を実施し、`type`/`base`/`bold`/`animate` の全組み合わせ（135ケース）で完全一致することを確認済み。Storybookの `Components/NotificationBar` で表示に変化がないことを目視確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * NotificationBar のプロパティ定義を明示化し、型の一貫性と開発時の検証精度を向上しました。
  * `base` や `type` などのスタイルバリエーションに対する型チェックを強化しました。
  * 表示や操作方法など、エンドユーザー向けの動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->