### PR TITLE
refactor(Reel): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Reel/Reel.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Reel/Reel.tsx
@@ -5,17 +5,18 @@ import {
   forwardRef,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { Scroller } from '../../Scroller'
 import { useSectionWrapper } from '../../SectioningContent'
 
-import type { Gap } from '../../../types'
+import type { PositiveGap } from '../../../types'
 
-type Props = VariantProps<typeof classNameGenerator> &
-  PropsWithChildren<{
-    as?: string | ComponentType<any>
-  }> &
+type Props = PropsWithChildren<{
+  as?: string | ComponentType<any>
+  gap?: PositiveGap
+  padding?: PositiveGap
+}> &
   ComponentPropsWithRef<'div'>
 
 const classNameGenerator = tv({
@@ -52,7 +53,7 @@ const classNameGenerator = tv({
       XL: 'shr-gap-3',
       XXL: 'shr-gap-3.5',
       X3L: 'shr-gap-4',
-    } as { [key in Gap]: string },
+    } satisfies Record<NonNullable<Props['gap']>, string>,
     padding: {
       0: 'shr-p-0',
       0.25: 'shr-p-0.25',
@@ -76,7 +77,7 @@ const classNameGenerator = tv({
       XL: 'shr-p-3',
       XXL: 'shr-p-3.5',
       X3L: 'shr-p-4',
-    } as { [key in Gap]: string },
+    } satisfies Record<NonNullable<Props['padding']>, string>,
   },
 })
 

--- a/packages/smarthr-ui/src/themes/createSpacing.ts
+++ b/packages/smarthr-ui/src/themes/createSpacing.ts
@@ -19,11 +19,26 @@ export type CreatedSpacingTheme = {
 
 export type CreatedSpacingByCharTheme = (size: CharRelativeSize) => string
 
+export const positivePrimitiveTokens = [
+  0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 8,
+] as const
 export const primitiveTokens = [
-  0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 3.5, 4, 8, -0.25, -0.5, -0.75, -1, -1.25, -1.5, -2,
-  -2.5, -3, -3.5, -4, -8,
+  ...positivePrimitiveTokens,
+  -0.25,
+  -0.5,
+  -0.75,
+  -1,
+  -1.25,
+  -1.5,
+  -2,
+  -2.5,
+  -3,
+  -3.5,
+  -4,
+  -8,
 ] as const
 
+export type PositiveCharRelativeSize = (typeof positivePrimitiveTokens)[number]
 export type CharRelativeSize = (typeof primitiveTokens)[number]
 export type AbstractSize = keyof CreatedSpacingTheme
 

--- a/packages/smarthr-ui/src/themes/index.ts
+++ b/packages/smarthr-ui/src/themes/index.ts
@@ -3,7 +3,7 @@ export {
   defaultMediaQuery,
   type CreatedMediaQueryTheme,
 } from './createMediaQuery'
-export type { AbstractSize, CharRelativeSize } from './createSpacing'
+export type { AbstractSize, CharRelativeSize, PositiveCharRelativeSize } from './createSpacing'
 export { createSpacingByChar, primitiveTokens } from './createSpacing'
 export type { FontSizes } from './createFontSize'
 export { defaultHtmlFontSize, defaultFontSize } from './createFontSize'

--- a/packages/smarthr-ui/src/types/Gap.ts
+++ b/packages/smarthr-ui/src/types/Gap.ts
@@ -1,4 +1,4 @@
-import type { AbstractSize, CharRelativeSize } from '../themes'
+import type { AbstractSize, CharRelativeSize, PositiveCharRelativeSize } from '../themes'
 
 // smarthr-design-systemでtypes exportされています:
 // import type { Gap, SeparateGap } from 'smarthr-ui/types'
@@ -7,3 +7,5 @@ export type SeparateGap = {
   row: Gap
   column: Gap
 }
+// マイナスマージン用途を除いた、0以上のGap
+export type PositiveGap = PositiveCharRelativeSize | AbstractSize

--- a/packages/smarthr-ui/src/types/index.ts
+++ b/packages/smarthr-ui/src/types/index.ts
@@ -1,3 +1,3 @@
-export type { Gap, SeparateGap } from './Gap'
+export type { Gap, PositiveGap, SeparateGap } from './Gap'
 export type { ElementRef, ElementRefProps } from './ComponentTypes'
 export type { ResponseStatus, ResponseStatusWithoutProcessing } from '../hooks/useResponseStatus'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7050 等）の一環。`Reel` コンポーネントに対応する。

## 変更内容

`Reel.tsx` の `Props` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`gap` / `padding`）に対応する明示的な型定義に置き換えた。`satisfies Record<NonNullable<Props['xxx']>, string>` で variants の各キーが型と一致することを担保する。

`Reel` の `gap` / `padding` はマイナスマージン用途を除いた0以上の値のみを受け付ける設計で、既存の `Gap` 型（マイナス値を含む）とは範囲が異なっていた。これは元々 `VariantProps` がvariantsの実際のキーから型を自動導出していたため機能していたもので、単純に `Gap` 型へ置き換えると受け付けない値まで型上許容してしまう。

そこで以下の共通型を新設した:
- `src/themes/createSpacing.ts`: 正の値のみの `positivePrimitiveTokens` 配列と、そこから導出する `PositiveCharRelativeSize` 型を追加（既存の `primitiveTokens` は `positivePrimitiveTokens` + マイナス値の配列として再構成。値・順序は変わらない）
- `src/types/Gap.ts`: `PositiveCharRelativeSize | AbstractSize` として `PositiveGap` 型を追加

`Reel` の `gap` / `padding` にはこの `PositiveGap` を使うようにした。`PositiveGap` は今後同様の制約を持つ他コンポーネント（Cluster、Stack 等）でも再利用できる。

型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`Reel` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Reel` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる
- `createSpacing.ts` / `Gap.ts` は多くのコンポーネントから利用される共通ファイルのため、リポジトリ全体のテストスイート（70ファイル444件）を実行し退行がないことを確認済み