### PR TITLE
refactor(ControlledTooltip): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Tooltip/ControlledTooltip.tsx
+++ b/packages/smarthr-ui/src/components/Tooltip/ControlledTooltip.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, type PropsWithChildren, memo, useMemo } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 // HINT: trianble部分はRetinaディスプレイなどで途切れてしまう場合があるので
 // 1pxほど大きめに描画してbody部分と被るようにしています。
@@ -39,7 +39,7 @@ const classNameGenerator = tv({
       ],
       right: '',
       left: '',
-    },
+    } satisfies Record<NonNullable<Props['horizontal']>, string | string[]>,
     vertical: {
       top: [
         'before:-shr-top-[5px]',
@@ -67,7 +67,7 @@ const classNameGenerator = tv({
         'after:shr-top-1/2',
         'after:-shr-translate-y-[5px]',
       ],
-    },
+    } satisfies Record<NonNullable<Props['vertical']>, string | string[]>,
     triggerIcon: {
       true: '',
     },
@@ -126,12 +126,13 @@ const classNameGenerator = tv({
   ],
 })
 
-type BaseProps = PropsWithChildren<
-  VariantProps<typeof classNameGenerator> & {
-    /** レンダリングするタグ */
-    as?: 'div' | 'span'
-  }
->
+type BaseProps = PropsWithChildren<{
+  /** レンダリングするタグ */
+  as?: 'div' | 'span'
+  horizontal?: 'center' | 'right' | 'left'
+  vertical?: 'top' | 'bottom' | 'middle'
+  triggerIcon?: boolean
+}>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'div'>, keyof BaseProps>
 
 export const ControlledTooltip = memo<Props>(


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7045 等）の一環。`ControlledTooltip`（公開名 `Balloon`）コンポーネントに対応する。

## 変更内容

`ControlledTooltip.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`horizontal` / `vertical` / `triggerIcon`）に対応する明示的な型定義に置き換えた。

`horizontal` / `vertical` は `satisfies Record<NonNullable<Props['xxx']>, string | string[]>` で variants の各キーが型と一致することを担保する。`triggerIcon` は `boolean` 型で `Record` のキー制約（`string | number | symbol`）を満たさないため、`satisfies` は付与していない。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`ControlledTooltip`（`Balloon`）の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `pnpm ui test -- --run src/components/Tooltip` で既存テストが通ることを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタリング**
  - ツールチップのバリアント設定における型定義を整理し、各設定値の検証をより明確化しました。
  - ツールチップの表示や操作方法に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->