### PR TITLE
fix(TableReel): ResizeObserverのloop通知(コンソール警告)を解消

### DIFF
--- a/packages/smarthr-ui/src/components/Table/client/TableReel.tsx
+++ b/packages/smarthr-ui/src/components/Table/client/TableReel.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useAnimationFrame } from '../../../hooks/client/useAnimationFrame'
 import { useCallbackRefCleanupForReact18 } from '../../../hooks/client/useCallbackRefCleanupForReact18'
 import { TableScroller } from '../TableScroller'
 import { reelShadowClassNameGenerator } from '../reelShadowStyle'
@@ -36,112 +37,105 @@ export const TableReel: FC<Props> = ({ className, children, fixedHead, ...rest }
   // TODO: stateではなくdata属性などを直接変更することで再レンダリングを引き起こさない形にしたい
   const [showShadow, setShowShadow] = useState(false)
 
+  const frame = useAnimationFrame()
+
   const callbackRef = useCallbackRefCleanupForReact18(
-    useCallback((node: HTMLElement | null) => {
-      if (!node) {
-        return
-      }
-
-      let rafId: number | null = null
-
-      const handleScroll = () => {
-        if (!node.querySelector(HAS_FIXED_SELECTOR)) {
-          setShowShadow(false)
+    useCallback(
+      (node: HTMLElement | null) => {
+        if (!node) {
           return
         }
 
-        let isVisible = false
-        const commonAction = (
-          cells: HTMLElement[] | NodeListOf<HTMLElement>,
-          direction: 'left' | 'right',
-          visible: boolean,
-        ) => {
-          let position = 0
+        const handleScroll = () => {
+          if (!node.querySelector(HAS_FIXED_SELECTOR)) {
+            setShowShadow(false)
+            return
+          }
 
-          cells.forEach((cell, index) => {
-            if (cell.classList.toggle('fixed', visible)) {
-              isVisible = true
-              cell.style[direction] = `${position}px`
-              cell.style.zIndex = (index + 1).toString()
+          let isVisible = false
+          const commonAction = (
+            cells: HTMLElement[] | NodeListOf<HTMLElement>,
+            direction: 'left' | 'right',
+            visible: boolean,
+          ) => {
+            let position = 0
 
-              position += cell.offsetWidth
+            cells.forEach((cell, index) => {
+              if (cell.classList.toggle('fixed', visible)) {
+                isVisible = true
+                cell.style[direction] = `${position}px`
+                cell.style.zIndex = (index + 1).toString()
+
+                position += cell.offsetWidth
+              }
+            })
+          }
+
+          node.querySelectorAll<HTMLElement>(TR_SELECTOR).forEach((tr) => {
+            const leftCells = tr.querySelectorAll<HTMLElement>(FIXED_LEFT_SELECTOR)
+            const rightCells = tr.querySelectorAll<HTMLElement>(FIXED_RIGHT_SELECTOR)
+
+            if (leftCells.length > 0) {
+              commonAction(leftCells, 'left' as const, node.scrollLeft > 0)
+            }
+
+            if (rightCells.length > 0) {
+              commonAction(
+                Array.from(rightCells).reverse(),
+                'right' as const,
+                node.scrollLeft < node.scrollWidth - node.clientWidth - 1,
+              )
             }
           })
+
+          setShowShadow(isVisible)
         }
 
-        node.querySelectorAll<HTMLElement>(TR_SELECTOR).forEach((tr) => {
-          const leftCells = tr.querySelectorAll<HTMLElement>(FIXED_LEFT_SELECTOR)
-          const rightCells = tr.querySelectorAll<HTMLElement>(FIXED_RIGHT_SELECTOR)
+        // HINT: handleScrollは監視対象セルのstyle/classを書き換える。これをResizeObserverの
+        //       コールバックから同期的に呼ぶと、同一配信サイクル内で通知が積み上がり
+        //       「ResizeObserver loop completed with undelivered notifications」を発生させる。
+        //       frame.requestで次フレームに逃がし、フレーム内の複数通知をコアレスする。
+        const scheduleHandleScroll = () => frame.request(handleScroll)
 
-          if (leftCells.length > 0) {
-            commonAction(leftCells, 'left' as const, node.scrollLeft > 0)
-          }
+        // HINT: cellObserverでのobserveをhandleScroll内で毎回やり直すと、observe自体が次フレームに
+        //       初回通知を発火させ、handleScroll→observe→通知→handleScroll…と毎フレーム回り続ける。
+        //       observeの張り直しは監視対象セルが変わるDOM構造変更時(mutationObserver)とmount時だけに限定し、
+        //       handleScroll(計測・style適用)から分離する。
+        const cellObserver = new ResizeObserver(scheduleHandleScroll)
+        const observeCells = () => {
+          cellObserver.disconnect()
+          node
+            .querySelectorAll<HTMLElement>(HAS_FIXED_SELECTOR)
+            .forEach((cell) => cellObserver.observe(cell))
+        }
 
-          if (rightCells.length > 0) {
-            commonAction(
-              Array.from(rightCells).reverse(),
-              'right' as const,
-              node.scrollLeft < node.scrollWidth - node.clientWidth - 1,
-            )
-          }
+        observeCells()
+        handleScroll()
+        node.addEventListener('scroll', scheduleHandleScroll, { passive: true })
+
+        const resizeObserver = new ResizeObserver(scheduleHandleScroll)
+        resizeObserver.observe(node)
+
+        // HINT: Paginationと組み合わせた際などにテーブル構造の変更を検知して監視対象を張り直す
+        const mutationObserver = new MutationObserver(() => {
+          observeCells()
+          scheduleHandleScroll()
+        })
+        mutationObserver.observe(node, {
+          childList: true,
+          subtree: true,
         })
 
-        setShowShadow(isVisible)
-      }
-
-      // HINT: handleScrollは監視対象セルのstyle/classを書き換える。これをResizeObserverの
-      //       コールバックから同期的に呼ぶと、同一配信サイクル内で通知が積み上がり
-      //       「ResizeObserver loop completed with undelivered notifications」を発生させる。
-      //       requestAnimationFrameで次フレームに逃がし、フレーム内の複数通知をコアレスする。
-      const scheduleHandleScroll = () => {
-        if (rafId === null) {
-          rafId = requestAnimationFrame(() => {
-            rafId = null
-            handleScroll()
-          })
+        return () => {
+          node.removeEventListener('scroll', scheduleHandleScroll)
+          resizeObserver.unobserve(node)
+          mutationObserver.disconnect()
+          cellObserver.disconnect()
+          frame.cancel()
         }
-      }
-
-      // HINT: cellObserverでのobserveをhandleScroll内で毎回やり直すと、observe自体が次フレームに
-      //       初回通知を発火させ、handleScroll→observe→通知→handleScroll…と毎フレーム回り続ける。
-      //       observeの張り直しは監視対象セルが変わるDOM構造変更時(mutationObserver)とmount時だけに限定し、
-      //       handleScroll(計測・style適用)から分離する。
-      const cellObserver = new ResizeObserver(scheduleHandleScroll)
-      const observeCells = () => {
-        cellObserver.disconnect()
-        node
-          .querySelectorAll<HTMLElement>(HAS_FIXED_SELECTOR)
-          .forEach((cell) => cellObserver.observe(cell))
-      }
-
-      observeCells()
-      handleScroll()
-      node.addEventListener('scroll', scheduleHandleScroll, { passive: true })
-
-      const resizeObserver = new ResizeObserver(scheduleHandleScroll)
-      resizeObserver.observe(node)
-
-      // HINT: Paginationと組み合わせた際などにテーブル構造の変更を検知して監視対象を張り直す
-      const mutationObserver = new MutationObserver(() => {
-        observeCells()
-        scheduleHandleScroll()
-      })
-      mutationObserver.observe(node, {
-        childList: true,
-        subtree: true,
-      })
-
-      return () => {
-        node.removeEventListener('scroll', scheduleHandleScroll)
-        resizeObserver.unobserve(node)
-        mutationObserver.disconnect()
-        cellObserver.disconnect()
-
-        if (rafId !== null) {
-          cancelAnimationFrame(rafId)
-        }
-      }
-    }, []),
+      },
+      [frame],
+    ),
   )
 
   const classNames = useMemo(() => {

--- a/packages/smarthr-ui/src/components/Table/client/TableReel.tsx
+++ b/packages/smarthr-ui/src/components/Table/client/TableReel.tsx
@@ -42,9 +42,9 @@ export const TableReel: FC<Props> = ({ className, children, fixedHead, ...rest }
         return
       }
 
-      const handleScroll = () => {
-        cellObserver.disconnect()
+      let rafId: number | null = null
 
+      const handleScroll = () => {
         if (!node.querySelector(HAS_FIXED_SELECTOR)) {
           setShowShadow(false)
           return
@@ -66,8 +66,6 @@ export const TableReel: FC<Props> = ({ className, children, fixedHead, ...rest }
 
               position += cell.offsetWidth
             }
-
-            cellObserver.observe(cell)
           })
         }
 
@@ -91,28 +89,57 @@ export const TableReel: FC<Props> = ({ className, children, fixedHead, ...rest }
         setShowShadow(isVisible)
       }
 
-      // HINT: cellObserverはhandleScroll先頭でdisconnect→再observeするため、
-      //       nodeを監視するresizeObserverとは分けている
-      const cellObserver = new ResizeObserver(handleScroll)
+      // HINT: handleScrollは監視対象セルのstyle/classを書き換える。これをResizeObserverの
+      //       コールバックから同期的に呼ぶと、同一配信サイクル内で通知が積み上がり
+      //       「ResizeObserver loop completed with undelivered notifications」を発生させる。
+      //       requestAnimationFrameで次フレームに逃がし、フレーム内の複数通知をコアレスする。
+      const scheduleHandleScroll = () => {
+        if (rafId === null) {
+          rafId = requestAnimationFrame(() => {
+            rafId = null
+            handleScroll()
+          })
+        }
+      }
 
+      // HINT: cellObserverでのobserveをhandleScroll内で毎回やり直すと、observe自体が次フレームに
+      //       初回通知を発火させ、handleScroll→observe→通知→handleScroll…と毎フレーム回り続ける。
+      //       observeの張り直しは監視対象セルが変わるDOM構造変更時(mutationObserver)とmount時だけに限定し、
+      //       handleScroll(計測・style適用)から分離する。
+      const cellObserver = new ResizeObserver(scheduleHandleScroll)
+      const observeCells = () => {
+        cellObserver.disconnect()
+        node
+          .querySelectorAll<HTMLElement>(HAS_FIXED_SELECTOR)
+          .forEach((cell) => cellObserver.observe(cell))
+      }
+
+      observeCells()
       handleScroll()
-      node.addEventListener('scroll', handleScroll, { passive: true })
+      node.addEventListener('scroll', scheduleHandleScroll, { passive: true })
 
-      const resizeObserver = new ResizeObserver(handleScroll)
+      const resizeObserver = new ResizeObserver(scheduleHandleScroll)
       resizeObserver.observe(node)
 
-      // HINT: Paginationと組み合わせた際などにテーブル構造の変更を検知して再生成
-      const mutationObserver = new MutationObserver(handleScroll)
+      // HINT: Paginationと組み合わせた際などにテーブル構造の変更を検知して監視対象を張り直す
+      const mutationObserver = new MutationObserver(() => {
+        observeCells()
+        scheduleHandleScroll()
+      })
       mutationObserver.observe(node, {
         childList: true,
         subtree: true,
       })
 
       return () => {
-        node.removeEventListener('scroll', handleScroll)
+        node.removeEventListener('scroll', scheduleHandleScroll)
         resizeObserver.unobserve(node)
         mutationObserver.disconnect()
         cellObserver.disconnect()
+
+        if (rafId !== null) {
+          cancelAnimationFrame(rafId)
+        }
       }
     }, []),
   )


### PR DESCRIPTION
## 関連URL

なし

## 概要

Table コンポーネントを使用する際、固定カラム（`<Th/Td fixed="left|right">`）のある `reel` のテーブルを表示すると、`ResizeObserver loop completed with undelivered notifications.` が初期表示・スクロール・ウィンドウリサイズのたびに、かつ無操作でも発生し続ける問題がある。

この警告は `console.error` ではなく `window` の `error` イベントとして dispatch される（Chrome はこの benign な ResizeObserver 通知を Console パネルに print しない）。そのため見え方が環境によって異なる。

- DevTools の Console パネルにエラーが表示される類のもではないし、本番環境では特に動作に問題は起きない
- smarthr-ui の Storybook（Vite preview）でも顕在化しない。Vite の overlay は自身のコンパイル / HMR エラーしか表示せず、runtime の window error を拾わないため
- ただ、Next.js などの dev server では開発中にエラーオーバーレイが出て、さらに無限にこのエラーが発生するのでオーバーレイを消すことができず、開発ができなくなる。Next.js の dev overlay や webpack-dev-server（react-error-overlay）などは uncaught な window error を捕捉してオーバーレイ表示するため

<img width="4018" height="3210" alt="image" src="https://github.com/user-attachments/assets/512e5232-acbc-4f99-99a4-299e6d705baa" />

### 根本原因

`TableReel` の `handleScroll` は ResizeObserver（`cellObserver`）のコールバックとして動くが、その中で監視対象セルの `class`/`style`（`.fixed` トグル・`left`/`right`/`zIndex`）を同期的に書き換えたうえ、毎回 `cellObserver.disconnect()` → 全固定セルを `observe()` し直していた。`observe()` は次フレームに初回通知を必ず発火させるため、`handleScroll → observe → 通知 → handleScroll …` が永久に回り続ける。これが連続警告の正体（＝無操作でも件数が増え続ける）。

## 変更内容

対象: `packages/smarthr-ui/src/components/Table/client/TableReel.tsx`

- **rAF コアレス**: `scheduleHandleScroll`（`rafId` でコアレス）を導入し、`cellObserver`/`resizeObserver`/`mutationObserver` のコールバックと `scroll` リスナーはこれ経由にした。style 書き換えを ResizeObserver の配信サイクル外（次フレーム）へ追い出す。
- **observe の分離**: `observe()` の張り直しを `handleScroll` から切り出し（`observeCells()`）、実行を **mount 時**と**構造変更時（`MutationObserver`）だけ**に限定した。`handleScroll` は計測＋style 適用のみに専念。セルサイズ変化時は RO が1回発火 → rAF → 適用で settle する（`position: sticky` や `left`/`right`/`zIndex` は `offsetWidth` を変えないため再発火しない）。
- cleanup に `cancelAnimationFrame(rafId)` を追加。既存の各 `disconnect`/`unobserve` は維持。

> 補足: 当初 rAF コアレス**単独**も試したが、それだけだと警告は消える一方で `handleScroll` が毎フレーム回り続ける（無操作 rest でも `requestAnimationFrame` が ~120回/秒）busy loop が残った。observe を `handleScroll` から分離して初めて完全に settle する。

導入経緯: #4316（ResizeObserver 導入＝セルサイズの動的変化を検知）→ #6404（`MutationObserver` 化）→ #6801（複数行・左右両方の固定列で位置が更新されないバグを修正）。本 PR はこれらの挙動を保ったまま loop 通知を解消する。

## プロダクト側で対応が必要な事項

なし（挙動は現状維持。公開 API 変更なし）。副次的に、本 PR を取り込むとプロダクトの dev server で出ていた ResizeObserver 由来のエラーオーバーレイが解消される。

## 確認方法

Storybook の `Components/Table > reel`（固定カラム左右あり・横スクロールが発生する幅）で確認する。ただし前述のとおり **この警告は Console パネルには出ない**ため、観測には window の `error` イベントを拾う必要がある。

### window error イベントの拾い方

DevTools Console に以下を貼ってから reel story をスクロール／リサイズすると件数が観測できる。
Storybook は isolation mode で表示しておく必要がある。

```js
let n = 0
addEventListener('error', (e) => {
  if (/ResizeObserver loop/.test(e.message)) console.warn('RO warning', ++n, e.message)
})
```

- **master**: 初期表示だけで数百件、放置でも増え続け、スクロール／リサイズでさらに増える
- **本 PR**: 同手順で **0 件**のまま

（本 PR での検証も同様に、iframe で story を isolate し、`window` の `error` イベントで警告件数を、`requestAnimationFrame` のラップで rest 時のフレーム発火数を計測している。）

<img width="1370" height="567" alt="image" src="https://github.com/user-attachments/assets/133523ed-112b-4e7d-9b84-053c3c798949" />

### before / after（story `components-table--reel`）

| 指標 | before (master) | after |
|---|---|---|
| 初期表示の警告 | 687件（500ms内） | **0** |
| rest 1秒の警告 | 増え続ける（687→1437…） | **0** |
| スクロール中の警告 | 計2695件 | **0** |
| リサイズ後の警告 | さらに増加 | **0** |
| rest 時の rAF/秒（busy loop） | 実質毎フレーム | **0**（初期/スクロール後/リサイズ後すべて 0＝完全 settle） |

### 挙動保全の確認（after）

- `scrollLeft=0`: 左列は fixed なし / 右列は fixed（`right:0px`）
- `scrollLeft=300`: 左列 fixed（`left:0px`, `z-index:1`）/ 右列 fixed（`right:0px`, `z-index:1`）— 貼り付き位置・zIndex とも正しい（#6801 の複数行・左右両方も維持）
- 対照 `components-table--border-type`（reel あり／固定カラムなし）: 警告 0・rest rAF 0 のまま
- **Pagination 相当の構造変更（#5526 観点）**: tbody の行を新規ノードへ差し替え後、新しい固定セルをリサイズすると RO が1回発火（＝新セルが再 observe されている）→ settle。警告 0。

### test / lint

- Table 関連テスト: 5/5 pass
- `eslint` / `prettier` / `tsc --noEmit -p tsconfig.build.json`: いずれも pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## バグ修正
- テーブルのスクロールシャドウ表示を安定化しました。
- スクロールやリサイズ時の処理を最適化し、表示のちらつきや不要な更新を抑制しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
