### PR TITLE
refactor(MultiSelectedItem): useRef+useEffectをcallback refに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiSelectedItem.tsx
@@ -1,11 +1,12 @@
+'use client'
+
 import {
   type KeyboardEvent,
-  type RefObject,
+  type RefCallback,
   memo,
-  useEffect,
+  useCallback,
   useId,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { tv } from 'tailwind-variants'
@@ -119,7 +120,7 @@ export function MultiSelectedItem<T>({ item, enableEllipsis, disabled, handleDel
 }
 
 type LowerMultiSelectedItemProps<T> = Omit<Props<T>, 'item' | 'enableEllipsis' | 'handleDelete'> & {
-  labelRef?: RefObject<HTMLSpanElement>
+  labelRef?: RefCallback<HTMLElement>
   itemLabel: ComboboxItem<T>['label']
   itemDeletable: boolean
   functions: {
@@ -141,17 +142,14 @@ const BaseEllipsisMultiSelectedItem = <T,>({
   ...rest
 }: LowerMultiSelectedItemProps<T>) => {
   const [needsTooltip, setNeedsTooltip] = useState(false)
-  const labelRef = useRef<HTMLSpanElement>(null)
 
-  useEffect(() => {
-    const elem = labelRef.current
-
-    if (elem) {
-      setNeedsTooltip(elem.offsetWidth < elem.scrollWidth)
+  const callbackRef = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      setNeedsTooltip(node.offsetWidth < node.scrollWidth)
     }
   }, [])
 
-  const body = <ActualMultiSelectedItem {...rest} labelRef={labelRef} itemLabel={itemLabel} />
+  const body = <ActualMultiSelectedItem {...rest} labelRef={callbackRef} itemLabel={itemLabel} />
 
   if (needsTooltip) {
     return <Tooltip message={itemLabel}>{body}</Tooltip>


### PR DESCRIPTION
## 関連URL

なし

## 概要

`useEffect` の見直しプロジェクトの一環。`MultiSelectedItem` の `EllipsisMultiSelectedItem` で、ラベル要素がマウントされた際に `offsetWidth`/`scrollWidth` を比較してTooltipの要否を判定する処理が `useRef` + `useEffect` で実装されていたため、DOM要素のmount/unmountに連動する処理としてcallback ref化できないか検証した。

## 変更内容

`labelRef`（`useRef` + `useEffect` で判定）を、DOM要素がアタッチされた時点で直接判定するcallback refに置き換えた。cleanup関数を返さないシンプルなcallback refのため、React 18/19の互換性ラッパー（`useCallbackRefCleanupForReact18`）は不要（cleanup関数を返す場合にのみ必要な対応のため）。

`callback ref` はコミット後・ペイント前のタイミングで発火するため、`useEffect`（ペイント後）よりも早くTooltip要否を判定できる。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm ui test -- --run src/components/Combobox/MultiCombobox` で既存テスト（12件）が通ることを確認済み。Storybookの `Components/Combobox/MultiCombobox` で選択済みアイテムのラベルが長い場合のTooltip表示に変化がないことを目視確認できる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 複数選択コンボボックスで、ラベルが省略表示された際のツールチップ判定を改善しました。
  * 表示幅を適切なタイミングで測定し、省略状態がより正確に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->