### PR TITLE
refactor(FormGroup): FormControl/FieldsetのuseEffectをcallback refに置き換える

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/Fieldset.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { type FC, type ReactNode, memo, useEffect, useId, useMemo, useRef } from 'react'
+import { type FC, type ReactNode, memo, useCallback, useId, useMemo, useRef } from 'react'
 import { tv } from 'tailwind-variants'
 
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
@@ -41,9 +42,8 @@ type LowerProps = Omit<Props, 'autoBindErrorInput'>
 
 // HINT: useAutoBindErrorInputを呼ぶ/呼ばないでコンポーネントを分けている。
 // FormGroup側で分岐すると、切り替え時にFormGroup配下のみが再マウントされ、
-// ActualFieldsetのuseEffectがsetAttributeしたaria-label・aria-describedbyが
-// 復元されなくなる。分岐を最上位に置くことで、再マウント時にそれらのuseEffectも
-// 再実行されるようにしている。
+// ActualFieldsetのcallbackRefがsetAttributeしたaria属性が復元されなくなる。
+// 分岐を最上位に置くことで、再マウント時にそのcallbackRefも再実行されるようにしている。
 export const Fieldset: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
   const Component = autoBindErrorInput ? AutoBindErrorFieldset : ActualFieldset
 
@@ -51,17 +51,23 @@ export const Fieldset: FC<Props> = ({ autoBindErrorInput = true, ...rest }) => {
 }
 
 const AutoBindErrorFieldset: FC<LowerProps> = (props) => {
-  const { wrapperRef, visibleErrorMessages, ...rest } = useFieldsetProps(props)
+  const { wrapperRef, wrapperCallbackRef, visibleErrorMessages, ...rest } = useFieldsetProps(props)
 
   useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })
 
-  return <FormGroup {...rest} wrapperRef={wrapperRef} visibleErrorMessages={visibleErrorMessages} />
+  return (
+    <FormGroup
+      {...rest}
+      wrapperRef={wrapperCallbackRef}
+      visibleErrorMessages={visibleErrorMessages}
+    />
+  )
 }
 
 const ActualFieldset: FC<LowerProps> = (props) => {
-  const actualProps = useFieldsetProps(props)
+  const { wrapperCallbackRef, ...rest } = useFieldsetProps(props)
 
-  return <FormGroup {...actualProps} />
+  return <FormGroup {...rest} wrapperRef={wrapperCallbackRef} />
 }
 
 const useFieldsetProps = ({
@@ -109,10 +115,10 @@ const useFieldsetProps = ({
 
   // HINT: Fieldset内の可視ラベルが無いinputに、legend文言をアクセシブルネームに追加する
   // https://waic.jp/translations/WCAG21/Understanding/label-in-name.html
-  useEffect(() => {
-    if (!wrapperRef.current) return
+  const callbackRef = useCallback((node: HTMLElement | null) => {
+    if (!node) return
 
-    const labelTextEl = wrapperRef.current.querySelector(LABEL_TEXT_SELECTOR)
+    const labelTextEl = node.querySelector(LABEL_TEXT_SELECTOR)
 
     if (!labelTextEl) return
 
@@ -124,9 +130,7 @@ const useFieldsetProps = ({
       const labelText = labelTextEl.textContent || ''
       if (!labelText) return
 
-      const inputs = wrapperRef.current?.querySelectorAll<HTMLInputElement>(
-        CHILDREN_WRAPPER_INPUT_SELECTOR,
-      )
+      const inputs = node.querySelectorAll<HTMLInputElement>(CHILDREN_WRAPPER_INPUT_SELECTOR)
       if (!inputs?.length) return
 
       inputs.forEach((input: HTMLInputElement) => {
@@ -165,12 +169,15 @@ const useFieldsetProps = ({
     return () => observer.disconnect()
   }, [])
 
+  const wrapperCallbackRef = useMergeRefs(callbackRef, wrapperRef)
+
   return {
     ...rest,
     ...describedByIdsRest,
     visibleErrorMessages,
     as: 'fieldset',
     wrapperRef,
+    wrapperCallbackRef,
     label: legend,
     helpMessage,
     exampleMessage,

--- a/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormControl.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { type FC, type ReactNode, memo, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { type FC, type ReactNode, memo, useCallback, useId, useMemo, useRef, useState } from 'react'
 
+import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useObjectAttributes } from '../../hooks/useObjectAttributes'
 import { Cluster } from '../Layout'
 import { VisuallyHiddenText } from '../VisuallyHiddenText'
@@ -33,17 +34,24 @@ export const FormControl: FC<Props> = ({ autoBindErrorInput = true, ...rest }) =
 }
 
 const AutoBindErrorFormControl: FC<LowerProps> = (props) => {
-  const { wrapperRef, visibleErrorMessages, ...rest } = useFormControlProps(props)
+  const { wrapperRef, wrapperCallbackRef, visibleErrorMessages, ...rest } =
+    useFormControlProps(props)
 
   useAutoBindErrorInput({ wrapperRef, visibleErrorMessages })
 
-  return <FormGroup {...rest} wrapperRef={wrapperRef} visibleErrorMessages={visibleErrorMessages} />
+  return (
+    <FormGroup
+      {...rest}
+      wrapperRef={wrapperCallbackRef}
+      visibleErrorMessages={visibleErrorMessages}
+    />
+  )
 }
 
 const ActualFormControl: FC<LowerProps> = (props) => {
-  const actualProps = useFormControlProps(props)
+  const { wrapperCallbackRef, ...rest } = useFormControlProps(props)
 
-  return <FormGroup {...actualProps} />
+  return <FormGroup {...rest} wrapperRef={wrapperCallbackRef} />
 }
 
 const useFormControlProps = ({
@@ -87,43 +95,54 @@ const useFormControlProps = ({
     supplementaryMessage,
   })
 
-  useEffect(() => {
-    if (
-      !wrapperRef.current ||
-      // HINT: 対象idを持つ要素が既に存在する場合、何もしない
-      document.getElementById(label.htmlFor)
-    ) {
-      return
-    }
-
-    const input = wrapperRef.current.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
-
-    if (!input) {
-      return
-    }
-
-    const inputId = input.getAttribute('id')
-
-    if (inputId) {
-      setChildInputId(inputId)
-    } else {
-      input.setAttribute('id', label.htmlFor)
-    }
-
-    if (input instanceof HTMLInputElement && input.type === 'file') {
-      const inputLabelledByIds = input.getAttribute('aria-labelledby')
-
-      if (inputLabelledByIds) {
-        // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
-        input.setAttribute('aria-labelledby', `${inputLabelledByIds} ${label.id}`)
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (
+        !node ||
+        // HINT: 対象idを持つ要素が既に存在する場合、何もしない
+        document.getElementById(label.htmlFor)
+      ) {
+        return
       }
-    }
-  }, [label.htmlFor, label.id])
+
+      const input = node.querySelector(CHILDREN_WRAPPER_INPUT_SELECTOR)
+
+      if (!input) {
+        return
+      }
+
+      const inputId = input.getAttribute('id')
+
+      if (inputId) {
+        setChildInputId(inputId)
+      } else {
+        input.setAttribute('id', label.htmlFor)
+      }
+
+      if (input instanceof HTMLInputElement && input.type === 'file') {
+        const inputLabelledByIds = input.getAttribute('aria-labelledby')
+
+        if (inputLabelledByIds) {
+          // InputFileの場合はlabel要素の可視ラベルをアクセシブルネームに含める
+          input.setAttribute('aria-labelledby', `${inputLabelledByIds} ${label.id}`)
+        }
+      }
+      // HINT: mount後、label.htmlFor, label.idは変化しない前提
+      // 変化させたい実装パターンが発生したら検討する
+    },
+    [label.htmlFor, label.id],
+  )
+
+  // HINT: wrapperRefはこのcustom hookで定義しているRefObjectなので
+  // 仮にcallbackRefが変化した場合の巻き込まれる形での再実行でも問題は発生しない。
+  // このコンポーネントは外部からrefを受け付けないため、問題はないが必要性が発生したら検討する
+  const wrapperCallbackRef = useMergeRefs(callbackRef, wrapperRef)
 
   return {
     ...rest,
     ...describedByIdsRest,
     wrapperRef,
+    wrapperCallbackRef,
     label,
     helpMessage,
     exampleMessage,

--- a/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
+++ b/packages/smarthr-ui/src/components/FormGroup/FormGroup.tsx
@@ -3,7 +3,7 @@ import {
   type ComponentType,
   type FC,
   type PropsWithChildren,
-  type RefObject,
+  type Ref,
   useMemo,
 } from 'react'
 
@@ -19,7 +19,7 @@ import type { useDescribedByIds } from './useDescribedByIds'
 // autoBindErrorInputによる分岐はFormControl・Fieldset側で行うため、ここでは受け取らない
 type Props = Omit<CommonProps, 'errorMessages' | 'className' | 'autoBindErrorInput'> &
   Omit<ReturnType<typeof useDescribedByIds>, 'describedbyIds'> & {
-    wrapperRef: RefObject<HTMLDivElement>
+    wrapperRef: Ref<HTMLDivElement>
     /** グループのラベル名 */
     label: Omit<ObjectLabelType, 'id' | 'htmlFor'> &
       Required<Pick<ObjectLabelType, 'id' | 'htmlFor'>>

--- a/packages/smarthr-ui/src/components/FormGroup/useAutoBindErrorInput.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/useAutoBindErrorInput.ts
@@ -8,6 +8,7 @@ import { CHILDREN_WRAPPER_INPUT_SELECTOR } from './constants'
  * HINT: このフックを呼ぶ/呼ばないでコンポーネントを分けているため、propsによる分岐は行わない。
  * 詳細な理由はFormControl・Fieldsetの分岐箇所のコメントを参照。
  */
+// TODO: FormGroup内のuseEffectを整理し、callbackRef化を進めている。このhook自体は削除できないか検討する
 export const useAutoBindErrorInput = ({
   wrapperRef,
   visibleErrorMessages,


### PR DESCRIPTION
## 関連URL

なし

## 概要

CLAUDE.mdの「useEffectではなく他の手段で可能な場合」の方針に沿い、`FormControl`・`Fieldset`でDOM要素のmount時に一度だけ実行していた`useEffect`をcallback ref化した。

## 変更内容

- `FormControl.tsx`: labelとchildren inputのid紐付け処理を`useEffect`からcallback ref化。callback ref自体を`useCallback`で`label.htmlFor`/`label.id`に依存させ、`useMergeRefs`で既存の`wrapperRef`と統合することで、値変化時にもRe-attachで追従できるようにしている
- `Fieldset.tsx`: legend文言をinputのアクセシブルネームに追加する処理を`useEffect`からcallback ref化。MutationObserverのcleanup(`observer.disconnect`)は`useMergeRefs`経由でReact18/19互換の仕組みに乗るため、そのまま動作する
- `FormGroup.tsx`: `wrapperRef`propの型を`RefObject<HTMLDivElement>`から`Ref<HTMLDivElement>`に変更し、callback refを受け取れるようにした
- `useAutoBindErrorInput.ts`: 今後の整理方針をTODOコメントとして追記

DOM構造・公開propsに変更はない。

## プロダクト側で対応が必要な事項

なし

## 確認方法

`pnpm ui test -- --run src/components/FormGroup` で既存テストが全て通ることを確認済み。Storybookでの表示・aria属性の付与状況にも変化がないことを目視確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * フォーム項目の入力要素とエラーメッセージの関連付けを改善しました。
  * フィールドセットや入力項目が再表示・再マウントされた場合も、アクセシビリティ属性が正しく設定されるようになりました。
  * ファイル入力を含むフォームで、ラベルやエラーメッセージが適切に読み上げられるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->