### PR TITLE
refactor(Textarea): client専用処理をclient/に切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/Textarea/client/Textarea.test.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/client/Textarea.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { useEffect, useState } from 'react'
 
-import { IntlProvider } from '../../intl'
-import { FormControl } from '../FormGroup'
+import { IntlProvider } from '../../../intl'
+import { FormControl } from '../../FormGroup'
 
 import { Textarea } from './Textarea'
 

--- a/packages/smarthr-ui/src/components/Textarea/client/Textarea.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/client/Textarea.tsx
@@ -17,14 +17,14 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useMergeRefs } from '../../hooks/client/useMergeRefs'
-import { useOnce } from '../../hooks/client/useOnce'
-import { useTheme } from '../../hooks/client/useTheme'
-import { useLatest } from '../../hooks/useLatest'
-import { Localizer } from '../../intl'
-import { debounce } from '../../libs/debounce'
-import { defaultHtmlFontSize } from '../../themes'
-import { VisuallyHiddenText } from '../VisuallyHiddenText'
+import { useMergeRefs } from '../../../hooks/client/useMergeRefs'
+import { useOnce } from '../../../hooks/client/useOnce'
+import { useTheme } from '../../../hooks/client/useTheme'
+import { useLatest } from '../../../hooks/useLatest'
+import { Localizer } from '../../../intl'
+import { debounce } from '../../../libs/debounce'
+import { defaultHtmlFontSize } from '../../../themes'
+import { VisuallyHiddenText } from '../../VisuallyHiddenText'
 
 type BaseProps = {
   /** 入力値にエラーがあるかどうか */

--- a/packages/smarthr-ui/src/components/Textarea/client/index.ts
+++ b/packages/smarthr-ui/src/components/Textarea/client/index.ts
@@ -1,0 +1,1 @@
+export { Textarea } from './Textarea'

--- a/packages/smarthr-ui/src/components/Textarea/index.ts
+++ b/packages/smarthr-ui/src/components/Textarea/index.ts
@@ -1,1 +1,1 @@
-export { Textarea } from './Textarea'
+export { Textarea } from './client'

--- a/packages/smarthr-ui/src/components/Textarea/stories/Textarea.stories.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/stories/Textarea.stories.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '../../Layout'
-import { Textarea } from '../Textarea'
+import { Textarea } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 

--- a/packages/smarthr-ui/src/components/Textarea/stories/VRTTextarea.stories.tsx
+++ b/packages/smarthr-ui/src/components/Textarea/stories/VRTTextarea.stories.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '../../Layout'
-import { Textarea } from '../Textarea'
+import { Textarea } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

`'use client'` 削除・境界整理プロジェクト（`DefinitionListItem`, `Checkbox`, `Button`, `AnchorButton`, `WarekiPicker` 等）の一環。`Textarea` の実装（`useState`/`useRef`/`useEffect` 等を使うため `'use client'` が必須）を `client/` ディレクトリに切り出す。

## 変更内容

- `Textarea.tsx` / `Textarea.test.tsx` を `client/` 配下に移動（`'use client'` はそのまま維持）
- `client/index.ts` を新設し、`Textarea` をre-export（component用バレル）
- 公開バレル（`Textarea/index.ts`）は `./client` から re-export するだけに変更。ディレクティブを持たないため、Server Componentからも参照は可能になる（`Textarea`コンポーネント自体は引き続き`'use client'`を持つため、実際にレンダーする用途はクライアント側に限られる）

rollupビルド出力で、公開バレル（`lib/components/Textarea/index.js`）に `"use client"` が付かず、`client/Textarea.js`側にのみ付与されることを実測済み。

## プロダクト側で対応が必要な事項

なし。`Textarea` の公開 props・DOM 構造・`'use client'` の有無に変更はない（ファイル移動のみ）。

## 確認方法

- `tsc --noEmit` で型エラーがないことを確認済み
- `eslint` で問題ないことを確認済み
- `pnpm ui test -- --run src/components/Textarea` で既存テストが通ることを確認済み
- rollupビルド出力で `'use client'` の境界が正しい位置にあることを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Textarea の参照先を新しい構成に合わせて整理しました。
  * クライアント側のエントリーポイントから Textarea を利用できるようになりました。
  * 既存の機能、テスト内容、ストーリー、ビジュアルリグレッションシナリオに変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->