### PR TITLE
chore: smarthr-ui-chartsのリリースバージョンを0.2.4に固定する

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
       "initial-version": "87.0.0"
     },
     "packages/charts": {
-      "initial-version": "0.1.0"
+      "initial-version": "0.1.0",
+      "release-as": "0.2.4"
     }
   }
 }


### PR DESCRIPTION
## 関連URL

- #6962（リリースPR。本PRの目的の対象）
- #6999（smarthr-uiに`Release-As: 99.6.1`を付与したPR。footerがmonorepo全体にグローバル適用される仕様と知らず、charts側を巻き込んでしまった）

## 概要

#6999で付与した`Release-As: 99.6.1`フッターは、smarthr-uiパッケージのv100回避を意図したものだったが、release-pleaseの仕様上このfooterはmonorepo内の**全パッケージ**に一律適用される。そのため無関係のsmarthr-ui-chartsまで`99.6.1`として計算されてしまった（本来の正しい計算結果は`0.2.4`）。

release-please-config.jsonの`release-as`はパッケージ単位で設定でき、かつcommit footerのRELEASE ASノートより優先されるため、chartsパッケージにのみ`"release-as": "0.2.4"`を設定して個別に修正する。

## 変更内容

`release-please-config.json`の`packages["packages/charts"]`に`"release-as": "0.2.4"`を追加。

マージ後、release-please-actionが再実行され、#6962のsmarthr-ui-charts側が`0.2.4`（smarthr-ui側は引き続き`99.6.1`のまま）に修正される見込み。

## プロダクト側で対応が必要な事項

なし

## 確認方法

マージ後、#6962の内容を確認し、smarthr-ui-chartsが`0.2.4`、smarthr-uiが`99.6.1`になっていることを確認する。

**注意（後続作業）**: `release-as`はrelease-please側で自動的に消えない永続設定のため、本リリース（#6962）が完了（マージ・タグ打ち）した後、次のリリースに影響しないよう`release-please-config.json`からこのエントリを削除する後続PRが必要。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 次回のチャート関連パッケージのリリースバージョンを **0.2.4** に固定しました。
  - 初期バージョン **0.1.0** は変更されていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->