### PR TITLE
refactor(DropdownTrigger): useRef+useEffectをcallback refに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -47,20 +47,6 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
   useEffect(() => {
-    if (!triggerElementRef.current) {
-      return
-    }
-
-    // apply ARIA to all focusable elements in trigger
-    const triggers = tabbable(triggerElementRef.current, { shouldIgnoreVisibility: true })
-
-    triggers.forEach((trigger) => {
-      trigger.setAttribute('aria-expanded', active.toString())
-      trigger.setAttribute('aria-controls', contentId)
-    })
-  }, [active, triggerElementRef, contentId])
-
-  useEffect(() => {
     const triggerElement = triggerElementRef.current
     if (!triggerElement) {
       return
@@ -110,6 +96,20 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
       observer.disconnect()
     }
   }, [handleClickTrigger, triggerElementRef])
+
+  useEffect(() => {
+    if (!triggerElementRef.current) {
+      return
+    }
+
+    // apply ARIA to all focusable elements in trigger
+    const triggers = tabbable(triggerElementRef.current, { shouldIgnoreVisibility: true })
+
+    triggers.forEach((trigger) => {
+      trigger.setAttribute('aria-expanded', active.toString())
+      trigger.setAttribute('aria-controls', contentId)
+    })
+  }, [active, triggerElementRef, contentId])
 
   return (
     <div ref={triggerElementRef} className={actualClassName}>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownTrigger.tsx
@@ -5,12 +5,14 @@ import {
   type FC,
   type PropsWithChildren,
   type ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { tabbable } from '../../libs/tabbable'
 import { Tooltip } from '../Tooltip'
 
@@ -46,56 +48,60 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
   const { active, handleClickTrigger, contentId, triggerElementRef } = useContext(DropdownContext)
   const actualClassName = useMemo(() => classNameGenerator({ className }), [className])
 
-  useEffect(() => {
-    const triggerElement = triggerElementRef.current
-    if (!triggerElement) {
-      return
-    }
-
-    let currentCleanup: (() => void) | undefined
-
-    const setupButton = () => {
-      // 既存のクリーンアップを実行
-      currentCleanup?.()
-      currentCleanup = undefined
-
-      const button = triggerElement.querySelector<HTMLButtonElement>('button')
-
-      // 引き金となる要素が disabled な場合、処理を差し込む必要がないため、そのまま出力する
-      if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) {
         return
       }
 
-      // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
-      // そのためcaptureで開く処理を実行する
-      const callback = (e: MouseEvent) => {
-        handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
+      let currentCleanup: (() => void) | undefined
+
+      const setupButton = () => {
+        // 既存のクリーンアップを実行
+        currentCleanup?.()
+        currentCleanup = undefined
+
+        const button = node.querySelector<HTMLButtonElement>('button')
+
+        // 引き金となる要素が disabled な場合、処理を差し込む必要がないため、そのまま出力する
+        if (!button || button.disabled || button.getAttribute('aria-disabled') === 'true') {
+          return
+        }
+
+        // HINT: Trigger要素自体にonClickが設定されている場合、先にDropdownを開いた状態で処理を行いたい
+        // そのためcaptureで開く処理を実行する
+        const callback = (e: MouseEvent) => {
+          handleClickTrigger((e.currentTarget! as HTMLButtonElement).getBoundingClientRect())
+        }
+
+        button.addEventListener('click', callback, CAPTURE_OPTION)
+
+        currentCleanup = () => {
+          button.removeEventListener('click', callback, CAPTURE_OPTION)
+        }
       }
 
-      button.addEventListener('click', callback, CAPTURE_OPTION)
+      setupButton()
 
-      currentCleanup = () => {
-        button.removeEventListener('click', callback, CAPTURE_OPTION)
+      const observer = new MutationObserver(setupButton)
+
+      observer.observe(node, {
+        childList: true,
+        subtree: true,
+        // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
+        attributes: true,
+        attributeFilter: ['disabled', 'aria-disabled'],
+      })
+
+      return () => {
+        currentCleanup?.()
+        observer.disconnect()
       }
-    }
+    },
+    [handleClickTrigger],
+  )
 
-    setupButton()
-
-    const observer = new MutationObserver(setupButton)
-
-    observer.observe(triggerElement, {
-      childList: true,
-      subtree: true,
-      // button要素の disabled / aria-disabled が動的に変化した場合も検知してリスナーを貼り直す
-      attributes: true,
-      attributeFilter: ['disabled', 'aria-disabled'],
-    })
-
-    return () => {
-      currentCleanup?.()
-      observer.disconnect()
-    }
-  }, [handleClickTrigger, triggerElementRef])
+  const mergedRef = useMergeRefs(triggerElementRef, callbackRef)
 
   useEffect(() => {
     if (!triggerElementRef.current) {
@@ -112,7 +118,7 @@ export const DropdownTrigger: FC<Props> = ({ children, className, tooltip }) => 
   }, [active, triggerElementRef, contentId])
 
   return (
-    <div ref={triggerElementRef} className={actualClassName}>
+    <div ref={mergedRef} className={actualClassName}>
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex */}
       <ConditionalWrapper
         shouldWrapContent={tooltip?.show}


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DropdownTrigger`内で、`triggerElementRef.current`をuseEffect経由で間接的に参照し、MutationObserverの設置・クリーンアップを行っていた。CLAUDE.mdの方針（DOM要素のmount/unmountに連動する処理はcallback ref化する）に沿って、要素のアタッチ/デタッチに直接ロジックを紐付ける形にする。

## 変更内容

- `useEffect` + `triggerElementRef.current`経由の間接参照をやめ、callback ref内で直接DOM操作（MutationObserverの設置・disabled監視）を行うようにした
- 外部（DropdownContext）から渡される`triggerElementRef`と、新設したcallback refを`useMergeRefs`で統合した
- cleanup関数は`useMergeRefs`が内部で実装しているReact 18/19互換の仕組みにより、両バージョンで正しく実行される

## プロダクト側で対応が必要な事項

なし。公開コンポーネント（`DropdownTrigger`）のprops・DOM構造に変更はない。

## 確認方法

`pnpm ui test -- --run src/components/Dropdown`で既存テスト（14件）が通ることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ドロップダウンのトリガー要素に対するイベント監視を、要素の割り当て・解除に合わせて適切に設定・解除するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->