### PR TITLE
refactor(Container): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Container/Container.tsx
@@ -1,18 +1,17 @@
 'use client'
 
 import { type ComponentProps, type FC, type PropsWithChildren, useMemo } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { useEnvironment } from '../../../hooks/client/useEnvironment'
 import { paddingBlock, paddingInline } from '../../../tailwind'
 
 import type { Gap } from '../../../types'
 
-type BaseProps = PropsWithChildren<
-  Omit<VariantProps<typeof classNameGenerator>, 'paddingBlock' | 'paddingInline'> & {
-    padding?: Gap | SeparatePadding
-  }
->
+type BaseProps = PropsWithChildren<{
+  size?: 'NARROW' | 'DEFAULT' | 'WIDE' | 'FULL'
+  padding?: Gap | SeparatePadding
+}>
 type Props = BaseProps & Omit<ComponentProps<'div'>, keyof BaseProps>
 
 type SeparatePadding = {
@@ -32,7 +31,7 @@ const classNameGenerator = tv({
       DEFAULT: 'shr-max-w-col8',
       WIDE: 'shr-max-w-col9',
       FULL: '',
-    },
+    } satisfies Record<NonNullable<Props['size']>, string>,
     paddingBlock,
     paddingInline,
   },


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7049 等）の一環。`Container` コンポーネントに対応する。

## 変更内容

`Container.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`size`）に対応する明示的な型定義に置き換えた。`satisfies Record<NonNullable<Props['size']>, string>` で variants の各キーが型と一致することを担保する。

`paddingBlock` / `paddingInline` は元々 `Omit` で公開 props から除外されており（利用者は代わりに `padding` prop を使う）、`satisfies` の対象外とする。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`Container` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Container` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる