### PR TITLE
fix: vrtMobileをStorybook 10のAPIに追従させる

### DIFF
--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -44,7 +44,7 @@ const preview: Preview = {
       },
     },
     viewport: {
-      viewports: {
+      options: {
         ...INITIAL_VIEWPORTS,
         vrtMobile: {
           name: 'VRT Mobile',

--- a/packages/smarthr-ui/src/components/LineClamp/stories/VRTLineClamp.stories.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/stories/VRTLineClamp.stories.tsx
@@ -6,10 +6,10 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5'
 export default {
   title: 'Components/LineClamp/VRT',
   render: MaxLines.render,
+  globals: {
+    viewport: { value: 'vrtMobile', isRotated: false },
+  },
   parameters: {
-    viewport: {
-      defaultViewport: 'vrtMobile',
-    },
     chromatic: {
       modes: {
         vrtMobile: { viewport: 'vrtMobile' },

--- a/packages/smarthr-ui/src/components/LineClamp/stories/VRTLineClamp.stories.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/stories/VRTLineClamp.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/LineClamp/VRT',
   render: MaxLines.render,
   globals: {
-    viewport: { value: 'vrtMobile', isRotated: false },
+    viewport: { value: 'vrtMobile' },
   },
   parameters: {
     chromatic: {

--- a/packages/smarthr-ui/src/components/Pagination/stories/VRTPagination.stories.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/stories/VRTPagination.stories.tsx
@@ -48,10 +48,10 @@ export const VRT: StoryObj<typeof Pagination> = {
 
 export const VRTNarrowView: StoryObj<typeof Pagination> = {
   render: meta.render,
+  globals: {
+    viewport: { value: 'vrtMobile', isRotated: false },
+  },
   parameters: {
-    viewport: {
-      defaultViewport: 'vrtMobile',
-    },
     chromatic: {
       modes: {
         vrtMobile: { viewport: 'vrtMobile' },

--- a/packages/smarthr-ui/src/components/Pagination/stories/VRTPagination.stories.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/stories/VRTPagination.stories.tsx
@@ -49,7 +49,7 @@ export const VRT: StoryObj<typeof Pagination> = {
 export const VRTNarrowView: StoryObj<typeof Pagination> = {
   render: meta.render,
   globals: {
-    viewport: { value: 'vrtMobile', isRotated: false },
+    viewport: { value: 'vrtMobile' },
   },
   parameters: {
     chromatic: {

--- a/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
@@ -90,7 +90,7 @@ export const VRT = {
 export const VRTNarrowView: StoryObj = {
   ...VRT,
   globals: {
-    viewport: { value: 'vrtMobile', isRotated: false },
+    viewport: { value: 'vrtMobile' },
   },
   parameters: {
     chromatic: {

--- a/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
@@ -89,10 +89,10 @@ export const VRT = {
 
 export const VRTNarrowView: StoryObj = {
   ...VRT,
+  globals: {
+    viewport: { value: 'vrtMobile', isRotated: false },
+  },
   parameters: {
-    viewport: {
-      defaultViewport: 'vrtMobile',
-    },
     chromatic: {
       modes: {
         vrtMobile: { viewport: 'vrtMobile' },


### PR DESCRIPTION
## 関連URL

なし

## 概要

Storybook 10への更新後、旧Viewport APIが残っていたため、`vrtMobile`が登録・適用されない状態を修正します。

## 変更内容

- Viewportの登録を`viewport.viewports`から`viewport.options`へ移行
- `vrtMobile`を利用するVRTストーリーの指定を`parameters.viewport.defaultViewport`から`globals.viewport`へ移行

## プロダクト側で対応が必要な事項

なし

## 確認方法

- ESLintが成功すること
- Prettierチェックが成功すること
- Storybookビルドが成功すること

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * Storybook のビジュアルリグレッションテストにおけるビューポート設定を更新しました。
  * モバイル表示のテストでは、`vrtMobile` ビューポートを引き続き使用します。
  * 初期ビューポートおよびカスタムビューポートの設定は維持されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->