### PR TITLE
refactor(DropdownContentInner): useRef+useEffectをcallback refに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/Checkbox/client/ActualCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/client/ActualCheckbox.tsx
@@ -39,6 +39,8 @@ const callbackRef = (node: HTMLInputElement | null) => {
 }
 
 export const ActualCheckbox: FC<Props> = ({ checkboxRef, checked, mixed, error, ...rest }) => {
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(callbackRef, checkboxRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -440,6 +440,8 @@ const ActualMultiCombobox = <T,>(
 
   const listBoxCallbackRef = useAreaClickCallbackRef([triggerRef], functions.blur)
 
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(inputRef, listBoxFunctions.cleanupListBoxCallbackRef, ref)
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -80,6 +80,8 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
     }, []),
   )
 
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(nodeRef, callbackRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -186,6 +186,8 @@ export const DropdownContentInner: FC<Props> = ({
     [latest],
   )
 
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(wrapperRef, callbackRef)
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -91,45 +91,6 @@ export const DropdownContentInner: FC<Props> = ({
     }
   })()
 
-  useEffect(() => {
-    if (wrapperRef.current) {
-      setContentBox(
-        getContentBoxStyle(
-          triggerRect,
-          {
-            width: wrapperRef.current.offsetWidth,
-            height: wrapperRef.current.offsetHeight,
-          },
-          {
-            width: document.body.clientWidth,
-            height: innerHeight,
-          },
-          {
-            top: scrollY,
-            left: scrollX,
-          },
-        ),
-      )
-      setIsActive(true)
-    }
-  }, [triggerRect])
-
-  // setIsActive(true) と同じ useEffect 内で直接 focus() を呼ぶことはできない。
-  // このコンポーネントは Dropdown が開かれた時のみマウントされるが、マウント直後は
-  // 位置計算が完了していないためコンテンツが誤った位置にちらつくのを防ぐために
-  // shr-invisible (visibility: hidden) でレンダリングされる。
-  // ちらつき防止には実寸法を保持したまま視覚的に隠せる visibility: hidden が唯一の手段となる。
-  // visibility: hidden の要素はフォーカスを受け付けないため、setIsActive(true) の直後に
-  // focus() を呼んでも DOM がまだ更新されておらず無効になる。
-  //
-  // useEffect([isActive]) であれば、isActive=true になった後の render commit 後に
-  // 必ず実行されることが保証されるため、この実装が最も信頼性が高い。
-  useEffect(() => {
-    if (isActive) {
-      focusTargetRef.current?.focus()
-    }
-  }, [isActive])
-
   const { triggerElementRef, rootTriggerRef, handleDelegateClickCloser } =
     useContext(DropdownContext)
 
@@ -221,6 +182,45 @@ export const DropdownContentInner: FC<Props> = ({
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [latest])
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      setContentBox(
+        getContentBoxStyle(
+          triggerRect,
+          {
+            width: wrapperRef.current.offsetWidth,
+            height: wrapperRef.current.offsetHeight,
+          },
+          {
+            width: document.body.clientWidth,
+            height: innerHeight,
+          },
+          {
+            top: scrollY,
+            left: scrollX,
+          },
+        ),
+      )
+      setIsActive(true)
+    }
+  }, [triggerRect])
+
+  // setIsActive(true) と同じ useEffect 内で直接 focus() を呼ぶことはできない。
+  // このコンポーネントは Dropdown が開かれた時のみマウントされるが、マウント直後は
+  // 位置計算が完了していないためコンテンツが誤った位置にちらつくのを防ぐために
+  // shr-invisible (visibility: hidden) でレンダリングされる。
+  // ちらつき防止には実寸法を保持したまま視覚的に隠せる visibility: hidden が唯一の手段となる。
+  // visibility: hidden の要素はフォーカスを受け付けないため、setIsActive(true) の直後に
+  // focus() を呼んでも DOM がまだ更新されておらず無効になる。
+  //
+  // useEffect([isActive]) であれば、isActive=true になった後の render commit 後に
+  // 必ず実行されることが保証されるため、この実装が最も信頼性が高い。
+  useEffect(() => {
+    if (isActive) {
+      focusTargetRef.current?.focus()
+    }
+  }, [isActive])
 
   return (
     <div {...rest} ref={wrapperRef} className={actualClassName} style={style}>

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -5,6 +5,7 @@ import {
   type FC,
   type PropsWithChildren,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -13,6 +14,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useTheme } from '../../hooks/client/useTheme'
 import { useLatest } from '../../hooks/useLatest'
 import { tabbable } from '../../libs/tabbable'
@@ -100,71 +102,71 @@ export const DropdownContentInner: FC<Props> = ({
     handleDelegateClickCloser,
   })
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Tab') {
-        if (
-          !wrapperRef.current ||
-          !latest.triggerElementRef.current ||
-          !latest.rootTriggerRef?.current
-        ) {
-          return
-        }
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) {
+        return
+      }
 
