### PR TITLE
refactor(SmartHRLogo): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/SmartHRLogo/SmartHRLogo.tsx
+++ b/packages/smarthr-ui/src/components/SmartHRLogo/SmartHRLogo.tsx
@@ -1,5 +1,5 @@
 import { type ComponentPropsWithoutRef, memo } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 type BaseProps = {
   /** コンポーネントのタイトル */
@@ -8,7 +8,8 @@ type BaseProps = {
   width?: number | string
   /** コンポーネントの高さ */
   height?: number | string
-} & VariantProps<typeof classNameGenerator>
+  fill?: 'white' | 'brand' | 'black'
+}
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'svg'>, keyof BaseProps>
 
 const classNameGenerator = tv({
@@ -18,7 +19,7 @@ const classNameGenerator = tv({
       white: 'shr-fill-white',
       brand: 'shr-fill-brand',
       black: 'shr-fill-black',
-    },
+    } satisfies Record<NonNullable<Props['fill']>, string>,
   },
 })
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7047 等）の一環。`SmartHRLogo` コンポーネントに対応する。

## 変更内容

`SmartHRLogo.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`fill`）に対応する明示的な型定義（`fill?: 'white' | 'brand' | 'black'`）に置き換えた。`satisfies Record<NonNullable<Props['fill']>, string>` で variants の各キーが型と一致することを担保する。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`SmartHRLogo` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `SmartHRLogo` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる