### PR TITLE
refactor(Stack): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/FormGroup/type.ts
+++ b/packages/smarthr-ui/src/components/FormGroup/type.ts
@@ -1,4 +1,4 @@
-import type { Gap } from '../../types'
+import type { PositiveGap } from '../../types'
 import type { StatusLabel } from '../StatusLabel'
 import type { Text, TextProps } from '../Text'
 import type {
@@ -30,7 +30,7 @@ type BaseCommonProps = PropsWithChildren<{
   /** タイトル右の領域 */
   subActionArea?: ReactNode
   /** タイトル群と子要素の間の間隔調整用（基本的には不要） */
-  innerMargin?: Gap
+  innerMargin?: PositiveGap
   /** タイトルの隣に表示する `StatusLabel` の配列 */
   statusLabels?: StatusLabelType | StatusLabelType[]
   /** タイトルの下に表示するヘルプメッセージ */

--- a/packages/smarthr-ui/src/components/Layout/Stack/Stack.tsx
+++ b/packages/smarthr-ui/src/components/Layout/Stack/Stack.tsx
@@ -5,11 +5,21 @@ import {
   forwardRef,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { useSectionWrapper } from '../../SectioningContent'
 
-import type { Gap } from '../../../types'
+import type { PositiveGap } from '../../../types'
+
+type AlignType = 'start' | 'flex-start' | 'end' | 'flex-end' | 'center' | 'baseline' | 'stretch'
+
+type Props = PropsWithChildren<{
+  as?: string | ComponentType<any>
+  inline?: boolean
+  gap?: PositiveGap
+  align?: AlignType
+}> &
+  ComponentPropsWithRef<'div'>
 
 const classNameGenerator = tv({
   base: 'shr-flex-col shr-justify-start [&_>_*]:shr-my-0',
@@ -41,7 +51,7 @@ const classNameGenerator = tv({
       XL: 'shr-gap-y-3',
       XXL: 'shr-gap-y-3.5',
       X3L: 'shr-gap-y-4',
-    } as { [key in Gap]: string },
+    } satisfies Record<PositiveGap, string>,
     align: {
       start: 'shr-items-start',
       'flex-start': 'shr-items-start',
@@ -50,15 +60,9 @@ const classNameGenerator = tv({
       center: 'shr-items-center',
       baseline: 'shr-items-baseline',
       stretch: 'shr-items-stretch',
-    },
+    } satisfies Record<AlignType, string>,
   },
 })
-
-type Props = VariantProps<typeof classNameGenerator> &
-  PropsWithChildren<{
-    as?: string | ComponentType<any>
-  }> &
-  ComponentPropsWithRef<'div'>
 
 export const Stack = forwardRef<HTMLDivElement, Props>(
   ({ as: Component = 'div', inline = false, gap = 1, align, className, ...rest }, ref) => {


### PR DESCRIPTION
## 関連URL

- #7055（`FormGroup.innerMargin`の型を先行して揃えるPR。本PRはそれに積むstacked PR）

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7054 等）の一環。`Stack` コンポーネントに対応する。

## 変更内容

`Stack.tsx` の `Props` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`inline` / `gap` / `align`）に対応する明示的な型定義に置き換えた。

`gap` はマイナスマージン用途を除いた0以上の値のみを受け付ける設計のため、`PositiveGap`（#7051）を使う。`Stack`の`gap`に値を渡している`FormGroup.innerMargin`の型は #7055 で先行して`PositiveGap`に揃えてある。

`gap` / `align` は `satisfies Record<...>` で variants の各キーが型と一致することを担保する。`inline`（`true`/`false`固定の2値）は`satisfies`を付けても型との対応関係を検証できない（固定リテラルどうしの比較になり、Props側の型変更を検知できない）ため付与しない。

型として提供される内容に変化はない（`gap`の範囲が狭まる点は#7055と同じ理由で実害なし）。

## プロダクト側で対応が必要な事項

なし。`Stack` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `Stack` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる
- 広く使われるコンポーネントのため、リポジトリ全体のテストスイート（70ファイル444件）を実行し退行がないことを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - `FormGroup` の `innerMargin` に、正の間隔値のみ指定できるようになりました。
  - `Stack` の `gap` に、正の間隔値のみ指定できるようになりました。
  - `Stack` の `align` に指定できる値が明確になり、型安全性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->