### PR TITLE
refactor(StatusLabel): VariantPropsをやめ明示的な型定義に変更

### DIFF
--- a/packages/smarthr-ui/src/components/StatusLabel/StatusLabel.tsx
+++ b/packages/smarthr-ui/src/components/StatusLabel/StatusLabel.tsx
@@ -5,9 +5,17 @@ import {
   memo,
   useMemo,
 } from 'react'
-import { type VariantProps, tv } from 'tailwind-variants'
+import { tv } from 'tailwind-variants'
 
 import { FaCircleExclamationIcon, FaTriangleExclamationIcon } from '../Icon'
+
+type StatusLabelType = 'grey' | 'blue' | 'green' | 'red' | 'warning' | 'error'
+
+type BaseProps = PropsWithChildren<{
+  type?: StatusLabelType
+  bold?: boolean
+}>
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'span'>, keyof BaseProps>
 
 const classNameGenerator = tv({
   base: [
@@ -26,7 +34,7 @@ const classNameGenerator = tv({
       red: 'shr-text-danger',
       warning: 'shr-border-warning-yellow shr-bg-warning-yellow shr-text-black',
       error: 'shr-border-danger shr-bg-danger shr-text-white',
-    },
+    } satisfies Record<NonNullable<Props['type']>, string | string[]>,
     bold: {
       true: 'shr-text-white',
     },
@@ -61,9 +69,6 @@ const classNameGenerator = tv({
     },
   ],
 })
-
-type BaseProps = PropsWithChildren<VariantProps<typeof classNameGenerator>>
-type Props = BaseProps & Omit<ComponentPropsWithoutRef<'span'>, keyof BaseProps>
 
 export const StatusLabel = memo<Props>(
   ({ type = 'grey', bold = false, className, children, ...rest }) => {


### PR DESCRIPTION
## 関連URL

なし

## 概要

`VariantProps` を使った型定義をやめ、明示的な型定義に統一していく一連の対応（#6901、#7042〜#7054 等）の一環。`StatusLabel` コンポーネントに対応する。

## 変更内容

`StatusLabel.tsx` の `BaseProps` から `VariantProps<typeof classNameGenerator>` を削除し、`classNameGenerator` の variants（`type` / `bold`）に対応する明示的な型定義に置き換えた。

`type` は `satisfies Record<NonNullable<Props['type']>, string | string[]>` で variants の各キーが型と一致することを担保する。`bold` は `{ true: ... }` のみが定義されたboolean variantで、`Record`のキー制約（`string | number | symbol`）を`boolean`型が満たさないため、`satisfies` は付与せず型定義（`bold?: boolean`）のみ行う。型として提供される内容に変化はない。

## プロダクト側で対応が必要な事項

なし。`StatusLabel` の公開 props・DOM 構造に変更はない。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `StatusLabel` コンポーネントにはテストファイルが存在しないため、Storybook での表示確認で問題ないことを確認できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * StatusLabel のプロパティ型を明示化し、`type` と `bold` の指定をより分かりやすくしました。
  * `type` の指定に対する型チェックを強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->