### PR TITLE
refactor(Scroller): client専用処理をclient/に切り出す

### DIFF
--- a/packages/smarthr-ui/src/components/Scroller/client/Scroller.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/client/Scroller.tsx
@@ -10,8 +10,8 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { useMergeRefs } from '../../hooks/client/useMergeRefs'
-import { useSectionWrapper } from '../SectioningContent'
+import { useMergeRefs } from '../../../hooks/client/useMergeRefs'
+import { useSectionWrapper } from '../../SectioningContent'
 
 type BaseProps = PropsWithChildren<{
   as?: string | ComponentType<any>

--- a/packages/smarthr-ui/src/components/Scroller/client/index.ts
+++ b/packages/smarthr-ui/src/components/Scroller/client/index.ts
@@ -1,0 +1,1 @@
+export { Scroller } from './Scroller'

--- a/packages/smarthr-ui/src/components/Scroller/index.ts
+++ b/packages/smarthr-ui/src/components/Scroller/index.ts
@@ -1,1 +1,1 @@
-export { Scroller } from './Scroller'
+export { Scroller } from './client'

--- a/packages/smarthr-ui/src/components/Scroller/stories/Scroller.stories.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/stories/Scroller.stories.tsx
@@ -1,5 +1,5 @@
 import { Panel } from '../../Panel'
-import { Scroller } from '../Scroller'
+import { Scroller } from '../client'
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 

--- a/packages/smarthr-ui/src/components/Scroller/stories/VRTScroller.stories.tsx
+++ b/packages/smarthr-ui/src/components/Scroller/stories/VRTScroller.stories.tsx
@@ -7,7 +7,7 @@ import {
   StyleTypeScroll,
 } from './Scroller.stories'
 
-import type { Scroller } from '../Scroller'
+import type { Scroller } from '../client'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 export default {


### PR DESCRIPTION
## 関連URL

なし

## 概要

WarekiPicker(#7059)/Textarea(#7060)/SegmentedControl(#7062)と同様のパターンで、Scrollerの'use client'が必要な実装をclient/ディレクトリに切り出す。公開バレル(index.ts)自体は'use client'を持たないようにすることで、Server Componentからの参照経路を確保する。

## 変更内容

- `Scroller.tsx`を`client/Scroller.tsx`へ移動('use client'は維持)
- `client/index.ts`を新設
- 公開`index.ts`: `export { Scroller } from './client'`
- storiesのimportを`../client`経由に修正
- 公開`index.ts`・公開props・DOM構造に変更なし

## プロダクト側で対応が必要な事項

なし。公開コンポーネント`Scroller`のprops・DOM構造に変更はない。

## 確認方法

- `tsc --noEmit -p packages/smarthr-ui/tsconfig.build.json` / `eslint` ともにエラーなし
- rollupビルド実測で、`lib/components/Scroller/index.js`(公開バレル)に`"use client"`が付かず、`lib/components/Scroller/client/Scroller.js`にのみ付くことを確認
- Scrollerに既存のユニットテストはないため、Storybookでの動作確認を推奨（`pnpm ui dev` → Scroller）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - Scroller の公開エントリーポイントを整理し、クライアント向けモジュールから利用できるようになりました。
  - Scroller の既存機能や動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->