### PR TITLE
fix(DropdownMenuButton): 矢印キーでのフォーカス移動時に背後のページがスクロールする不具合を修正

### DIFF
--- a/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/packages/smarthr-ui/src/components/Dropdown/DropdownMenuButton/DropdownMenuButton.tsx
@@ -186,12 +186,14 @@ export const DropdownMenuButton: FC<Props> = ({
 
         // HINT: tabとarrow keyで挙動を揃えるため、tabもhandling対象にする
         if (e.key === 'Tab') {
-          // HINT: tbのデフォルトの挙動の場合のみ、preventDefaultが必要
           e.preventDefault()
           direction = e.shiftKey ? -1 : 1
         } else if (KEY_UP_REGEX.test(e.key)) {
+          // HINT: 矢印キーでのフォーカス移動時に背後のページがスクロールしないようにする
+          e.preventDefault()
           direction = -1
         } else if (KEY_DOWN_REGEX.test(e.key)) {
+          e.preventDefault()
           direction = 1
         }
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

ドロップダウンメニューを開いた状態で上下矢印キーによりフォーカスを移動すると、フォーカス移動と同時に背後のページがスクロールしてしまうことが分かった（hanica のヘッダーの「従業員管理」で再現）

hanica 側の実装ではなく `DropdownMenuButton` 内部のキーボードハンドリングに起因するため、smarthr-ui 側を修正する

<img width="1370" height="483" alt="image" src="https://github.com/user-attachments/assets/5f59ecaa-9388-4f9f-aa14-3e99689bb4aa" />


## 変更内容

`DropdownMenuButton.tsx` の `handleKeyDown`（`<menu role="menu">` にアタッチされている `document` レベルの keydown リスナー）を修正した。

`Tab` の分岐にのみ呼ばれていた `e.preventDefault()` を、Arrow/Left/Right の分岐にも追加した。これにより、メニュー内でのフォーカス移動時にブラウザ標準の「矢印キーでページをスクロールする」動作が発火しなくなる。

## プロダクト側で対応が必要な事項

なし。破壊的変更ではなく、プロダクト側のコード変更は不要。

## 確認方法

Storybook の `Components/Dropdown/DropdownMenuButton` ストーリーで以下を確認済み。

- メニューを開いた状態でページをスクロールし、矢印キー（↑↓）でメニュー内のフォーカスを移動しても背後のページがスクロールしないこと（`window.scrollY` が変化しないこと）
- 既存の矢印キー・Tabキーによるフォーカス移動、disabled項目のスキップなど既存動作に回帰が無いこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)