### PR TITLE
refactor(Dialog)!: onClickClose/onPressEscapeのイベント型を統一する

### DIFF
--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialog.test.tsx
@@ -52,4 +52,50 @@ describe('ControlledActionDialog', () => {
     // ダイアログを閉じた後、トリガがフォーカスされることを確認
     expect(screen.getByRole('button', { name: 'ControlledActionDialog' })).toHaveFocus()
   })
+
+  it('閉じるボタンのクリックでonClickCloseに実際のMouseEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ControlledActionDialog
+          isOpen
+          onClickClose={handleClickClose}
+          onClickAction={(_, { close }) => close()}
+          heading="ControlledActionDialog"
+          actionButton="保存"
+        >
+          <p>本文</p>
+        </ControlledActionDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    expect(handleClickClose.mock.calls[0][0].nativeEvent).toBeInstanceOf(MouseEvent)
+  })
+
+  it('Escapeキー押下でonClickCloseに実際のKeyboardEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ControlledActionDialog
+          isOpen
+          onClickClose={handleClickClose}
+          onClickAction={(_, { close }) => close()}
+          heading="ControlledActionDialog"
+          actionButton="保存"
+        >
+          <p>本文</p>
+        </ControlledActionDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    const receivedEvent = handleClickClose.mock.calls[0][0]
+    expect(receivedEvent).toBeInstanceOf(KeyboardEvent)
+    expect(receivedEvent.key).toBe('Escape')
+  })
 })

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ActionDialogContentInner.tsx
@@ -59,7 +59,7 @@ export type BaseProps = PropsWithChildren<
 >
 
 export type ActionDialogContentInnerProps = BaseProps & {
-  handleClickClose: () => void
+  handleClickClose: (e?: MouseEvent<HTMLButtonElement>) => void
   responseStatus?: ResponseStatus
 }
 

--- a/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ControlledActionDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledActionDialog/ControlledActionDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ComponentProps, type FC, type ReactNode, useMemo } from 'react'
+import { type ComponentProps, type FC, type MouseEvent, type ReactNode, useMemo } from 'react'
 
 import { useLatest } from '../../../hooks/useLatest'
 import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
@@ -36,7 +36,7 @@ type BaseProps = Omit<
     /**
      * 閉じるボタンをクリックした時に発火するコールバック関数
      */
-    onClickClose: () => void
+    onClickClose: (e?: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void
   }
 type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
