### PR TITLE
fix: eslint-plugin-smarthrが要求するtsconfig.jsonのpaths設定を復元する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "compilerOptions": {}
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
 }


### PR DESCRIPTION
## 関連URL

なし

## 概要

PR #7011（Storybook 10への移行漏れ修正）で、TypeScript 6の非推奨対応としてルートの`tsconfig.json`から`baseUrl`/`paths`設定が削除された。しかし`eslint-plugin-smarthr`（`a11y-prohibit-sectioning-content-in-form`等のルール）は、モジュールロード時にcwd直下の`tsconfig.json`の`compilerOptions.paths`の存在を必須としており、存在しないと例外を投げてESLint自体がクラッシュする設計になっている。

`packages/smarthr-ui`をcwdにしてeslintを実行する場合はそのディレクトリの`tsconfig.json`（`paths: {}`を保持）が使われるため問題にならないが、`git commit`のpre-commitフック（lint-staged）は常にリポジトリルートをcwdとして実行されるため、ルートの`tsconfig.json`を見てクラッシュし、**`.ts`/`.tsx`ファイルを含むコミットが一切できない状態**になっていた。

## 変更内容

ルートの`tsconfig.json`に`compilerOptions.paths`（`@/*`エイリアス）を復元する。ただし`baseUrl`はPR #7011の意図（TypeScript 6での非推奨対応）を尊重し復元しない。TypeScript 5.4以降は`baseUrl`なしでも`paths`が機能するため、非推奨警告を避けつつ`eslint-plugin-smarthr`の要求を満たせる。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`git commit`で`.tsx`ファイルを含むコミットが正常に完了することを確認済み。`pnpm ui lint`・`pnpm ui test`も通ることを確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **設定**
  * `@/*` 形式のパスをプロジェクトルート配下へ解決できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->