### PR TITLE
refactor(Select): client境界をActualSelectに限定しSelect.tsx自体をServer Component化

### DIFF
--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -46,7 +46,6 @@ const classNameGenerator = tv({
       'shr-pointer-events-none shr-absolute shr-inset-y-0 shr-inline-flex shr-items-center shr-text-grey',
       'peer-focus-visible:shr-text-black peer-disabled:shr-text-disabled',
     ],
-    blankOptgroup: 'shr-hidden',
   },
   variants: {
     size: {
@@ -72,7 +71,7 @@ const BaseSelect = <T extends string>(
   ref: ForwardedRef<HTMLSelectElement>,
 ) => {
   const classNames = useMemo(() => {
-    const { wrapper, select, iconWrap, blankOptgroup } = classNameGenerator()
+    const { wrapper, select, iconWrap } = classNameGenerator()
     const sizeProps = {
       size: size || 'M',
     }
@@ -81,7 +80,6 @@ const BaseSelect = <T extends string>(
       wrapper: wrapper({ className }),
       select: select(sizeProps),
       iconWrap: iconWrap(sizeProps),
-      blankOptGroup: blankOptgroup(),
     }
   }, [size, className])
 
@@ -97,7 +95,7 @@ const BaseSelect = <T extends string>(
         {options.map((option, index) => (
           <Option {...option} key={index} />
         ))}
-        <NotOmittingLabelsInMobileSafari className={classNames.blankOptGroup} />
+        <NotOmittingLabelsInMobileSafari />
       </ActualSelect>
       <span className={classNames.iconWrap}>
         <FaAngleDownIcon />

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -68,20 +68,7 @@ const classNameGenerator = tv({
 })
 
 const BaseSelect = <T extends string>(
-  {
-    options,
-    onChange,
-    onChangeValue,
-    error,
-    width,
-    hasBlank,
-    blankLabel,
-    size,
-    className,
-    disabled,
-    required,
-    ...rest
-  }: Props<T>,
+  { options, width, hasBlank, blankLabel, size, className, ...rest }: Props<T>,
   ref: ForwardedRef<HTMLSelectElement>,
 ) => {
   const classNames = useMemo(() => {
@@ -105,17 +92,7 @@ const BaseSelect = <T extends string>(
         width: typeof width === 'number' ? `${width}px` : width,
       }}
     >
-      <ActualSelect
-        {...rest}
-        outerRef={ref}
-        required={required}
-        disabled={disabled}
-        error={error}
-        className={classNames.select}
-        onChange={onChange}
-        onChangeValue={onChangeValue}
-        options={options}
-      >
+      <ActualSelect {...rest} outerRef={ref} className={classNames.select} options={options}>
         <BlankOption hasBlank={hasBlank}>{blankLabel ?? ''}</BlankOption>
         {options.map((option, index) => (
           <Option {...option} key={index} />

--- a/packages/smarthr-ui/src/components/Select/Select.tsx
+++ b/packages/smarthr-ui/src/components/Select/Select.tsx
@@ -1,40 +1,20 @@
-'use client'
-
-// HINT: libs/uaはtypeof window !== 'undefined'でガードされているためRSCで例外にはならないが、
-// isIOS・isMobileSafariは実機のUAをブラウザ側で検出する必要がある。Server Componentのままだと
-// navigatorが存在しないサーバ上で1回だけ評価され常にfalseに固定されるため、'use client'が必要
-
 import {
-  type ChangeEvent,
   type ComponentPropsWithoutRef,
   type ForwardedRef,
-  type OptgroupHTMLAttributes,
-  type OptionHTMLAttributes,
   type PropsWithChildren,
   memo,
   useMemo,
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { isIOS, isMobileSafari } from '../../libs/ua'
 import { genericsForwardRef } from '../../libs/util'
 import { FaAngleDownIcon } from '../Icon'
 
-type Option<T extends string> = {
-  value: T
-} & Omit<OptionHTMLAttributes<HTMLOptionElement>, 'value'>
-type Optgroup<T extends string> = {
-  label: string
-  options: Array<Option<T>>
-} & OptgroupHTMLAttributes<HTMLOptGroupElement>
+import { ActualSelect, NotOmittingLabelsInMobileSafari } from './client'
 
-type BaseProps<T extends string> = {
-  /** 選択肢のデータの配列 */
-  options: Array<Option<T> | Optgroup<T>>
-  /** フォームの値が変わったときに発火するコールバック関数 */
-  onChangeValue?: (value: T) => void
-  /** フォームの値にエラーがあるかどうか */
-  error?: boolean
+import type { ActualSelectProps } from './client'
+
+type BaseProps<T extends string> = Omit<ActualSelectProps<T>, 'outerRef' | 'children'> & {
   /** コンポーネントの幅 */
   width?: number | string
   /** コンポーネントの大きさ */
@@ -87,7 +67,7 @@ const classNameGenerator = tv({
   },
 })
 
-const ActualSelect = <T extends string>(
+const BaseSelect = <T extends string>(
   {
     options,
     onChange,
@@ -125,40 +105,23 @@ const ActualSelect = <T extends string>(
         width: typeof width === 'number' ? `${width}px` : width,
       }}
     >
-      <select
+      <ActualSelect
         {...rest}
-        ref={ref}
-        // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
-        //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
-        //    - エラーメッセージが表示されない
-        //    - 問題のある入力フィールドまでスクロールしない
-        // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
-        // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
-        required={isIOS ? undefined : required}
+        outerRef={ref}
+        required={required}
         disabled={disabled}
+        error={error}
         className={classNames.select}
-        aria-invalid={error || undefined}
-        data-smarthr-ui-input="true"
-        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-          onChange?.(e)
-
-          if (onChangeValue) {
-            const selectedOption = options
-              .flatMap((option) => ('value' in option ? [option] : option.options))
-              .find((option) => option.value === e.target.value)
-
-            if (selectedOption) {
-              onChangeValue(selectedOption.value)
-            }
-          }
-        }}
+        onChange={onChange}
+        onChangeValue={onChangeValue}
+        options={options}
       >
         <BlankOption hasBlank={hasBlank}>{blankLabel ?? ''}</BlankOption>
         {options.map((option, index) => (
           <Option {...option} key={index} />
         ))}
         <NotOmittingLabelsInMobileSafari className={classNames.blankOptGroup} />
-      </select>
+      </ActualSelect>
       <span className={classNames.iconWrap}>
         <FaAngleDownIcon />
       </span>
@@ -190,9 +153,4 @@ const Option = memo<Props<string>['options'][number]>((option) => {
   )
 })
 
-// Support for not omitting labels in Mobile Safari
-const NotOmittingLabelsInMobileSafari = memo<{ className: string }>(
-  ({ className }) => isMobileSafari && <optgroup className={className} />,
-)
-
-export const Select = genericsForwardRef(ActualSelect)
+export const Select = genericsForwardRef(BaseSelect)

--- a/packages/smarthr-ui/src/components/Select/client/ActualSelect.tsx
+++ b/packages/smarthr-ui/src/components/Select/client/ActualSelect.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+// HINT: libs/uaはtypeof window !== 'undefined'でガードされているためRSCで例外にはならないが、
+// isIOS・isMobileSafariは実機のUAをブラウザ側で検出する必要がある。Server Componentのままだと
+// navigatorが存在しないサーバ上で1回だけ評価され常にfalseに固定されるため、'use client'が必要
+
+import {
+  type ChangeEvent,
+  type ComponentPropsWithoutRef,
+  type OptgroupHTMLAttributes,
+  type OptionHTMLAttributes,
+  type PropsWithChildren,
+  type Ref,
+  memo,
+} from 'react'
+
+import { isIOS, isMobileSafari } from '../../../libs/ua'
+
+type Option<T extends string> = {
+  value: T
+} & Omit<OptionHTMLAttributes<HTMLOptionElement>, 'value'>
+type Optgroup<T extends string> = {
+  label: string
+  options: Array<Option<T>>
+} & OptgroupHTMLAttributes<HTMLOptGroupElement>
+
+type BaseProps<T extends string> = PropsWithChildren<{
+  outerRef?: Ref<HTMLSelectElement>
+  /** 選択肢のデータの配列 */
+  options: Array<Option<T> | Optgroup<T>>
+  /** フォームの値が変わったときに発火するコールバック関数 */
+  onChangeValue?: (value: T) => void
+  /** フォームの値にエラーがあるかどうか */
+  error?: boolean
+}>
+
+export type Props<T extends string> = BaseProps<T> &
+  Omit<ComponentPropsWithoutRef<'select'>, keyof BaseProps<string> | 'children' | 'size'>
+
+export const ActualSelect = <T extends string>({
+  outerRef,
+  options,
+  onChange,
+  onChangeValue,
+  error,
+  required,
+  children,
+  ...rest
+}: Props<T>) => (
+  <select
+    {...rest}
+    ref={outerRef}
+    // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
+    //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
+    //    - エラーメッセージが表示されない
+    //    - 問題のある入力フィールドまでスクロールしない
+    // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
+    // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
+    required={isIOS ? undefined : required}
+    aria-invalid={error || undefined}
+    data-smarthr-ui-input="true"
+    onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+      onChange?.(e)
+
+      if (onChangeValue) {
+        const selectedOption = options
+          .flatMap((option) => ('value' in option ? [option] : option.options))
+          .find((option) => option.value === e.target.value)
+
+        if (selectedOption) {
+          onChangeValue(selectedOption.value)
+        }
+      }
+    }}
+  >
+    {children}
+  </select>
+)
+
+// Support for not omitting labels in Mobile Safari
+export const NotOmittingLabelsInMobileSafari = memo<{ className: string }>(
+  ({ className }) => isMobileSafari && <optgroup className={className} />,
+)

--- a/packages/smarthr-ui/src/components/Select/client/ActualSelect.tsx
+++ b/packages/smarthr-ui/src/components/Select/client/ActualSelect.tsx
@@ -35,6 +35,8 @@ type BaseProps<T extends string> = PropsWithChildren<{
 }>
 
 export type Props<T extends string> = BaseProps<T> &
+  // HINT: HTML標準のsize属性（表示行数、number型）はSelectコンポーネント独自の
+  // size prop（'M' | 'S'）と名前が衝突するため、ここでOmitして呼び出し元に独自定義させる
   Omit<ComponentPropsWithoutRef<'select'>, keyof BaseProps<string> | 'children' | 'size'>
 
 export const ActualSelect = <T extends string>({

--- a/packages/smarthr-ui/src/components/Select/client/ActualSelect.tsx
+++ b/packages/smarthr-ui/src/components/Select/client/ActualSelect.tsx
@@ -35,8 +35,6 @@ type BaseProps<T extends string> = PropsWithChildren<{
 }>
 
 export type Props<T extends string> = BaseProps<T> &
-  // HINT: HTML標準のsize属性（表示行数、number型）はSelectコンポーネント独自の
-  // size prop（'M' | 'S'）と名前が衝突するため、ここでOmitして呼び出し元に独自定義させる
   Omit<ComponentPropsWithoutRef<'select'>, keyof BaseProps<string> | 'children' | 'size'>
 
 export const ActualSelect = <T extends string>({
@@ -80,6 +78,6 @@ export const ActualSelect = <T extends string>({
 )
 
 // Support for not omitting labels in Mobile Safari
-export const NotOmittingLabelsInMobileSafari = memo<{ className: string }>(
-  ({ className }) => isMobileSafari && <optgroup className={className} />,
+export const NotOmittingLabelsInMobileSafari = memo(
+  () => isMobileSafari && <optgroup className="shr-hidden" />,
 )

--- a/packages/smarthr-ui/src/components/Select/client/index.ts
+++ b/packages/smarthr-ui/src/components/Select/client/index.ts
@@ -1,0 +1,2 @@
+export { ActualSelect, NotOmittingLabelsInMobileSafari } from './ActualSelect'
+export type { Props as ActualSelectProps } from './ActualSelect'


### PR DESCRIPTION
## 関連URL

なし

## 概要

Select.tsx全体に`'use client'`が付いていたが、実際にclient専用APIを必要とするのは`<select>`要素本体とiOS/MobileSafari判定ロジック（`isIOS`/`isMobileSafari`）のみだった。WarekiPicker(#7059)/Textarea(#7060)で確立したclient境界の切り出しパターンをSelectにも適用し、Select.tsx自体をServer Componentから利用可能にする。

## 変更内容

- `<select>`要素本体と`onChangeValue`のロジック、`isIOS`/`isMobileSafari`を使う判定を`client/ActualSelect.tsx`（`'use client'`あり）に切り出し
- `client/index.ts`を新設し、`ActualSelect`・`NotOmittingLabelsInMobileSafari`・型`ActualSelectProps`をexport
- `Select.tsx`からは`'use client'`を削除。`memo`/`useMemo`/`genericsForwardRef`（`forwardRef`）のみで構成され、Server Componentのグラフでも評価可能になった
- 公開`index.ts`・公開propsに変更なし

## プロダクト側で対応が必要な事項

なし。公開コンポーネント`Select`のprops・DOM構造に変更はない。

## 確認方法

- `tsc --noEmit -p packages/smarthr-ui/tsconfig.build.json` / `eslint` ともにエラーなし
- rollupビルド実測で、`lib/components/Select/Select.js`に`"use client"`が付かず、`lib/components/Select/client/ActualSelect.js`にのみ付くことを確認
- Selectに既存のユニットテストはないため、Storybookでの動作確認を推奨（`pnpm ui dev` → Select）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - iOSおよびMobile Safariで、選択フィールドの必須入力やラベル表示が正しく動作するよう改善しました。
  - 選択肢の変更時に、通常の変更通知と選択された値の通知が適切に処理されるようになりました。
- **リファクタ**
  - 選択フィールドのクライアント側処理を整理し、各種環境での安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->