### PR TITLE
refactor(Chip): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Chip/Chip.tsx
+++ b/packages/smarthr-ui/src/components/Chip/Chip.tsx
@@ -1,9 +1,12 @@
 import { type ComponentPropsWithoutRef, type FC, type PropsWithChildren, useMemo } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 type Props = PropsWithChildren<
-  VariantProps<typeof classNameGenerator> &
-    ComponentPropsWithoutRef<'span'> & { disabled?: boolean }
+  {
+    disabled?: boolean
+    color?: 'grey' | 'blue' | 'green' | 'orange' | 'red'
+    size?: 'S'
+  } & ComponentPropsWithoutRef<'span'>
 >
 
 const classNameGenerator = tv({
@@ -20,10 +23,10 @@ const classNameGenerator = tv({
       green: 'shr-border-green',
       orange: 'shr-border-orange',
       red: 'shr-border-danger',
-    },
+    } satisfies Record<NonNullable<Props['color']>, string>,
     size: {
       S: 'shr-px-0.5 shr-py-0.25 shr-text-sm',
-    },
+    } satisfies Record<NonNullable<Props['size']>, string>,
   },
 })
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7048 等）の一環。`Chip` コンポーネントに対応する。

## 変更内容

`Chip.tsx` の `Props` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`color` / `size`）に対応する明示的な型定義に置き換えた。`satisfies Record<NonNullable<Props['xxx']>, string>` で variants の各キーが型と一致することを担保する。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`Chip` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Chip` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる