### PR TITLE
refactor: TableReelのResizeObserver後処理とFileViewerのref管理を整理する

### DIFF
--- a/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
+++ b/packages/smarthr-ui/src/components/FileViewer/FileViewer.tsx
@@ -8,12 +8,11 @@ import {
   type PropsWithChildren,
   type ReactNode,
   memo,
-  useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 
+import { useLayoutEffectRef } from '../../hooks/client/useLayoutEffectRef'
 import { useLatest } from '../../hooks/useLatest'
 import { Localizer } from '../../intl'
 import { Button } from '../Button'
@@ -238,28 +237,30 @@ const ActualFileViewer: FC<
     }
   >
 > = ({ scale, loaded, hasWidth, setWidth, scaleSteps, functions, searchController, children }) => {
-  const ref = useRef<HTMLDivElement>(null)
   const loading = children && !loaded
 
-  useEffect(() => {
-    if (!ref.current || hasWidth) {
-      return
-    }
+  const layoutEffectRef = useLayoutEffectRef(
+    (node: HTMLElement | null) => {
+      if (!node || hasWidth) {
+        return
+      }
 
-    const resizeObserver = new ResizeObserver(() => {
-      setWidth((ref.current?.clientWidth ?? 0) - 64)
-    })
+      const resizeObserver = new ResizeObserver(() => {
+        setWidth((node.clientWidth ?? 0) - 64)
+      })
 
-    resizeObserver.observe(ref.current)
+      resizeObserver.observe(node)
 
-    return () => {
-      resizeObserver.disconnect()
-    }
-  }, [hasWidth, setWidth])
+      return () => {
+        resizeObserver.disconnect()
+      }
+    },
+    [hasWidth, setWidth],
+  )
 
   return (
     <Scroller
-      ref={ref}
+      ref={layoutEffectRef}
       direction="both"
       className="shr-flex shr-h-full shr-w-full shr-flex-col shr-gap-2 shr-bg-scrim shr-bg-[radial-gradient(theme(textColor.black)_1px,_transparent_0)] shr-bg-[length:16px_16px]"
     >

--- a/packages/smarthr-ui/src/components/Table/client/TableReel.tsx
+++ b/packages/smarthr-ui/src/components/Table/client/TableReel.tsx
@@ -128,7 +128,7 @@ export const TableReel: FC<Props> = ({ className, children, fixedHead, ...rest }
 
         return () => {
           node.removeEventListener('scroll', scheduleHandleScroll)
-          resizeObserver.unobserve(node)
+          resizeObserver.disconnect()
           mutationObserver.disconnect()
           cellObserver.disconnect()
           frame.cancel()


### PR DESCRIPTION
## 関連URL

なし

## 概要

TableReelのResizeObserver破棄処理と、FileViewerのDOM要素監視処理を整理する。

## 変更内容

- `TableReel.tsx`: cleanup時の `resizeObserver.unobserve(node)` を `disconnect()` に変更。このresizeObserverはnode専用インスタンスのため実質的な差分はないが、他の2つのobserver（mutationObserver, cellObserver）と表記を統一した
- `FileViewer.tsx`: `ActualFileViewer` 内の幅監視処理を `useRef` + `useEffect` から `useLayoutEffectRef` に置き換え。DOM要素のmount/unmountに連動する処理のため、callback ref化の方針に沿う形にした

## プロダクト側で対応が必要な事項

なし。いずれも内部実装の変更で、公開コンポーネント（TableReel/FileViewer）のprops・DOM出力に変更はない。

## 確認方法

- `pnpm ui test -- --run src/components/Table` `pnpm ui test -- --run src/components/FileViewer` で既存テストが全てパスすることを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ファイルビューアーのサイズ監視処理を整理し、表示レイアウトの安定性を維持しました。
  - テーブルの表示終了時にサイズ監視を適切に解除するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->