### PR TITLE
refactor(SegmentedControl): client専用処理をclient/に切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/SegmentedControl/client/SegmentedControl.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/client/SegmentedControl.tsx
@@ -11,9 +11,9 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useCallbackRefCleanupForReact18 } from '../../hooks/client/useCallbackRefCleanupForReact18'
-import { useLatest } from '../../hooks/useLatest'
-import { Button } from '../Button'
+import { useCallbackRefCleanupForReact18 } from '../../../hooks/client/useCallbackRefCleanupForReact18'
+import { useLatest } from '../../../hooks/useLatest'
+import { Button } from '../../Button'
 
 export type Option = {
   /** 選択時に返される値 */

--- a/packages/smarthr-ui/src/components/SegmentedControl/client/index.ts
+++ b/packages/smarthr-ui/src/components/SegmentedControl/client/index.ts
@@ -1,0 +1,1 @@
+export { SegmentedControl, type Option } from './SegmentedControl'

--- a/packages/smarthr-ui/src/components/SegmentedControl/index.ts
+++ b/packages/smarthr-ui/src/components/SegmentedControl/index.ts
@@ -1,1 +1,1 @@
-export { SegmentedControl, type Option as SegmentedControlOption } from './SegmentedControl'
+export { SegmentedControl, type Option as SegmentedControlOption } from './client'

--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/SegmentedControl.stories.tsx
@@ -8,7 +8,7 @@ import {
   FaTableIcon,
 } from '../../Icon'
 import { Stack } from '../../Layout'
-import { SegmentedControl } from '../SegmentedControl'
+import { SegmentedControl } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 

--- a/packages/smarthr-ui/src/components/SegmentedControl/stories/VRTSegmentedControl.stories.tsx
+++ b/packages/smarthr-ui/src/components/SegmentedControl/stories/VRTSegmentedControl.stories.tsx
@@ -2,7 +2,7 @@ import { userEvent } from 'storybook/test'
 
 import { FaChartAreaIcon, FaChartBarIcon, FaChartLineIcon } from '../../Icon'
 import { Stack } from '../../Layout'
-import { type Option, SegmentedControl } from '../SegmentedControl'
+import { type Option, SegmentedControl } from '../client'
 
 import type { StoryObj } from '@storybook/react-vite'
 


### PR DESCRIPTION
## 関連URL

なし

## 概要

WarekiPicker(#7059)/Textarea(#7060)と同様のパターンで、SegmentedControlの'use client'が必要な実装をclient/ディレクトリに切り出す。公開バレル(index.ts)自体は'use client'を持たないようにすることで、Server Componentからの参照経路を確保する。

## 変更内容

- `SegmentedControl.tsx`を`client/SegmentedControl.tsx`へ移動('use client'は維持)
- `client/index.ts`を新設: `export { SegmentedControl, type Option } from './SegmentedControl'`
- 公開`index.ts`: `export { SegmentedControl, type Option as SegmentedControlOption } from './client'`
- storiesのimportを`../client`経由に修正
- 公開`index.ts`・公開props・DOM構造に変更なし

## プロダクト側で対応が必要な事項

なし。公開コンポーネント`SegmentedControl`のprops・DOM構造に変更はない。

## 確認方法

- `tsc --noEmit -p packages/smarthr-ui/tsconfig.build.json` / `eslint` ともにエラーなし
- rollupビルド実測で、`lib/components/SegmentedControl/index.js`(公開バレル)に`"use client"`が付かず、`lib/components/SegmentedControl/client/SegmentedControl.js`にのみ付くことを確認
- SegmentedControlに既存のユニットテストはないため、Storybookでの動作確認を推奨（`pnpm ui dev` → SegmentedControl）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - SegmentedControl のクライアント向けエントリーポイントを整理しました。
  - コンポーネントおよび型の公開方法を統一し、利用時の互換性を維持しています。
  - 機能や公開 API に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->