### PR TITLE
refactor(LanguageSwitcher): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/packages/smarthr-ui/src/components/Header/LanguageSwitcher/LanguageSwitcher.tsx
@@ -9,7 +9,7 @@ import {
   memo,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { useLatest } from '../../../hooks/useLatest'
 import { Localizer, useAvailableLocales } from '../../../intl'
@@ -27,7 +27,9 @@ export type BaseProps = {
   defaultLocale?: string
   /** 言語切替UIで言語を選択した時に発火するコールバック関数 */
   onLanguageSelect?: (code: string) => void
-} & VariantProps<typeof classNameGenerator>
+  invert?: boolean
+  enableNew?: boolean
+}
 
 type Props = BaseProps & Omit<HTMLAttributes<HTMLElement>, keyof BaseProps>
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042 等）の一環。`LanguageSwitcher` コンポーネントに対応する。

## 変更内容

`LanguageSwitcher.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`invert` / `enableNew`）に対応する明示的な型定義（`invert?: boolean` / `enableNew?: boolean`）に置き換えた。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`LanguageSwitcher` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `LanguageSwitcher` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 言語切り替え機能で利用できるオプションを明示し、`invert` と `enableNew` を設定できるようにしました。
  - 公開プロパティの型定義を整理し、設定時の補完や型チェックを分かりやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->