### PR TITLE
fix(FormGroup): innerMarginの型をPositiveGapに絞る

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/type.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/type.ts
@@ -1,4 +1,4 @@
-import type { Gap } from '../../types'
+import type { PositiveGap } from '../../types'
 import type { StatusLabel } from '../StatusLabel'
 import type { Text, TextProps } from '../Text'
 import type {
@@ -30,7 +30,7 @@ type BaseCommonProps = PropsWithChildren<{
   /** タイトル右の領域 */
   subActionArea?: ReactNode
   /** タイトル群と子要素の間の間隔調整用（基本的には不要） */
-  innerMargin?: Gap
+  innerMargin?: PositiveGap
   /** タイトルの隣に表示する `StatusLabel` の配列 */
   statusLabels?: StatusLabelType | StatusLabelType[]
   /** タイトルの下に表示するヘルプメッセージ */


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` 廃止プロジェクトの一環で `Stack` コンポーネントの `gap` propの型を `PositiveGap`（マイナスマージン用途を除いた0以上の値）に絞る対応を進めている。`FormGroup`（`FormControl` / `Fieldset`）の `innerMargin` prop は内部で `Stack` の `gap` にそのまま渡しているため、先行して型を揃える。

## 変更内容

`FormGroup/type.ts` の `innerMargin` prop の型を `Gap`（マイナス値含む）から `PositiveGap`（マイナス値を除いた0以上の値）に変更した。

`innerMargin` に負の値を渡しても、`Stack` 側の `gap` variantsには負の値に対応するキーが存在しないため、これまでもスタイルが適用されない無効な値だった。型を絞ることでコンパイル時に検出できるようになるだけで、実質的な挙動の変化はない。

## プロダクト側で対応が必要な事項

なし。`innerMargin`に負の値を渡していた場合は型エラーになるが、元々効果のなかった値のため実害はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `pnpm ui test -- --run src/components/FormGroup` で既存テスト（11件）が通ることを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * `FormGroup`の`innerMargin`で、負の間隔を指定できないよう型定義を変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->