-        const tabbablesInContent = tabbable(wrapperRef.current)
-
-        if (tabbablesInContent.length === 0) {
-          return
-        }
-
-        const trigger = tabbable(latest.triggerElementRef.current).at(-1)
-        const firstTabbable = tabbablesInContent[0]
-
-        if (e.target === trigger) {
-          if (e.shiftKey) {
-            // move focus previous of the Trigger
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Tab') {
+          if (!latest.triggerElementRef.current || !latest.rootTriggerRef?.current) {
             return
           }
 
-          // focus a first tabbable element in the dropdown content
-          e.preventDefault()
-          firstTabbable.focus()
+          const tabbablesInContent = tabbable(node)
 
-          return
-        } else if (e.shiftKey) {
-          if (e.target === firstTabbable || e.target === focusTargetRef.current) {
-            // focus the Trigger
+          if (tabbablesInContent.length === 0) {
+            return
+          }
+
+          const trigger = tabbable(latest.triggerElementRef.current).at(-1)
+          const firstTabbable = tabbablesInContent[0]
+
+          if (e.target === trigger) {
+            if (e.shiftKey) {
+              // move focus previous of the Trigger
+              return
+            }
+
+            // focus a first tabbable element in the dropdown content
             e.preventDefault()
-            trigger!.focus()
-            latest.handleDelegateClickCloser()
+            firstTabbable.focus()
+
+            return
+          } else if (e.shiftKey) {
+            if (e.target === firstTabbable || e.target === focusTargetRef.current) {
+              // focus the Trigger
+              e.preventDefault()
+              trigger!.focus()
+              latest.handleDelegateClickCloser()
+            }
+          } else if (e.target === tabbablesInContent.at(-1)) {
+            // move focus next of the Trigger
+            const rootTrigger = tabbable(latest.rootTriggerRef.current).at(-1)
+
+            if (rootTrigger) {
+              rootTrigger.focus()
+              latest.handleDelegateClickCloser()
+            }
           }
-        } else if (e.target === tabbablesInContent.at(-1)) {
-          // move focus next of the Trigger
-          const rootTrigger = tabbable(latest.rootTriggerRef.current).at(-1)
-
-          if (rootTrigger) {
-            rootTrigger.focus()
+        } else if (KEY_ESCAPE.test(e.key)) {
+          if (e.target && e.target === focusTargetRef.current) {
             latest.handleDelegateClickCloser()
+
+            return
           }
-        }
-      } else if (KEY_ESCAPE.test(e.key)) {
-        if (e.target && e.target === focusTargetRef.current) {
-          latest.handleDelegateClickCloser()
 
-          return
-        }
+          const trigger = getFirstTabbable(latest.triggerElementRef)
 
-        const trigger = getFirstTabbable(latest.triggerElementRef)
+          if (trigger && e.target === trigger) {
+            // close the dropdown when the Trigger is focused and Esc key is pressed
+            latest.handleDelegateClickCloser()
 
-        if (trigger && e.target === trigger) {
-          // close the dropdown when the Trigger is focused and Esc key is pressed
-          latest.handleDelegateClickCloser()
+            return
+          }
 
-          return
-        }
-
-        if (wrapperRef.current) {
-          for (const inner of tabbable(wrapperRef.current)) {
+          for (const inner of tabbable(node)) {
             if (inner === e.target) {
               // close the dropdown when an element that is included in dropdown content is focused and Esc key is pressed
               latest.handleDelegateClickCloser()
@@ -174,14 +176,17 @@ export const DropdownContentInner: FC<Props> = ({
           }
         }
       }
-    }
 
-    window.addEventListener('keydown', handleKeyDown)
+      window.addEventListener('keydown', handleKeyDown)
 
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [latest])
+      return () => {
+        window.removeEventListener('keydown', handleKeyDown)
+      }
+    },
+    [latest],
+  )
+
+  const mergedRef = useMergeRefs(wrapperRef, callbackRef)
 
   useEffect(() => {
     if (wrapperRef.current) {
@@ -223,7 +228,7 @@ export const DropdownContentInner: FC<Props> = ({
   }, [isActive])
 
   return (
-    <div {...rest} ref={wrapperRef} className={actualClassName} style={style}>
+    <div {...rest} ref={mergedRef} className={actualClassName} style={style}>
       {/* eslint-disable-next-line smarthr/a11y-scroller-has-tabindex -- dummy element for focus management. */}
       <div ref={focusTargetRef} tabIndex={-1} />
       {controllable ? (

--- a/packages/smarthr-ui/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -71,6 +71,9 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
     }, [latest])
 
     const callbackRef = useOnce(functions.baseCallbackRef)
+
+    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
     const mergedRef = useMergeRefs(innerRef, callbackRef, ref)
 
     useEffect(() => {

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -111,6 +111,8 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       }
     })
 
+    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
     const mergedRef = useMergeRefs(callbackRef, ref)
 
     const classNames = useMemo(() => {

--- a/packages/smarthr-ui/src/components/Table/client/FixedHeadTableScroller.tsx
+++ b/packages/smarthr-ui/src/components/Table/client/FixedHeadTableScroller.tsx
@@ -37,6 +37,8 @@ export const FixedHeadTableScroller: FC<Props> = ({
     }
   }, [])
 
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(callbackRef, forwardedRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -280,6 +280,8 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
     [latest],
   )
 
+  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
+  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(useOnce(functions.baseCallbackRef), externalRef)
 
   return (


### PR DESCRIPTION
## 関連URL

なし

## 概要

`DropdownContentInner`内で、`wrapperRef.current`をuseEffect経由で間接的に参照し、Tab/Escapeキー操作時のフォーカス制御を行っていた。CLAUDE.mdの方針（DOM要素のmount/unmountに連動する処理はcallback ref化する）に沿って、要素のアタッチ/デタッチに直接ロジックを紐付ける形にする。

## 変更内容

- `useEffect` + `wrapperRef.current`経由の間接参照をやめ、callback ref内で直接`window`へのkeydownリスナー登録・解除を行うようにした
- `wrapperRef`と、新設したcallback refを`useMergeRefs`で統合した
- cleanup関数は`useMergeRefs`が内部で実装しているReact 18/19互換の仕組みにより、両バージョンで正しく実行される

## プロダクト側で対応が必要な事項

なし。公開コンポーネント（`Dropdown`）のprops・DOM構造に変更はない。

## 確認方法

`pnpm ui test -- --run src/components/Dropdown`で既存テスト（14件）が通ることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ドロップダウンで、キーボード操作に関するイベント監視を対象要素に正しく紐づけるよう改善しました。
  - ドロップダウンの表示・非表示や要素の切り替え時に、不要なイベント監視が残らないようになりました。

- **内部改善**
  - フォーム入力、チェックボックス、ダイアログ、テーブルなどの参照処理に関する互換性確認用の注記を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->