### PR TITLE
chore: Storybook 10への移行漏れを修正する

### DIFF
--- a/packages/smarthr-ui/.storybook/preview.tsx
+++ b/packages/smarthr-ui/.storybook/preview.tsx
@@ -36,8 +36,6 @@ if (isProduction) {
 const preview: Preview = {
   parameters: {
     options: {
-      isFullscreen: false,
-      isToolshown: true,
       storySort: {
         method: 'alphabetical',
         order: ['*', 'Charts'],

--- a/packages/smarthr-ui/scaffold/templates/stories/VRT{{ pascalCase name }}.stories.tsx.hbs
+++ b/packages/smarthr-ui/scaffold/templates/stories/VRT{{ pascalCase name }}.stories.tsx.hbs
@@ -3,7 +3,7 @@ import { fireEvent, within } from '@storybook/test'
 import { Stack } from '../../Layout'
 import { {{ name }} } from '../{{ name }}'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'SomeCategory（カテゴリ）/{{ name }}/VRT',

--- a/packages/smarthr-ui/scaffold/templates/stories/{{ pascalCase name }}.stories.tsx.hbs
+++ b/packages/smarthr-ui/scaffold/templates/stories/{{ pascalCase name }}.stories.tsx.hbs
@@ -1,6 +1,6 @@
 import { {{ name }} } from '../{{ name }}'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'SomeCategory（カテゴリ）/{{ name }}',

--- a/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanel.stories.tsx
@@ -6,7 +6,7 @@ import { AccordionPanelContent } from '../AccordionPanelContent'
 import { AccordionPanelItem } from '../AccordionPanelItem'
 import { AccordionPanelTrigger } from '../AccordionPanelTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 const _defaultExpandedOptions = {

--- a/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanelContent.stories.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanelContent.stories.tsx
@@ -3,7 +3,7 @@ import { AccordionPanelContent } from '../AccordionPanelContent'
 import { AccordionPanelItem } from '../AccordionPanelItem'
 import { AccordionPanelTrigger } from '../AccordionPanelTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/AccordionPanel/AccordionPanelContent',

--- a/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanelItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanelItem.stories.tsx
@@ -3,7 +3,7 @@ import { AccordionPanelContent } from '../AccordionPanelContent'
 import { AccordionPanelItem } from '../AccordionPanelItem'
 import { AccordionPanelTrigger } from '../AccordionPanelTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/AccordionPanel/AccordionPanelItem',

--- a/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanelTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/stories/AccordionPanelTrigger.stories.tsx
@@ -3,7 +3,7 @@ import { AccordionPanelContent } from '../AccordionPanelContent'
 import { AccordionPanelItem } from '../AccordionPanelItem'
 import { AccordionPanelTrigger } from '../AccordionPanelTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 export default {

--- a/packages/smarthr-ui/src/components/AccordionPanel/stories/VRTAccordionPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/AccordionPanel/stories/VRTAccordionPanel.stories.tsx
@@ -4,7 +4,7 @@ import { AccordionPanelContent } from '../AccordionPanelContent'
 import { AccordionPanelItem } from '../AccordionPanelItem'
 import { AccordionPanelTrigger } from '../AccordionPanelTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/AccordionPanel/VRT',

--- a/packages/smarthr-ui/src/components/AppHeader/stories/AppHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/stories/AppHeader.stories.tsx
@@ -2,7 +2,7 @@ import { AppHeader } from '../AppHeader'
 
 import { args } from './args'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/AppHeader',

--- a/packages/smarthr-ui/src/components/AppHeader/stories/VRTAppHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppHeader/stories/VRTAppHeader.stories.tsx
@@ -4,7 +4,7 @@ import { AppHeader } from '../AppHeader'
 
 import { args } from './args'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/AppHeader/VRT',

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNavi.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNavi.stories.tsx
@@ -9,7 +9,7 @@ import { AppNaviButton } from '../AppNaviButton'
 import { AppNaviCustomTag } from '../AppNaviCustomTag'
 import { AppNaviDropdownMenuButton } from '../AppNaviDropdownMenuButton'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 import type { FC, ReactNode } from 'react'
 
 const Link: FC<{

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviAnchor.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviAnchor.stories.tsx
@@ -1,7 +1,7 @@
 import { FaGearIcon } from '../../Icon'
 import { AppNaviAnchor } from '../AppNaviAnchor'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentPropsWithoutRef } from 'react'
 
 const _iconOptions = {

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviButton.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { FaGearIcon } from '../../Icon'
 import { AppNaviButton } from '../AppNaviButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _iconOptions = {
   なし: undefined,

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviCustomTag.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviCustomTag.stories.tsx
@@ -1,7 +1,7 @@
 import { FaGearIcon } from '../../Icon'
 import { AppNaviCustomTag } from '../AppNaviCustomTag'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { FC, ReactNode } from 'react'
 
 const _iconOptions = {

--- a/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/AppNaviDropdownMenuButton.stories.tsx
@@ -1,7 +1,7 @@
 import { AnchorButton, Button } from '../../Button'
 import { AppNaviDropdownMenuButton } from '../AppNaviDropdownMenuButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/AppNavi/AppNaviDropdownMenuButton',

--- a/packages/smarthr-ui/src/components/AppNavi/stories/VRTAppNavi.stories.tsx
+++ b/packages/smarthr-ui/src/components/AppNavi/stories/VRTAppNavi.stories.tsx
@@ -8,7 +8,7 @@ import { Text } from '../../Text'
 import { Template } from './AppNavi.stories'
 
 import type { AppNavi } from '../AppNavi'
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/AppNavi/VRT',

--- a/packages/smarthr-ui/src/components/Badge/stories/Badge.stories.tsx
+++ b/packages/smarthr-ui/src/components/Badge/stories/Badge.stories.tsx
@@ -1,7 +1,7 @@
 import { Cluster, Stack } from '../../Layout'
 import { Badge } from '../Badge'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Badge',

--- a/packages/smarthr-ui/src/components/Badge/stories/VRTBadge.stories.tsx
+++ b/packages/smarthr-ui/src/components/Badge/stories/VRTBadge.stories.tsx
@@ -1,7 +1,7 @@
 import { Cluster, Stack } from '../../Layout'
 import { Badge } from '../Badge'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Badge/VRT',

--- a/packages/smarthr-ui/src/components/BottomFixedArea/stories/BottomFixedArea.stories.tsx
+++ b/packages/smarthr-ui/src/components/BottomFixedArea/stories/BottomFixedArea.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../../Button'
 import { FaThumbtackIcon } from '../../Icon'
 import { BottomFixedArea } from '../BottomFixedArea'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export const _primaryButtonOptions = {
   なし: undefined,

--- a/packages/smarthr-ui/src/components/BottomFixedArea/stories/VRTBottomFixedArea.stories.tsx
+++ b/packages/smarthr-ui/src/components/BottomFixedArea/stories/VRTBottomFixedArea.stories.tsx
@@ -6,7 +6,7 @@ import {
   _tertiaryLinksOptions,
 } from './BottomFixedArea.stories'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/BottomFixedArea（非推奨）/VRT',

--- a/packages/smarthr-ui/src/components/Browser/stories/Browser.stories.tsx
+++ b/packages/smarthr-ui/src/components/Browser/stories/Browser.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 
 import { Browser } from '../Browser'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Browser',

--- a/packages/smarthr-ui/src/components/Browser/stories/VRTBrowser.stories.tsx
+++ b/packages/smarthr-ui/src/components/Browser/stories/VRTBrowser.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Browser } from '../Browser'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Browser/VRT',

--- a/packages/smarthr-ui/src/components/Button/stories/AnchorButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/stories/AnchorButton.stories.tsx
@@ -2,7 +2,7 @@ import { FaCaretDownIcon, FaCirclePlusIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { AnchorButton } from '../AnchorButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Button/AnchorButton',

--- a/packages/smarthr-ui/src/components/Button/stories/Button.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/stories/Button.stories.tsx
@@ -4,7 +4,7 @@ import { AnchorButton } from '../AnchorButton'
 import { Button } from '../Button'
 import { UnstyledButton } from '../UnstyledButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Button',

--- a/packages/smarthr-ui/src/components/Button/stories/UnstyledButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/stories/UnstyledButton.stories.tsx
@@ -1,6 +1,6 @@
 import { UnstyledButton } from '../UnstyledButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Button/UnstyledButton',

--- a/packages/smarthr-ui/src/components/Button/stories/VRTAnchorButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/stories/VRTAnchorButton.stories.tsx
@@ -3,7 +3,7 @@ import { Cluster, Stack } from '../../Layout'
 import { Groupbox } from '../../Panel'
 import { AnchorButton } from '../AnchorButton'
 
-import type { StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { StoryFn, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 type Variant = ComponentProps<typeof AnchorButton>['variant']

--- a/packages/smarthr-ui/src/components/Button/stories/VRTButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/stories/VRTButton.stories.tsx
@@ -3,7 +3,7 @@ import { Cluster, Stack } from '../../Layout'
 import { Groupbox } from '../../Panel'
 import { Button } from '../Button'
 
-import type { StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { StoryFn, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 type Variant = ComponentProps<typeof Button>['variant']

--- a/packages/smarthr-ui/src/components/Button/stories/VRTUnstyledButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Button/stories/VRTUnstyledButton.stories.tsx
@@ -1,7 +1,7 @@
 import Story from './UnstyledButton.stories'
 
 import type { UnstyledButton } from '../UnstyledButton'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Button/UnstyledButton/VRT',

--- a/packages/smarthr-ui/src/components/Calendar/stories/Calendar.stories.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/stories/Calendar.stories.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs'
 
 import { Calendar } from '../Calendar'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Calendar',

--- a/packages/smarthr-ui/src/components/Calendar/stories/VRTCalendar.stories.tsx
+++ b/packages/smarthr-ui/src/components/Calendar/stories/VRTCalendar.stories.tsx
@@ -4,7 +4,7 @@ import { userEvent, within } from 'storybook/test'
 import { Cluster } from '../../Layout'
 import { Calendar } from '../Calendar'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Calendar/VRT',

--- a/packages/smarthr-ui/src/components/Checkbox/stories/Checkbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/stories/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from '../Checkbox'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Checkbox',

--- a/packages/smarthr-ui/src/components/Checkbox/stories/VRTCheckbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Checkbox/stories/VRTCheckbox.stories.tsx
@@ -3,7 +3,7 @@ import { Cluster, Stack } from '../../Layout'
 import { Section } from '../../SectioningContent'
 import { Checkbox } from '../Checkbox'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 // ペアワイズ法は使わずに総当りする
 const mixed = [true, false]

--- a/packages/smarthr-ui/src/components/Chip/stories/Chip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Chip/stories/Chip.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Chip } from '../Chip'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Chip',

--- a/packages/smarthr-ui/src/components/Chip/stories/VRTChip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Chip/stories/VRTChip.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Chip } from '../Chip'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Chip/VRT',

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/MultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/MultiCombobox.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from 'storybook/preview-api'
 import { Stack } from '../../../Layout'
 import { MultiCombobox } from '../MultiCombobox'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export const defaultItems = {
   'option 1': {

--- a/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/VRTMultiCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/MultiCombobox/stories/VRTMultiCombobox.stories.tsx
@@ -7,7 +7,7 @@ import { MultiCombobox } from '../MultiCombobox'
 import { defaultItems } from './MultiCombobox.stories'
 
 import type { ComboboxItem } from '../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 /*
  * pict multiCombobox.pict

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/SingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/SingleCombobox.stories.tsx
@@ -5,7 +5,7 @@ import { FaCirclePlusIcon } from '../../../Icon'
 import { Stack } from '../../../Layout'
 import { SingleCombobox } from '../SingleCombobox'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export const defaultItems = {
   'option 1': {

--- a/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/VRTSingleCombobox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Combobox/SingleCombobox/stories/VRTSingleCombobox.stories.tsx
@@ -5,7 +5,7 @@ import { SingleCombobox } from '../SingleCombobox'
 
 import { defaultItems, prefixes } from './SingleCombobox.stories'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 /* pict singleCombobox.pict
  * disabled        error   width   prefix  selectedItem

--- a/packages/smarthr-ui/src/components/DatePicker/stories/DatePicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/stories/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from 'storybook/test'
 
 import { DatePicker } from '../DatePicker'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DatePicker（非推奨）',

--- a/packages/smarthr-ui/src/components/DatePicker/stories/VRTDatePicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/DatePicker/stories/VRTDatePicker.stories.tsx
@@ -4,7 +4,7 @@ import { userEvent, within } from 'storybook/test'
 import { Cluster } from '../../Layout'
 import { DatePicker } from '../DatePicker'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DatePicker（非推奨）/VRT',

--- a/packages/smarthr-ui/src/components/DefinitionList/stories/DefinitionList.stories.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/stories/DefinitionList.stories.tsx
@@ -1,7 +1,7 @@
 import { DefinitionList } from '../DefinitionList'
 import { DefinitionListItem } from '../DefinitionListItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DefinitionList',

--- a/packages/smarthr-ui/src/components/DefinitionList/stories/DefinitionListItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/stories/DefinitionListItem.stories.tsx
@@ -1,7 +1,7 @@
 import { DefinitionList } from '../DefinitionList'
 import { DefinitionListItem } from '../DefinitionListItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DefinitionList/DefinitionListItem',

--- a/packages/smarthr-ui/src/components/DefinitionList/stories/VRTDefinitionList.stories.tsx
+++ b/packages/smarthr-ui/src/components/DefinitionList/stories/VRTDefinitionList.stories.tsx
@@ -2,7 +2,7 @@ import { Stack } from '../../Layout'
 import { DefinitionList } from '../DefinitionList'
 import { DefinitionListItem } from '../DefinitionListItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DefinitionList/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/stories/ActionDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/stories/ActionDialog.stories.tsx
@@ -6,7 +6,7 @@ import { Cluster } from '../../../Layout'
 import { RadioButton } from '../../../RadioButton'
 import { ControlledActionDialog } from '../ControlledActionDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _widthOptions = {
   string: '30em',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/stories/VRTActionDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/stories/VRTActionDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { Button } from '../../../Button'
 import { ControlledActionDialog } from '../ControlledActionDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ControlledActionDialog/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/stories/FormDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/stories/FormDialog.stories.tsx
@@ -8,7 +8,7 @@ import { Cluster } from '../../../Layout'
 import { RadioButton } from '../../../RadioButton'
 import { ControlledFormDialog } from '../ControlledFormDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _widthOptions = {
   string: '30em',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/stories/VRTFormDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/stories/VRTFormDialog.stories.tsx
@@ -3,7 +3,7 @@ import { FormControl } from '../../../FormGroup'
 import { Input } from '../../../Input'
 import { ControlledFormDialog } from '../ControlledFormDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ControlledFormDialog/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/stories/MessageDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/stories/MessageDialog.stories.tsx
@@ -4,7 +4,7 @@ import { action } from 'storybook/actions'
 import { Button } from '../../../Button'
 import { ControlledMessageDialog } from '../ControlledMessageDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ControlledMessageDialog',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/stories/VRTMessageDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/stories/VRTMessageDialog.stories.tsx
@@ -1,6 +1,6 @@
 import { ControlledMessageDialog } from '../ControlledMessageDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ControlledMessageDialog/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/stories/StepFormDialogItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/stories/StepFormDialogItem.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../../Button'
 import { ControlledStepFormDialog } from '../ControlledStepFormDialog'
 import { StepFormDialogItem } from '../StepFormDialogItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ControlledStepFormDialog/StepFormDialogItem',

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/stories/VRTStepFormDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/stories/VRTStepFormDialog.stories.tsx
@@ -1,6 +1,6 @@
 import { ControlledStepFormDialog } from '../ControlledStepFormDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ControlledStepFormDialog/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/stories/ModelessDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/stories/ModelessDialog.stories.tsx
@@ -4,7 +4,7 @@ import { action } from 'storybook/actions'
 import { Button } from '../../../Button'
 import { ModelessDialog } from '../ModelessDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ModelessDialog',

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/stories/VRTModelessDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/stories/VRTModelessDialog.stories.tsx
@@ -1,6 +1,6 @@
 import { ModelessDialog } from '../ModelessDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/ModelessDialog/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/ActionDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/ActionDialog.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../../../Button'
 import { ActionDialog } from '../ActionDialog'
 import { RemoteDialogTrigger } from '../RemoteDialogTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 /** props は [ActionDialog](./?path=/docs/dialog（ダイアログ）-dialog-actiondialog--docs) を参照してください。 */
 export default {

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/FormDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/FormDialog.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../../../Button'
 import { FormDialog } from '../FormDialog'
 import { RemoteDialogTrigger } from '../RemoteDialogTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 /** props は [FormDialog](./?path=/docs/dialog（ダイアログ）-dialog-formdialog--docs) を参照してください。 */
 export default {

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/MessageDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/MessageDialog.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../../Button'
 import { MessageDialog } from '../MessageDialog'
 import { RemoteDialogTrigger } from '../RemoteDialogTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 /** props は [MessageDialog](./?path=/docs/dialog（ダイアログ）-dialog-messagedialog--docs) を参照してください。 */
 export default {

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/RemoteDialogTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/RemoteDialogTrigger.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../../Button'
 import { MessageDialog } from '../MessageDialog'
 import { RemoteDialogTrigger } from '../RemoteDialogTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/RemoteDialogTrigger',

--- a/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/StepFormDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/RemoteDialogTrigger/stories/StepFormDialog.stories.tsx
@@ -5,7 +5,7 @@ import { StepFormDialogItem } from '../../ControlledStepFormDialog'
 import { RemoteDialogTrigger } from '../RemoteDialogTrigger'
 import { StepFormDialog } from '../StepFormDialog'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 /** props は [StepFormDialog](./?path=/docs/dialog（ダイアログ）-dialog-stepformdialog--docs) を参照してください。 */
 export default {

--- a/packages/smarthr-ui/src/components/Dialog/stories/Dialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/Dialog.stories.tsx
@@ -9,7 +9,7 @@ import { DialogContent } from '../DialogContent'
 import { DialogTrigger } from '../DialogTrigger'
 import { DialogWrapper } from '../DialogWrapper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _widthOptions = {
   string: '30em',

--- a/packages/smarthr-ui/src/components/Dialog/stories/DialogCloser.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/DialogCloser.stories.tsx
@@ -4,7 +4,7 @@ import { DialogContent } from '../DialogContent'
 import { DialogTrigger } from '../DialogTrigger'
 import { DialogWrapper } from '../DialogWrapper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/DialogCloser',

--- a/packages/smarthr-ui/src/components/Dialog/stories/DialogContent.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/DialogContent.stories.tsx
@@ -7,7 +7,7 @@ import { DialogContent } from '../DialogContent'
 import { DialogTrigger } from '../DialogTrigger'
 import { DialogWrapper } from '../DialogWrapper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _widthOptions = {
   string: '30em',

--- a/packages/smarthr-ui/src/components/Dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/DialogTrigger.stories.tsx
@@ -4,7 +4,7 @@ import { DialogContent } from '../DialogContent'
 import { DialogTrigger } from '../DialogTrigger'
 import { DialogWrapper } from '../DialogWrapper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/DialogTrigger',

--- a/packages/smarthr-ui/src/components/Dialog/stories/DialogWrapper.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/DialogWrapper.stories.tsx
@@ -4,7 +4,7 @@ import { DialogContent } from '../DialogContent'
 import { DialogTrigger } from '../DialogTrigger'
 import { DialogWrapper } from '../DialogWrapper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/DialogWrapper',

--- a/packages/smarthr-ui/src/components/Dialog/stories/VRTDialog.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/VRTDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { IsOpen } from './Dialog.stories'
 
 import type { Dialog } from '../Dialog'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dialog/VRT',

--- a/packages/smarthr-ui/src/components/Dialog/stories/VRTDialogContent.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/stories/VRTDialogContent.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from 'storybook/test'
 import DialogContentStory from './DialogContent.stories'
 
 import type { Dialog } from '../Dialog'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   ...DialogContentStory,

--- a/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureContent.stories.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureContent.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../Button'
 import { DisclosureContent } from '../DisclosureContent'
 import { DisclosureTrigger } from '../DisclosureTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Disclosure/DisclosureContent',

--- a/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/stories/DisclosureTrigger.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../../Button'
 import { DisclosureContent } from '../DisclosureContent'
 import { DisclosureTrigger } from '../DisclosureTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Disclosure/DisclosureTrigger',

--- a/packages/smarthr-ui/src/components/Disclosure/stories/VRTDisclosure.stories.tsx
+++ b/packages/smarthr-ui/src/components/Disclosure/stories/VRTDisclosure.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../Button'
 import { DisclosureContent } from '../DisclosureContent'
 import { DisclosureTrigger } from '../DisclosureTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Disclosure/VRT',

--- a/packages/smarthr-ui/src/components/DropZone/stories/DropZone.stories.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/stories/DropZone.stories.tsx
@@ -2,7 +2,7 @@ import { action } from 'storybook/actions'
 
 import { DropZone } from '../DropZone'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DropZone',

--- a/packages/smarthr-ui/src/components/DropZone/stories/VRTDropZone.stories.tsx
+++ b/packages/smarthr-ui/src/components/DropZone/stories/VRTDropZone.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { DropZone } from '../DropZone'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/DropZone/VRT',

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuButton.stories.tsx
@@ -6,7 +6,7 @@ import { FaGearIcon } from '../../../Icon'
 import { DropdownMenuButton } from '../DropdownMenuButton'
 import { DropdownMenuGroup } from '../DropdownMenuGroup'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _sampleTriggerIcons = {
   undefined,

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuGroup.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/DropdownMenuGroup.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../../Button'
 import { DropdownMenuButton } from '../DropdownMenuButton'
 import { DropdownMenuGroup } from '../DropdownMenuGroup'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/DropdownMenuButton/DropdownMenuGroup',

--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/stories/VRTDropdownMenuButton.stories.tsx
@@ -11,7 +11,7 @@ import { DropdownTrigger } from '../../DropdownTrigger'
 import { DropdownMenuButton } from '../DropdownMenuButton'
 import { DropdownMenuGroup } from '../DropdownMenuGroup'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/stories/FilterDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/stories/FilterDropdown.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Stack } from '../../../Layout'
 import { FilterDropdown } from '../FilterDropdown'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/FilterDropdown',

--- a/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/stories/VRTFilterDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/stories/VRTFilterDropdown.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from 'storybook/test'
 import { Cluster } from '../../../Layout'
 import { FilterDropdown } from '../FilterDropdown'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/Dropdown/SortDropdown/stories/SortDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/SortDropdown/stories/SortDropdown.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Cluster } from '../../../Layout'
 import { SortDropdown } from '../SortDropdown'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/SortDropdown',

--- a/packages/smarthr-ui/src/components/Dropdown/SortDropdown/stories/VRTSortDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/SortDropdown/stories/VRTSortDropdown.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from 'storybook/test'
 import { Cluster } from '../../../Layout'
 import { SortDropdown } from '../SortDropdown'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/SortDropdown/VRT',

--- a/packages/smarthr-ui/src/components/Dropdown/stories/Dropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/stories/Dropdown.stories.tsx
@@ -6,7 +6,7 @@ import { DropdownCloser } from '../DropdownCloser'
 import { DropdownContent } from '../DropdownContent'
 import { DropdownTrigger } from '../DropdownTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown',

--- a/packages/smarthr-ui/src/components/Dropdown/stories/DropdownCloser.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/stories/DropdownCloser.stories.tsx
@@ -4,7 +4,7 @@ import { DropdownCloser } from '../DropdownCloser'
 import { DropdownContent } from '../DropdownContent'
 import { DropdownTrigger } from '../DropdownTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/DropdownCloser',

--- a/packages/smarthr-ui/src/components/Dropdown/stories/DropdownContent.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/stories/DropdownContent.stories.tsx
@@ -3,7 +3,7 @@ import { Dropdown } from '../Dropdown'
 import { DropdownContent } from '../DropdownContent'
 import { DropdownTrigger } from '../DropdownTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/DropdownContent',

--- a/packages/smarthr-ui/src/components/Dropdown/stories/DropdownTrigger.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/stories/DropdownTrigger.stories.tsx
@@ -3,7 +3,7 @@ import { Dropdown } from '../Dropdown'
 import { DropdownContent } from '../DropdownContent'
 import { DropdownTrigger } from '../DropdownTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/DropdownTrigger',

--- a/packages/smarthr-ui/src/components/Dropdown/stories/VRTDropdown.stories.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/stories/VRTDropdown.stories.tsx
@@ -5,7 +5,7 @@ import { Dropdown } from '../Dropdown'
 import { DropdownContent } from '../DropdownContent'
 import { DropdownTrigger } from '../DropdownTrigger'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Dropdown/VRT',

--- a/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/FileViewer.stories.tsx
@@ -1,6 +1,6 @@
 import { FileViewer } from '../FileViewer'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/FileViewer',

--- a/packages/smarthr-ui/src/components/FileViewer/stories/VRTFileViewer.stories.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/stories/VRTFileViewer.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { FileViewer } from '../FileViewer'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/FileViewer/VRT',

--- a/packages/smarthr-ui/src/components/FloatArea/stories/FloatArea.stories.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/stories/FloatArea.stories.tsx
@@ -4,7 +4,7 @@ import { Panel } from '../../Panel'
 import { FloatArea } from '../FloatArea'
 
 import type { ResponseStatusWithoutProcessing } from '../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _primaryButtonOptions = {
   'あり（省略不可）': <Button variant="primary">プライマリーボタン</Button>,

--- a/packages/smarthr-ui/src/components/FloatArea/stories/VRTFloatArea.stories.tsx
+++ b/packages/smarthr-ui/src/components/FloatArea/stories/VRTFloatArea.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Layout'
 import { Panel } from '../../Panel'
 import { FloatArea } from '../FloatArea'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/FloatArea/VRT',

--- a/packages/smarthr-ui/src/components/FormGroup/stories/Fieldset.stories.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/stories/Fieldset.stories.tsx
@@ -7,7 +7,7 @@ import { STYLE_TYPE_MAP } from '../../Text'
 import { Fieldset } from '../Fieldset'
 import { FormControl } from '../FormControl'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export const _childrenOptions = {
   radio: (

--- a/packages/smarthr-ui/src/components/FormGroup/stories/FormControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/stories/FormControl.stories.tsx
@@ -12,7 +12,7 @@ import { STYLE_TYPE_MAP } from '../../Text'
 import { Textarea } from '../../Textarea'
 import { FormControl } from '../FormControl'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _childrenOptions = {
   '<Input />': <Input name="formcontrol_input" />,

--- a/packages/smarthr-ui/src/components/FormGroup/stories/VRTFieldset.stories.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/stories/VRTFieldset.stories.tsx
@@ -5,7 +5,7 @@ import { Fieldset } from '../Fieldset'
 
 import { _childrenOptions } from './Fieldset.stories'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Fieldset/VRT',

--- a/packages/smarthr-ui/src/components/FormGroup/stories/VRTFormControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/stories/VRTFormControl.stories.tsx
@@ -4,7 +4,7 @@ import { Cluster, Stack } from '../../Layout'
 import { StatusLabel } from '../../StatusLabel'
 import { FormControl } from '../FormControl'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/FormControl/VRT',

--- a/packages/smarthr-ui/src/components/Header/stories/AppLauncher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/AppLauncher.stories.tsx
@@ -1,6 +1,6 @@
 import { AppLauncher } from '../AppLauncher'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const apps = [
   {

--- a/packages/smarthr-ui/src/components/Header/stories/Header.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/Header.stories.tsx
@@ -5,7 +5,7 @@ import { Header } from '../Header'
 import { HeaderDropdownMenuButton } from '../HeaderDropdownMenuButton'
 import { HeaderLink } from '../HeaderLink'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _logoOptions = {
   default: undefined,

--- a/packages/smarthr-ui/src/components/Header/stories/HeaderDropdownMenuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/HeaderDropdownMenuButton.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../Button'
 import { Header } from '../Header'
 import { HeaderDropdownMenuButton } from '../HeaderDropdownMenuButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Header/HeaderDropdownMenuButton',

--- a/packages/smarthr-ui/src/components/Header/stories/HeaderLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/HeaderLink.stories.tsx
@@ -1,7 +1,7 @@
 import { FaRegCircleQuestionIcon } from '../../Icon'
 import { HeaderLink } from '../HeaderLink'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Header/HeaderLink',

--- a/packages/smarthr-ui/src/components/Header/stories/LanguageSwitcher.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/LanguageSwitcher.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { localeMap } from '../../../intl'
 import { LanguageSwitcher } from '../LanguageSwitcher'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Header/LanguageSwitcher',

--- a/packages/smarthr-ui/src/components/Header/stories/VRTHeader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Header/stories/VRTHeader.stories.tsx
@@ -8,7 +8,7 @@ import { LanguageSwitcher } from '../LanguageSwitcher'
 
 import { _appsOptions } from './Header.stories'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Header/VRT',

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/stories/PageHeading.stories.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/stories/PageHeading.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../../Layout'
 import { PageHeading } from '../PageHeading'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentPropsWithoutRef } from 'react'
 
 export default {

--- a/packages/smarthr-ui/src/components/Heading/PageHeading/stories/VRTPageHeading.stories.tsx
+++ b/packages/smarthr-ui/src/components/Heading/PageHeading/stories/VRTPageHeading.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../../Layout'
 import { PageHeading } from '../PageHeading'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Heading/PageHeading/VRT',

--- a/packages/smarthr-ui/src/components/Heading/stories/Heading.stories.tsx
+++ b/packages/smarthr-ui/src/components/Heading/stories/Heading.stories.tsx
@@ -2,7 +2,7 @@ import { FaAddressBookIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Heading } from '../Heading'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentPropsWithoutRef } from 'react'
 
 export default {

--- a/packages/smarthr-ui/src/components/Heading/stories/VRTHeading.stories.tsx
+++ b/packages/smarthr-ui/src/components/Heading/stories/VRTHeading.stories.tsx
@@ -2,7 +2,7 @@ import { FaAddressBookIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Heading } from '../Heading'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Heading/VRT',

--- a/packages/smarthr-ui/src/components/Icon/stories/Icon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Icon/stories/Icon.stories.tsx
@@ -7,7 +7,7 @@ import { SparklesIcon } from '../SparklesIcon'
 import { WarningIcon } from '../WarningIcon'
 import { colorSet } from '../generateIcon'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const FaAddressBookIcon = Icons.FaAddressBookIcon
 

--- a/packages/smarthr-ui/src/components/Icon/stories/VRTIcon.stories.tsx
+++ b/packages/smarthr-ui/src/components/Icon/stories/VRTIcon.stories.tsx
@@ -2,7 +2,7 @@ import { Stack } from '../../Layout'
 import { FaAddressBookIcon } from '../FaIcon'
 import { WarningIcon } from '../WarningIcon'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Icon/VRT',

--- a/packages/smarthr-ui/src/components/InformationPanel/stories/InformationPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/stories/InformationPanel.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Stack } from '../../Layout'
 import { InformationPanel } from '../InformationPanel'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/InformationPanel',

--- a/packages/smarthr-ui/src/components/InformationPanel/stories/VRTInformationPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/InformationPanel/stories/VRTInformationPanel.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { InformationPanel } from '../InformationPanel'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/Input/CurrencyInput/stories/CurrencyInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/CurrencyInput/stories/CurrencyInput.stories.tsx
@@ -1,7 +1,7 @@
 import { FaMoneyCheckDollarIcon } from '../../../Icon'
 import { CurrencyInput } from '../CurrencyInput'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _prefixOptions = {
   なし: undefined,

--- a/packages/smarthr-ui/src/components/Input/SearchInput/stories/SearchInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/stories/SearchInput.stories.tsx
@@ -2,7 +2,7 @@ import { Stack } from '../../../Layout'
 import InputStory from '../../stories/Input.stories'
 import { SearchInput } from '../SearchInput'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Input/SearchInput',

--- a/packages/smarthr-ui/src/components/Input/SearchInput/stories/VRTSearchInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/SearchInput/stories/VRTSearchInput.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from 'storybook/test'
 import { Width } from './SearchInput.stories'
 
 import type { SearchInput } from '../SearchInput'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Input/SearchInput/VRT',

--- a/packages/smarthr-ui/src/components/Input/stories/Input.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/stories/Input.stories.tsx
@@ -6,7 +6,7 @@ import { CurrencyInput } from '../CurrencyInput'
 import { Input, backgroundColor } from '../Input'
 import { SearchInput } from '../SearchInput'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _affixOptions = {
   あり: <FaMagnifyingGlassIcon alt="検索" />,

--- a/packages/smarthr-ui/src/components/Input/stories/VRTInput.stories.tsx
+++ b/packages/smarthr-ui/src/components/Input/stories/VRTInput.stories.tsx
@@ -2,7 +2,7 @@ import { FaMagnifyingGlassIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Input } from '../Input'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/InputFile/stories/InputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/stories/InputFile.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Stack } from '../../Layout'
 import { InputFile } from '../InputFile'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/InputFile',

--- a/packages/smarthr-ui/src/components/InputFile/stories/TestInputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/stories/TestInputFile.stories.tsx
@@ -8,7 +8,7 @@ import { Stack } from '../../Layout'
 import { Groupbox } from '../../Panel'
 import { InputFile } from '../InputFile'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/InputFile/Test',

--- a/packages/smarthr-ui/src/components/InputFile/stories/VRTInputFile.stories.tsx
+++ b/packages/smarthr-ui/src/components/InputFile/stories/VRTInputFile.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent } from 'storybook/test'
 import { Stack } from '../../Layout'
 import { InputFile } from '../InputFile'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/InputFile/VRT',

--- a/packages/smarthr-ui/src/components/Layout/Center/stories/Center.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Center/stories/Center.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Stack'
 import { Center, centerClassNameGenerator } from '../Center'
 
 import type { Gap as GapType } from '../../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const centerPadding = Object.keys(centerClassNameGenerator.variants.padding)
   // Tシャツサイズは後方互換性のために残しており、できるだけ使われたくない

--- a/packages/smarthr-ui/src/components/Layout/Center/stories/VRTCenter.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Center/stories/VRTCenter.stories.tsx
@@ -2,7 +2,7 @@ import { Center } from '../Center'
 
 import { Padding } from './Center.stories'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Center/VRT',

--- a/packages/smarthr-ui/src/components/Layout/Cluster/stories/Cluster.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/stories/Cluster.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Stack'
 import { Cluster, clusterClassNameGenerator } from '../Cluster'
 
 import type { Gap as GapType } from '../../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const clusterGap = Object.keys(clusterClassNameGenerator.variants.rowGap)
   // Tシャツサイズは後方互換性のために残しており、できるだけ使われたくない

--- a/packages/smarthr-ui/src/components/Layout/Cluster/stories/VRTCluster.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/stories/VRTCluster.stories.tsx
@@ -2,7 +2,7 @@ import { Cluster } from '../Cluster'
 
 import { Gap } from './Cluster.stories'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Cluster/VRT',

--- a/packages/smarthr-ui/src/components/Layout/Container/stories/Container.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/stories/Container.stories.tsx
@@ -4,7 +4,7 @@ import { Panel } from '../../../Panel'
 import { Stack } from '../../Stack'
 import { Container } from '../Container'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof Container> = ({ size, ...rest }) => (
   <Container {...rest} size={size}>

--- a/packages/smarthr-ui/src/components/Layout/Container/stories/VRTContainer.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/stories/VRTContainer.stories.tsx
@@ -6,15 +6,18 @@ import type { Meta } from '@storybook/react-webpack5'
 export default {
   title: 'Components/Layout/Container/VRT',
   render: Size.render,
+  globals: {
+    viewport: { value: 'vrtWide' },
+  },
   parameters: {
     chromatic: { disableSnapshot: false },
     viewport: {
-      defaultViewport: 'vrtWide',
-      viewports: {
+      options: {
         vrtWide: {
           name: 'VRT Wide',
           styles: {
             width: '2048px',
+            height: '900px',
           },
         },
       },

--- a/packages/smarthr-ui/src/components/Layout/Container/stories/VRTContainer.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/stories/VRTContainer.stories.tsx
@@ -1,7 +1,7 @@
 import { Size } from './Container.stories'
 
 import type { Container } from '../Container'
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Container/VRT',

--- a/packages/smarthr-ui/src/components/Layout/Reel/stories/Reel.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Reel/stories/Reel.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Stack'
 import { Reel } from '../Reel'
 
 import type { Gap } from '../../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/Layout/Reel',

--- a/packages/smarthr-ui/src/components/Layout/Reel/stories/VRTReel.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Reel/stories/VRTReel.stories.tsx
@@ -2,7 +2,7 @@ import { Reel } from '../Reel'
 
 import { GapStory, Padding } from './Reel.stories'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Reel/VRT',

--- a/packages/smarthr-ui/src/components/Layout/Sidebar/stories/Sidebar.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Sidebar/stories/Sidebar.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Stack'
 import { Sidebar } from '../Sidebar'
 
 import type { Gap } from '../../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/Layout/Sidebar',

--- a/packages/smarthr-ui/src/components/Layout/Sidebar/stories/VRTSidebar.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Sidebar/stories/VRTSidebar.stories.tsx
@@ -3,7 +3,7 @@ import { Sidebar } from '../Sidebar'
 
 import { Align as AlignStory, GapStory } from './Sidebar.stories'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Sidebar/VRT',

--- a/packages/smarthr-ui/src/components/Layout/Stack/stories/Stack.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Stack/stories/Stack.stories.tsx
@@ -3,7 +3,7 @@ import { ColorBox } from '../../ComponentsForStories'
 import { Stack } from '../Stack'
 
 import type { Gap } from '../../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Stack',

--- a/packages/smarthr-ui/src/components/Layout/Stack/stories/VRTStack.stories.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Stack/stories/VRTStack.stories.tsx
@@ -2,7 +2,7 @@ import { Stack } from '../Stack'
 
 import { GapStory } from './Stack.stories'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Layout/Stack/VRT',

--- a/packages/smarthr-ui/src/components/LineClamp/stories/LineClamp.stories.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/stories/LineClamp.stories.tsx
@@ -2,7 +2,7 @@ import { Stack } from '../../Layout'
 import { TextLink } from '../../TextLink'
 import { LineClamp } from '../LineClamp'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/LineClamp',

--- a/packages/smarthr-ui/src/components/LineClamp/stories/VRTLineClamp.stories.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/stories/VRTLineClamp.stories.tsx
@@ -1,7 +1,7 @@
 import { MaxLines } from './LineClamp.stories'
 
 import type { LineClamp } from '../LineClamp'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/LineClamp/VRT',

--- a/packages/smarthr-ui/src/components/Loader/stories/Loader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Loader/stories/Loader.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Loader } from '../Loader'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Loader',

--- a/packages/smarthr-ui/src/components/Loader/stories/VRTLoader.stories.tsx
+++ b/packages/smarthr-ui/src/components/Loader/stories/VRTLoader.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Loader } from '../Loader'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/NotificationBar/stories/NotificationBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/stories/NotificationBar.stories.tsx
@@ -6,7 +6,7 @@ import { Text } from '../../Text'
 import { TextLink } from '../../TextLink'
 import { NotificationBar } from '../NotificationBar'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export const sampleChildrens = {
   String: 'NotificationBar が表示されました',

--- a/packages/smarthr-ui/src/components/NotificationBar/stories/VRTNotificationBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/NotificationBar/stories/VRTNotificationBar.stories.tsx
@@ -7,7 +7,7 @@ import {
   sampleSubActionAreas,
 } from './NotificationBar.stories'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 /* ペアワイズ法による網羅
 base  bold   type     children   subActionArea  layer      onClose  */

--- a/packages/smarthr-ui/src/components/PageCounter/stories/PageCounter.stories.tsx
+++ b/packages/smarthr-ui/src/components/PageCounter/stories/PageCounter.stories.tsx
@@ -1,6 +1,6 @@
 import { PageCounter } from '../PageCounter'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/PageCounter',

--- a/packages/smarthr-ui/src/components/PageCounter/stories/VRTPageCounter.stories.tsx
+++ b/packages/smarthr-ui/src/components/PageCounter/stories/VRTPageCounter.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { PageCounter } from '../PageCounter'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const cases = [
   { start: 1, end: 50 },

--- a/packages/smarthr-ui/src/components/Pagination/stories/Pagination.stories.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/stories/Pagination.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Stack } from '../../Layout'
 import { Pagination } from '../Pagination'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ReactNode } from 'react'
 
 const meta = {

--- a/packages/smarthr-ui/src/components/Pagination/stories/VRTPagination.stories.tsx
+++ b/packages/smarthr-ui/src/components/Pagination/stories/VRTPagination.stories.tsx
@@ -5,7 +5,7 @@ import { Stack } from '../../Layout'
 import { Current } from './Pagination.stories'
 
 import type { Pagination } from '../Pagination'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/Pagination/VRT',

--- a/packages/smarthr-ui/src/components/Panel/stories/Groupbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Panel/stories/Groupbox.stories.tsx
@@ -4,7 +4,7 @@ import { Groupbox } from '../Groupbox'
 import { panelClassNameGenerator } from '../Panel'
 
 import type { Gap } from '../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const basePadding = Object.keys(panelClassNameGenerator.variants.paddingBlock)
   // Tシャツサイズは後方互換性のために残しており、できるだけ使われたくない

--- a/packages/smarthr-ui/src/components/Panel/stories/Panel.stories.tsx
+++ b/packages/smarthr-ui/src/components/Panel/stories/Panel.stories.tsx
@@ -3,7 +3,7 @@ import { Groupbox } from '../Groupbox'
 import { Panel, panelClassNameGenerator } from '../Panel'
 
 import type { Gap } from '../../../types'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 const basePadding = Object.keys(panelClassNameGenerator.variants.paddingBlock)

--- a/packages/smarthr-ui/src/components/Panel/stories/VRTGroupbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Panel/stories/VRTGroupbox.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Layout'
 import { BgColor, Padding, Rounded } from './Groupbox.stories'
 
 import type { Groupbox } from '../Groupbox'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Base/BaseColumn/VRT',

--- a/packages/smarthr-ui/src/components/Panel/stories/VRTPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/Panel/stories/VRTPanel.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Layout'
 import { Layer, Overflow, Padding, Radius } from './Panel.stories'
 
 import type { Panel } from '../Panel'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Base/VRT',

--- a/packages/smarthr-ui/src/components/RadioButton/stories/RadioButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/stories/RadioButton.stories.tsx
@@ -1,6 +1,6 @@
 import { RadioButton } from '../RadioButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/RadioButton',

--- a/packages/smarthr-ui/src/components/RadioButton/stories/VRTRadioButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/stories/VRTRadioButton.stories.tsx
@@ -1,7 +1,7 @@
 import { Cluster, Stack } from '../../Layout'
 import { RadioButton } from '../RadioButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/RadioButton/VRT',

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/RadioButtonPanel.stories.tsx
@@ -1,6 +1,6 @@
 import { RadioButtonPanel } from '../RadioButtonPanel'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _asOptions = { なし: undefined, '<span>': 'span', '<p>': 'p' }
 

--- a/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
+++ b/packages/smarthr-ui/src/components/RadioButtonPanel/stories/VRTRadioButtonPanel.stories.tsx
@@ -1,7 +1,7 @@
 import { Cluster, Stack } from '../../Layout'
 import { RadioButtonPanel } from '../RadioButtonPanel'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/RadioButtonPanel/VRT',

--- a/packages/smarthr-ui/src/components/ResponseMessage/stories/ResponseMessage.stories.tsx
+++ b/packages/smarthr-ui/src/components/ResponseMessage/stories/ResponseMessage.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { ResponseMessage } from '../ResponseMessage'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/ResponseMessage',

--- a/packages/smarthr-ui/src/components/ResponseMessage/stories/VRTResponseMessage.stories.tsx
+++ b/packages/smarthr-ui/src/components/ResponseMessage/stories/VRTResponseMessage.stories.tsx
@@ -2,7 +2,7 @@ import { pictParser } from '../../../libs/pictParser'
 import { Stack } from '../../Layout'
 import { ResponseMessage } from '../ResponseMessage'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 type ResponseMessageProps = ComponentProps<typeof ResponseMessage>

--- a/packages/smarthr-ui/src/components/Scroller/stories/Scroller.stories.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/stories/Scroller.stories.tsx
@@ -1,7 +1,7 @@
 import { Panel } from '../../Panel'
 import { Scroller } from '../Scroller'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Scroller',

--- a/packages/smarthr-ui/src/components/Scroller/stories/VRTScroller.stories.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/stories/VRTScroller.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from './Scroller.stories'
 
 import type { Scroller } from '../Scroller'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Scroller/VRT',

--- a/packages/smarthr-ui/src/components/SectioningContent/stories/SectioningContent.stories.tsx
+++ b/packages/smarthr-ui/src/components/SectioningContent/stories/SectioningContent.stories.tsx
@@ -2,7 +2,7 @@ import { Heading } from '../../Heading'
 import { Stack } from '../../Layout'
 import { Article, Aside, Nav, Section } from '../SectioningContent'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SectioningContent',

--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { Stack } from '../../Layout'
 import { SegmentedControl } from '../SegmentedControl'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const tableIcon = <FaTableIcon />
 const chartBarIcon = <FaChartBarIcon />

--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/VRTSegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/VRTSegmentedControl.stories.tsx
@@ -4,7 +4,7 @@ import { FaChartAreaIcon, FaChartBarIcon, FaChartLineIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { type Option, SegmentedControl } from '../SegmentedControl'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 const chartBarIcon = <FaChartBarIcon />
 const chartAreaIcon = <FaChartAreaIcon />

--- a/packages/smarthr-ui/src/components/Select/stories/Select.stories.tsx
+++ b/packages/smarthr-ui/src/components/Select/stories/Select.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Stack } from '../../Layout'
 import { Select } from '../Select'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Select',

--- a/packages/smarthr-ui/src/components/Select/stories/VRTSelect.stories.tsx
+++ b/packages/smarthr-ui/src/components/Select/stories/VRTSelect.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Select } from '../Select'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/SideMenu/stories/SideMenu.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/stories/SideMenu.stories.tsx
@@ -3,7 +3,7 @@ import { SideMenu } from '../SideMenu'
 import { SideMenuGroup } from '../SideMenuGroup'
 import { SideMenuItem } from '../SideMenuItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const meta = {
   title: 'Components/SideMenu',

--- a/packages/smarthr-ui/src/components/SideMenu/stories/SideMenuGroup.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/stories/SideMenuGroup.stories.tsx
@@ -2,7 +2,7 @@ import { SideMenu } from '../SideMenu'
 import { SideMenuGroup } from '../SideMenuGroup'
 import { SideMenuItem } from '../SideMenuItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SideMenu/SideMenuGroup',

--- a/packages/smarthr-ui/src/components/SideMenu/stories/SideMenuItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/stories/SideMenuItem.stories.tsx
@@ -2,7 +2,7 @@ import { FaMessageIcon } from '../../Icon'
 import { SideMenu } from '../SideMenu'
 import { SideMenuItem } from '../SideMenuItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SideMenu/SideMenuItem',

--- a/packages/smarthr-ui/src/components/SideMenu/stories/VRTSideMenu.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideMenu/stories/VRTSideMenu.stories.tsx
@@ -2,7 +2,7 @@ import { SideMenu } from '../SideMenu'
 import { SideMenuGroup } from '../SideMenuGroup'
 import { SideMenuItem } from '../SideMenuItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SideMenu/VRT',

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNav.stories.tsx
@@ -6,7 +6,7 @@ import { StatusLabel } from '../../StatusLabel'
 import { SideNav } from '../SideNav'
 import { SideNavItemAnchor, SideNavItemButton } from '../SideNavItemButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export const _sideNavItems = [
   {

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemAnchor.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemAnchor.stories.tsx
@@ -1,7 +1,7 @@
 import { StatusLabel } from '../../StatusLabel'
 import { SideNavItemAnchor } from '../SideNavItemButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SideNav/SideNavItemAnchor',

--- a/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/SideNavItemButton.stories.tsx
@@ -1,7 +1,7 @@
 import { StatusLabel } from '../../StatusLabel'
 import { SideNavItemButton } from '../SideNavItemButton'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SideNav/SideNavItemButton',

--- a/packages/smarthr-ui/src/components/SideNav/stories/VRTSideNav.stories.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/stories/VRTSideNav.stories.tsx
@@ -6,7 +6,7 @@ import { SideNavItemAnchor, SideNavItemButton } from '../SideNavItemButton'
 
 import { _sideNavItems } from './SideNav.stories'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 const sizeCasse: Array<ComponentProps<typeof SideNav>['size']> = [undefined, 'M', 'S']
 

--- a/packages/smarthr-ui/src/components/SmartHRAILogo/stories/SmartHRAILogo.stories.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRAILogo/stories/SmartHRAILogo.stories.tsx
@@ -1,6 +1,6 @@
 import { SmartHRAILogo } from '../SmartHRAILogo'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SmartHRAILogo',

--- a/packages/smarthr-ui/src/components/SmartHRAILogo/stories/VRTSmartHRAILogo.stories.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRAILogo/stories/VRTSmartHRAILogo.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { SmartHRAILogo } from '../SmartHRAILogo'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SmartHRAILogo/VRT',

--- a/packages/smarthr-ui/src/components/SmartHRLogo/stories/SmartHrLogo.stories.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRLogo/stories/SmartHrLogo.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { SmartHRLogo } from '../SmartHRLogo'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SmartHRLogo',

--- a/packages/smarthr-ui/src/components/SmartHRLogo/stories/VRTSmartHrLogo.stories.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRLogo/stories/VRTSmartHrLogo.stories.tsx
@@ -3,7 +3,7 @@ import { SmartHRLogo } from '../SmartHRLogo'
 
 import { Fill } from './SmartHrLogo.stories'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SmartHRLogo/VRT',

--- a/packages/smarthr-ui/src/components/SpreadsheetTable/stories/SpreadsheetTable.stories.tsx
+++ b/packages/smarthr-ui/src/components/SpreadsheetTable/stories/SpreadsheetTable.stories.tsx
@@ -2,7 +2,7 @@ import { Text } from '../../Text'
 import { SpreadsheetTable } from '../SpreadsheetTable'
 import { SpreadsheetTableCorner } from '../SpreadsheetTableCorner'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SpreadsheetTable',

--- a/packages/smarthr-ui/src/components/SpreadsheetTable/stories/VRTSpreadsheetTable.stories.tsx
+++ b/packages/smarthr-ui/src/components/SpreadsheetTable/stories/VRTSpreadsheetTable.stories.tsx
@@ -1,7 +1,7 @@
 import Story, { Data } from './SpreadsheetTable.stories'
 
 import type { SpreadsheetTable } from '../SpreadsheetTable'
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/SpreadsheetTable/VRT',

--- a/packages/smarthr-ui/src/components/StatusLabel/RequiredLabel/stories/RequiredLabel.stories.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/RequiredLabel/stories/RequiredLabel.stories.tsx
@@ -1,6 +1,6 @@
 import { RequiredLabel } from '../RequiredLabel'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/StatusLabel/RequiredLabel',

--- a/packages/smarthr-ui/src/components/StatusLabel/RequiredLabel/stories/VRTStatusLabel.stories.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/RequiredLabel/stories/VRTStatusLabel.stories.tsx
@@ -1,7 +1,7 @@
 import Story from './RequiredLabel.stories'
 
 import type { RequiredLabel } from '../RequiredLabel'
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/StatusLabel/RequiredLabel/VRT',

--- a/packages/smarthr-ui/src/components/StatusLabel/stories/StatusLabel.stories.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/stories/StatusLabel.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { StatusLabel } from '../StatusLabel'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/StatusLabel',

--- a/packages/smarthr-ui/src/components/StatusLabel/stories/VRTStatusLabel.stories.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/stories/VRTStatusLabel.stories.tsx
@@ -3,7 +3,7 @@ import { Stack } from '../../Layout'
 import { Bold, Type } from './StatusLabel.stories'
 
 import type { StatusLabel } from '../StatusLabel'
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/StatusLabel/VRT',

--- a/packages/smarthr-ui/src/components/Stepper/stories/Stepper.stories.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/stories/Stepper.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Stepper } from '../Stepper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Stepper',

--- a/packages/smarthr-ui/src/components/Stepper/stories/VRTStepper.stories.tsx
+++ b/packages/smarthr-ui/src/components/Stepper/stories/VRTStepper.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Stepper } from '../Stepper'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _steps = {
   horizontal: [

--- a/packages/smarthr-ui/src/components/Switch/stories/Switch.stories.tsx
+++ b/packages/smarthr-ui/src/components/Switch/stories/Switch.stories.tsx
@@ -1,6 +1,6 @@
 import { Switch } from '../Switch'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Switch',

--- a/packages/smarthr-ui/src/components/Switch/stories/VRTSwitch.stories.tsx
+++ b/packages/smarthr-ui/src/components/Switch/stories/VRTSwitch.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Switch } from '../Switch'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/TabBar/stories/TabBar-bordered.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/TabBar-bordered.stories.tsx
@@ -1,6 +1,6 @@
 import TabBarStories from './TabBar.stories'
 
-import type { StoryObj } from '@storybook/react-webpack5'
+import type { StoryObj } from '@storybook/react-vite'
 
 export default {
   ...TabBarStories,

--- a/packages/smarthr-ui/src/components/TabBar/stories/TabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/TabBar.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { TabBar } from '../TabBar'
 import { TabItem } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/TabBar',

--- a/packages/smarthr-ui/src/components/TabBar/stories/TabItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/TabItem.stories.tsx
@@ -3,7 +3,7 @@ import { action } from 'storybook/actions'
 import { Badge } from '../../Badge'
 import { TabItem } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/TabBar/TabItem',

--- a/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
+++ b/packages/smarthr-ui/src/components/TabBar/stories/VRTTabBar.stories.tsx
@@ -7,7 +7,7 @@ import { Stack } from '../../Layout'
 import { TabBar } from '../TabBar'
 import { TabItem } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/TabBar/VRT',

--- a/packages/smarthr-ui/src/components/Table/stories/BulkActionRow.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/BulkActionRow.stories.tsx
@@ -1,7 +1,7 @@
 import { Table } from '../Table'
 import { BulkActionRow } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Table/BulkActionRow',

--- a/packages/smarthr-ui/src/components/Table/stories/EmptyTableBody.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/EmptyTableBody.stories.tsx
@@ -3,7 +3,7 @@ import { Table } from '../Table'
 import { Th } from '../Th'
 import { EmptyTableBody } from '../client'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof EmptyTableBody> = ({ children, ...rest }) => (
   <Table>

--- a/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/Table.stories.tsx
@@ -8,7 +8,7 @@ import { Th } from '../Th'
 import { WakuWakuButton } from '../WakuWakuButton'
 import { BulkActionRow, EmptyTableBody, ThCheckbox } from '../client'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof Table> = (args) => (
   <Table {...args}>

--- a/packages/smarthr-ui/src/components/Table/stories/Td.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/Td.stories.tsx
@@ -3,7 +3,7 @@ import { Table } from '../Table'
 import { Td } from '../Td'
 import { Th } from '../Th'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof Td> = (args) => (
   <Table>

--- a/packages/smarthr-ui/src/components/Table/stories/TdCheckbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/TdCheckbox.stories.tsx
@@ -2,7 +2,7 @@ import { Table } from '../Table'
 import { Td } from '../Td'
 import { TdCheckbox } from '../TdCheckbox'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof TdCheckbox> = (args) => (
   <Table>

--- a/packages/smarthr-ui/src/components/Table/stories/TdRadioButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/TdRadioButton.stories.tsx
@@ -2,7 +2,7 @@ import { Table } from '../Table'
 import { Td } from '../Td'
 import { TdRadioButton } from '../TdRadioButton'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof TdRadioButton> = (args) => (
   <Table>

--- a/packages/smarthr-ui/src/components/Table/stories/Th.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/Th.stories.tsx
@@ -5,7 +5,7 @@ import { Stack } from '../../Layout'
 import { Table } from '../Table'
 import { Th } from '../Th'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof Th> = (args) => (
   <Table>

--- a/packages/smarthr-ui/src/components/Table/stories/ThCheckbox.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/ThCheckbox.stories.tsx
@@ -1,7 +1,7 @@
 import { Table } from '../Table'
 import { ThCheckbox } from '../client'
 
-import type { Meta, StoryFn, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite'
 
 const Template: StoryFn<typeof ThCheckbox> = (args) => (
   <Table>

--- a/packages/smarthr-ui/src/components/Table/stories/VRTBulkActionRow.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/VRTBulkActionRow.stories.tsx
@@ -2,7 +2,7 @@ import { Table } from '../Table'
 import { Th } from '../Th'
 import { BulkActionRow } from '../client'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Table/BulkActionRow/VRT',

--- a/packages/smarthr-ui/src/components/Table/stories/VRTEmptyTableBody.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/VRTEmptyTableBody.stories.tsx
@@ -2,7 +2,7 @@ import { Table } from '../Table'
 import { Th } from '../Th'
 import { EmptyTableBody } from '../client'
 
-import type { Meta } from '@storybook/react-webpack5'
+import type { Meta } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Table/EmptyTableBody/VRT',

--- a/packages/smarthr-ui/src/components/Table/stories/VRTTable.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/VRTTable.stories.tsx
@@ -8,7 +8,7 @@ import { Th } from '../Th'
 import { WakuWakuButton } from '../WakuWakuButton'
 import { BulkActionRow, ThCheckbox } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Table/VRT',

--- a/packages/smarthr-ui/src/components/Table/stories/WakuWakuButton.stories.tsx
+++ b/packages/smarthr-ui/src/components/Table/stories/WakuWakuButton.stories.tsx
@@ -3,7 +3,7 @@ import { Table } from '../Table'
 import { WakuWakuButton } from '../WakuWakuButton'
 import { BulkActionRow } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 // TODO: WakuWakuButtonは非推奨のため、完全に削除するまではストーリーを残す必要があるが、削除後はこのファイルも削除すること
 export default {

--- a/packages/smarthr-ui/src/components/Text/stories/Text.stories.tsx
+++ b/packages/smarthr-ui/src/components/Text/stories/Text.stories.tsx
@@ -2,7 +2,7 @@ import { FaAddressBookIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Text } from '../Text'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const asOptions = { なし: undefined, '<p>': 'p', '<h1>': 'h1' }
 

--- a/packages/smarthr-ui/src/components/Text/stories/VRTText.stories.tsx
+++ b/packages/smarthr-ui/src/components/Text/stories/VRTText.stories.tsx
@@ -2,7 +2,7 @@ import { pictParser } from '../../../libs/pictParser'
 import { Stack } from '../../Layout'
 import { STYLE_TYPE_MAP, Text } from '../Text'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 // $ pict text.pict

--- a/packages/smarthr-ui/src/components/TextLink/HelpLink/stories/HelpLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/HelpLink/stories/HelpLink.stories.tsx
@@ -2,7 +2,7 @@ import { action } from 'storybook/actions'
 
 import { HelpLink } from '../HelpLink'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentPropsWithoutRef } from 'react'
 
 const _elementAsOptions = {

--- a/packages/smarthr-ui/src/components/TextLink/stories/TextLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/stories/TextLink.stories.tsx
@@ -5,7 +5,7 @@ import { Table, Th } from '../../Table'
 import { TextLink } from '../TextLink'
 import { UpwardLink } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentPropsWithoutRef } from 'react'
 
 const _prefixOptions = {

--- a/packages/smarthr-ui/src/components/TextLink/stories/UpwardLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/stories/UpwardLink.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { UpwardLink } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentPropsWithoutRef } from 'react'
 
 const _elementAsOptions = {

--- a/packages/smarthr-ui/src/components/TextLink/stories/VRTTextLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/stories/VRTTextLink.stories.tsx
@@ -4,7 +4,7 @@ import { FaCircleQuestionIcon, OpenInNewTabIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { TextLink } from '../TextLink'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
 /**

--- a/packages/smarthr-ui/src/components/TextLink/stories/VRTUpwardLink.stories.tsx
+++ b/packages/smarthr-ui/src/components/TextLink/stories/VRTUpwardLink.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { UpwardLink } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/TextLink/UpwardLink/VRT',

--- a/packages/smarthr-ui/src/components/Textarea/stories/Textarea.stories.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/stories/Textarea.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Textarea } from '../Textarea'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Textarea',

--- a/packages/smarthr-ui/src/components/Textarea/stories/VRTTextarea.stories.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/stories/VRTTextarea.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { Textarea } from '../Textarea'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Textarea/VRT',

--- a/packages/smarthr-ui/src/components/Timeline/stories/Timeline.stories.tsx
+++ b/packages/smarthr-ui/src/components/Timeline/stories/Timeline.stories.tsx
@@ -1,7 +1,7 @@
 import { Timeline } from '../Timeline'
 import { TimelineItem } from '../TimelineItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Timeline',

--- a/packages/smarthr-ui/src/components/Timeline/stories/TimelineItem.stories.tsx
+++ b/packages/smarthr-ui/src/components/Timeline/stories/TimelineItem.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { TimelineItem } from '../TimelineItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Timeline/TimelineItem',

--- a/packages/smarthr-ui/src/components/Timeline/stories/VRTTimeline.stories.tsx
+++ b/packages/smarthr-ui/src/components/Timeline/stories/VRTTimeline.stories.tsx
@@ -5,7 +5,7 @@ import { TextLink } from '../../TextLink'
 import { Timeline } from '../Timeline'
 import { TimelineItem } from '../TimelineItem'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Timeline/VRT',

--- a/packages/smarthr-ui/src/components/Tooltip/stories/ControlledTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/ControlledTooltip.stories.tsx
@@ -1,6 +1,6 @@
 import { ControlledTooltip } from '../ControlledTooltip'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Tooltip（Internal）/ControlledTooltip',

--- a/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/Tooltip.stories.tsx
@@ -3,7 +3,7 @@ import { FaCircleQuestionIcon, FaPencilIcon } from '../../Icon'
 import { Cluster, Stack } from '../../Layout'
 import { Tooltip } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const _messages = {
   'テキスト（sting）': 'メッセージ',

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTControlledTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTControlledTooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { Cluster } from '../../Layout'
 import { ControlledTooltip } from '../ControlledTooltip'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Tooltip（Internal）/ControlledTooltip/VRT',

--- a/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/stories/VRTTooltip.stories.tsx
@@ -5,7 +5,7 @@ import { FaCircleQuestionIcon, FaPencilIcon } from '../../Icon'
 import { Stack } from '../../Layout'
 import { Tooltip } from '../client'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/Tooltip/VRT',

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/stories/VRTVisuallyHiddenText.stories.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/stories/VRTVisuallyHiddenText.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/VisuallyHiddenText/VRT',

--- a/packages/smarthr-ui/src/components/VisuallyHiddenText/stories/VisuallyHiddenText.stories.tsx
+++ b/packages/smarthr-ui/src/components/VisuallyHiddenText/stories/VisuallyHiddenText.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '../../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const asOptions = { なし: undefined, '<p>': 'p', '<div>': 'div', '<span>': 'span' }
 

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
@@ -4,7 +4,7 @@ import { userEvent, within } from 'storybook/test'
 import { Cluster } from '../../Layout'
 import { WarekiPicker } from '../WarekiPicker'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/WarekiPicker/VRT',

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from 'storybook/test'
 
 import { WarekiPicker } from '../WarekiPicker'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Components/WarekiPicker',

--- a/packages/smarthr-ui/src/hooks/client/useSV/useSV.stories.tsx
+++ b/packages/smarthr-ui/src/hooks/client/useSV/useSV.stories.tsx
@@ -2,7 +2,7 @@ import { EnvironmentProvider } from '../useEnvironment'
 
 import { type VariantProps, defineSV, useSV } from './useSV'
 
-import type { Meta, StoryFn } from '@storybook/react-webpack5'
+import type { Meta, StoryFn } from '@storybook/react-vite'
 import type { FC } from 'react'
 
 const sv = defineSV(({ mobile }) => ({

--- a/packages/smarthr-ui/src/intl/stories/DateFormatter.stories.tsx
+++ b/packages/smarthr-ui/src/intl/stories/DateFormatter.stories.tsx
@@ -1,6 +1,6 @@
 import { DateFormatter } from '../DateFormatter'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Internal/DateFormatter',

--- a/packages/smarthr-ui/src/intl/stories/Localizer.stories.tsx
+++ b/packages/smarthr-ui/src/intl/stories/Localizer.stories.tsx
@@ -1,6 +1,6 @@
 import { Localizer } from '../Localizer'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Internal/Localizer',

--- a/packages/smarthr-ui/src/intl/stories/TimeFormatter.stories.tsx
+++ b/packages/smarthr-ui/src/intl/stories/TimeFormatter.stories.tsx
@@ -1,6 +1,6 @@
 import { TimeFormatter } from '../TimeFormatter'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {
   title: 'Internal/TimeFormatter',

--- a/packages/smarthr-ui/src/intl/stories/TimestampFormatter.stories.tsx
+++ b/packages/smarthr-ui/src/intl/stories/TimestampFormatter.stories.tsx
@@ -1,6 +1,6 @@
 import { TimestampFormatter } from '../TimestampFormatter'
 
-import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
 const testTimestamp = '2025-01-01T22:40:30+09:00' // 2025年1月1日 22:40:30
 

--- a/packages/smarthr-ui/tsconfig.json
+++ b/packages/smarthr-ui/tsconfig.json
@@ -2,10 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib",
+    "rootDir": "./src",
     "lib": ["es2022", "dom"],
     "target": "es2022",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "inlineSources": true,
     "types": ["node", "react", "vitest/globals", "@testing-library/jest-dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["/*"]
-    }
-  }
+  "compilerOptions": {}
 }


### PR DESCRIPTION
## 関連URL

- https://github.com/kufu/smarthr-ui/pull/6995

## 概要

Storybook 10への更新後も残っていた旧設定と、実際のbuilderに一致しない型importを整理します。

## 変更内容

- ContainerのVRTで使用する`vrtWide`を現行のViewport APIへ移行
- Storybook 10で無視される`isFullscreen`と`isToolshown`を削除
- Storyおよびscaffoldテンプレートの型importを`@storybook/react-webpack5`から`@storybook/react-vite`へ統一
- TypeScriptのmodule解決をbundler向けに更新し、Storybook 10の型をIDEで解決できるように変更
- 未使用かつTypeScript 6で非推奨のルート`baseUrl` / `paths`設定を削除

## プロダクト側で対応が必要な事項

なし

## 確認方法

- 旧設定と旧importが残っていないことを確認
- IDE診断で`@storybook/react-vite`の型解決エラーがないことを確認
- smarthr-uiとchartsのTypeScriptチェックが成功することを確認
- ESLintが成功することを確認
- Prettierチェックが成功することを確認
- Storybookビルドが成功することを確認