### PR TITLE
refactor(SideNav): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
+++ b/packages/smarthr-ui/src/components/SideNav/SideNav.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, type FC, type PropsWithChildren, useMemo } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import type { SideNavSizeType } from './SideNavItemButton'
 
@@ -8,8 +8,8 @@ type BaseProps = PropsWithChildren<{
   size?: SideNavSizeType
   /** コンポーネントに適用するクラス名 */
   className?: string
-}> &
-  VariantProps<typeof classNameGenerator>
+  rounded?: boolean | 'all' | 'top' | 'right' | 'bottom' | 'left'
+}>
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'ul'>, keyof BaseProps>
 
 const ROUNDED = {
@@ -30,7 +30,7 @@ const classNameGenerator = tv({
       right: ['shr-rounded-r-l', ROUNDED.t_r, ROUNDED.b_r],
       bottom: ['shr-rounded-b-l', ROUNDED.b_l, ROUNDED.b_r],
       left: ['shr-rounded-l-l', ROUNDED.t_l, ROUNDED.b_l],
-    },
+    } satisfies Record<Exclude<NonNullable<Props['rounded']>, boolean> | 'true', string[]>,
   },
   defaultVariants: {
     rounded: false,


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7046 等）の一環。`SideNav` コンポーネントに対応する。

## 変更内容

`SideNav.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`rounded`）に対応する明示的な型定義（`rounded?: boolean | 'all' | 'top' | 'right' | 'bottom' | 'left'`）に置き換えた。`rounded` は `boolean` を含む複合型で `Record` のキー制約（`string | number | symbol`）を満たさないため、`satisfies` は付与していない。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`SideNav` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `SideNav` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる