### PR TITLE
chore: smarthr-ui-chartsのrelease-as設定を削除する

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,8 +12,7 @@
       "initial-version": "87.0.0"
     },
     "packages/charts": {
-      "initial-version": "0.1.0",
-      "release-as": "0.2.4"
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## 関連URL

- #7000（本PRの前提。`release-as: "0.2.4"`を追加したPR）
- #6962（リリースPR）

## 概要

#7000で`release-please-config.json`の`packages/charts`に`"release-as": "0.2.4"`を追加した。この設定はrelease-please側で自動的に消えない永続設定のため、そのままでは今後のリリースでもcharts側がずっと`0.2.4`に固定され続けてしまう。

**本PRは#6962（リリースPR）が実際にマージ・タグ打ちされて完了した後にマージすること。** 先にマージすると、まだリリース前の#6962の計算結果からrelease-as指定が外れてしまい、chartsのバージョンが再び`99.6.1`（smarthr-ui側のRelease-Asに巻き込まれた値）に戻ってしまう。

## 変更内容

`release-please-config.json`の`packages/charts`から`"release-as": "0.2.4"`を削除し、通常のconventional commits計算に戻す。

## プロダクト側で対応が必要な事項

なし

## 確認方法

#6962のリリース完了後にマージし、次回のリリースPR計算でsmarthr-ui-chartsが通常のconventional commits計算（release-as指定なし）に戻っていることを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **設定**
  * リリースバージョン設定を整理し、初期バージョン指定のみを保持しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->