@@ -81,9 +81,9 @@ export const ControlledActionDialog: FC<Props> = ({
 
   const functions = useMemo(
     () => ({
-      handleClickClose: () => {
+      handleClickClose: (e?: MouseEvent<HTMLButtonElement>) => {
         if (latest.isOpen) {
-          latest.onClickClose()
+          latest.onClickClose(e)
         }
       },
       handleClickAction: (e: React.MouseEvent<Element>, helpers: ActionDialogHelpers) => {

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/ControlledFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/ControlledFormDialog.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { type ComponentProps, type FC, type FormEvent, type ReactNode, useMemo } from 'react'
+import {
+  type ComponentProps,
+  type FC,
+  type FormEvent,
+  type MouseEvent,
+  type ReactNode,
+  useMemo,
+} from 'react'
 
 import { useLatest } from '../../../hooks/useLatest'
 import { useObjectAttributes } from '../../../hooks/useObjectAttributes'
@@ -36,7 +43,7 @@ type BaseProps = Omit<
     /**
      * 閉じるボタンをクリックした時に発火するコールバック関数
      */
-    onClickClose: () => void
+    onClickClose: (e?: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void
   }
 type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
@@ -80,9 +87,9 @@ export const ControlledFormDialog: FC<Props> = ({
   const latest = useLatest({ onClickClose, onSubmit, isOpen })
 
   const functions = useMemo(() => {
-    const handleClickClose = () => {
+    const handleClickClose = (e?: MouseEvent<HTMLButtonElement>) => {
       if (latest.isOpen) {
-        latest.onClickClose()
+        latest.onClickClose(e)
       }
     }
 

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialog.test.tsx
@@ -117,4 +117,50 @@ describe('ControlledFormDialog', () => {
     // ダイアログを閉じた後、トリガがフォーカスされることを確認
     expect(screen.getByRole('button', { name: '開いた状態で DOM に投入' })).toHaveFocus()
   })
+
+  it('閉じるボタンのクリックでonClickCloseに実際のMouseEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ControlledFormDialog
+          isOpen
+          actionText="保存"
+          onSubmit={(_, { close }) => close()}
+          onClickClose={handleClickClose}
+          heading="ControlledFormDialog"
+        >
+          ダイアログの中身です
+        </ControlledFormDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    expect(handleClickClose.mock.calls[0][0].nativeEvent).toBeInstanceOf(MouseEvent)
+  })
+
+  it('Escapeキー押下でonClickCloseに実際のKeyboardEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ControlledFormDialog
+          isOpen
+          actionText="保存"
+          onSubmit={(_, { close }) => close()}
+          onClickClose={handleClickClose}
+          heading="ControlledFormDialog"
+        >
+          ダイアログの中身です
+        </ControlledFormDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    const receivedEvent = handleClickClose.mock.calls[0][0]
+    expect(receivedEvent).toBeInstanceOf(KeyboardEvent)
+    expect(receivedEvent.key).toBe('Escape')
+  })
 })

--- a/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledFormDialog/FormDialogContentInner.tsx
@@ -1,4 +1,11 @@
-import { type FC, type FormEvent, type PropsWithChildren, type ReactNode, memo } from 'react'
+import {
+  type FC,
+  type FormEvent,
+  type MouseEvent,
+  type PropsWithChildren,
+  type ReactNode,
+  memo,
+} from 'react'
 import { tv } from 'tailwind-variants'
 
 import { type ResponseStatus, useResponseStatus } from '../../../hooks/useResponseStatus'
@@ -50,7 +57,7 @@ export type BaseProps = PropsWithChildren<
 >
 
 export type FormDialogContentInnerProps = BaseProps & {
-  handleClickClose: () => void
+  handleClickClose: (e?: MouseEvent<HTMLButtonElement>) => void
   responseStatus?: ResponseStatus
 }
 

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/ControlledMessageDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/ControlledMessageDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ComponentProps, type FC, type ReactNode, useMemo } from 'react'
+import { type ComponentProps, type FC, type MouseEvent, type ReactNode, useMemo } from 'react'
 
 import { useLatest } from '../../../hooks/useLatest'
 import { DialogContentInner } from '../DialogContentInner'
@@ -20,7 +20,7 @@ type HeadingType = ReactNode | ObjectHeadingType
 type BaseProps = Omit<MessageDialogContentInnerProps, 'heading' | 'handleClickClose'> &
   DialogProps & {
     heading: HeadingType
-    onClickClose: MessageDialogContentInnerProps['handleClickClose']
+    onClickClose: (e?: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void
   }
 type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
@@ -53,9 +53,9 @@ export const ControlledMessageDialog: FC<Props> = ({
 
   const functions = useMemo(
     () => ({
-      handleClickClose: () => {
+      handleClickClose: (e: MouseEvent<HTMLButtonElement>) => {
         if (latest.isOpen) {
-          latest.onClickClose()
+          latest.onClickClose(e)
         }
       },
     }),

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialog.test.tsx
@@ -48,4 +48,46 @@ describe('ControlledMessageDialog', () => {
     // ダイアログを閉じた後、トリガがフォーカスされることを確認
     expect(screen.getByRole('button', { name: 'ControlledMessageDialog' })).toHaveFocus()
   })
+
+  it('閉じるボタンのクリックでonClickCloseに実際のMouseEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ControlledMessageDialog
+          isOpen
+          onClickClose={handleClickClose}
+          heading="ControlledMessageDialog"
+        >
+          <p>説明です</p>
+        </ControlledMessageDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: '閉じる' }))
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    expect(handleClickClose.mock.calls[0][0].nativeEvent).toBeInstanceOf(MouseEvent)
+  })
+
+  it('Escapeキー押下でonClickCloseに実際のKeyboardEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ControlledMessageDialog
+          isOpen
+          onClickClose={handleClickClose}
+          heading="ControlledMessageDialog"
+        >
+          <p>説明です</p>
+        </ControlledMessageDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    const receivedEvent = handleClickClose.mock.calls[0][0]
+    expect(receivedEvent).toBeInstanceOf(KeyboardEvent)
+    expect(receivedEvent.key).toBe('Escape')
+  })
 })

--- a/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledMessageDialog/MessageDialogContentInner.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, memo } from 'react'
+import { type FC, type MouseEvent, type ReactNode, memo } from 'react'
 
 import { Localizer } from '../../../intl'
 import { Button } from '../../Button'
@@ -18,7 +18,7 @@ export type BaseProps = DialogBodyProps & {
 }
 
 export type MessageDialogContentInnerProps = BaseProps & {
-  handleClickClose: () => void
+  handleClickClose: (e: MouseEvent<HTMLButtonElement>) => void
 }
 
 const CLASS_NAMES = (() => {

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/ControlledStepFormDialog.tsx
@@ -4,6 +4,7 @@ import {
   type ComponentProps,
   type FC,
   type FormEvent,
+  type MouseEvent,
   type ReactNode,
   useContext,
   useMemo,
@@ -49,7 +50,7 @@ type BaseProps = Omit<
     closeButton?: ButtonArgType | ObjectButtonType
     backButton?: ButtonArgType | ObjectButtonType
     onSubmit: BaseStepFormDialogContentInnerProps['handleSubmit']
-    onClickClose: () => void
+    onClickClose: (e?: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void
     onClickBack?: () => void
   }
 type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
@@ -203,10 +204,10 @@ const ActualControlledStepFormDialog: FC<Omit<Props, 'portalParent'>> = ({
 
   const functions = useMemo(
     () => ({
-      handleClickClose: () => {
+      handleClickClose: (e?: MouseEvent<HTMLButtonElement>) => {
         if (latest.isOpen) {
           focusTrapRef.current?.focus()
-          latest.onClickClose()
+          latest.onClickClose(e)
         }
       },
       handleSubmit: (e: FormEvent<HTMLFormElement>, helpers: Parameters<typeof onSubmit>[1]) => {

--- a/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ControlledStepFormDialog/StepFormDialogContentInner.tsx
@@ -3,6 +3,7 @@
 import {
   type FC,
   type FormEvent,
+  type MouseEvent,
   type PropsWithChildren,
   type ReactNode,
   memo,
@@ -56,7 +57,7 @@ export type BaseProps = PropsWithChildren<
 
 export type StepFormDialogContentInnerProps = BaseProps & {
   firstStep: StepItem
-  handleClickClose: () => void
+  handleClickClose: (e?: MouseEvent<HTMLButtonElement>) => void
   responseStatus?: ResponseStatus
   /** ステップの総数 */
   stepLength: number
@@ -110,8 +111,8 @@ export const StepFormDialogContentInner: FC<StepFormDialogContentInnerProps> = (
   })
 
   const functions = useMemo(() => {
-    const handleCloseAction = () => {
-      latest.handleClickClose()
+    const handleCloseAction = (e?: MouseEvent<HTMLButtonElement>) => {
+      latest.handleClickClose(e)
       setTimeout(() => {
         // HINT: ダイアログが閉じるtransitionが完了してから初期化をしている
         latest.stepQueueRef.current = []
@@ -233,7 +234,7 @@ const BackButton = memo<{
 ))
 
 const CloseButton = memo<{
-  handleClick: () => void
+  handleClick: (e: MouseEvent<HTMLButtonElement>) => void
   variant: CommonButtonType['theme']
   disabled: boolean
   text: ReactNode

--- a/packages/smarthr-ui/src/components/Dialog/Dialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/Dialog.test.tsx
@@ -197,4 +197,33 @@ describe('Dialog', () => {
       screen.getByRole('textbox', { name: '特定の要素をフォーカスするダイアログのInput' }),
     ).toHaveFocus()
   })
+
+  it('Escapeキー押下時、onPressEscapeに実際のKeyboardEventが渡されること', async () => {
+    const handlePressEscape = vi.fn()
+    const DialogTemplateWithPressEscape: FC = () => {
+      const [isOpen, setIsOpen] = useState<boolean>(true)
+      return (
+        <Dialog
+          isOpen={isOpen}
+          ariaLabel="Escapeイベント検証ダイアログ"
+          onPressEscape={(e) => {
+            handlePressEscape(e)
+            setIsOpen(false)
+          }}
+        >
+          <p>本文</p>
+        </Dialog>
+      )
+    }
+    renderWithIntl(<DialogTemplateWithPressEscape />)
+
+    expect(screen.getByRole('dialog', { name: 'Escapeイベント検証ダイアログ' })).toBeVisible()
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(handlePressEscape).toHaveBeenCalledTimes(1)
+    const receivedEvent = handlePressEscape.mock.calls[0][0]
+    expect(receivedEvent).toBeInstanceOf(KeyboardEvent)
+    expect(receivedEvent.key).toBe('Escape')
+  })
 })

--- a/packages/smarthr-ui/src/components/Dialog/DialogContentInner.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/DialogContentInner.tsx
@@ -30,7 +30,7 @@ export type DialogContentInnerProps = PropsWithChildren<{
    * エスケープキーを押下した時に発火するコールバック関数
    * @todo イベントハンドラー命名規則に従い handlePressEscape に変更すべき（影響範囲大のため別PR）
    */
-  onPressEscape?: () => void
+  onPressEscape?: (e: KeyboardEvent) => void
   /**
    * ダイアログを開いているかどうか
    */
@@ -122,9 +122,9 @@ export const DialogContentInner: FC<Props> = ({
 
   const functions = useMemo(
     () => ({
-      handlePressEscape: () => {
+      handlePressEscape: (e: KeyboardEvent) => {
         if (latest.isOpen) {
-          latest.onPressEscape?.()
+          latest.onPressEscape?.(e)
         }
       },
       handleClickOverlay: () => {

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.test.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.test.tsx
@@ -50,4 +50,43 @@ describe('ModelessDialog', () => {
       { timeout: 1000 },
     )
   })
+
+  it('閉じるボタンのクリックでonClickCloseに実際のMouseEventが渡されること', async () => {
+    const handleClickClose = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ModelessDialog isOpen onClickClose={handleClickClose} heading="座標指定表示">
+          <p>ダイアログの中身</p>
+        </ModelessDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: '閉じる' }))
+
+    expect(handleClickClose).toHaveBeenCalledTimes(1)
+    expect(handleClickClose.mock.calls[0][0].nativeEvent).toBeInstanceOf(MouseEvent)
+  })
+
+  it('Escapeキー押下でonPressEscapeに実際のKeyboardEventが渡されること', async () => {
+    const handlePressEscape = vi.fn()
+    render(
+      <IntlProvider locale="ja">
+        <ModelessDialog
+          isOpen
+          onClickClose={() => {}}
+          onPressEscape={handlePressEscape}
+          heading="座標指定表示"
+        >
+          <p>ダイアログの中身</p>
+        </ModelessDialog>
+      </IntlProvider>,
+    )
+
+    await userEvent.keyboard('{Escape}')
+
+    expect(handlePressEscape).toHaveBeenCalledTimes(1)
+    const receivedEvent = handlePressEscape.mock.calls[0][0]
+    expect(receivedEvent).toBeInstanceOf(KeyboardEvent)
+    expect(receivedEvent.key).toBe('Escape')
+  })
 })

--- a/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
+++ b/packages/smarthr-ui/src/components/Dialog/ModelessDialog/ModelessDialog.tsx
@@ -2,9 +2,9 @@
 
 import {
   type FC,
-  type KeyboardEvent,
   type MouseEvent,
   type PropsWithChildren,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
   type RefObject,
   type SetStateAction,
@@ -51,11 +51,11 @@ type BaseProps = PropsWithChildren<{
   /**
    * 閉じるボタンを押下したときのハンドラ
    */
-  onClickClose?: (e: MouseEvent<HTMLButtonElement>) => void
+  onClickClose?: (e?: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void
   /**
    * ダイアログが開いている状態で Escape キーを押下したときのハンドラ
    */
-  onPressEscape?: () => void
+  onPressEscape?: (e: KeyboardEvent) => void
   /**
    * @deprecated ダイアログの幅を指定する場合は、`width` ではなく `size` を使用してください。
    * ダイアログの幅
@@ -256,7 +256,7 @@ export const ModelessDialog: FC<Props> = ({
         debounceLiveRegionText.cancel()
       },
       setActualPosition,
-      handleArrowKeyDown: (e: KeyboardEvent) => {
+      handleArrowKeyDown: (e: ReactKeyboardEvent) => {
         if (!latest.isOpen || document.activeElement !== e.currentTarget) {
           return
         }
@@ -298,9 +298,9 @@ export const ModelessDialog: FC<Props> = ({
         lastFocusElementRef.current?.focus()
         latest.onClickClose?.(e)
       },
-      handlePressEscape: () => {
+      handlePressEscape: (e: KeyboardEvent) => {
         lastFocusElementRef.current?.focus()
-        latest.onPressEscape?.()
+        latest.onPressEscape?.(e)
       },
       handleDragStart: (_: any, data: { x: number; y: number }) => setActualPosition(data),
       handleDrag: (_: any, data: { deltaX: number; deltaY: number }) => {
@@ -480,7 +480,7 @@ export const ModelessDialog: FC<Props> = ({
 
 const Handler = memo<{
   className: string
-  handleArrowKeyDown: (e: KeyboardEvent) => void
+  handleArrowKeyDown: (e: ReactKeyboardEvent) => void
 }>(({ handleArrowKeyDown, ...rest }) => {
   const { localize } = useIntl()
 

--- a/packages/smarthr-ui/src/hooks/client/useEscapeCallbackRef.ts
+++ b/packages/smarthr-ui/src/hooks/client/useEscapeCallbackRef.ts
@@ -7,12 +7,12 @@ import { useCallbackRefCleanupForReact18 } from './useCallbackRefCleanupForReact
 // Esc is a IE/Edge specific value
 const ESCAPE_KEY_REGEX = /^Esc(ape)?$/
 
-export const useEscapeCallbackRef = (memoizedCallback: () => void) =>
+export const useEscapeCallbackRef = (memoizedCallback: (e: KeyboardEvent) => void) =>
   useCallbackRefCleanupForReact18(
     useCallback(() => {
       const handleKeyPress = (e: KeyboardEvent) => {
         if (ESCAPE_KEY_REGEX.test(e.key)) {
-          memoizedCallback()
+          memoizedCallback(e)
         }
       }
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

Dialog系コンポーネント（`ControlledMessageDialog` / `ControlledActionDialog` / `ControlledFormDialog` / `ControlledStepFormDialog` / `ModelessDialog`）の「閉じる」イベント（`onClickClose` / `onPressEscape`）の型・実装がコンポーネントごとに不統一だった。

- `useEscapeCallbackRef`（Escapeキー検知の共通hook）が実際の `KeyboardEvent` を握りつぶし、コールバックを引数なしで呼んでいた
- `ControlledMessageDialog` はMouseEventを渡せるが、Escape経由では `undefined` になっていた
- `ControlledActionDialog` / `ControlledFormDialog` / `ControlledStepFormDialog` の `onClickClose` はそもそも一切イベントを渡していなかった
- `ModelessDialog` の `onClickClose` は `MouseEvent` 必須で、Escapeキーとは無関係だった

この不統一を解消し、クリック・Escapeどちらの経路でも実際に発生したイベント（`MouseEvent` または `KeyboardEvent`）をコールバックに正しく伝えられるようにする。

## 変更内容

- `useEscapeCallbackRef` が実際の `KeyboardEvent` をコールバックに渡すよう変更
- 対象5コンポーネントすべてで `onClickClose` の型を `(e?: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void` に統一
- 対象5コンポーネントすべてで `onPressEscape` の型を `(e: KeyboardEvent) => void` に統一
- `ControlledActionDialog` / `ControlledFormDialog` / `ControlledStepFormDialog` の実装を変更し、物理クリック時は実際の `MouseEvent` を、Escapeキー押下時（`onPressEscape` 未指定時のデフォルトフォールバック経由）は実際の `KeyboardEvent` を `onClickClose` に転送するようにした
- Escapeキー押下時の「呼ばれる/呼ばれない」という既定の挙動自体は変更していない（`ModelessDialog` のモバイル表示で「Escapeでは閉じない」仕様も現状維持）
- アクションボタン・フォーム送信成功時などに利用者が手動でダイアログを閉じるための `helpers.close()`（`ActionDialogHelpers.close` 等）は従来通り引数なしで呼び出せる

### 変更例

```tsx
// Before: onClickCloseの引数にMouseEvent固有プロパティが渡ることを前提にしていた場合
<ControlledActionDialog
  onClickClose={() => {
    setIsOpen(false)
  }}
  ...
/>

// After: MouseEvent | KeyboardEvent | undefined のunion型になる
<ControlledActionDialog
  onClickClose={(e) => {
    // eはMouseEvent、KeyboardEvent、またはundefined（helpers.close()経由の場合）
    setIsOpen(false)
  }}
  ...
/>
```

## プロダクト側で対応が必要な事項

`onClickClose` のコールバック引数の型が変わる（破壊的変更）。

- `onClickClose` のコールバック引数に `MouseEvent<HTMLButtonElement>` 型を明示的に注釈していた場合、`MouseEvent<HTMLButtonElement> | KeyboardEvent | undefined` に書き換える必要がある
- 引数の `MouseEvent` 固有プロパティ（`clientX` など）に型ガード無しでアクセスしていた場合、`KeyboardEvent` や `undefined` の可能性を考慮した型ガードの追加が必要になる
- 単に `onClickClose={() => setIsOpen(false)}` のように引数を使わずに閉じているだけの実装は影響を受けない

## 確認方法

- `pnpm ui test -- --run src/components/Dialog` で既存テストおよび新規追加テスト（クリック/Escapeそれぞれで実際のイベントが伝播することを検証）が通ることを確認済み
- `tsc --noEmit` でリポジトリ全体に型エラーがないことを確認済み（`RemoteDialogTrigger` 配下は別パターン `(close: () => void) => void` のため無影響）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - ダイアログの閉じる操作で、クリックや Escape キーの実際のイベント情報をコールバックで受け取れるようになりました。
  - Escape キー操作時に、キー情報を含むキーボードイベントを取得できます。

- **テスト**
  - 各種ダイアログで、クリックおよび Escape キー操作時のイベント 전달を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->