### PR TITLE
build!: peerDependenciesのReactサポートを19系のみに変更する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1034,12 +1034,12 @@ const mergedRef = useMergeRefs(innerRef, functions.callbackRef, ref)
 const mergedRef = useMergeRefs(functions.callbackRef, innerRef, ref)
 ```
 
-#### callback ref の cleanup 関数と React 18/19 互換性
+#### callback ref の cleanup 関数
 
-React 19 では callback ref がcleanup関数を返せるようになり、要素がデタッチされる際にReactが自動で実行します。しかし React 18 にはこの仕組みがなく、返り値は無視されて `ref(null)` が呼ばれるだけです。smarthr-ui は `react: "^18.0.0 || ^19.0.0"` を peerDependency としてサポートしているため、callback ref から直接cleanup関数を返す実装は避けてください。
+React 19 では callback ref がcleanup関数を返せるようになり、要素がデタッチされる際にReactが自動で実行します。
 
 ```tsx
-// ❌ React 19でしか正しく動作しない（React 18ではcleanup関数が無視される）
+// ✅ callback refがcleanup関数を返す
 const callbackRef = useCallback((node: HTMLElement | null) => {
   if (!node) return
 
@@ -1050,25 +1050,7 @@ const callbackRef = useCallback((node: HTMLElement | null) => {
 }, [])
 ```
 
-**対応方法:**
-- 単一の ref を扱う場合は `useCallbackRefCleanupForReact18`（`src/hooks/useCallbackRefCleanupForReact18.ts`）でラップする
-- 複数の ref を1つに統合する場合は `useMergeRefs` を使う（内部で同じ仕組みを実装済み）
-
-どちらも「callback が返した cleanup 関数を自前で保持しておき、`node = null` で呼ばれたときに手動で実行する」という同じ仕組みで React 18/19 の挙動を統一しています。そのため、これらのフックを経由すれば callback ref の cleanup 関数はどちらのバージョンでも正しく動作します。
-
-```tsx
-// ✅ useCallbackRefCleanupForReact18でラップする
-const callbackRef = useCallbackRefCleanupForReact18(
-  useCallback((node: HTMLElement | null) => {
-    if (!node) return
-
-    const observer = new MutationObserver(callback)
-    observer.observe(node, { childList: true })
-
-    return () => observer.disconnect()
-  }, []),
-)
-```
+複数の ref を1つに統合する場合は `useMergeRefs` を使います。
 
 #### useOnce
 
@@ -1156,17 +1138,15 @@ useEffect(() => {
 }, [])
 
 // ✅ callback refに直接書く（要素がアタッチされた瞬間に実行されることが一目でわかる）
-const callbackRef = useCallbackRefCleanupForReact18(
-  useCallback((node: HTMLUListElement | null) => {
-    if (!node) return
-    const observer = new MutationObserver(callback)
-    observer.observe(node, { childList: true })
-    return () => observer.disconnect()
-  }, []),
-)
+const callbackRef = useCallback((node: HTMLUListElement | null) => {
+  if (!node) return
+  const observer = new MutationObserver(callback)
+  observer.observe(node, { childList: true })
+  return () => observer.disconnect()
+}, [])
 ```
 
-**理由:** `ref.current` 経由の間接参照ではなく、要素のアタッチ/デタッチそのものにロジックを紐付けられる。cleanup関数を返す場合はReact 18互換のため `useCallbackRefCleanupForReact18`（または `useMergeRefs`）でラップする。
+**理由:** `ref.current` 経由の間接参照ではなく、要素のアタッチ/デタッチそのものにロジックを紐付けられる。
 
 **2. マウント時に一度だけ計算する初期値 → useStateの遅延初期化**
 

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -43,8 +43,8 @@
     "watch:css": "tailwindcss -i ./src/styles/index.css -o ./lib/styles.css --watch"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-intl": "^7.0.4 || ^8.0.0 || ^10.0.0",
     "smarthr-ui": "workspace:^",
     "styled-components": "^5.0.1"

--- a/packages/smarthr-ui/package.json
+++ b/packages/smarthr-ui/package.json
@@ -81,8 +81,8 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-intl": "^7.0.4 || ^8.0.0 || ^10.0.0",
     "styled-components": "^5.0.1"
   },

--- a/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/components/mobile/MenuDialog.tsx
@@ -125,8 +125,6 @@ export const Content: FC<
       // HINT: Contentをanimationで非表示にしたい
       // アニメーションが終われば、CSSTransitionのchildrenはunmountされるため、
       // unmount時に操作内容のclearを行う
-      // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-      // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
       callbackRef: () => () => {
         clearReleaseNote()
         clearAppLauncher()
@@ -139,8 +137,6 @@ export const Content: FC<
     }
   }, [latest])
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(functions.callbackRef, domRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Checkbox/client/ActualCheckbox.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/client/ActualCheckbox.tsx
@@ -39,8 +39,6 @@ const callbackRef = (node: HTMLInputElement | null) => {
 }
 
 export const ActualCheckbox: FC<Props> = ({ checkboxRef, checked, mixed, error, ...rest }) => {
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(callbackRef, checkboxRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/MultiCombobox.tsx
@@ -440,8 +440,6 @@ const ActualMultiCombobox = <T,>(
 
   const listBoxCallbackRef = useAreaClickCallbackRef([triggerRef], functions.blur)
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(inputRef, listBoxFunctions.cleanupListBoxCallbackRef, ref)
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/SingleCombobox.tsx
@@ -411,8 +411,6 @@ const ActualSingleCombobox = <T,>(
     isFocused || selectedItem ? undefined : functions.selectDefaultItem,
   )
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const cleanupCallbackRef = useCallback(() => selectFrame.cancel, [selectFrame.cancel])
 
   const mergedRef = useMergeRefs(inputRef, cleanupCallbackRef, ref)

--- a/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/DatePicker.tsx
@@ -348,8 +348,6 @@ export const DatePicker = forwardRef<HTMLInputElement, Props>(
       }
     }, [latest])
 
-    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
     const mergedRef = useMergeRefs(functions.inputCallbackRef, ref)
 
     const mergedCalendarRef = useMergeRefs(

--- a/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/Portal.tsx
@@ -11,8 +11,6 @@ type Props = PropsWithChildren<{
 export const Portal: FC<Props> = ({ inputRect, children }) => {
   const { createPortal } = usePortal()
 
-  // HINT: cleanup functionをreturnしていないためuseCallbackRefCleanupForReact18は不要。
-  // React v18の対応を切ったらこのコメントも削除する
   const callbackRef = useCallback(
     (node: HTMLDivElement | null) => {
       if (node) {

--- a/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogOverlap.tsx
@@ -80,8 +80,6 @@ export const DialogOverlap: FC<Props> = ({ isOpen, className, children, as }) =>
     }, []),
   )
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(nodeRef, callbackRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/FocusTrap.tsx
@@ -76,8 +76,6 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
 
         window.addEventListener('keydown', handleKeyDown)
 
-        // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-        // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
         return () => {
           cancelAnimationFrame(rAFId)
           window.removeEventListener('keydown', handleKeyDown)
@@ -91,8 +89,6 @@ export const FocusTrap = forwardRef<FocusTrapRef, Props>(({ firstFocusTarget, ch
     }
   }, [firstFocusTarget])
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(innerRef, functions.callbackRef)
 
   useImperativeHandle(ref, () => functions as { focus: () => void }, [functions])

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -390,8 +390,6 @@ export const ModelessDialog: FC<Props> = ({
 
       document.addEventListener('focus', focusHandler, true)
 
-      // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-      // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
       return () => {
         functions.cleanupLiveRegion()
         document.removeEventListener('focus', focusHandler, true)
@@ -400,8 +398,6 @@ export const ModelessDialog: FC<Props> = ({
     [isOpen, functions, latest],
   )
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(wrapperRef, callbackRef)
 
   // HINT: mergedRefに混ぜ込んでも実害はなさそうだが、Dialogが表示されている際

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownContentInner.tsx
@@ -186,8 +186,6 @@ export const DropdownContentInner: FC<Props> = ({
     [latest],
   )
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(wrapperRef, callbackRef)
 
   useEffect(() => {

--- a/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
@@ -6,8 +6,8 @@ import { Heading } from './Heading'
 
 describe('Heading', () => {
   // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
-  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
+  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
     const memoized = Heading as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
 
     expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))

--- a/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/Heading.test.tsx
@@ -5,15 +5,7 @@ import { createRef } from 'react'
 import { Heading } from './Heading'
 
 describe('Heading', () => {
-  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
-  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
-    const memoized = Heading as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
-
-    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
-    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
-  })
-
+  // TODO: forwardRefの利用をやめたら不要になる可能性がある。その際は削除を検討する
   test('ref を転送する', () => {
     const ref = createRef<HTMLHeadingElement>()
     render(<Heading ref={ref}>見出し</Heading>)

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
@@ -12,8 +12,8 @@ describe('PageHeading', () => {
   })
 
   // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
-  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
+  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
     const memoized = PageHeading as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
 
     expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.test.tsx
@@ -11,15 +11,6 @@ describe('PageHeading', () => {
     document.title = ''
   })
 
-  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
-  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
-    const memoized = PageHeading as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
-
-    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
-    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
-  })
-
   test('ページのタイトルを自動で設定する', async () => {
     render(<PageHeading>これはタイトルです</PageHeading>)
 

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/PageHeading.tsx
@@ -133,8 +133,6 @@ const AutoPageTitleHeading: FC<
         subtree: true,
       })
 
-      // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-      // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
       return () => {
         observer.disconnect()
         latest.titleFrame.cancel()
@@ -149,8 +147,6 @@ const AutoPageTitleHeading: FC<
     [latest],
   )
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(callbackRef, outerRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Input/CurrencyInput/CurrencyInput.tsx
+++ b/packages/smarthr-ui/src/components/Input/CurrencyInput/CurrencyInput.tsx
@@ -72,8 +72,6 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(
 
     const callbackRef = useOnce(functions.baseCallbackRef)
 
-    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
     const mergedRef = useMergeRefs(innerRef, callbackRef, ref)
 
     useEffect(() => {

--- a/packages/smarthr-ui/src/components/Input/Input.tsx
+++ b/packages/smarthr-ui/src/components/Input/Input.tsx
@@ -111,8 +111,6 @@ export const Input = forwardRef<HTMLInputElement, Props>(
       }
     })
 
-    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
     const mergedRef = useMergeRefs(callbackRef, ref)
 
     const classNames = useMemo(() => {

--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -123,8 +123,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
         const resizeObserver = new ResizeObserver(autoTabIndex)
         resizeObserver.observe(node)
 
-        // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-        // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
         return () => {
           node.removeAttribute('tabIndex')
           resizeObserver.disconnect()
@@ -133,8 +131,6 @@ export const Scroller = forwardRef<HTMLDivElement, Props>(
       [direction],
     )
 
-    // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-    // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
     const mergedRef = useMergeRefs(callbackRef, ref)
 
     const Wrapper = useSectionWrapper(Component)

--- a/packages/smarthr-ui/src/components/Table/client/FixedHeadTableScroller.tsx
+++ b/packages/smarthr-ui/src/components/Table/client/FixedHeadTableScroller.tsx
@@ -37,8 +37,6 @@ export const FixedHeadTableScroller: FC<Props> = ({
     }
   }, [])
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(callbackRef, forwardedRef)
 
   return (

--- a/packages/smarthr-ui/src/components/Text/Text.test.tsx
+++ b/packages/smarthr-ui/src/components/Text/Text.test.tsx
@@ -6,8 +6,8 @@ import { Text } from './Text'
 
 describe('Text', () => {
   // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
-  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
+  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
     const memoized = Text as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
 
     expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))

--- a/packages/smarthr-ui/src/components/Text/Text.test.tsx
+++ b/packages/smarthr-ui/src/components/Text/Text.test.tsx
@@ -5,15 +5,7 @@ import { createRef } from 'react'
 import { Text } from './Text'
 
 describe('Text', () => {
-  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
-  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
-    const memoized = Text as unknown as { $$typeof: symbol; type: { $$typeof: symbol } }
-
-    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
-    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
-  })
-
+  // TODO: forwardRefの利用をやめたら不要になる可能性がある。その際は削除を検討する
   test('ref を転送する', () => {
     const ref = createRef<HTMLSpanElement>()
     render(<Text ref={ref}>テキスト</Text>)

--- a/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/Textarea.tsx
@@ -280,8 +280,6 @@ const ActualTextarea: FC<Omit<LocalTextareaProps, 'maxLetters'>> = ({
     [latest],
   )
 
-  // HINT: useMergeRefsはv18でもcallbackRefのcleanup関数に対応している
-  // もしuseMergeRefsをなくす場合、react v18対応が不要になっているかどうか確認する
   const mergedRef = useMergeRefs(useOnce(functions.baseCallbackRef), externalRef)
 
   return (

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.test.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.test.tsx
@@ -5,8 +5,8 @@ import { VisuallyHiddenText } from './VisuallyHiddenText'
 
 describe('VisuallyHiddenText', () => {
   // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは React 18 でのデグレを検知できない。そのため構造そのものを検証する
-  test('React 18 でも ref を転送できるよう memo(forwardRef()) でラップされている', () => {
+  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
+  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
     const memoized = VisuallyHiddenText as unknown as {
       $$typeof: symbol
       type: { $$typeof: symbol }

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.test.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/VisuallyHiddenText.test.tsx
@@ -4,18 +4,7 @@ import { createRef } from 'react'
 import { VisuallyHiddenText } from './VisuallyHiddenText'
 
 describe('VisuallyHiddenText', () => {
-  // HINT: React 19 は ref を通常の props として扱うため forwardRef がなくても動いてしまい、
-  // 挙動のテストだけでは forwardRef が外れたことによるデグレを検知できない。そのため構造そのものを検証する
-  test('ref を転送できるよう memo(forwardRef()) でラップされている', () => {
-    const memoized = VisuallyHiddenText as unknown as {
-      $$typeof: symbol
-      type: { $$typeof: symbol }
-    }
-
-    expect(memoized.$$typeof).toBe(Symbol.for('react.memo'))
-    expect(memoized.type.$$typeof).toBe(Symbol.for('react.forward_ref'))
-  })
-
+  // TODO: forwardRefの利用をやめたら不要になる可能性がある。その際は削除を検討する
   test('ref を転送する', () => {
     const ref = createRef<HTMLSpanElement>()
     render(<VisuallyHiddenText ref={ref}>テキスト</VisuallyHiddenText>)

--- a/packages/smarthr-ui/src/hooks/client/useEscapeCallbackRef.ts
+++ b/packages/smarthr-ui/src/hooks/client/useEscapeCallbackRef.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-// TODO: React v18を切れたらclientから移動できるか確認
 import { useCallbackRefCleanupForReact18 } from './useCallbackRefCleanupForReact18'
 
 // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key


### PR DESCRIPTION
## 関連URL

なし

## 概要

React18サポートを終了する（v100の主目的）。まず契約変更（peerDependencies）とドキュメント・コメントの整理のみを行い、実際のワークアラウンド（`useCallbackRefCleanupForReact18`等）の削除は後続の別PRで行う。

## 変更内容

- `packages/smarthr-ui`・`packages/charts`のpeerDependenciesを`"react": "^18.0.0 || ^19.0.0"`から`"react": "^19.0.0"`に変更（`react-dom`も同様）
- コメント・テストの文言からReact18対応への言及を削除（ロジックは変更していない）
- `CLAUDE.md`のReact18互換性に関する記述を削除

既存コード内の`useCallbackRefCleanupForReact18`（および`useMergeRefs`内部のReact18向けcleanup機構）はこの時点ではまだ削除していない。実装自体は変わらないため、React18環境でも引き続き問題なく動作する。

## プロダクト側で対応が必要な事項

React18を使用しているプロダクトは、本バージョンへのアップデート前にReact19への移行が必要。

## 確認方法

`pnpm ui lint`・`pnpm ui test`で既存の型チェック・テストが通ることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **互換性**
  - React 19に対応範囲を統一しました。
  - `@smarthr/smarthr-ui`およびチャートパッケージは、React 19専用となります。

- **ドキュメント**
  - React 19のcallback ref cleanupに関する利用方針と例を更新しました。
  - 複数のrefを統合する方法についての説明を整理しました。

- **テスト**
  - React 18固有の内部構造に依存する検証を整理し、ref転送などの動作検証を維持しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->