### PR TITLE
refactor(Header): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Header/Header.tsx
+++ b/packages/smarthr-ui/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import {
   memo,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../hooks/useLatest'
 import { Button } from '../Button'
@@ -69,8 +69,8 @@ type BaseProps = PropsWithChildren<{
   onTenantSelect?: (id: string) => void
   /** @deprecated internal-ui から利用するので使わないでください。 */
   enableNew?: boolean
-}> &
-  VariantProps<typeof classNameGenerator>
+}>
+
 type Props = BaseProps & Omit<ComponentProps<'header'>, keyof BaseProps>
 
 const COMMON_GAP = { column: 0.25, row: 0 } as const


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901 等）の一環。`Header` コンポーネントに対応する。

## 変更内容

`Header.tsx` の `Props` 型から `VariantProps<typeof classNameGenerator>` を削除した。`classNameGenerator` の variants は `enableNew` のみで、`BaseProps` に既に `enableNew?: boolean` という明示的な型定義があったため、`VariantProps<typeof classNameGenerator>` は実質的に重複していた型だった。削除しても型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`Header` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Header` コンポーネントにはテストファイルが存在しないため、Storybook（`Header.stories.tsx` / `VRTHeader.stories.tsx`）での表示確認で問題ないことを確認できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ヘッダーコンポーネントの公開プロパティ型を整理し、不要なバリアント型の指定を削除しました。
  * `enableNew` など既存のプロパティは引き続き利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->