### PR TITLE
refactor(Scroller): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/Scroller.tsx
@@ -8,16 +8,16 @@ import {
   useCallback,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { useMergeRefs } from '../../hooks/client/useMergeRefs'
 import { useSectionWrapper } from '../SectioningContent'
 
-type BaseProps = PropsWithChildren<
-  VariantProps<typeof classNameGenerator> & {
-    as?: string | ComponentType<any>
-  }
->
+type BaseProps = PropsWithChildren<{
+  as?: string | ComponentType<any>
+  direction?: 'horizontal' | 'vertical' | 'both'
+  styleType?: 'auto' | 'scroll'
+}>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps | 'tabIndex'>
 
 const classNameGenerator = tv({
@@ -27,11 +27,11 @@ const classNameGenerator = tv({
       horizontal: '',
       vertical: '',
       both: '',
-    },
+    } satisfies Record<NonNullable<Props['direction']>, string>,
     styleType: {
       auto: '',
       scroll: '',
-    },
+    } satisfies Record<NonNullable<Props['styleType']>, string>,
   },
   compoundVariants: [
     {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042、#7043 等）の一環。`Scroller` コンポーネントに対応する。

## 変更内容

`Scroller.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`direction` / `styleType`）に対応する明示的な型定義に置き換えた。あわせて、`classNameGenerator` の `variants` オブジェクト側にも `satisfies Record<NonNullable<Props['direction']>, string>` のような制約を追加し、型と variants の各キーが一致することを担保する。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`Scroller` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Scroller` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Scrollerコンポーネントの`as`、`direction`、`styleType`プロパティの型定義を明確化しました。
  * 各バリエーションの指定値に対する型の整合性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->