### PR TITLE
refactor(RadioButton): client境界をActualRadioButtonに限定しRadioButton.tsx自体をServer Component化

### DIFF
--- a/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/RadioButton.tsx
@@ -1,9 +1,3 @@
-'use client'
-
-// HINT: libs/uaはtypeof window !== 'undefined'でガードされているためRSCで例外にはならないが、
-// isIOS・isMobileSafariは実機のUAをブラウザ側で検出する必要がある。Server Componentのままだと
-// navigatorが存在しないサーバ上で1回だけ評価され常にfalseに固定されるため、'use client'が必要
-
 import {
   type ComponentPropsWithRef,
   type PropsWithChildren,
@@ -14,7 +8,7 @@ import {
 } from 'react'
 import { tv } from 'tailwind-variants'
 
-import { isIOS } from '../../libs/ua'
+import { ActualRadioButton } from './client'
 
 type Props = PropsWithChildren<ComponentPropsWithRef<'input'>>
 
@@ -52,7 +46,7 @@ const classNameGenerator = tv({
 })
 
 export const RadioButton = forwardRef<HTMLInputElement, Props>(
-  ({ children, className, required, id, disabled, ...rest }, ref) => {
+  ({ children, className, id, disabled, ...rest }, ref) => {
     const classNames = useMemo(() => {
       const { wrapper, innerWrapper, box, input, label } = classNameGenerator()
 
@@ -71,18 +65,10 @@ export const RadioButton = forwardRef<HTMLInputElement, Props>(
     return (
       <span className={classNames.wrapper} data-disabled={disabled}>
         <span className={classNames.innerWrapper}>
-          <input
+          <ActualRadioButton
             {...rest}
-            ref={ref}
-            type="radio"
+            outerRef={ref}
             id={radioButtonId}
-            // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
-            //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
-            //    - エラーメッセージが表示されない
-            //    - 問題のある入力フィールドまでスクロールしない
-            // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
-            // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
-            required={isIOS ? undefined : required}
             disabled={disabled}
             className={classNames.input}
             data-smarthr-ui-input="true"

--- a/packages/smarthr-ui/src/components/RadioButton/client/ActualRadioButton.tsx
+++ b/packages/smarthr-ui/src/components/RadioButton/client/ActualRadioButton.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+// HINT: libs/uaはtypeof window !== 'undefined'でガードされているためRSCで例外にはならないが、
+// isIOS・isMobileSafariは実機のUAをブラウザ側で検出する必要がある。Server Componentのままだと
+// navigatorが存在しないサーバ上で1回だけ評価され常にfalseに固定されるため、'use client'が必要
+
+import { isIOS } from '../../../libs/ua'
+
+import type { ComponentPropsWithRef, FC, PropsWithChildren, Ref } from 'react'
+
+type Props = PropsWithChildren<
+  {
+    outerRef: Ref<HTMLInputElement>
+  } & ComponentPropsWithRef<'input'>
+>
+
+export const ActualRadioButton: FC<Props> = ({ outerRef, required, ...rest }) => (
+  <input
+    {...rest}
+    ref={outerRef}
+    type="radio"
+    // HINT: required属性を設定すると、iOS端末で以下の問題が発生します
+    //  - フォームのsubmit時にバリデーションは行われるが、ユーザーにフィードバックがない
+    //    - エラーメッセージが表示されない
+    //    - 問題のある入力フィールドまでスクロールしない
+    // 歴史的に一部の端末ではrequired属性が無視されることがあるため、HTMLのバリデーションのみとすることは少ないです
+    // そのため、iOS端末ではrequired属性を設定しない方がユーザーがsubmitできない理由をエラーメッセージなどで正しく理解できるようになります
+    required={isIOS ? undefined : required}
+    data-smarthr-ui-input="true"
+  />
+)

--- a/packages/smarthr-ui/src/components/RadioButton/client/index.ts
+++ b/packages/smarthr-ui/src/components/RadioButton/client/index.ts
@@ -1,0 +1,1 @@
+export { ActualRadioButton } from './ActualRadioButton'


### PR DESCRIPTION
## 関連URL

なし

## 概要

RadioButton.tsx全体に'use client'が付いていたが、実際にclient専用APIを必要とするのは`<input type="radio">`要素本体とiOS判定ロジック(`isIOS`)のみだった。WarekiPicker(#7059)/Textarea(#7060)/Select(#7061)で確立したclient境界の切り出しパターンをRadioButtonにも適用し、RadioButton.tsx自体をServer Componentから利用可能にする。

## 変更内容

- `<input type="radio">`要素本体と`required`のiOS判定ロジックを`client/ActualRadioButton.tsx`('use client'あり)に切り出し
- `client/index.ts`を新設し、`ActualRadioButton`をexport
- `RadioButton.tsx`からは'use client'を削除。`forwardRef`/`memo`/`useMemo`/`useId`のみで構成され、Server Componentのグラフでも評価可能になった
- 公開`index.ts`・公開propsに変更なし

## プロダクト側で対応が必要な事項

なし。公開コンポーネント`RadioButton`のprops・DOM構造に変更はない。

## 確認方法

- `tsc --noEmit -p packages/smarthr-ui/tsconfig.build.json` / `eslint` ともにエラーなし
- rollupビルド実測で、`lib/components/RadioButton/RadioButton.js`に`"use client"`が付かず、`lib/components/RadioButton/client/ActualRadioButton.js`にのみ付くことを確認
- RadioButtonに既存のユニットテストはないため、Storybookでの動作確認を推奨（`pnpm ui dev` → RadioButton）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * iOS環境でのラジオボタンの必須入力処理を調整し、フォーム送信時の動作を改善しました。
  * ラジオボタンの属性や参照情報の扱いを見直し、環境に応じた表示・入力動作に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->