### PR TITLE
refactor(LineClamp): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
+++ b/packages/smarthr-ui/src/components/LineClamp/LineClamp.tsx
@@ -9,11 +9,13 @@ import {
   useRef,
   useState,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { Tooltip } from '../Tooltip'
 
-type BaseProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
+type BaseProps = PropsWithChildren<{
+  maxLines?: 1 | 2 | 3 | 4 | 5 | 6
+}>
 type Props = BaseProps & Omit<ComponentPropsWithRef<'span'>, keyof BaseProps>
 
 const classNameGenerator = tv({
@@ -45,7 +47,7 @@ const classNameGenerator = tv({
       6: {
         clampedLine: 'shr-line-clamp-[6]',
       },
-    },
+    } satisfies Record<NonNullable<BaseProps['maxLines']>, { clampedLine: string }>,
   },
   compoundVariants: [
     {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7051 等）の一環。`LineClamp` コンポーネントに対応する。

## 変更内容

`LineClamp.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`maxLines`）に対応する明示的な型定義（`maxLines?: 1 | 2 | 3 | 4 | 5 | 6`）に置き換えた。`satisfies Record<NonNullable<BaseProps['maxLines']>, { clampedLine: string }>` で variants の各キーが型と一致することを担保する。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`LineClamp` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `LineClamp` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる