### PR TITLE
refactor(WarekiPicker): client専用処理をclient/に切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/WarekiPicker/client/WarekiPicker.test.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/client/WarekiPicker.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { act } from 'react'
 
-import { IntlProvider } from '../../intl'
-import { FormControl } from '../FormGroup'
+import { IntlProvider } from '../../../intl'
+import { FormControl } from '../../FormGroup'
 
 import { WarekiPicker } from './WarekiPicker'
 

--- a/packages/smarthr-ui/src/components/WarekiPicker/client/WarekiPicker.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/client/WarekiPicker.tsx
@@ -2,9 +2,9 @@
 
 import { type ComponentProps, type FC, useCallback } from 'react'
 
-import { useLatest } from '../../hooks/useLatest'
-import { useIntl } from '../../intl'
-import { DatePicker } from '../DatePicker'
+import { useLatest } from '../../../hooks/useLatest'
+import { useIntl } from '../../../intl'
+import { DatePicker } from '../../DatePicker'
 
 type Props = Omit<ComponentProps<typeof DatePicker>, 'showAlternative'>
 

--- a/packages/smarthr-ui/src/components/WarekiPicker/client/index.ts
+++ b/packages/smarthr-ui/src/components/WarekiPicker/client/index.ts
@@ -1,0 +1,1 @@
+export { WarekiPicker } from './WarekiPicker'

--- a/packages/smarthr-ui/src/components/WarekiPicker/index.ts
+++ b/packages/smarthr-ui/src/components/WarekiPicker/index.ts
@@ -1,1 +1,1 @@
-export { WarekiPicker } from './WarekiPicker'
+export { WarekiPicker } from './client'

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/VRTWarekiPicker.stories.tsx
@@ -2,7 +2,7 @@ import dayjs from 'dayjs'
 import { userEvent, within } from 'storybook/test'
 
 import { Cluster } from '../../Layout'
-import { WarekiPicker } from '../WarekiPicker'
+import { WarekiPicker } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 

--- a/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
+++ b/packages/smarthr-ui/src/components/WarekiPicker/stories/WarekiPicker.stories.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import { userEvent, within } from 'storybook/test'
 
-import { WarekiPicker } from '../WarekiPicker'
+import { WarekiPicker } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`'use client'` 削除・境界整理プロジェクト（`DefinitionListItem`, `Checkbox`, `Button`, `AnchorButton` 等）の一環。`WarekiPicker` の実装（`useCallback` を使うため `'use client'` が必須）を `client/` ディレクトリに切り出す。

## 変更内容

- `WarekiPicker.tsx` / `WarekiPicker.test.tsx` を `client/` 配下に移動（`'use client'` はそのまま維持）
- `client/index.ts` を新設し、`WarekiPicker` をre-export（component用バレル）
- 公開バレル（`WarekiPicker/index.ts`）は `./client` から re-export するだけに変更。ディレクティブを持たないため、Server Componentからも参照は可能になる（`WarekiPicker`コンポーネント自体は引き続き`'use client'`を持つため、実際にレンダーする用途はクライアント側に限られる）

rollupビルド出力で、公開バレル（`lib/components/WarekiPicker/index.js`）に `"use client"` が付かず、`client/WarekiPicker.js`側にのみ付与されることを実測済み。

## プロダクト側で対応が必要な事項

なし。`WarekiPicker` の公開 props・DOM 構造・`'use client'` の有無に変更はない（ファイル移動のみ）。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `pnpm ui test -- --run src/components/WarekiPicker` で既存テスト（3件）が通ることを確認済み
- rollupビルド出力で `'use client'` の境界が正しい位置にあることを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 和暦日付選択コンポーネントの公開エントリーポイントを整理しました。
  * コンポーネント、テスト、ストーリーの参照先を統一し、現在の構成に対応しました。
* **テスト**
  * 既存のテストおよびビジュアルリグレッションテストが、更新後の構成で実行されるよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->