### PR TITLE
refactor(Cluster): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Cluster/Cluster.tsx
@@ -5,12 +5,34 @@ import {
   type PropsWithChildren,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { genericsForwardRef } from '../../../libs/util'
 import { useSectionWrapper } from '../../SectioningContent'
 
-import type { Gap, SeparateGap } from '../../../types'
+import type { PositiveGap, SeparatePositiveGap } from '../../../types'
+
+type AlignType = 'start' | 'flex-start' | 'end' | 'flex-end' | 'center' | 'baseline' | 'stretch'
+type JustifyType =
+  | 'normal'
+  | 'start'
+  | 'flex-start'
+  | 'end'
+  | 'flex-end'
+  | 'center'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+  | 'stretch'
+
+type Props<T extends ElementType> = PropsWithChildren<{
+  as?: T
+  gap?: PositiveGap | SeparatePositiveGap
+  inline?: boolean
+  align?: AlignType
+  justify?: JustifyType
+}> &
+  ComponentPropsWithoutRef<T>
 
 export const clusterClassNameGenerator = tv({
   base: 'shr-flex-wrap [&:empty]:shr-gap-0',
@@ -43,7 +65,7 @@ export const clusterClassNameGenerator = tv({
       XL: 'shr-gap-y-3',
       XXL: 'shr-gap-y-3.5',
       X3L: 'shr-gap-y-4',
-    } as { [key in Gap]: string },
+    } satisfies Record<PositiveGap, string>,
     columnGap: {
       0: 'shr-gap-x-0',
       0.25: 'shr-gap-x-0.25',
@@ -67,7 +89,7 @@ export const clusterClassNameGenerator = tv({
       XL: 'shr-gap-x-3',
       XXL: 'shr-gap-x-3.5',
       X3L: 'shr-gap-x-4',
-    } as { [key in Gap]: string },
+    } satisfies Record<PositiveGap, string>,
     align: {
       start: 'shr-items-start',
       'flex-start': 'shr-items-start',
@@ -76,7 +98,7 @@ export const clusterClassNameGenerator = tv({
       center: 'shr-items-center',
       baseline: 'shr-items-baseline',
       stretch: 'shr-items-stretch',
-    },
+    } satisfies Record<AlignType, string>,
     justify: {
       normal: 'shr-justify-normal',
       start: 'shr-justify-start',
@@ -88,17 +110,9 @@ export const clusterClassNameGenerator = tv({
       'space-around': 'shr-justify-around',
       'space-evenly': 'shr-justify-evenly',
       stretch: 'shr-justify-stretch',
-    },
+    } satisfies Record<JustifyType, string>,
   },
 })
-
-type Props<T extends ElementType> = PropsWithChildren<
-  Omit<VariantProps<typeof clusterClassNameGenerator>, 'rowGap' | 'columnGap'> & {
-    as?: T
-    gap?: Gap | SeparateGap
-  }
-> &
-  ComponentPropsWithoutRef<T>
 
 const ActualCluster = <T extends ElementType = 'div'>(
   { as, gap = 0.5, inline = false, align, justify, className, ...rest }: Props<T>,

--- a/packages/smarthr-ui/src/types/Gap.ts
+++ b/packages/smarthr-ui/src/types/Gap.ts
@@ -9,3 +9,7 @@ export type SeparateGap = {
 }
 // マイナスマージン用途を除いた、0以上のGap
 export type PositiveGap = PositiveCharRelativeSize | AbstractSize
+export type SeparatePositiveGap = {
+  row: PositiveGap
+  column: PositiveGap
+}

--- a/packages/smarthr-ui/src/types/index.ts
+++ b/packages/smarthr-ui/src/types/index.ts
@@ -1,3 +1,3 @@
-export type { Gap, PositiveGap, SeparateGap } from './Gap'
+export type { Gap, PositiveGap, SeparateGap, SeparatePositiveGap } from './Gap'
 export type { ElementRef, ElementRefProps } from './ComponentTypes'
 export type { ResponseStatus, ResponseStatusWithoutProcessing } from '../hooks/useResponseStatus'


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7053 等）の一環。`Cluster` コンポーネントに対応する。

## 変更内容

`Cluster.tsx` の `Props` から `VariantProps<typeof clusterClassNameGenerator>` を削除し、`clusterClassNameGenerator` の variants（`inline` / `rowGap` / `columnGap` / `align` / `justify`）に対応する明示的な型定義に置き換えた。`satisfies Record<...>` で variants の各キーが型と一致することを担保する。

`rowGap` / `columnGap` はマイナスマージン用途を除いた0以上の値のみを受け付ける設計のため、`PositiveGap`（#7051で新設）を使う。公開propの`gap`も同様に`PositiveGap`（複数指定時は`SeparatePositiveGap`）に揃えた。以前は`gap`に負の値を渡しても`rowGap`/`columnGap`のvariantsに対応するキーが無くスタイルが適用されないだけだったため、実質的な挙動の変化はない（誤って負の値を渡していた場合、型エラーで検出できるようになる）。

`SeparateGap`のPositiveGap版として`src/types/Gap.ts`に`SeparatePositiveGap`を追加した（`Sidebar`でも再利用予定）。

## プロダクト側で対応が必要な事項

なし。`gap`propの型が`PositiveGap`に絞られるが、負の値は元々スタイルが適用されない無効な値だったため実害はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Cluster` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる
- `Gap.ts` は多くのコンポーネントから利用される共通型のため、リポジトリ全体のテストスイート（70ファイル444件）を実行し退行がないことを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - レイアウトの間隔設定で、正の値のみを指定できるようになりました。
  - 行方向・列方向の間隔を個別に設定する際の指定が明確になりました。
  - 配置（整列・均等配置）と間隔に関する設定値の検証が強化され、誤った指定を事前に検出しやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->